### PR TITLE
chore(deps): bump resty.session from 4.0.0 to 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@
   [#10181](https://github.com/Kong/kong/pull/10181)
 - Bumped lua-resty-session from 3.10 to 4.0.0
   [#10199](https://github.com/Kong/kong/pull/10199)
+  [#10230](https://github.com/Kong/kong/pull/10230)
 
 #### Core
 

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
-  "lua-resty-session == 4.0.0",
+  "lua-resty-session == 4.0.1",
   "lua-resty-timer-ng == 0.2.0",
 }
 build = {


### PR DESCRIPTION
### Summary

#### Fixed
- fix(session): clear_request cookie to check remember_meta correctly before using it

#### Added
- feat(opm): add more dependencies in requires
- feat(opm): add right version number requirements
- docs(readme): add remark on dependencies on installation section