### PR TITLE
fix(cmd): log format error

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -113,8 +113,8 @@ local function gen_default_ssl_cert(kong_config, target)
     end
 
     if not exists(ssl_cert) and not exists(ssl_cert_key) then
-      log.verbose("generating %s SSL certificate (%s) and key (%s) for %s",
-        target or "proxy", ssl_cert, ssl_cert_key, "listener")
+      log.verbose("generating %s SSL certificate (%s) and key (%s) for listener",
+        target or "proxy", ssl_cert, ssl_cert_key)
 
       local key
       if suffix == "_ecdsa" then

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -113,7 +113,8 @@ local function gen_default_ssl_cert(kong_config, target)
     end
 
     if not exists(ssl_cert) and not exists(ssl_cert_key) then
-      log.verbose("generating %s SSL certificate (", ssl_cert, ") and key (", ssl_cert_key, ") for ", target or "proxy", " listener")
+      log.verbose("generating %s SSL certificate (%s) and key (%s) for %s",
+        target or "proxy", ssl_cert, ssl_cert_key, "listener")
 
       local key
       if suffix == "_ecdsa" then

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -114,7 +114,7 @@ local function gen_default_ssl_cert(kong_config, target)
 
     if not exists(ssl_cert) and not exists(ssl_cert_key) then
       log.verbose("generating %s SSL certificate (%s) and key (%s) for listener",
-        target or "proxy", ssl_cert, ssl_cert_key)
+                  target or "proxy", ssl_cert, ssl_cert_key)
 
       local key
       if suffix == "_ecdsa" then


### PR DESCRIPTION
Log line isn't correctly formatted.

FTI-4801