### PR TITLE
feat/proxy caching content type wildcard2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@
   Defaults to `nil` which means do not add any tags
   to the metrics.
   [#10118](https://github.com/Kong/kong/pull/10118)
+- **Proxy Cache**: Add wildcard and parameter match support for content_type
+  [#10055](https://github.com/Kong/kong/pull/10055)
 
 ### Fixes
 

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -176,11 +176,10 @@ local function cacheable_response(conf, cc)
       return false
     end
 
-    local opts = { ignorecase_params = { "charset" } }
-    local t, subtype, params = parse_mime_type(content_type, opts)
+    local t, subtype, params = parse_mime_type(content_type)
     local content_match = false
     for i = 1, #conf.content_type do
-      local t1, subtype1, params1 = parse_mime_type(conf.content_type[i], opts)
+      local t1, subtype1, params1 = parse_mime_type(conf.content_type[i])
       if (lower(t) == lower(t1) or t1 == "*") and
         (lower(subtype) == lower(subtype1) or subtype1 == "*") then
         local params_match = true

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -179,20 +179,24 @@ local function cacheable_response(conf, cc)
     local t, subtype, params = parse_mime_type(content_type)
     local content_match = false
     for i = 1, #conf.content_type do
-      local t1, subtype1, params1 = parse_mime_type(conf.content_type[i])
-      if (lower(t) == lower(t1) or t1 == "*") and
-        (lower(subtype) == lower(subtype1) or subtype1 == "*") then
-        local params_match = true
-        for key, value in pairs(params1 or EMPTY) do
-          if value ~= (params or EMPTY)[key] then
-            params_match = false
+      local expected_ct = conf.content_type[i]
+      local exp_type, exp_subtype, exp_params = parse_mime_type(expected_ct)
+      if exp_type then
+        if (exp_type == "*" or (t and lower(t) == lower(exp_type))) and
+          (exp_subtype == "*" or (subtype and
+            lower(subtype) == lower(exp_subtype))) then
+          local params_match = true
+          for key, value in pairs(exp_params or EMPTY) do
+            if value ~= (params or EMPTY)[key] then
+              params_match = false
+              break
+            end
+          end
+          if params_match and
+            (nkeys(params or EMPTY) == nkeys(exp_params or EMPTY)) then
+            content_match = true
             break
           end
-        end
-        if params_match and
-          (nkeys(params or EMPTY) == nkeys(params1 or EMPTY)) then
-          content_match = true
-          break
         end
       end
     end

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -1,7 +1,9 @@
 local require     = require
 local cache_key   = require "kong.plugins.proxy-cache.cache_key"
 local utils       = require "kong.tools.utils"
-local kong_meta = require "kong.meta"
+local kong_meta   = require "kong.meta"
+local mime_type   = require "kong.tools.mime_type"
+local nkeys       = require "table.nkeys"
 
 
 local ngx              = ngx
@@ -20,6 +22,7 @@ local ngx_re_gmatch    = ngx.re.gmatch
 local ngx_re_sub       = ngx.re.gsub
 local ngx_re_match     = ngx.re.match
 local parse_http_time  = ngx.parse_http_time
+local parse_mime_type  = mime_type.parse_mime_type
 
 
 local tab_new = require("table.new")
@@ -173,11 +176,25 @@ local function cacheable_response(conf, cc)
       return false
     end
 
+    local opts = { ignorecase_params = { "charset" } }
+    local t, subtype, params = parse_mime_type(content_type, opts)
     local content_match = false
     for i = 1, #conf.content_type do
-      if conf.content_type[i] == content_type then
-        content_match = true
-        break
+      local t1, subtype1, params1 = parse_mime_type(conf.content_type[i], opts)
+      if (lower(t) == lower(t1) or t1 == "*") and
+        (lower(subtype) == lower(subtype1) or subtype1 == "*") then
+        local params_match = true
+        for key, value in pairs(params1 or EMPTY) do
+          if value ~= (params or EMPTY)[key] then
+            params_match = false
+            break
+          end
+        end
+        if params_match and
+          (nkeys(params or EMPTY) == nkeys(params1 or EMPTY)) then
+          content_match = true
+          break
+        end
       end
     end
 

--- a/spec/03-plugins/31-proxy-cache/01-schema_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/01-schema_spec.lua
@@ -121,4 +121,32 @@ describe("proxy-cache schema", function()
     assert.is_nil(err)
     assert.is_truthy(entity)
   end)
+
+  it("accepts wildcard content_type", function()
+    local entity, err = v({
+      strategy = "memory",
+      content_type = { "application/*", "*/text" },
+    }, proxy_cache_schema)
+
+    assert.is_nil(err)
+    assert.is_truthy(entity)
+
+    local entity, err = v({
+      strategy = "memory",
+      content_type = { "*/*" },
+    }, proxy_cache_schema)
+
+    assert.is_nil(err)
+    assert.is_truthy(entity)
+  end)
+
+  it("accepts content_type with parameter", function()
+    local entity, err = v({
+      strategy = "memory",
+      content_type = { "application/json; charset=UTF-8" },
+    }, proxy_cache_schema)
+
+    assert.is_nil(err)
+    assert.is_truthy(entity)
+  end)
 end)

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -83,6 +83,9 @@ do
       local route18 = assert(bp.routes:insert({
         hosts = { "route-18.com" },
       }))
+      local route19 = assert(bp.routes:insert({
+        hosts = { "route-19.com" },
+      }))
 
 
       local consumer1 = assert(bp.consumers:insert {
@@ -266,6 +269,16 @@ do
           strategy = policy,
           [policy] = policy_config,
           content_type = { "application/xml; charset=UTF-8" },
+        },
+      })
+
+      assert(bp.plugins:insert {
+        name = "proxy-cache",
+        route = { id = route19.id },
+        config = {
+          strategy = policy,
+          [policy] = policy_config,
+          content_type = { "application/xml;" }, -- invalid content_type
         },
       })
 
@@ -1298,6 +1311,36 @@ do
           },
         })
 
+        assert.res_status(200, res)
+        assert.same("application/xml", res.headers["Content-Type"])
+        assert.same("Bypass", res.headers["X-Cache-Status"])
+      end)
+
+
+      it("should not cause error while upstream returns a invalid content type", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/response-headers?Content-Type=application/xml;",
+          headers = {
+            host = "route-18.com",
+          },
+        })
+
+        assert.res_status(200, res)
+        assert.same("application/xml;", res.headers["Content-Type"])
+        assert.same("Bypass", res.headers["X-Cache-Status"])
+      end)
+
+      it("should not cause error while config.content_type has invalid element", function()
+        local res, err = client:send {
+          method = "GET",
+          path = "/xml",
+          headers = {
+            host = "route-19.com",
+          },
+        }
+
+        assert.is_nil(err)
         assert.res_status(200, res)
         assert.same("application/xml", res.headers["Content-Type"])
         assert.same("Bypass", res.headers["X-Cache-Status"])


### PR DESCRIPTION
- feat(plugins/proxy-cache): add wildcard and parameter match support for content_type
- remove opts
- handle the cases of parsing failure
- update CHANGELOG.md

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
