### PR TITLE
fix(build/docker): add -n option to avoid ln failing to overwrite the existing symbolic link file

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -44,9 +44,9 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     kong prepare -p "$PREFIX" "$@"
 
-    ln -sf /dev/stdout $PREFIX/logs/access.log
-    ln -sf /dev/stdout $PREFIX/logs/admin_access.log
-    ln -sf /dev/stderr $PREFIX/logs/error.log
+    ln -sfn /dev/stdout $PREFIX/logs/access.log
+    ln -sfn /dev/stdout $PREFIX/logs/admin_access.log
+    ln -sfn /dev/stderr $PREFIX/logs/error.log
 
     exec /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \


### PR DESCRIPTION
### Summary

On some older kernels (below 4.2), executing `ln -sf /dev/stdout /tmp/access.log` multiple times will only work the first time. This is because those kernels have a bug that misleads `openat()` to recognize `/dev/stdout` as a directory, leading to `ln` does not able to overwrite the existing files.

This can lead to that once the container is started, it will continue to fail when restarting afterward due to the docker entrypoint does not execute properly.

Kernel `3.10`:

```
$ uname -a
Linux KONG 3.10.0-693.el7.x86_64 #1 SMP Tue Aug 22 21:09:27 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
$ 
$ docker run -it --privileged ubuntu:22.04 bash
root@03d0dfc6bb90:/# 
root@03d0dfc6bb90:/# ln -s /dev/stdout /tmp/access.log
root@03d0dfc6bb90:/# ln -s /dev/stdout /tmp/access.log
ln: failed to create symbolic link '/tmp/access.log/stdout': Not a directory
root@03d0dfc6bb90:/# 
```

Ref:
[1]: https://stackoverflow.com/questions/75305383/openat-recognized-dev-stdout-as-a-directory

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* add `-n` option to avoid `ln` failing to overwrite the existing symbolic link file

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
