### PR TITLE
chore(deps): bump resty.session from 4.0.2 to 4.0.3(back-port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [3.2.0](#320)
 - [3.1.0](#310)
 - [3.0.1](#301)
 - [3.0.0](#300)
@@ -67,7 +68,7 @@
 - [0.9.9 and prior](#099---20170202)
 
 
-## Unreleased
+## 3.2.0
 
 ### Breaking Changes
 
@@ -7815,6 +7816,7 @@ First version running with Cassandra.
 
 [Back to TOC](#table-of-contents)
 
+[3.2.0]: https://github.com/Kong/kong/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/Kong/kong/compare/3.0.1...3.1.0
 [3.0.1]: https://github.com/Kong/kong/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/Kong/kong/compare/2.8.1...3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@
 - [0.10.0](#0100---20170307)
 - [0.9.9 and prior](#099---20170202)
 
+## Unreleased
+
+### Dependencies
+
+- Bumped lua-resty-session from 4.0.2 to 4.0.3
+  [#10338](https://github.com/Kong/kong/pull/10338)
 
 ## 3.2.0
 

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
-  "lua-resty-session == 4.0.2",
+  "lua-resty-session == 4.0.3",
   "lua-resty-timer-ng == 0.2.3",
 }
 build = {


### PR DESCRIPTION
### Summary

Fixes Redis (non-cluster/sentinel) authentication.