### PR TITLE
chore(release): Boolean variables are passed as strings by Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
 
     - name: Upload Packages to PULP
       env:
-        OFFICIAL_RELEASE: ${{ github.event.inputs.official == true }}
+        OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin
         # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}


### PR DESCRIPTION
### Summary

Performing this comparison actually turns a "true" string into a false. We already check for a string when consuming this environment variable so there is no need to perform it here.

Without this change, releasing packages causes them to only end up in the internal channels.
