### PR TITLE
feat(conf_loader): load all WASM filters from conf path

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1819,3 +1819,5 @@
                                   # a string that identifies the plugin causing the
                                   # problem.  Queues are used by the http-log, statsd,
                                   # opentelemetry and datadog plugins.
+
+#wasm_filters_path=               # Path to WASM filters that Kong will load.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1820,5 +1820,8 @@
                                   # problem.  Queues are used by the http-log, statsd,
                                   # opentelemetry and datadog plugins.
 
-#wasm_filters_path=               # Path to the directory containing WASM filters
+#wasm = off                       # Use this setting to enable WasmX, this allows running
+                                  # Wasm filters to process request data.
+
+#wasm_filters_path=               # Path to the directory containing Wasm filters
                                   # that Kong must load on startup.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1820,4 +1820,5 @@
                                   # problem.  Queues are used by the http-log, statsd,
                                   # opentelemetry and datadog plugins.
 
-#wasm_filters_path=               # Path to WASM filters that Kong will load.
+#wasm_filters_path=               # Path to the directory containing WASM filters
+                                  # that Kong must load on startup.

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1985,10 +1985,14 @@ local function load(path, custom_conf, opts)
         filter_files[pathname] = pathname
 
         local extension = pl_path.extension(entry)
-        insert(wasm_modules, {
-          name = entry:sub(0, -#extension - 1),
-          path = pathname,
-        })
+        if string.lower(extension) == ".wasm" then
+          insert(wasm_modules, {
+            name = entry:sub(0, -#extension - 1),
+            path = pathname,
+          })
+        else
+          log(DEBUG, "ignoring file ", entry, " in ", conf.wasm_filters_path, ": does not contain wasm suffix")
+        end
       end
     end
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -580,6 +580,7 @@ local CONF_PARSERS = {
 
   max_queued_batches = { typ = "number" },
 
+  wasm = { typ = "boolean" },
   wasm_filters_path = { typ = "string" },
 }
 
@@ -1227,7 +1228,7 @@ local function check_and_parse(conf, opts)
     end
   end
 
-  if conf.wasm_filters_path then
+  if conf.wasm and conf.wasm_filters_path then
     if not exists(conf.wasm_filters_path) or not pl_path.isdir(conf.wasm_filters_path) then
       errors[#errors + 1] = fmt("wasm_filters_path '%s' is not a valid directory", 
                                 conf.wasm_filters_path)
@@ -1975,7 +1976,7 @@ local function load(path, custom_conf, opts)
   assert(require("kong.tools.dns")(conf))
 
   -- WebAssembly module support
-  if conf.wasm_filters_path then
+  if conf.wasm and conf.wasm_filters_path then
     local filter_files = {}
     local wasm_modules = {}
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -195,6 +195,5 @@ tracing_sampling_rate = 1.0
 
 max_queued_batches = 100
 
-wasm = off
-wasm_modules = NONE
+wasm_filters_path = NONE
 ]]

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -195,5 +195,6 @@ tracing_sampling_rate = 1.0
 
 max_queued_batches = 100
 
+wasm = off
 wasm_filters_path = NONE
 ]]

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -19,12 +19,12 @@ events {
 > end
 }
 
-> if wasm then
+> if #wasm_modules_parsed > 0 then
 wasm {
   shm_kv kong_wasm_rate_limiting_counters 12m;
 
 > for _, module in ipairs(wasm_modules_parsed) do
-    module $(module.name) $(module.path);
+  module $(module.name) $(module.path);
 > end
 }
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1681,16 +1681,16 @@ describe("Configuration loader", function()
   describe("#wasm properties", function()
     it("wasm_modules", function()
       local conf, err = conf_loader(nil, {
-        wasm_modules = { "spec/fixtures/filter.wasm" },
+        wasm_filters_path = "spec/fixtures/wasm/unit-test",
       })
       assert.is_nil(err)
       assert.same({
           {
-              name = "filter",
-              path = "spec/fixtures/filter.wasm",
+              name = "empty-filter",
+              path = "spec/fixtures/wasm/unit-test/empty-filter.wasm",
           }
       }, conf.wasm_modules_parsed)
-      assert.same({ "spec/fixtures/filter.wasm" }, conf.wasm_modules)
+      assert.same("spec/fixtures/wasm/unit-test", conf.wasm_filters_path)
     end)
   end)
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1710,6 +1710,16 @@ describe("Configuration loader", function()
       }, conf.wasm_modules_parsed)
       assert.same("spec/fixtures/wasm/unit-test", conf.wasm_filters_path)
     end)
+
+    it("invalid wasm_filters_path", function()
+      local conf, err = conf_loader(nil, {
+        wasm = "on",
+        wasm_filters_path = "spec/fixtures/no-wasm-here/unit-test",
+      })
+      assert.same(err, "wasm_filters_path 'spec/fixtures/no-wasm-here/unit-test' is not a valid directory")
+      assert.is_nil(conf)
+    end)
+
   end)
 
   describe("errors", function()

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1679,8 +1679,26 @@ describe("Configuration loader", function()
   end)
 
   describe("#wasm properties", function()
-    it("wasm_modules", function()
+    it("wasm disabled", function()
       local conf, err = conf_loader(nil, {
+        wasm = "off",
+        wasm_filters_path = "spec/fixtures/wasm/unit-test",
+      })
+      assert.is_nil(err)
+      assert.is_nil(conf.wasm_modules_parsed)
+    end)
+
+    it("wasm default disabled", function()
+      local conf, err = conf_loader(nil, {
+        wasm_filters_path = "spec/fixtures/wasm/unit-test",
+      })
+      assert.is_nil(err)
+      assert.is_nil(conf.wasm_modules_parsed)
+    end)
+
+    it("wasm_filters_path", function()
+      local conf, err = conf_loader(nil, {
+        wasm = "on",
         wasm_filters_path = "spec/fixtures/wasm/unit-test",
       })
       assert.is_nil(err)

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -773,13 +773,13 @@ describe("NGINX conf compiler", function()
     describe("#wasm subsystem", function()
       it("injects the wasm{} subsystem", function()
         local conf = assert(conf_loader(nil, {
-          wasm_modules = { "spec/fixtures/filter.wasm" },
+          wasm_filters_path = "spec/fixtures/wasm/unit-test/",
         }))
-        assert.is_true(conf.wasm)
+        assert.equal(conf.wasm_filters_path, "spec/fixtures/wasm/unit-test/")
 
         local nginx_conf = prefix_handler.compile_nginx_conf(conf)
         assert.matches("wasm {", nginx_conf)
-        assert.matches("module filter spec/fixtures/filter.wasm;", nginx_conf)
+        assert.matches("module empty%-filter spec/fixtures/wasm/unit%-test/empty%-filter.wasm;", nginx_conf)
       end)
     end)
   end)

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -773,6 +773,7 @@ describe("NGINX conf compiler", function()
     describe("#wasm subsystem", function()
       it("injects the wasm{} subsystem", function()
         local conf = assert(conf_loader(nil, {
+          wasm = "on",
           wasm_filters_path = "spec/fixtures/wasm/unit-test/",
         }))
         assert.equal(conf.wasm_filters_path, "spec/fixtures/wasm/unit-test/")

--- a/spec/03-plugins/38-proxy-wasm/02-filters_spec.lua
+++ b/spec/03-plugins/38-proxy-wasm/02-filters_spec.lua
@@ -68,7 +68,7 @@ describe("Plugin: proxy-wasm filters (#wasm)", function()
       database = DATABASE,
       plugins = "bundled, proxy-wasm",
       nginx_conf = "spec/fixtures/custom_nginx.template",
-      wasm_modules = PROXY_WASM_PATH .. "/target/wasm32-wasi/debug/tests.wasm",
+      wasm_filters_path = PROXY_WASM_PATH .. "/target/wasm32-wasi/debug",
     })
   end)
 

--- a/spec/03-plugins/38-proxy-wasm/02-filters_spec.lua
+++ b/spec/03-plugins/38-proxy-wasm/02-filters_spec.lua
@@ -68,6 +68,7 @@ describe("Plugin: proxy-wasm filters (#wasm)", function()
       database = DATABASE,
       plugins = "bundled, proxy-wasm",
       nginx_conf = "spec/fixtures/custom_nginx.template",
+      wasm = "on",
       wasm_filters_path = PROXY_WASM_PATH .. "/target/wasm32-wasi/debug",
     })
   end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -20,12 +20,15 @@ events {
 > end
 }
 
-> if wasm then
+> if #wasm_modules_parsed > 0 then
 wasm {
+  shm_kv kong_wasm_rate_limiting_counters 12m;
+
 > for _, module in ipairs(wasm_modules_parsed) do
-    module $(module.name) $(module.path);
+  module $(module.name) $(module.path);
 > end
 }
+
 
 env RUST_BACKTRACE=1;
 env WASMTIME_BACKTRACE_DETAILS=1;


### PR DESCRIPTION
### Summary

Load WASM filters from configured path.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

- load wasm filters from configured path.
- do not expect individual files.
- added new directive to template.

### Issue reference

KAG-500