### PR TITLE
chore(ci) add schema-change-noteworthy label for any schema.lua file change

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -172,6 +172,8 @@ plugins/opentelemetry:
 
 schema-change-noteworthy:
 - kong/db/schema/entities/**/*
+- kong/**/schema.lua
+- kong/plugins/**/daos.lua
 
 build/bazel:
 - '**/*.bazel'


### PR DESCRIPTION


### Summary

This commit updates the CI configuration to add the "schema-change-noteworthy" label for every PR that touches any schema.lua file. This helps communicate schema changes in Kong to downstream projects like Konnect, decK, KIC, Kong Manager track each and every schema change and adapt accordingly.

### Checklist

- [x] The Pull Request has tests - Not needed
- [x] There's an entry in the CHANGELOG - Not needed
- [x] There is a user-facing docs PR - Not Needed