### PR TITLE
fix(clustering): session renamed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 
 - Fix an issue where control plane does not downgrade config for `aws_lambda` and `zipkin` for older version of data planes.
   [#10346](https://github.com/Kong/kong/pull/10346)
+- Fix an issue where control plane does not rename fields correctly for `session` for older version of data planes.
+  [#10352](https://github.com/Kong/kong/pull/10352)
 
 ## 3.2.0
 

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -238,6 +238,7 @@ end
 local function rename_field(config, name_from, name_to, has_update)
   if config[name_from] ~= nil then
     config[name_to] = config[name_from]
+    config[name_from] = nil
     return true
   end
   return has_update

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -157,6 +157,9 @@ describe("kong.clustering.compat", function()
             "goodbye",
             "my.nested.field",
           },
+          session = {
+            "anything",
+          },
         },
       })
     end)
@@ -271,6 +274,37 @@ describe("kong.clustering.compat", function()
                   stay = "I'm still here",
                 }
               },
+            },
+          },
+        },
+      },
+
+      {
+        name = "renamed fields",
+        version = "1.0.0",
+        plugins = {
+          {
+            name = "session",
+            config = {
+              idling_timeout = 60,
+              rolling_timeout = 60,
+              stale_ttl = 60,
+              cookie_same_site = "Default",
+              cookie_http_only = false,
+              remember = true,
+            },
+          },
+        },
+        expect = {
+          {
+            name = "session",
+            config = {
+              cookie_idletime = 60,
+              cookie_lifetime = 60,
+              cookie_discard = 60,
+              cookie_samesite = "Lax",
+              cookie_httponly = false,
+              cookie_persistent = true,
             },
           },
         },


### PR DESCRIPTION
### Summary

for older DPs, session "renamed" fields were just copied, this fixes it by removing the old field from the configuration

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

[KAG-738](https://konghq.atlassian.net/browse/KAG-738)


[KAG-738]: https://konghq.atlassian.net/browse/KAG-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ