### PR TITLE
fix(conf_loader): propagate renamed tracing conf values

### DIFF
--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -190,8 +190,8 @@ openresty_path =
 
 opentelemetry_tracing = off
 opentelemetry_tracing_sampling_rate = 1.0
-tracing_instrumentations = off
-tracing_sampling_rate = 1.0
+tracing_instrumentations = NONE
+tracing_sampling_rate = NONE
 
 max_queued_batches = 100
 ]]

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1765,7 +1765,33 @@ describe("Configuration loader", function()
       assert.equal(nil, err)
     end)
 
-    it("opentelemetry_tracing", function()
+    it("propagates tracing default values to their aliased replacements", function()
+      local conf, err = assert(conf_loader(nil, {
+      }))
+      assert.is_nil(err)
+
+      assert.same({ "off" }, conf.tracing_instrumentations)
+      assert.same({ "off" }, conf.opentelemetry_tracing)
+
+      assert.equal(1, conf.tracing_sampling_rate)
+      assert.equal(1, conf.opentelemetry_tracing_sampling_rate)
+    end)
+
+    it("propagates tracing user values back to their deprecated equivalents", function()
+      local conf, err = assert(conf_loader(nil, {
+        tracing_instrumentations = "balancer",
+        tracing_sampling_rate = 0.25,
+      }))
+      assert.is_nil(err)
+
+      assert.same({ "balancer" }, conf.tracing_instrumentations)
+      assert.same({ "balancer" }, conf.opentelemetry_tracing)
+
+      assert.equal(0.25, conf.tracing_sampling_rate)
+      assert.equal(0.25, conf.opentelemetry_tracing_sampling_rate)
+    end)
+
+    it("opentelemetry_tracing => tracing_instrumentations", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing = "request,router",
       }))
@@ -1781,7 +1807,7 @@ describe("Configuration loader", function()
       assert.equal(nil, err)
     end)
 
-    it("opentelemetry_tracing_sampling_rate", function()
+    it("opentelemetry_tracing_sampling_rate => tracing_sampling_rate", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing_sampling_rate = 0.5,
       }))

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1795,6 +1795,7 @@ describe("Configuration loader", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing = "request,router",
       }))
+      assert.same({"request", "router"}, conf.opentelemetry_tracing)
       assert.same({"request", "router"}, conf.tracing_instrumentations)
       assert.equal(nil, err)
 
@@ -1803,6 +1804,7 @@ describe("Configuration loader", function()
         opentelemetry_tracing = "request,router",
         tracing_instrumentations = "balancer",
       }))
+      assert.same({ "request", "router" }, conf.opentelemetry_tracing)
       assert.same({ "balancer" }, conf.tracing_instrumentations)
       assert.equal(nil, err)
     end)
@@ -1811,6 +1813,7 @@ describe("Configuration loader", function()
       local conf, err = assert(conf_loader(nil, {
         opentelemetry_tracing_sampling_rate = 0.5,
       }))
+      assert.same(0.5, conf.opentelemetry_tracing_sampling_rate)
       assert.same(0.5, conf.tracing_sampling_rate)
       assert.equal(nil, err)
 
@@ -1819,6 +1822,7 @@ describe("Configuration loader", function()
         opentelemetry_tracing_sampling_rate = 0.5,
         tracing_sampling_rate = 0.75,
       }))
+      assert.same(0.5, conf.opentelemetry_tracing_sampling_rate)
       assert.same(0.75, conf.tracing_sampling_rate)
       assert.equal(nil, err)
     end)

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -51,7 +51,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end
 
-    describe("#only configuration", function()
+    describe("configuration", function()
       local types = { "db_query", "router", "balancer" }
       local rate = 0.5
 
@@ -60,18 +60,17 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       local function validate()
-        local admin
+        local conf
         helpers.pwait_until(function()
-          admin = helpers.admin_client()
+          local admin = helpers.admin_client()
+          local res = admin:get("/")
+          assert.res_status(200, res)
+
+          local body = assert.response(res).has.jsonbody()
+          admin:close()
+
+          conf = body.configuration
         end, 5)
-
-        local res = admin:get("/")
-        assert.res_status(200, res)
-
-        local body = assert.response(res).has.jsonbody()
-        admin:close()
-
-        local conf = body.configuration
 
         assert.same(types, conf.tracing_instrumentations)
         assert.same(types, conf.opentelemetry_tracing)


### PR DESCRIPTION
This is the fix from #10257, but isolated to the two properties that were renamed.

## changelog

* clear default values for `tracing_sampling_rate` and `tracing_instrumentations`*
* for each property, if no user value is set for `$new`, set `$new = $old || default($old)`


\* we will set defaults for these fields when it is time to remove the old, deprecated ones