### PR TITLE
fix(gha): official input is a string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
 
     - name: Upload Packages to PULP
       env:
-        OFFICIAL_RELEASE: ${{ github.event.inputs.official == true }}
+        OFFICIAL_RELEASE: ${{ github.event.inputs.official == 'true' }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin
         # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}


### PR DESCRIPTION
### Summary

GitHub Action inputs are always strings.

So this comparison, was "(string) == boolean" which was always `false`. This is just part of the release process we don't exercise often.

Sister EE PR: https://github.com/Kong/kong-ee/pull/4627

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference