### PR TITLE
chore(deps) bump resty.session from 4.0.1 to 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,9 +204,10 @@
   [#10144](https://github.com/Kong/kong/pull/10144)
 - Bumped lua-kong-nginx-module from 0.5.0 to 0.5.1
   [#10181](https://github.com/Kong/kong/pull/10181)
-- Bumped lua-resty-session from 3.10 to 4.0.1
+- Bumped lua-resty-session from 3.10 to 4.0.2
   [#10199](https://github.com/Kong/kong/pull/10199)
   [#10230](https://github.com/Kong/kong/pull/10230)
+  [#10308](https://github.com/Kong/kong/pull/10308)
 - Bumped OpenSSL from 1.1.1s to 1.1.1t
   [#10266](https://github.com/Kong/kong/pull/10266)
 - Bumped lua-resty-timer-ng from 0.2.0 to 0.2.3

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
-  "lua-resty-session == 4.0.1",
+  "lua-resty-session == 4.0.2",
   "lua-resty-timer-ng == 0.2.3",
 }
 build = {


### PR DESCRIPTION
### Summary

#### Fixed

- fix(*): hkdf is not approved by FIPS, use PBKDF2 instead on FIPS-mode