### PR TITLE
fix(gha): ensure zlib installed for centos/rhel-7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       if: matrix.label == 'centos-7' || matrix.label == 'rhel-7'
       run: |
         echo "/usr/local/git/bin" >> $GITHUB_PATH
-        yum install -y which
+        yum install -y which zlib-devel
 
     - name: Checkout Kong source code
       uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

This change ultimately resolves a build failure when bazel goes to build openresty on RHEL-7/CentOS-7:
```
checking for zlib library ... not found

./configure: error: the HTTP gzip module requires the zlib library.
You can either disable the module by using --without-http_gzip_module
option, or install the zlib library into the system, or build the zlib library
statically from the source with nginx by using --with-zlib=<path> option.

ERROR: failed to run command: sh ./configure --prefix=/github/home/.cache/bazel/_bazel_root/9817ab78a41c88bbf8d96f8d6b963143/execroot/kong/bazel-out/k8-fastbuild/bin/external/openresty/openresty.build_tmpdir/openresty/nginx \...
```

The hope is that this change will be merged to release/3.2.x, then next/3.2.x.x in EE.
