### PR TITLE
refactor(clustering): simplify dp init_worker logic

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -75,11 +75,10 @@ function _M:init_worker(plugins_list)
 
   self.plugins_list = plugins_list
 
-  if clustering_utils.is_dp_worker_process() then
-    assert(ngx.timer.at(0, function(premature)
-      self:communicate(premature)
-    end))
-  end
+  -- only run in process which worker_id() == 0
+  assert(ngx.timer.at(0, function(premature)
+    self:communicate(premature)
+  end))
 end
 
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -86,16 +86,12 @@ end
 
 
 function _M:init_dp_worker(plugins_list)
-  local start_dp = function(premature)
-    if premature then
-      return
-    end
-
-    self.child = require("kong.clustering.data_plane").new(self)
-    self.child:init_worker(plugins_list)
+  if not is_dp_worker_process() then
+    return
   end
 
-  assert(ngx.timer.at(0, start_dp))
+  self.child = require("kong.clustering.data_plane").new(self)
+  self.child:init_worker(plugins_list)
 end
 
 
@@ -116,7 +112,7 @@ function _M:init_worker()
     return
   end
 
-  if role == "data_plane" and is_dp_worker_process() then
+  if role == "data_plane" then
     self:init_dp_worker(plugins_list)
   end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

In DP's `init_worker()` we start two zero-delayed timers, it is unnecessary.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* simplify `ngx.timer.at` calls
* simplify check of `is_dp_worker_process`

