### PR TITLE
fix(patches): disable unneeded pointer alignment assertion in dynamic upstream keepalive patch (#10212)

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/build/openresty/patches/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -673,7 +673,7 @@ index f71a3e00..0d403716 100644
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
-+    ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
++
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);


### PR DESCRIPTION
cherry-pick from #10212 

