### PR TITLE
fix(core): disable C assert in upstream keepalive patch

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -673,7 +673,7 @@ index f71a3e00..0d403716 100644
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
-+    ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
++    /*ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));*/
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);

--- a/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -673,8 +673,6 @@ index f71a3e00..0d403716 100644
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
-+    /*ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));*/
-+
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
 +        items[i].cpool = upool;

--- a/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -673,6 +673,8 @@ index f71a3e00..0d403716 100644
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
++
++
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
 +        items[i].cpool = upool;


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

See: KAG-474

Core code:

```
upool = lua_newuserdata(L, size); /* pools upool */

items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);

ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
```

`items` points to the memory that allocated by LuaJIT (lua_newuserdata),
so it may not fit the Nginx's alignment requirement.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


