### PR TITLE
chore(changelog): session breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@
   For that reason it is advisable that during upgrades mixed versions of proxy nodes run for
   as little as possible. During that time, the invalid sessions could cause failures and partial downtime.
   All existing sessions are invalidated when upgrading to this version.
+  The parameter `idling_timeout` now has a default value of 900: unless configured differently,
+  sessions expire after 900 seconds (15 minutes) of idling.
+  The parameter `absolute_timeout` has a default value of 86400: unless configured differently,
+  sessions expire after 86400 seconds (24 hours).
   [#10199](https://github.com/Kong/kong/pull/10199)
 
 ### Additions


### PR DESCRIPTION
### Summary

Add a note to highlight the new default value of the parameter: `idling_timeout`
(cherry pick of https://github.com/Kong/kong/pull/10312)

### Checklist

~The Pull Request has tests~
~There's an entry in the CHANGELOG~
~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

FTI-4827