### PR TITLE
perf(postgres): optimize the expired rows cleanup routine in postgres connector

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1202,6 +1202,11 @@ G# -----------------------
                                  # If not specified, then number of open connections
                                  # to the Postgres server is not limited.
 
+#pg_expired_rows_cleanup_interval = 60        # This value will control the interval of
+                                              # running cleanup on the expired rows(whose
+                                              # ttl < CURRENT_TIMESTAMP) in the Postgres
+                                              # database.
+
 #pg_ro_host =                    # Same as `pg_host`, but for the
                                  # read-only connection.
                                  # **Note:** Refer to the documentation

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -360,6 +360,7 @@ local CONF_PARSERS = {
   pg_keepalive_timeout = { typ = "number" },
   pg_pool_size = { typ = "number" },
   pg_backlog = { typ = "number" },
+  pg_expired_rows_cleanup_interval = { typ = "number" },
 
   pg_ro_port = { typ = "number" },
   pg_ro_timeout = { typ = "number" },
@@ -1017,6 +1018,16 @@ local function check_and_parse(conf, opts)
 
     if conf.pg_backlog ~= floor(conf.pg_backlog) then
       errors[#errors + 1] = "pg_backlog must be an integer greater than 0"
+    end
+  end
+
+  if conf.pg_expired_rows_cleanup_interval then
+    if conf.pg_expired_rows_cleanup_interval < 0 then
+      errors[#errors + 1] = "pg_expired_rows_cleanup_interval must be greater than 0"
+    end
+
+    if conf.pg_expired_rows_cleanup_interval ~= floor(conf.pg_expired_rows_cleanup_interval) then
+      errors[#errors + 1] = "pg_expired_rows_cleanup_interval must be an integer greater than 0"
     end
   end
 

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -337,7 +337,7 @@ function _mt:init_worker(strategies)
 
     local cleanup_statement = concat(cleanup_statements, "\n")
 
-    return timer_every(60, function(premature)
+    return timer_every(self.config.expired_rows_cleanup_interval, function(premature)
       if premature then
         return
       end
@@ -934,6 +934,7 @@ function _M.new(kong_config)
     sem_timeout = (kong_config.pg_semaphore_timeout or 60000) / 1000,
     pool_size   = kong_config.pg_pool_size,
     backlog     = kong_config.pg_backlog,
+    expired_rows_cleanup_interval = kong_config.pg_expired_rows_cleanup_interval or 60,
 
     --- not used directly by pgmoon, but used internally in connector to set the keepalive timeout
     keepalive_timeout = kong_config.pg_keepalive_timeout,

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -36,6 +36,7 @@ local insert       = table.insert
 
 local WARN                          = ngx.WARN
 local ERR                           = ngx.ERR
+local DEBUG                         = ngx.DEBUG
 local SQL_INFORMATION_SCHEMA_TABLES = [[
 SELECT table_name
   FROM information_schema.tables
@@ -318,6 +319,7 @@ end
 
 
 local function cleanup_expired_rows_in_table(connector, table_name)
+  local time1 = now()
   local ttl_escaped = connector:escape_identifier("ttl")
   local expired_at_escaped = connector:escape_identifier("expire_at")
   local column_name = table_name == "cluster_events" and expired_at_escaped
@@ -332,6 +334,10 @@ local function cleanup_expired_rows_in_table(connector, table_name)
   }
 
   local ok, err = connector:query(cleanup_statement)
+  local time2 = now()
+  local time_elapsed = tonumber(fmt("%.3f", time2 - time1))
+  log(DEBUG, "cleaning up expired rows from table '", table_name,
+            "' took ", time_elapsed, " seconds")
   if not ok then
     if err then
       log(WARN, "failed to clean expired rows from table '",

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -319,7 +319,7 @@ end
 
 local function cleanup_expired_rows_in_table(connector, table_name)
   local ttl_escaped = connector:escape_identifier("ttl")
-  local expired_at_escaped = connector:escape_identifier("expired_at")
+  local expired_at_escaped = connector:escape_identifier("expire_at")
   local column_name = table_name == "cluster_events" and expired_at_escaped
                                                       or ttl_escaped
 

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -361,7 +361,7 @@ local function cleanup_expired_rows_in_table(config, table_name)
       end
     end
 
-    if ok.affected_rows == 0 then
+    if tonumber(ok.affected_rows) < EXPIRED_ROW_BATCH_SIZE then
       break
     end
   end

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -1074,6 +1074,7 @@ end
 
 -- for tests only
 _mt._get_topologically_sorted_table_names = get_names_of_tables_with_ttl
+_mt._cleanup_expired_rows_in_table = cleanup_expired_rows_in_table
 
 
 return _M

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -110,6 +110,7 @@ pg_semaphore_timeout = 60000
 pg_keepalive_timeout = NONE
 pg_pool_size = NONE
 pg_backlog = NONE
+pg_expired_rows_cleanup_interval = 60
 
 pg_ro_host = NONE
 pg_ro_port = NONE

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1506,6 +1506,22 @@ describe("Configuration loader", function()
       assert.is_nil(conf)
       assert.equal("pg_backlog must be an integer greater than 0", err)
     end)
+
+    it("rejects a pg_expired_rows_cleanup_interval with a negative number", function()
+      local conf, err = conf_loader(nil, {
+        pg_expired_rows_cleanup_interval = -1,
+      })
+      assert.is_nil(conf)
+      assert.equal("pg_expired_rows_cleanup_interval must be greater than 0", err)
+    end)
+
+    it("rejects a pg_expired_rows_cleanup_interval with a decimal", function()
+      local conf, err = conf_loader(nil, {
+        pg_expired_rows_cleanup_interval = 0.1,
+      })
+      assert.is_nil(conf)
+      assert.equal("pg_expired_rows_cleanup_interval must be an integer greater than 0", err)
+    end)
   end)
 
   describe("pg read-only connection pool options", function()

--- a/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
+++ b/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
@@ -1,0 +1,97 @@
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  local postgres_only = strategy == "postgres" and describe or pending
+  postgres_only("postgres ttl cleanup logic", function()
+    describe("cleanup_expired_rows_in_table function", function ()
+      local bp, db, consumer1
+      lazy_setup(function()
+        bp, db = helpers.get_db_utils("postgres", {
+          "consumers",
+          "keyauth_credentials"
+        })
+
+        consumer1 = bp.consumers:insert {
+          username = "conumer1"
+        }
+      end)
+
+      lazy_teardown(function()
+        db:truncate()
+        db:close()
+      end)
+
+      it("cleanup expired rows should work as expected #test", function ()
+        local cleanup_func = db.connector._cleanup_expired_rows_in_table
+
+        local kauth_cred = bp.keyauth_credentials:insert({
+          key = "secret1",
+          consumer = { id = consumer1.id },
+        }, {ttl = 1})
+
+        local ok, err = db.connector:query("SELECT * FROM keyauth_credentials")
+        assert.is_nil(err)
+        assert.same(1, #ok)
+        helpers.wait_until(function()
+          -- wait until the keyauth credential expired
+          local kauth_cred2 = db.keyauth_credentials:select{id = kauth_cred.id}
+          return kauth_cred2 == nil
+        end, 3)
+        cleanup_func(db.connector.config, "keyauth_credentials")
+        ok, err = db.connector:query("SELECT * FROM keyauth_credentials")
+        assert.is_nil(err)
+        assert.same(0, #ok)
+      end)
+    end)
+
+    describe("ttl cleanup timer #postgres", function()
+      local bp, db, consumer1
+      lazy_setup(function()
+        bp, db = helpers.get_db_utils("postgres", {
+          "routes",
+          "services",
+          "plugins",
+          "consumers",
+          "keyauth_credentials"
+        })
+
+        consumer1 = bp.consumers:insert {
+          username = "conumer1"
+        }
+
+        assert(helpers.start_kong({
+          pg_expired_rows_cleanup_interval = 10,
+          database = strategy,
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+        db:truncate()
+      end)
+
+      it("init_worker should run ttl cleanup in background timer", function ()
+        helpers.clean_logfile()
+        local names_of_table_with_ttl = db.connector._get_topologically_sorted_table_names(db.strategies)
+        assert.truthy(#names_of_table_with_ttl > 0)
+        for _, name in ipairs(names_of_table_with_ttl) do
+          assert.errlog().has.line([[cleaning up expired rows from table ']] .. name .. [[' took \d+\.\d+ seconds]], false, 60)
+        end
+
+        local _ = bp.keyauth_credentials:insert({
+          key = "secret1",
+          consumer = { id = consumer1.id },
+        }, {ttl = 3})
+        helpers.clean_logfile()
+
+        helpers.wait_until(function()
+          return assert.errlog().has.line([[cleaning up expired rows from table ']] .. "keyauth_credentials" .. [[' took \d+\.\d+ seconds]], false, 12)
+        end, 20)
+
+        local ok, err = db.connector:query("SELECT * FROM keyauth_credentials")
+        assert.is_nil(err)
+        assert.same(0, #ok)
+      end)
+    end)
+  end)
+end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR tries to optimize the expired rows cleanup routine in the Postgres strategy connector.

Currently, the cleanup logic is managed by a `timer.every`, which will run multiple `DELETE` sub-queries in one big query and delete those rows that got expired. Concerns have been raised about such queries may lead to high load on database if the number of expired rows is large. The idea originates from [FTI-4746](https://konghq.atlassian.net/browse/FTI-4746) and [KAG-516](https://konghq.atlassian.net/browse/KAG-516), but the code that got changed in this PR may not be directly relevant to the root cause of the production issue. The logic itself is definitely worth some optimizing after all.

This PR brings the following changes to the cleanup logic:
- Makes the cleanup interval configurable. A new config parameter `pg_expired_rows_cleanup_interval` is introduced to control the interval of triggering the timer.
- A cluster mutex is added to ensure that in a "traditional" deployment cluster, only one cleanup will be running at the same time.
- The big query which contains multiple `DELETE` sub-queries has been split into multiple queries, with more obvious logging, so that if any errors are encountered, the table which caused such an error can be located easily. And each query will use its own connection so that if any of them got timed out on Kong's side(for example, waiting for locks in the Pg but the connection itself is timed out), the following cleanup will not be affected.
- Debug logging which shows the total time usage of each table is added.
- Batch delete is implemented in every DELETE query to avoid letting extremely slow query consuming database resources.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Optimize the expired rows cleanup routine in Postgres connector.
* Add a new config parameter `pg_expired_rows_cleanup_interval` to control the interval of expired rows cleanup routine.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
- [FTI-4746](https://konghq.atlassian.net/browse/FTI-4746)
- [KAG-516](https://konghq.atlassian.net/browse/KAG-516)


[FTI-4746]: https://konghq.atlassian.net/browse/FTI-4746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAG-516]: https://konghq.atlassian.net/browse/KAG-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-4746]: https://konghq.atlassian.net/browse/FTI-4746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ