### PR TITLE
fix(conf_loader): deprecate and alias otel properties

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -103,7 +103,7 @@
                                  # such in the Lua namespace:
                                  # `kong.vaults.{name}.*`.
 
-#opentelemetry_tracing = off                # Deprecated: use tracing_instrumentatios instead
+#opentelemetry_tracing = off                # Deprecated: use tracing_instrumentations instead
 
 #tracing_instrumentations = off             # Comma-separated list of tracing instrumentations
                                             # this node should load. By default, no instrumentations
@@ -939,10 +939,10 @@
                                         # connection may be kept open
                                         # indefinitely.
 
-#allow_debug_header = off               # Enable the `Kong-Debug` header function. 
-                                        # if it is `on`, kong will add 
-                                        # `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` 
-                                        # `Kong-Service-Name` debug headers to response when 
+#allow_debug_header = off               # Enable the `Kong-Debug` header function.
+                                        # if it is `on`, kong will add
+                                        # `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`
+                                        # `Kong-Service-Name` debug headers to response when
                                         # the client request header `Kong-Debug: 1` is present.
 
 #------------------------------------------------------------------------------

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -547,17 +547,32 @@ local CONF_PARSERS = {
   lmdb_environment_path = { typ = "string" },
   lmdb_map_size = { typ = "string" },
 
-  tracing_instrumentations= {
+  opentelemetry_tracing = {
     typ = "array",
+    alias = {
+      replacement = "tracing_instrumentations",
+    },
     deprecated = {
-      replacement = "opentelemetry_tracing",
+      replacement = "tracing_instrumentations",
     },
   },
-  tracing_sampling_rate = {
+
+  tracing_instrumentations = {
+    typ = "array",
+  },
+
+  opentelemetry_tracing_sampling_rate = {
     typ = "number",
     deprecated = {
-      replacement = "opentelemetry_tracing_sampling_rate",
+      replacement = "tracing_sampling_rate",
     },
+    alias = {
+      replacement = "tracing_sampling_rate",
+    },
+  },
+
+  tracing_sampling_rate = {
+    typ = "number",
   },
 
   proxy_server = { typ = "string" },

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1208,14 +1208,14 @@ local function check_and_parse(conf, opts)
 
     for _, trace_type in ipairs(conf.tracing_instrumentations) do
       if not available_types_map[trace_type] then
-        errors[#errors + 1] = "invalid opentelemetry tracing type: " .. trace_type
+        errors[#errors + 1] = "invalid tracing type: " .. trace_type
       end
     end
 
     if #conf.tracing_instrumentations > 1
       and tablex.find(conf.tracing_instrumentations, "off")
     then
-      errors[#errors + 1] = "invalid opentelemetry tracing types: off, other types are mutually exclusive"
+      errors[#errors + 1] = "invalid tracing types: off, other types are mutually exclusive"
     end
 
     if conf.tracing_sampling_rate < 0 or conf.tracing_sampling_rate > 1 then

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1764,6 +1764,38 @@ describe("Configuration loader", function()
       assert.equal("strict", conf.worker_consistency)
       assert.equal(nil, err)
     end)
+
+    it("opentelemetry_tracing", function()
+      local conf, err = assert(conf_loader(nil, {
+        opentelemetry_tracing = "request,router",
+      }))
+      assert.same({"request", "router"}, conf.tracing_instrumentations)
+      assert.equal(nil, err)
+
+      -- no clobber
+      conf, err = assert(conf_loader(nil, {
+        opentelemetry_tracing = "request,router",
+        tracing_instrumentations = "balancer",
+      }))
+      assert.same({ "balancer" }, conf.tracing_instrumentations)
+      assert.equal(nil, err)
+    end)
+
+    it("opentelemetry_tracing_sampling_rate", function()
+      local conf, err = assert(conf_loader(nil, {
+        opentelemetry_tracing_sampling_rate = 0.5,
+      }))
+      assert.same(0.5, conf.tracing_sampling_rate)
+      assert.equal(nil, err)
+
+      -- no clobber
+      conf, err = assert(conf_loader(nil, {
+        opentelemetry_tracing_sampling_rate = 0.5,
+        tracing_sampling_rate = 0.75,
+      }))
+      assert.same(0.75, conf.tracing_sampling_rate)
+      assert.equal(nil, err)
+    end)
   end)
 
   describe("vault references", function()


### PR DESCRIPTION
### Summary

These properties were not properly handled in #10122

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

ref KAG-446