### PR TITLE
[Backport release/3.2.x] chore(deps): bump resty.timerng from 0.2.0 to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,8 @@
   [#10230](https://github.com/Kong/kong/pull/10230)
 - Bumped OpenSSL from 1.1.1s to 1.1.1t
   [#10266](https://github.com/Kong/kong/pull/10266)
+- Bumped lua-resty-timer-ng from 0.2.0 to 0.2.3
+  [#10265](https://github.com/Kong/kong/pull/10265)
 
 #### Core
 

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
   "lua-resty-session == 4.0.1",
-  "lua-resty-timer-ng == 0.2.0",
+  "lua-resty-timer-ng == 0.2.3",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
Backport 3828b1f79c5c7aa5b353bc80e3798a15a9888101 from #10265.