### PR TITLE
fix(plugin): OTEL exporting with translate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,7 +195,7 @@
     [#10160](https://github.com/Kong/kong/pull/10160)
   - For `http.flavor`. It should be a string value, not a double.
     [#10160](https://github.com/Kong/kong/pull/10160)
-- **OpenTelemetry**: Fix a bug that when get trace of other formats, the trace ID reported and propagated could be of incorrect length.
+- **OpenTelemetry**: Fix a bug that when getting the trace of other formats, the trace ID reported and propagated could be of incorrect length.
     [#10332](https://github.com/Kong/kong/pull/10332)
 - **OAuth2**: `refresh_token_ttl` is now limited between `0` and `100000000` by schema validator. Previously numbers that are too large causes requests to fail.
   [#10068](https://github.com/Kong/kong/pull/10068)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,8 +193,10 @@
     [#10069](https://github.com/Kong/kong/pull/10069)
   - For `http.status_code`. It should be present on spans for requests that have a status code.
     [#10160](https://github.com/Kong/kong/pull/10160)
-  - For `http.flavor`. It should be a string value, not a double.
+  - For `http.flavor`. It should be a string value, not a double
     [#10160](https://github.com/Kong/kong/pull/10160)
+- **OpenTelemetry**: Fix a bug that when get trace of other formats, the trace ID reported and propagated could be of incorrect length.
+    [#10332](https://github.com/Kong/kong/pull/10332)
 - **OAuth2**: `refresh_token_ttl` is now limited between `0` and `100000000` by schema validator. Previously numbers that are too large causes requests to fail.
   [#10068](https://github.com/Kong/kong/pull/10068)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@
     [#10069](https://github.com/Kong/kong/pull/10069)
   - For `http.status_code`. It should be present on spans for requests that have a status code.
     [#10160](https://github.com/Kong/kong/pull/10160)
-  - For `http.flavor`. It should be a string value, not a double
+  - For `http.flavor`. It should be a string value, not a double.
     [#10160](https://github.com/Kong/kong/pull/10160)
 - **OpenTelemetry**: Fix a bug that when get trace of other formats, the trace ID reported and propagated could be of incorrect length.
     [#10332](https://github.com/Kong/kong/pull/10332)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -19,8 +19,8 @@ local propagation_parse = propagation.parse
 local propagation_set = propagation.set
 local null = ngx.null
 local encode_traces = otlp.encode_traces
-local translate_span = otlp.translate_span
-local transform_span = otlp.transform_span
+local translate_span_trace_id = otlp.translate_span
+local encode_span = otlp.transform_span
 
 local _log_prefix = "[otel] "
 
@@ -109,7 +109,7 @@ local function process_span(span, queue)
     span.trace_id = trace_id
   end
 
-  local pb_span = transform_span(span)
+  local pb_span = encode_span(span)
 
   queue:add(pb_span)
 end
@@ -147,7 +147,7 @@ function OpenTelemetryHandler:access()
     root_span.parent_id = parent_id
   end
 
-  propagation_set("preserve", header_type, translate_span(root_span), "w3c")
+  propagation_set("preserve", header_type, translate_span_trace_id(root_span), "w3c")
 end
 
 function OpenTelemetryHandler:log(conf)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -19,6 +19,7 @@ local propagation_parse = propagation.parse
 local propagation_set = propagation.set
 local null = ngx.null
 local encode_traces = otlp.encode_traces
+local translate_span = otlp.translate_span
 local transform_span = otlp.transform_span
 
 local _log_prefix = "[otel] "
@@ -132,6 +133,7 @@ function OpenTelemetryHandler:access()
   end
 
   -- overwrite trace id
+  -- as we are in a chain of existing trace
   if trace_id then
     root_span.trace_id = trace_id
     kong.ctx.plugin.trace_id = trace_id
@@ -145,7 +147,7 @@ function OpenTelemetryHandler:access()
     root_span.parent_id = parent_id
   end
 
-  propagation_set("preserve", header_type, root_span, "w3c")
+  propagation_set("preserve", header_type, translate_span(root_span), "w3c")
 end
 
 function OpenTelemetryHandler:log(conf)

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -10,6 +10,7 @@ local insert = table.insert
 local tablepool_fetch = tablepool.fetch
 local tablepool_release = tablepool.release
 local deep_copy = utils.deep_copy
+local shallow_copy = utils.shallow_copy
 local table_merge = utils.table_merge
 
 local POOL_OTLP = "KONG_OTLP"
@@ -84,7 +85,7 @@ local function translate_span(span)
     trace_id = string.rep("\0", 16 - #trace_id) .. trace_id
   end
 
-  local translated = deep_copy(span)
+  local translated = shallow_copy(span)
   translated.trace_id = trace_id
   return translated
 end

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -15,6 +15,7 @@ local table_merge = utils.table_merge
 local getmetatable = getmetatable
 local setmetatable = setmetatable
 
+local TRACE_ID_LEN = 16
 local NULL = "\0"
 local POOL_OTLP = "KONG_OTLP"
 local EMPTY_TAB = {}
@@ -83,11 +84,11 @@ local function translate_span(span)
   local new_id = trace_id
 
   -- make sure the trace id is of 16 bytes
-  if len > 16 then
-    new_id = trace_id:sub(-16)
+  if len > TRACE_ID_LEN then
+    new_id = trace_id:sub(-TRACE_ID_LEN)
 
-  elseif len < 16 then
-    new_id = NULL:rep(16 - len) .. trace_id
+  elseif len < TRACE_ID_LEN then
+    new_id = NULL:rep(TRACE_ID_LEN - len) .. trace_id
   end
 
   if new_id ~= trace_id then

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -83,6 +83,10 @@ local function translate_span(span)
   local len = #trace_id
   local new_id = trace_id
 
+  if len == TRACE_ID_LEN then
+    return span
+  end
+
   -- make sure the trace id is of 16 bytes
   if len > TRACE_ID_LEN then
     new_id = trace_id:sub(-TRACE_ID_LEN)

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -95,13 +95,11 @@ local function translate_span(span)
     new_id = NULL:rep(TRACE_ID_LEN - len) .. trace_id
   end
 
-  if new_id ~= trace_id then
-    local translated = shallow_copy(span)
-    setmetatable(translated, getmetatable(span))
+  local translated = shallow_copy(span)
+  setmetatable(translated, getmetatable(span))
 
-    translated.trace_id = new_id
-    span = translated
-  end
+  translated.trace_id = new_id
+  span = translated
 
   return span
 end

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -12,6 +12,8 @@ local tablepool_release = tablepool.release
 local deep_copy = utils.deep_copy
 local shallow_copy = utils.shallow_copy
 local table_merge = utils.table_merge
+local getmetatable = getmetatable
+local setmetatable = setmetatable
 
 local POOL_OTLP = "KONG_OTLP"
 local EMPTY_TAB = {}
@@ -87,6 +89,7 @@ local function translate_span(span)
 
   local translated = shallow_copy(span)
   translated.trace_id = trace_id
+  setmetatable(translated, getmetatable(span))
   return translated
 end
 

--- a/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
@@ -160,5 +160,23 @@ describe("propagation tests #" .. strategy, function()
 
     assert.equals(trace_id, json.headers["ot-tracer-traceid"])
   end)
+
+  it("propagates dd headers", function()
+    local trace_id = gen_trace_id()
+    local trace_id_truncated = trace_id:sub(1, 16)
+    local span_id = gen_span_id()
+    local r = proxy_client:get("/", {
+      headers = {
+        ["ot-tracer-traceid"] = trace_id_truncated,
+        ["ot-tracer-spanid"] = span_id,
+        ["ot-tracer-sampled"] = "1",
+        host = "http-route",
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+
+    assert.equals(string.rep("0", 8) .. trace_id_truncated, json.headers["ot-tracer-traceid"])
+  end)
 end)
 end

--- a/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
@@ -176,7 +176,11 @@ describe("propagation tests #" .. strategy, function()
     local body = assert.response(r).has.status(200)
     local json = cjson.decode(body)
 
-    assert.equals(string.rep("0", 8) .. trace_id_truncated, json.headers["ot-tracer-traceid"])
+    assert.equals(#trace_id, #json.headers["ot-tracer-traceid"],
+                  "trace ID was not padded correctly")
+
+    local expected = string.rep("0", 16) .. trace_id_truncated
+    assert.equals(expected, json.headers["ot-tracer-traceid"])
   end)
 end)
 end


### PR DESCRIPTION
### Summary

We represent trace spans with a universal format for all kinds of mainstream tracers and translate them to different formats when propagating headers and exporting traces. However, OTEL misses the handling of trace ID length.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
N/A There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-652
