### PR TITLE
feat(pdk): add lmdb metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,11 +197,17 @@
   Previously, the `header_type` was hardcoded to `preserve`, now it can be set to one of the
   following values: `preserve`, `ignore`, `b3`, `b3-single`, `w3c`, `jaeger`, `ot`.
   [#10620](https://github.com/Kong/kong/pull/10620)
+- **Prometheus**: add `lmdb_usage` related metrics in Prometheus plugin.
+  [#10301](https://github.com/Kong/kong/pull/10301)
+- **Statsd**: add `lmdb_usage` related metrics in Statsd plugin.
+  [#10301](https://github.com/Kong/kong/pull/10301)
 
 #### PDK
 
 - PDK now supports getting plugins' ID with `kong.plugin.get_id`.
   [#9903](https://github.com/Kong/kong/pull/9903)
+- PDK now supports getting lmdb environment information with `kong.node.get_memory_stats`.
+  [#10301](https://github.com/Kong/kong/pull/10301)
 
 ### Fixes
 

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -8,6 +8,7 @@ local type = type
 local ipairs = ipairs
 local table_insert = table.insert
 local table_sort = table.sort
+local table_remove = table.remove
 local gsub = string.gsub
 local deep_copy = utils.deep_copy
 local split = utils.split
@@ -245,6 +246,20 @@ local function rename_field(config, name_from, name_to, has_update)
   return has_update
 end
 
+local function remove_field_array_value(config, remove_val, has_update)
+  if config then
+    local iterate_table = config
+    for i, v in ipairs(iterate_table) do
+      if v == remove_val then
+        table_remove(config, i)
+        has_update = true
+      end
+    end
+  end
+
+  return has_update
+end
+
 
 local function invalidate_keys_from_config(config_plugins, keys, log_suffix, dp_version_num)
   if not config_plugins then
@@ -271,6 +286,15 @@ local function invalidate_keys_from_config(config_plugins, keys, log_suffix, dp_
 
             if config["cookie_samesite"] == "Default" then
               config["cookie_samesite"] = "Lax"
+            end
+          end
+        end
+
+        if dp_version_num < 3003000000 then
+          -- OSS
+          if name == "statsd" then
+            if utils.table_contains(config.metrics, "lmdb_usage") then
+              has_update = remove_field_array_value(config.metrics, "lmdb_usage", has_update)
             end
           end
         end

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -5,6 +5,7 @@
 local utils = require "kong.tools.utils"
 local ffi = require "ffi"
 local private_node = require "kong.pdk.private.node"
+local lmdb = require "resty.lmdb"
 
 
 local floor = math.floor
@@ -18,6 +19,7 @@ local shared = ngx.shared
 local C             = ffi.C
 local ffi_new       = ffi.new
 local ffi_str       = ffi.string
+local lmdb_get_env_info = lmdb.get_env_info
 
 local NODE_ID_KEY = "kong:node_id"
 
@@ -121,7 +123,17 @@ local function new(self)
   --       http_allocated_gc = 1102,
   --       pid = 18005
   --     }
-  --   }
+  --   },
+  --   -- if the `kong` uses dbless mode, the following will be present:
+  --  lmdb = {
+  --    map_size: "128.00 MiB",
+  --    used_size: "0.02 MiB",
+  --    last_used_page: 6,
+  --    last_txnid: 2,
+  --    max_readers: 126,
+  --    current_readers: 16
+  --   },
+  --}
   -- }
   --
   -- local res = kong.node.get_memory_stats("k", 1)
@@ -147,6 +159,15 @@ local function new(self)
   --       pid = 18005
   --     }
   --   }
+  --   -- if the `kong` uses dbless mode, the following will be present:
+  --  lmdb = {
+  --    map_size: "131072 KB",
+  --    used_size: "20.48 KB",
+  --    last_used_page: 6,
+  --    last_txnid: 2,
+  --    max_readers: 126,
+  --    current_readers: 16
+  --   },
   -- }
   function _NODE.get_memory_stats(unit, scale)
     -- validate arguments
@@ -227,6 +248,24 @@ local function new(self)
         capacity = convert_bytes(shm.capacity, unit, scale),
         allocated_slabs = convert_bytes(allocated, unit, scale),
       }
+    end
+
+    if kong and kong.configuration and kong.configuration.database == "off" then
+      local lmdb_info, err = lmdb_get_env_info()
+      if err then
+        res.lmdb = self.table.new(0, 1)
+        res.lmdb.err = "could not get kong lmdb status: " .. err
+
+      else
+        local info = self.table.new(0, 6)
+        info.map_size = convert_bytes(lmdb_info.map_size, unit, scale)
+        info.used_size = convert_bytes(lmdb_info.last_used_page * lmdb_info.page_size, unit, scale)
+        info.last_used_page = lmdb_info.last_used_page
+        info.last_txnid = lmdb_info.last_txnid
+        info.max_readers = lmdb_info.max_readers
+        info.current_readers = lmdb_info.num_readers
+        res.lmdb = info
+      end
     end
 
     return res

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -141,6 +141,17 @@ local function init()
                                                      {"node_id", "shared_dict", "kong_subsystem"},
                                                      prometheus.LOCAL_STORAGE)
 
+  if kong.configuration.database == "off" then
+    memory_stats.lmdb = prometheus:gauge("memory_lmdb_used_bytes",
+                                         "Used bytes in LMDB",
+                                         {"node_id"},
+                                         prometheus.LOCAL_STORAGE)
+    memory_stats.lmdb_capacity = prometheus:gauge("memory_lmdb_total_bytes",
+                                                  "Total capacity in bytes of LMDB",
+                                                  {"node_id"},
+                                                  prometheus.LOCAL_STORAGE)
+  end
+
   local res = kong.node.get_memory_stats()
   for shm_name, value in pairs(res.lua_shared_dicts) do
     memory_stats.shm_capacity:set(value.capacity, { node_id, shm_name, kong_subsystem })
@@ -444,6 +455,11 @@ local function metric_data(write_fn)
   for i = 1, #res.workers_lua_vms do
     metrics.memory_stats.worker_vms:set(res.workers_lua_vms[i].http_allocated_gc,
                                         { node_id, res.workers_lua_vms[i].pid, kong_subsystem })
+  end
+
+  if kong.configuration.database == "off" then
+    metrics.memory_stats.lmdb_capacity:set(res.lmdb.map_size, { node_id })
+    metrics.memory_stats.lmdb:set(res.lmdb.used_size, { node_id })
   end
 
   -- Hybrid mode status

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -2,6 +2,7 @@ local Queue = require "kong.tools.queue"
 local constants = require "kong.plugins.statsd.constants"
 local statsd_logger = require "kong.plugins.statsd.statsd_logger"
 local ws = require "kong.workspaces"
+local lmdb = require "resty.lmdb"
 
 local ngx = ngx
 local kong = kong
@@ -15,6 +16,7 @@ local ipairs = ipairs
 local tonumber = tonumber
 local knode = kong and kong.node or require "kong.pdk.node".new()
 local null = ngx.null
+local lmdb_get_env_info = lmdb.get_env_info
 
 local START_RANGE_IDX = 1
 local END_RANGE_IDX   = 2
@@ -97,6 +99,8 @@ local hostname = re_gsub(knode.get_hostname(), [[\.]], "_", "oj")
 -- downsample timestamp
 local shdict_metrics_last_sent = 0
 local SHDICT_METRICS_SEND_THRESHOLD = 60
+local lmdb_metrics_last_sent = 0
+local LMDB_METRICS_SEND_THRESHOLD = 60
 
 
 local get_consumer_id = {
@@ -271,6 +275,47 @@ if ngx.config.ngx_lua_version >= 10011 then
           end
         end
 
+      end
+    end
+  end
+  metrics.lmdb_usage = function (_, message, metric_config, logger, conf, tags)
+    -- we don't need this for every request, send every 1 minute
+    -- also only one worker needs to send this because it's shared
+    if worker_id ~= 0 then
+      return
+    end
+    if kong.configuration.database ~= "off" then
+      return
+    end
+
+    local now = ngx_time()
+    if lmdb_metrics_last_sent + LMDB_METRICS_SEND_THRESHOLD < now then
+      lmdb_metrics_last_sent = now
+      local lmdb_info, err = lmdb_get_env_info()
+      if err then
+        kong.log.err("failed to get lmdb info: ", err)
+        return
+      end
+      if conf.tag_style then
+        local tags = {
+          ["node"] = hostname,
+        }
+        logger:send_statsd("lmdb.used_space",
+          lmdb_info.last_used_page * lmdb_info.page_size, logger.stat_types.gauge,
+          metric_config.sample_rate, tags, conf.tag_style)
+        logger:send_statsd("lmdb.capacity",
+          lmdb_info.map_size, logger.stat_types.gauge,
+          metric_config.sample_rate, tags, conf.tag_style)
+
+      else
+        local lmdb_used_space_metric_name = conf.hostname_in_prefix and "lmdb.used_space" or string_format("node.%s.lmdb.used_space", hostname)
+        local lmdb_capacity_metric_name = conf.hostname_in_prefix and "lmdb.capacity" or string_format("node.%s.lmdb.capacity", hostname)
+        logger:send_statsd(lmdb_used_space_metric_name,
+            lmdb_info.last_used_page * lmdb_info.page_size, logger.stat_types.gauge,
+            metric_config.sample_rate)
+        logger:send_statsd(lmdb_capacity_metric_name,
+            lmdb_info.last_used_page * lmdb_info.page_size, logger.stat_types.gauge,
+            metric_config.sample_rate)
       end
     end
   end

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -8,7 +8,7 @@ local METRIC_NAMES = {
   "request_size", "response_size", "status_count", "status_count_per_user",
   "unique_users", "upstream_latency",
   "status_count_per_workspace", "status_count_per_user_per_route",
-  "shdict_usage",
+  "shdict_usage", "lmdb_usage",
 }
 
 
@@ -121,6 +121,12 @@ local DEFAULT_METRICS = {
     sample_rate        = 1,
     service_identifier = nil,
   },
+  {
+    name               = "lmdb_usage",
+    stat_type          = "gauge",
+    sample_rate        = 1,
+    service_identifier = nil,
+  },  
 }
 
 local TAG_TYPE = {

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -160,6 +160,9 @@ describe("kong.clustering.compat", function()
           session = {
             "anything",
           },
+          statsd = {
+            "anything",
+          },
         },
       })
     end)
@@ -305,6 +308,29 @@ describe("kong.clustering.compat", function()
               cookie_samesite = "Lax",
               cookie_httponly = false,
               cookie_persistent = true,
+            },
+          },
+        },
+      },
+      {
+        name = "statsd lmdb metrics",
+        version = "1.0.0",
+        plugins = {
+          {
+            name = "statsd",
+            config = {
+              metrics = {"lmdb_usage", "shdict_usage", "status_count_per_user_per_route"}
+            },
+          },
+        },
+        expect = {
+          {
+            name = "statsd",
+            config = {
+              metrics = { "shdict_usage", "status_count_per_user_per_route", },
+              flush_timeout = 2,
+              queue_size = 1,
+              retry_count = 10,
             },
           },
         },

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -2300,3 +2300,79 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 end
+
+local SERVICE_YML = [[
+- name: my-service-%d
+  url: %s
+  plugins:
+  - name: statsd
+    config: 
+      host: 127.0.0.1
+      port: 20000
+  routes:
+  - name: my-route-%d
+    paths:
+    - /
+    hosts: 
+    - logging%d.com
+]]
+
+
+describe("Plugin: statsd (log) #off", function()
+  local admin_client
+  local proxy_client
+  
+  lazy_setup(function()
+    assert(helpers.start_kong({
+      database   = "off",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+    proxy_client = assert(helpers.proxy_client())
+    admin_client = assert(helpers.admin_client())
+  end)
+
+  lazy_teardown(function()
+    admin_client:close()
+    proxy_client:close()
+    helpers.stop_kong(nil, true)
+  end)
+
+  it("expose lmdb metrics by statsd", function()
+    local buffer = {"_format_version: '1.1'", "services:"}
+    for i = 1, 10 do
+      local url = fmt("%s://%s:%s", helpers.mock_upstream_protocol,
+        helpers.mock_upstream_host, helpers.mock_upstream_port)
+      buffer[#buffer + 1] = fmt(SERVICE_YML, i, url, i, i)
+    end
+    local config = table.concat(buffer, "\n")
+
+    local admin_client = assert(helpers.admin_client())
+    local res = admin_client:post("/config",{
+      body = { config = config },
+      headers = {
+        ["Content-Type"] = "application/json",
+      }
+    })
+
+    assert.res_status(201, res)
+    admin_client:close()
+    local shdict_count = #get_shdicts()
+
+    local metrics_count = DEFAULT_METRICS_COUNT + shdict_count * 2 - 2
+    local thread = helpers.udp_server(UDP_PORT, metrics_count, 2)
+    local response = assert(proxy_client:send {
+      method  = "GET",
+      path    = "/request?apikey=kong",
+      headers = {
+        host  = "logging1.com"
+      }
+    })
+    assert.res_status(200, response)
+
+    local ok, metrics, err = thread:join()
+    assert(ok, metrics)
+    assert(#metrics == metrics_count, err)
+    assert.contains("kong.node..*.lmdb.used_space:%d+|g", metrics, true)
+    assert.contains("kong.node..*.lmdb.capacity:%d+|g", metrics, true)
+  end)
+end)

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -160,3 +160,39 @@ for _, strategy in helpers.each_strategy() do
 
   end)
 end
+
+describe("Plugin: prometheus (metrics) #off", function()
+  local admin_client
+
+  lazy_setup(function()
+    assert(helpers.start_kong({
+      database   = "off",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "bundled,prometheus",
+      status_listen = '127.0.0.1:' .. status_api_port .. ' ssl', -- status api does not support h2
+      status_access_log = "logs/status_access.log",
+      status_error_log = "logs/status_error.log"
+    }))
+
+    admin_client = assert(helpers.admin_client())
+  end)
+
+  lazy_teardown(function()
+    admin_client:close()
+    helpers.stop_kong(nil, true)
+  end)
+
+  it("expose lmdb metrics by status API", function()
+    local res = assert(admin_client:send{
+      method = "GET",
+      path = "/metrics",
+      headers = {
+        ["Host"] = "status.example.com"
+      }
+    })
+    local body = assert.res_status(200, res)
+
+    assert.matches('kong_memory_lmdb_used_bytes{node_id="' .. UUID_PATTERN .. '"} %d+', body)
+    assert.matches('kong_memory_lmdb_total_bytes{node_id="' .. UUID_PATTERN .. '"} %d+', body)
+  end)
+end)

--- a/t/01-pdk/12-node/02-get_memory_stats.t
+++ b/t/01-pdk/12-node/02-get_memory_stats.t
@@ -536,3 +536,47 @@ workers_lua_vms
   (?:\d+: 1024\s*){1,2}\Z
 --- no_error_log
 [error]
+
+
+=== TEST 11: node.get_memory_stats() returns lmdb stats
+--- main_config
+    lmdb_environment_path /tmp/dbless.lmdb;
+    lmdb_map_size         128m;
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+    lua_shared_dict kong_db_cache 32k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+
+        -- NOTE: insert garbage
+        ngx.shared.kong:set("kong:mem:foo", "garbage")
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            kong = {}
+            kong.configuration = {}
+            kong.configuration.database = "off"
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say(" lmdb map size: ", res.lmdb.map_size)
+            ngx.say(" lmdb map used size: ", res.lmdb.used_size)
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+ lmdb map size: 134217728
+ lmdb map used size: \d+
+--- no_error_log
+[error]


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
add lmdb metrics to prometheus and statsd, also extend PDK `kong.node.get_memory_stats()`  lmdb capabilities. 

sister PR : https://github.com/Kong/lua-resty-lmdb/pull/25

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE



### Issue reference

FTI-4749
