### PR TITLE
docs(DEVELOPER): add rust dependencies for build atc-router

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -393,6 +393,9 @@ sudo apt update \
     unzip \
     valgrind \
     zlib1g-dev
+
+# install rust dependencies for building atc-router
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh    
 ```
 
 Fedora:
@@ -413,6 +416,9 @@ dnf install \
     valgrind \
     valgrind-devel \
     zlib-devel
+
+# install rust dependencies for building atc-router
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 #### OpenResty


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

When building Kong from source, if we choose to build atc-router, then we need the rust dependency.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
