### PR TITLE
docs(changelog): add entry for renamed kong.conf properties (#10310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,19 @@
 
 ### Changed
 
+#### Core
+
+- Improve error message for invalid JWK entities.
+  [#9904](https://github.com/Kong/kong/pull/9904)
+- Renamed two configuration properties:
+    * `opentelemetry_tracing` => `tracing_instrumentations`
+    * `opentelemetry_tracing_sampling_rate` => `tracing_sampling_rate`
+
+  The old `opentelemetry_*` properties are considered deprecated and will be
+  fully removed in a future version of Kong.
+  [#10122](https://github.com/Kong/kong/pull/10122)
+  [#10220](https://github.com/Kong/kong/pull/10220)
+
 #### Hybrid Mode
 
 - Revert the removal of WebSocket protocol support for configuration sync,


### PR DESCRIPTION
(cherry picked from commit ee74ed9532e372898f8473598d2ab17f960e9d79)

There's an additional entry in here for #9904 that is also missing from the 3.2 release branch.