### PR TITLE
feat(ip-restriction): Add TCP support (#6679)

### DIFF
--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -1,3 +1,4 @@
+local cjson = require "cjson"
 local ipmatcher = require "resty.ipmatcher"
 
 
@@ -28,28 +29,62 @@ local function match_bin(list, binary_remote_addr)
 end
 
 
-function IpRestrictionHandler:access(conf)
+local function do_exit(status, message, is_http)
+  if is_http then
+    return kong.response.error(status, message)
+  else
+    local tcpsock, err = ngx.req.socket(true)
+    if err then
+      error(err)
+    end
+
+    tcpsock:send(cjson.encode({
+      status  = status,
+      message = message
+    }))
+
+    return ngx.exit()
+  end
+end
+
+
+local function handler(conf, is_http)
   local binary_remote_addr = ngx.var.binary_remote_addr
   if not binary_remote_addr then
-    return kong.response.error(403, "Cannot identify the client IP address, unix domain sockets are not supported.")
+    local status = 403
+    local message = "Cannot identify the client IP address, unix domain sockets are not supported."
+
+    do_exit(status, message, is_http)
   end
 
   local status = conf.status or 403
-  local message = conf.message or "Your IP address is not allowed"
+  local message = conf.message or string.format("IP address not allowed: %s", ngx.var.remote_addr)
 
   if conf.deny and #conf.deny > 0 then
     local blocked = match_bin(conf.deny, binary_remote_addr)
+
     if blocked then
-      return kong.response.error(status, message)
+      do_exit(status, message, is_http)
     end
   end
 
   if conf.allow and #conf.allow > 0 then
     local allowed = match_bin(conf.allow, binary_remote_addr)
+
     if not allowed then
-      return kong.response.error(status, message)
+      do_exit(status, message, is_http)
     end
   end
+end
+
+
+function IpRestrictionHandler:access(conf)
+  return handler(conf, true)
+end
+
+
+function IpRestrictionHandler:preread(conf)
+  return handler(conf, false)
 end
 
 

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -4,7 +4,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "ip-restriction",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } }, },
     { config = {
         type = "record",
         fields = {


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This change adds TCP support to the ip-restriction plugin by implementing the Stream module's preread function.

When a TCP connection is rejected due to IP restriction rules, a JSON error response is written to the stream and the connection is closed.

Note: This change is based on branch `release/2.8.x` so it targets this branch. However, since it is a new feature, it would probably be added in a 2.9.x release instead. There isn't currently a `release/2.9.x` or `release/2.x` branch.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add protocols to schema: "tcp", "tls", "grpc", "grpcs"
* Implement preread function
* Make handler logic generic to be shared by HTTP and TCP

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #6679
