### PR TITLE
chore(*): extend fixture `mock_upstream` to data plane (FTI-4782)

### DIFF
--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -455,12 +455,17 @@ http {
     }
 > end -- role == "control_plane"
 
-> if role ~= "data_plane" then
     server {
         server_name mock_upstream;
 
+> if role ~= "data_plane" then
         listen 15555;
         listen 15556 ssl;
+
+> else
+        listen 16665;
+        listen 16666 ssl;
+> end -- role ~= "data_plane"
 
 > for i = 1, #ssl_cert do
         ssl_certificate     $(ssl_cert[i]);
@@ -706,7 +711,6 @@ http {
             }
         }
     }
-> end -- role ~= "data_plane"
 
     include '*.http_mock';
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -20,6 +20,8 @@ local MOCK_UPSTREAM_PORT = 15555
 local MOCK_UPSTREAM_SSL_PORT = 15556
 local MOCK_UPSTREAM_STREAM_PORT = 15557
 local MOCK_UPSTREAM_STREAM_SSL_PORT = 15558
+local MOCK_UPSTREAM_DP_PORT = 16665
+local MOCK_UPSTREAM_DP_SSL_PORT = 16666
 local GRPCBIN_HOST = os.getenv("KONG_SPEC_TEST_GRPCBIN_HOST") or "localhost"
 local GRPCBIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_PORT")) or 9000
 local GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) or 9001
@@ -1860,7 +1862,7 @@ local function wait_for_all_config_update(opts)
     if stream_enabled then
       pwait_until(function ()
         local proxy = proxy_client(proxy_client_timeout, stream_port, stream_ip)
-  
+
         res = proxy:get("/always_200")
         local ok, err = pcall(assert, res.status == 200)
         proxy:close()
@@ -3518,6 +3520,14 @@ end
 -- @field mock_upstream_ssl_host
 -- @field mock_upstream_ssl_port
 -- @field mock_upstream_ssl_url Base url constructed from the components
+-- @field mock_upstream_dp_protocol
+-- @field mock_upstream_dp_host
+-- @field mock_upstream_dp_port
+-- @field mock_upstream_dp_url Base url constructed from the components
+-- @field mock_upstream_dp_ssl_protocol
+-- @field mock_upstream_dp_ssl_host
+-- @field mock_upstream_dp_ssl_port
+-- @field mock_upstream_dp_ssl_url Base url constructed from the components
 -- @field mock_upstream_stream_port
 -- @field mock_upstream_stream_ssl_port
 -- @field mock_grpc_upstream_proto_path
@@ -3572,6 +3582,20 @@ end
   mock_upstream_ssl_url      = MOCK_UPSTREAM_SSL_PROTOCOL .. "://" ..
                                MOCK_UPSTREAM_HOST .. ':' ..
                                MOCK_UPSTREAM_SSL_PORT,
+
+  mock_upstream_dp_protocol  = MOCK_UPSTREAM_PROTOCOL,
+  mock_upstream_dp_host      = MOCK_UPSTREAM_HOST,
+  mock_upstream_dp_port      = MOCK_UPSTREAM_DP_PORT,
+  mock_upstream_dp_url       = MOCK_UPSTREAM_PROTOCOL .. "://" ..
+                               MOCK_UPSTREAM_HOST .. ':' ..
+                               MOCK_UPSTREAM_DP_PORT,
+
+  mock_upstream_dp_ssl_protocol = MOCK_UPSTREAM_SSL_PROTOCOL,
+  mock_upstream_dp_ssl_host     = MOCK_UPSTREAM_HOST,
+  mock_upstream_dp_ssl_port     = MOCK_UPSTREAM_DP_SSL_PORT,
+  mock_upstream_dp_ssl_url      = MOCK_UPSTREAM_SSL_PROTOCOL .. "://" ..
+                                  MOCK_UPSTREAM_HOST .. ':' ..
+                                  MOCK_UPSTREAM_DP_SSL_PORT,
 
   mock_upstream_stream_port     = MOCK_UPSTREAM_STREAM_PORT,
   mock_upstream_stream_ssl_port = MOCK_UPSTREAM_STREAM_SSL_PORT,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This is just a test fixture. So, tests for data plane can make use of `mock_upstream`.

1. `control_plane` still uses port `15555/15556`.
2. `data_plane` uses a designated *new* port `16665/16666`. So, in `data_plane`, we set up mock upstream. 

For example, the RLA tests current we have to use `httpbin.org`, which makes tests flaky. Check <https://github.com/Kong/kong-ee/blob/master/plugins-ee/rate-limiting-advanced/spec/03-access_spec.lua#L1894>.

FTI-4782