### PR TITLE
docs(changelog): move some entries to the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,7 @@
 
 #### Core
 
-- Improve error message for invalid jwk entries.
+- Improve error message for invalid JWK entities.
   [#9904](https://github.com/Kong/kong/pull/9904)
 
 #### Hybrid Mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,11 @@
 
 ### Changed
 
+#### Core
+
+- Improve error message for invalid jwk entries.
+  [#9904](https://github.com/Kong/kong/pull/9904)
+
 #### Hybrid Mode
 
 - Revert the removal of WebSocket protocol support for configuration sync,
@@ -197,11 +202,6 @@
 - Bumped lua-resty-session from 3.10 to 4.0.0
   [#10199](https://github.com/Kong/kong/pull/10199)
   [#10230](https://github.com/Kong/kong/pull/10230)
-
-#### Core
-
-- Improve error message for invalid jwk entries.
-  [#9904](https://github.com/Kong/kong/pull/9904)
 
 
 ## 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 
 #### Core
 
-- Expose postgres connection pool configuration
+- Expose postgres connection pool configuration.
   [#9603](https://github.com/Kong/kong/pull/9603)
 - When `router_flavor` is `traditional_compatible`, verify routes created using the
   Expression router instead of the traditional router to ensure created routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 
 #### Core
 
+- Expose postgres connection pool configuration
+  [#9603](https://github.com/Kong/kong/pull/9603)
 - When `router_flavor` is `traditional_compatible`, verify routes created using the
   Expression router instead of the traditional router to ensure created routes
   are actually compatible.
@@ -141,8 +143,6 @@
 
 - Add back Postgres `FLOOR` function when calculating `ttl`, so the returned `ttl` is always a whole integer.
   [#9960](https://github.com/Kong/kong/pull/9960)
-- Expose postgres connection pool configuration
-  [#9603](https://github.com/Kong/kong/pull/9603)
 - Fix an issue where after a valid declarative configuration is loaded,
   the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
   [#9911](https://github.com/Kong/kong/pull/9911)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* move #9603 from fixes to the additions section
* move #9904 to the first part of the changed section


