### PR TITLE
fix(pdk): request headers what contains "_" unable to be case-insensitive matched

### DIFF
--- a/t/01-pdk/04-request/14-get_headers.t
+++ b/t/01-pdk/04-request/14-get_headers.t
@@ -72,17 +72,25 @@ Accept: application/json, text/html
             ngx.say("x-Foo-header: ", headers["x-Foo-header"])
             ngx.say("x_foo_header: ", headers.x_foo_header)
             ngx.say("x_Foo_header: ", headers.x_Foo_header)
+
+            ngx.say("X_Bar_Header: ", headers["X_Bar_Header"])
+            ngx.say("X_Bar_header: ", headers["X_Bar_header"])
+            ngx.say("x_bar_header: ", headers["X_Bar_header"])
         }
     }
 --- request
 GET /t
 --- more_headers
 X-Foo-Header: Hello
+X-Bar-Header: World
 --- response_body
 X-Foo-Header: Hello
 x-Foo-header: Hello
 x_foo_header: Hello
 x_Foo_header: Hello
+X_Bar_Header: World
+X_Bar_header: World
+x_bar_header: World
 --- no_error_log
 [error]
 


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
Backup PR for upstream PR https://github.com/openresty/lua-resty-core/pull/419

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
