### PR TITLE
fix(conf_loader): propagate values for aliased/deprecated properties

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1296,15 +1296,18 @@ local function parse_nginx_directives(dyn_namespace, conf, injected_in_namespace
 end
 
 
-local function aliased_properties(conf)
+local function aliased_properties(conf, defaults)
   for property_name, v_schema in pairs(CONF_PARSERS) do
     local alias = v_schema.alias
+    local value = conf[property_name]
+    if value == nil then
+      value = defaults[property_name]
+    end
 
-    if alias and conf[property_name] ~= nil and conf[alias.replacement] == nil then
+    if alias and value ~= nil and conf[alias.replacement] == nil then
       if alias.alias then
         conf[alias.replacement] = alias.alias(conf)
       else
-        local value = conf[property_name]
         if type(value) == "boolean" then
           value = value and "on" or "off"
         end
@@ -1557,7 +1560,7 @@ local function load(path, custom_conf, opts)
     log.disable()
   end
 
-  aliased_properties(user_conf)
+  aliased_properties(user_conf, defaults)
   dynamic_properties(user_conf)
   deprecated_properties(user_conf, opts)
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -190,8 +190,8 @@ openresty_path =
 
 opentelemetry_tracing = off
 opentelemetry_tracing_sampling_rate = 1.0
-tracing_instrumentations = off
-tracing_sampling_rate = 1.0
+tracing_instrumentations = NONE
+tracing_sampling_rate = NONE
 
 max_queued_batches = 100
 ]]

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1765,7 +1765,20 @@ describe("Configuration loader", function()
       assert.equal(nil, err)
     end)
 
-    it("opentelemetry_tracing", function()
+    it("propagates opentelemetry defaults to their replacements", function()
+      local conf, err = assert(conf_loader(nil, {
+      }))
+      assert.is_nil(err)
+
+      assert.same({ "off" }, conf.tracing_instrumentations)
+      assert.same({ "off" }, conf.opentelemetry_tracing)
+
+      assert.equal(1, conf.tracing_sampling_rate)
+      assert.equal(1, conf.opentelemetry_tracing_sampling_rate)
+    end)
+
+
+    it("opentelemetry_tracing => tracing_instrumentations", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing = "request,router",
       }))
@@ -1781,7 +1794,7 @@ describe("Configuration loader", function()
       assert.equal(nil, err)
     end)
 
-    it("opentelemetry_tracing_sampling_rate", function()
+    it("opentelemetry_tracing_sampling_rate => tracing_sampling_rate", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing_sampling_rate = 0.5,
       }))

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1765,7 +1765,7 @@ describe("Configuration loader", function()
       assert.equal(nil, err)
     end)
 
-    it("propagates opentelemetry defaults to their replacements", function()
+    it("propagates default values to their aliased replacements", function()
       local conf, err = assert(conf_loader(nil, {
       }))
       assert.is_nil(err)
@@ -1777,6 +1777,19 @@ describe("Configuration loader", function()
       assert.equal(1, conf.opentelemetry_tracing_sampling_rate)
     end)
 
+    it("propagates user values back to their deprecated equivalents", function()
+      local conf, err = assert(conf_loader(nil, {
+        tracing_instrumentations = "balancer",
+        tracing_sampling_rate = 0.25,
+      }))
+      assert.is_nil(err)
+
+      assert.same({ "balancer" }, conf.tracing_instrumentations)
+      assert.same({ "balancer" }, conf.opentelemetry_tracing)
+
+      assert.equal(0.25, conf.tracing_sampling_rate)
+      assert.equal(0.25, conf.opentelemetry_tracing_sampling_rate)
+    end)
 
     it("opentelemetry_tracing => tracing_instrumentations", function()
       local conf, err = assert(conf_loader(nil, {


### PR DESCRIPTION
## summary

This updates the behavior for aliased and deprecated properties.

### aliases

> Property `X` is an alias of property `Y` (`X.alias.replacement == "Y"`).

A) the user sets `X` but not `Y`: set `Y = X`
B) the user does not set `X`: set `X = <default>`, `Y = X`
C) the user sets both `X` and `Y`: `warn()`

A and B are skipped when a custom `alias.alias()` handler is registered for `X`.

### deprecated properties

> Property `X` is deprecated and superseded by `Y` (`X.deprecated.replacement == "Y"`).

A) the user sets `X` but not `Y`: set `Y = X`, `warn()`
B) the user does not `X`: set `X = Y` (for backwards compatibility)
C) the user sets both `X` and `Y`: set `X = Y`, `warn()`

A and C are skipped when a custom `deprecated.alias()` handler is registered for `X`.