### PR TITLE
fix(plugin): compat issue for config sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@
   [#10247](https://github.com/Kong/kong/pull/10247)
 - Fix an issue where 'X-Kong-Upstream-Status' cannot be emitted when response is buffered.
   [#10056](https://github.com/Kong/kong/pull/10056)
+- Fix an issue where control plane does not downgrade config for `aws_lambda` and `zipkin` for older version of data planes.
+  [#10346](https://github.com/Kong/kong/pull/10346)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@
 - Bumped lua-resty-session from 4.0.2 to 4.0.3
   [#10338](https://github.com/Kong/kong/pull/10338)
 
+### Fix
+
+#### Core
+
+- Fix an issue where control plane does not downgrade config for `aws_lambda` and `zipkin` for older version of data planes.
+  [#10346](https://github.com/Kong/kong/pull/10346)
+
 ## 3.2.0
 
 ### Breaking Changes
@@ -168,8 +175,6 @@
   [#10247](https://github.com/Kong/kong/pull/10247)
 - Fix an issue where 'X-Kong-Upstream-Status' cannot be emitted when response is buffered.
   [#10056](https://github.com/Kong/kong/pull/10056)
-- Fix an issue where control plane does not downgrade config for `aws_lambda` and `zipkin` for older version of data planes.
-  [#10346](https://github.com/Kong/kong/pull/10346)
 
 #### Plugins
 

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -48,5 +48,11 @@ return {
       "response_headers",
       "request_headers",
     },
+    aws_lambda = {
+      "aws_imds_protocol_version",
+    },
+    zipkin = {
+      "phase_duration_flavor",
+    }
   },
 }


### PR DESCRIPTION
### Summary

For 3.2, we added `aws_imds_protocol_version` for `aws_lambda` plugin, and `aws_imds_protocol_version` for `zipkin` plugin, but we did not add corresponding `removed_fields` entries.

### Checklist

The Pull Request has tests -- N/A, we removed tests to `removed_fileds` as it does not mean much but causes flakiness.

- [x] There's an entry in the CHANGELOG

There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com -- N/A, it's a bug fix

### Issue reference

Fix KAG-725
