### PR TITLE
fix(bazel): fix intel detection

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -70,6 +70,8 @@ def _github_release_impl(ctx):
 
     if os_arch == "aarch64":
         os_arch = "arm64"
+    if os_arch == "x86_64":
+        os_arch = "amd64"
     elif os_arch != "amd64":
         fail("Unsupported arch %s" % os_arch)
 


### PR DESCRIPTION
### Summary

`uname -m` on my intel mac laptop is detected in bazel as `x86_64` and not `amd64`.

```bash
$ uname -m
x86_64
$ sw_vers
ProductName:		macOS
ProductVersion:		13.1
BuildVersion:		22C65
```

mirror of: https://github.com/Kong/kong-ee/pull/4402

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
