### PR TITLE
fix(db/lmdb): hash the cache_key that exceeds LMDB max_key_size

### DIFF
--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -29,6 +29,7 @@ local sha256 = utils.sha256_hex
 
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+local LMDB_MAXKEYSIZE = 511 -- LMDB default max key size
 
 
 local function find_or_create_current_workspace(name)
@@ -294,7 +295,12 @@ local function load_into_cache(entities, meta, hash)
 
       if schema.cache_key then
         local cache_key = dao:cache_key(item)
-        t:set(cache_key, item_marshalled)
+        if #cache_key > LMDB_MAXKEYSIZE then
+          local hash_cache_key = sha256(cache_key)
+          t:set(hash_cache_key, item_marshalled)
+        else
+          t:set(cache_key, item_marshalled)
+        end
       end
 
       for i = 1, #uniques do


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Fix bug in #10219 to use sha256 to generate fixed size cache_key.


### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #10219
