### PR TITLE
fix(gha): use regctl for (multiarch) image copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,7 +534,7 @@ jobs:
           suffix=-${{ matrix.label }}
 
     - name: Install regctl
-      uses: regclient/actions/regctl-installer@main
+      uses: regclient/actions/regctl-installer@b6614f5f56245066b533343a85f4109bdc38c8cc
 
     - name: Push Images
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,6 +533,9 @@ jobs:
           latest=false
           suffix=-${{ matrix.label }}
 
+    - name: Install regctl
+      uses: regclient/actions/regctl-installer@main
+
     - name: Push Images
       env:
         TAGS: "${{ steps.meta.outputs.tags }}"
@@ -540,6 +543,5 @@ jobs:
         PRERELEASE_IMAGE=${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ github.sha }}-${{ matrix.label }}
         docker pull $PRERELEASE_IMAGE
         for tag in $TAGS; do
-          docker tag $PRERELEASE_IMAGE $tag
-          docker push $tag
+          regctl -v debug image copy $PRERELEASE_IMAGE $tag
         done


### PR DESCRIPTION
### Summary

This PR pivots the docker hub re-tagging portions of the release github action to utilize `regctl image copy` instead of plain ole' `docker pull`.
The `docker pull` approach lacked support for multi-architecture builds, result in only `amd64` image tags being added to unofficial/official repos.

Sister PR to: https://github.com/Kong/kong-ee/pull/4624

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
