### PR TITLE
refactor(pdk/log): removal and extraction of redundant code

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -845,11 +845,11 @@ do
       local ongx = options.ngx or ngx
       local okong = options.kong or kong
       
-      local authenticated_entity, tls_info = prepare_serialize(ongx, okong)
-
       local ctx = ongx.ctx
       local var = ongx.var
 
+      local authenticated_entity, tls_info = prepare_serialize(ctx, var)
+      
       local host_port = ctx.host_port or var.server_port
 
       return edit_result(ctx, {

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -701,7 +701,7 @@ do
     if ctx.authenticated_credential ~= nil then
       authenticated_entity = {
         id = ctx.authenticated_credential.id,
-        consumer_id = ctx.authenticated_credential.consumer_id
+        consumer_id = ctx.authenticated_credential.consumer_id,
       }
     end
 

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -706,17 +706,16 @@ do
     return authenticated_entity
   end
 
-  local function build_tls_info(var)
+  local function build_tls_info(var, override)
     local tls_info
     local tls_info_ver = ngx_ssl.get_tls1_version_str()
     if tls_info_ver then
       tls_info = {
         version = tls_info_ver,
         cipher = var.ssl_cipher,
-        client_verify = var.ssl_client_verify,
+        client_verify = override or var.ssl_client_verify,
       }
     end
-
     return tls_info
   end
 
@@ -812,7 +811,7 @@ do
           method = okong.request.get_method(), -- http method
           headers = okong.request.get_headers(),
           size = request_size,
-          tls = build_tls_info(var),
+          tls = build_tls_info(var, ctx.CLIENT_VERIFY_OVERRIDE),
         },
         upstream_uri = upstream_uri,
         response = {
@@ -853,7 +852,7 @@ do
       
       local root = {
         session = {
-          tls = build_tls_info(var),
+          tls = build_tls_info(var, ctx.CLIENT_VERIFY_OVERRIDE),
           received = tonumber(var.bytes_received, 10),
           sent = tonumber(var.bytes_sent, 10),
           status = ongx.status,

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -690,11 +690,12 @@ do
     return root
   end
 
-  local prepare_serialize = function(ongx, okong)
+  -- create authenticated_entity and tls_info tables for both http and non-http serializing
+  -- @param ctx the ngx.ctx table
+  -- @param var the ngx.var table
+  -- @return authenticated_entity, tls_info
+  local function prepare_serialize(ctx, var)
     check_phase(PHASES_LOG)
-
-    local ctx = ongx.ctx
-    local var = ongx.var
 
     local authenticated_entity
     if ctx.authenticated_credential ~= nil then
@@ -777,7 +778,7 @@ do
       local ctx = ongx.ctx
       local var = ongx.var
 
-      local authenticated_entity, tls_info = prepare_serialize(ongx, okong)
+      local authenticated_entity, tls_info = prepare_serialize(ctx, var)
 
       local request_uri = var.request_uri or ""
 
@@ -810,7 +811,7 @@ do
           method = okong.request.get_method(), -- http method
           headers = okong.request.get_headers(),
           size = request_size,
-          tls = tls_info
+          tls = tls_info,
         },
         upstream_uri = upstream_uri,
         response = {
@@ -836,8 +837,9 @@ do
 
   else
     function serialize(options)
-      local ongx = (options or {}).ngx or ngx
-      local okong = (options or {}).kong or kong
+      options = options or {}
+      local ongx = options.ngx or ngx
+      local okong = options.kong or kong
       
       local authenticated_entity, tls_info = prepare_serialize(ongx, okong)
 

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -23,6 +23,7 @@ local type = type
 local find = string.find
 local select = select
 local concat = table.concat
+local insert = table.insert
 local getinfo = debug.getinfo
 local reverse = string.reverse
 local tostring = tostring
@@ -109,13 +110,13 @@ local function parse_modifiers(format)
     if mod then
       if mod.message then
         buf.message_idxs = buf.message_idxs or {}
-        table.insert(buf.message_idxs, i)
+        insert(buf.message_idxs, i)
 
       else
         buf.debug_flags = (buf.debug_flags or "") .. mod.flag
 
         buf.modifiers = buf.modifiers or {}
-        table.insert(buf.modifiers, {
+        insert(buf.modifiers, {
           idx = i,
           info = mod.info,
           info_key = mod.info_key,
@@ -342,11 +343,11 @@ local function gen_log_func(lvl_const, imm_buf, to_string, stack_level, sep)
       errlog.raw_log(lvl_const, header)
 
       while i <= fullmsg_len do
-        local part = string.sub(fullmsg, i, i + WRAP - 1)
+        local part = sub(fullmsg, i, i + WRAP - 1)
         local nl = part:match("()\n")
 
         if nl then
-          part = string.sub(fullmsg, i, i + nl - 2)
+          part = sub(fullmsg, i, i + nl - 2)
           i = i + nl
 
         else
@@ -719,7 +720,6 @@ do
     end
 
     return authenticated_entity, tls_info
-
   end
 
   ---

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -822,7 +822,7 @@ do
         },
         latencies = {
           kong = (ctx.KONG_PROXY_LATENCY or ctx.KONG_RESPONSE_LATENCY or 0) +
-          (ctx.KONG_RECEIVE_TIME or 0),
+                 (ctx.KONG_RECEIVE_TIME or 0),
           proxy = ctx.KONG_WAITING_TIME or -1,
           request = var.request_time * 1000
         },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests -- old tests work
- [x] There's an entry in the CHANGELOG -- no outer visible change. only modified internal implementation.
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com -- changes is not visible to users.

### Full changelog

* Line 607, `options or {}` is redundant
* Line 283 `not sys_log_level` is true forever, removed.
* The two `serialize` functions have got many same codes. Extracted them to `prepare_serialize` function

