### PR TITLE
(feat/container-scanning): Integrate container and cve scanning post …

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -14,8 +14,6 @@ build-images:
 smoke-tests:
 - label: ubuntu
 
-scan-vulnerabilities:
-
 release-packages:
 
 release-images:

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -102,12 +102,6 @@ smoke-tests:
 - label: rhel
 - label: alpine
 
-scan-vulnerabilities:
-- label: ubuntu
-- label: debian
-- label: rhel
-- label: alpine
-
 release-packages:
 # Ubuntu
 - label: ubuntu-18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,7 @@ jobs:
       id: image_manifest_metadata
       run: |
         manifest_list_exists="$(
-          if regctl manifest get "${IMAGE}" --format raw-body --require-list -v panic 2>&1 >/dev/null; then
+          if regctl manifest get "${IMAGE}" --format raw-body --require-list -v panic &> /dev/null; then
             echo true
           else
             echo false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,9 +321,64 @@ jobs:
           Docker image available `${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}`
           Artifacts available https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  scan:
+    name: Scan - ${{ matrix.label }}
+    needs: [metadata, build-images]
+    runs-on: ubuntu-22.04
+    if: |-
+      always() 
+      && fromJSON(needs.metadata.outputs.matrix)['build-images'] != '' 
+      && needs.build-images.result == 'success' 
+      && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
+    steps:
+    - name: Install regctl
+      uses: regclient/actions/regctl-installer@main
+
+    - name: Login to Docker Hub
+      if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN }}
+      uses: docker/login-action@bc135a1993a1d0db3e9debefa0cfcb70443cc94c
+      with:
+        username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
+        password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+
+    # TODO: Refactor matrix file to support and parse platforms specific to distro
+    # Workaround: Look for specific amd64 and arm64  hardcooded architectures
+    - name: Parse Architecture Specific Image Manifest Digests
+      id: image_manifest_metadata
+      run: |
+        manifest_list_exists=$(regctl manifest get ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --format raw-body --require-list -v panic &> /dev/null && echo true || echo false)
+        amd64_sha=$(regctl image digest ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --platform linux/amd64 || echo '')
+        arm64_sha=$(regctl image digest ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --platform linux/arm64 || echo '')
+        echo "manifest_list_exists=$manifest_list_exists"
+        echo "manifest_list_exists=$manifest_list_exists" >> $GITHUB_OUTPUT
+        echo "amd64_sha=$amd64_sha"
+        echo "amd64_sha=$amd64_sha" >> $GITHUB_OUTPUT
+        echo "arm64_sha=$arm64_sha"
+        echo "arm64_sha=$arm64_sha" >> $GITHUB_OUTPUT
+
+    - name: Scan AMD64 Image digest
+      id: sbom_action_amd64
+      if: steps.image_manifest_metadata.outputs.amd64_sha != ''
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
+      with:
+        asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-amd64
+        image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
+
+    - name: Scan ARM64 Image digest
+      if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
+      id: sbom_action_arm64
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
+      with:
+        asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-arm64
+        image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
+
   smoke-tests:
     name: Smoke Tests - ${{ matrix.label }}
-    needs: [metadata, build-images]
+    needs: [metadata, build-images, scan]
     runs-on: ubuntu-22.04
     if: |-
       fromJSON(needs.metadata.outputs.matrix)['smoke-tests'] != ''
@@ -379,37 +434,9 @@ jobs:
     - name: Smoke Tests - Admin API
       run: build/tests/01-admin-api.sh
 
-  scan-vulnerabilities:
-    name: Scan Vulnerabilities - ${{ matrix.label }}
-    needs: [metadata, build-images]
-    runs-on: ubuntu-22.04
-    if: |-
-      fromJSON(needs.metadata.outputs.matrix)['scan-vulnerabilities'] != ''
-      && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
-
-    strategy:
-      # runs all jobs sequentially
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        include: "${{ fromJSON(needs.metadata.outputs.matrix)['scan-vulnerabilities'] }}"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@cff3e9a7f62c41dd51975266d0ae235709e39c41 # v0.9.0
-        env:
-          TRIVY_USERNAME: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
-          TRIVY_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
-        with:
-          image-ref: ${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ github.sha }}-${{ matrix.label }}
-          severity: 'CRITICAL,HIGH'
-
   release-packages:
     name: Release Packages - ${{ matrix.label }} - ${{ needs.metadata.outputs.release-desc }}
-    needs: [metadata, build-packages, build-images, smoke-tests]
+    needs: [metadata, build-packages, scan, smoke-tests]
     runs-on: ubuntu-22.04
     if: fromJSON(needs.metadata.outputs.matrix)['release-packages'] != ''
     timeout-minutes: 5 # PULP takes a while to publish
@@ -448,7 +475,7 @@ jobs:
 
   release-images:
     name: Release Images - ${{ matrix.label }} - ${{ needs.metadata.outputs.release-desc }}
-    needs: [metadata, build-images, smoke-tests]
+    needs: [metadata, build-images, scan, smoke-tests]
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update && sudo apt-get install libyaml-dev -y
-      
+
     - name: Install Ubuntu Cross Build Dependencies (arm64)
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true' && endsWith(matrix.label, 'arm64')
       run: |
@@ -326,14 +326,16 @@ jobs:
     needs: [metadata, build-images]
     runs-on: ubuntu-22.04
     if: |-
-      always() 
-      && fromJSON(needs.metadata.outputs.matrix)['build-images'] != '' 
-      && needs.build-images.result == 'success' 
+      always()
+      && fromJSON(needs.metadata.outputs.matrix)['build-images'] != ''
+      && needs.build-images.result == 'success'
       && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
     strategy:
       fail-fast: false
       matrix:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
+    env:
+      IMAGE: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }}
     steps:
     - name: Install regctl
       uses: regclient/actions/regctl-installer@main
@@ -350,11 +352,18 @@ jobs:
     - name: Parse Architecture Specific Image Manifest Digests
       id: image_manifest_metadata
       run: |
-        manifest_list_exists=$(regctl manifest get ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --format raw-body --require-list -v panic &> /dev/null && echo true || echo false)
-        amd64_sha=$(regctl image digest ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --platform linux/amd64 || echo '')
-        arm64_sha=$(regctl image digest ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }} --platform linux/arm64 || echo '')
+        manifest_list_exists="$(
+          if regctl manifest get "${IMAGE}" --format raw-body --require-list -v panic 2>&1 >/dev/null; then
+            echo true
+          else
+            echo false
+          fi
+        )"
         echo "manifest_list_exists=$manifest_list_exists"
         echo "manifest_list_exists=$manifest_list_exists" >> $GITHUB_OUTPUT
+
+        amd64_sha="$(regctl image digest "${IMAGE}" --platform linux/amd64 || echo '')"
+        arm64_sha="$(regctl image digest "${IMAGE}" --platform linux/arm64 || echo '')"
         echo "amd64_sha=$amd64_sha"
         echo "amd64_sha=$amd64_sha" >> $GITHUB_OUTPUT
         echo "arm64_sha=$arm64_sha"
@@ -366,7 +375,7 @@ jobs:
       uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
       with:
         asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-amd64
-        image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
+        image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
@@ -374,7 +383,7 @@ jobs:
       uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
       with:
         asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-arm64
-        image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}-${{ matrix.label }}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
+        image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}
 
   smoke-tests:
     name: Smoke Tests - ${{ matrix.label }}


### PR DESCRIPTION
…publishing

### Summary
- Integrate container and CVE scanning after publishing to registry
- Support container scanning  for statically defined amd64 / arm64 platforms
- Use Syft for generating SBOMS for container 
- Use Grype for CVE scanning 
- Uploads the scan assets (SBOM, CVE report) as workflow assets

<!--- Why is this change required? What problem does it solve? -->
### Expected outcome

- Visibility into packages and licenses within container images
- Visibility into CVE's for AMD and ARM platforms 

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
