### PR TITLE
fix(gha): Set Package Architecture when Uploading to Pulp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,8 +474,19 @@ jobs:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
 
+    - name: Set package architecture
+      id: pkg-arch
+      run: |
+        arch='amd64'
+        if [[ '${{ matrix.label }}' == *'arm64' ]]; then
+          arch='arm64'
+        fi
+        echo "arch=$arch"
+        echo "arch=$arch" >> $GITHUB_OUTPUT
+
     - name: Upload Packages to PULP
       env:
+        ARCHITECTURE: ${{ steps.pkg-arch.outputs.arch }}
         OFFICIAL_RELEASE: ${{ github.event.inputs.official == true }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -487,7 +487,7 @@ jobs:
     - name: Upload Packages to PULP
       env:
         ARCHITECTURE: ${{ steps.pkg-arch.outputs.arch }}
-        OFFICIAL_RELEASE: ${{ github.event.inputs.official == true }}
+        OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin
         # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}


### PR DESCRIPTION
### Summary

This needed to have been ported from EE -> CE (which we don't have a formal process for).
In EE, it's a fix that got applied along my arm64 Amazon Linux work.
CE also needs this fix.

Without this fix, arm64 package files are erroneously uploaded with "amd64" in the filename-- sometimes overwriting previously uploaded (legitimate amd64) packages.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference