### PR TITLE
style(runloop/events): remove unnecessary `set_workspace`

### DIFF
--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -277,6 +277,8 @@ end
 
 
 local function crud_consumers_handler(data)
+  workspaces.set_workspace(data.workspace)  -- no-op in OSS
+
   local old_entity = data.old_entity
   local old_username
   if old_entity then

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -277,8 +277,6 @@ end
 
 
 local function crud_consumers_handler(data)
-  workspaces.set_workspace(data.workspace)
-
   local old_entity = data.old_entity
   local old_username
   if old_entity then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

`set_workspace()` is useless in CE, we should remove this line.

NOTICE: in EE we MUST have this line.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


