### PR TITLE
feat(ip-restriction): Add TCP support

### DIFF
--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -1,49 +1,26 @@
-local lrucache = require "resty.lrucache"
+local cjson = require "cjson"
 local ipmatcher = require "resty.ipmatcher"
-local kong_meta = require "kong.meta"
 
 
-local ngx_var = ngx.var
+local ngx = ngx
 local kong = kong
 local error = error
 
 
-local IPMATCHER_COUNT = 512
-local IPMATCHER_TTL   = 3600
-local cache = lrucache.new(IPMATCHER_COUNT)
-
-
 local IpRestrictionHandler = {
   PRIORITY = 990,
-  VERSION = kong_meta.version,
+  VERSION = "2.0.0",
 }
 
 
-local isempty
-do
-  local tb_isempty = require "table.isempty"
-
-  isempty = function(t)
-    return t == nil or tb_isempty(t)
-  end
-end
-
-
 local function match_bin(list, binary_remote_addr)
-  local matcher, err
-
-  matcher = cache:get(list)
-  if not matcher then
-    matcher, err = ipmatcher.new(list)
-    if err then
-      return error("failed to create a new ipmatcher instance: " .. err)
-    end
-
-    cache:set(list, matcher, IPMATCHER_TTL)
+  local ip, err = ipmatcher.new(list)
+  if err then
+    return error("failed to create a new ipmatcher instance: " .. err)
   end
 
   local is_match
-  is_match, err = matcher:match_bin(binary_remote_addr)
+  is_match, err = ip:match_bin(binary_remote_addr)
   if err then
     return error("invalid binary ip address: " .. err)
   end
@@ -52,30 +29,60 @@ local function match_bin(list, binary_remote_addr)
 end
 
 
-function IpRestrictionHandler:access(conf)
-  local binary_remote_addr = ngx_var.binary_remote_addr
+local function do_exit(status, message, is_http)
+  if is_http then
+    return kong.response.error(status, message)
+  else
+    local tcpsock, err = ngx.req.socket(true)
+    if err then
+      error(err)
+    end
+
+    tcpsock:send(cjson.encode({
+      status  = status,
+      message = message
+    }))
+
+    return ngx.exit()
+  end
+end
+
+
+local function handler(conf, is_http)
+  local binary_remote_addr = ngx.var.binary_remote_addr
   if not binary_remote_addr then
-    return kong.response.error(403, "Cannot identify the client IP address, unix domain sockets are not supported.")
+    local status = 403
+    local message = "Cannot identify the client IP address, unix domain sockets are not supported."
+
+    do_exit(status, message, is_http)
   end
 
-  local deny = conf.deny
-  local allow = conf.allow
   local status = conf.status or 403
-  local message = conf.message or "Your IP address is not allowed"
+  local message = conf.message or string.format("IP address not allowed: %s", ngx.var.remote_addr)
 
-  if not isempty(deny) then
-    local blocked = match_bin(deny, binary_remote_addr)
+  if conf.deny and #conf.deny > 0 then
+    local blocked = match_bin(conf.deny, binary_remote_addr)
     if blocked then
-      return kong.response.error(status, message)
+      do_exit(status, message, is_http)
     end
   end
 
-  if not isempty(allow) then
-    local allowed = match_bin(allow, binary_remote_addr)
+  if conf.allow and #conf.allow > 0 then
+    local allowed = match_bin(conf.allow, binary_remote_addr)
     if not allowed then
-      return kong.response.error(status, message)
+      do_exit(status, message, is_http)
     end
   end
+end
+
+
+function IpRestrictionHandler:access(conf)
+  return handler(conf, true)
+end
+
+
+function IpRestrictionHandler:preread(conf)
+  return handler(conf, false)
 end
 
 

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -4,7 +4,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "ip-restriction",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } }, },
     { config = {
         type = "record",
         fields = {


### PR DESCRIPTION
### Summary
This change adds TCP support to the ip-restriction plugin by implementing the Stream module's preread function.

When a TCP connection is rejected due to IP restriction rules, a JSON error response is written to the stream and the connection is closed.

### Full changelog

* Add protocols to schema: "tcp", "tls", "grpc", "grpcs"
* Implement preread function 
* Make handler logic generic to be shared by HTTP and TCP

### Issue reference
Fix #6679 
