### PR TITLE
[Backport release/3.2.x] chore(release): Boolean variables are passed as strings by Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,7 +471,7 @@ jobs:
 
     - name: Upload Packages to PULP
       env:
-        OFFICIAL_RELEASE: ${{ github.event.inputs.official == true }}
+        OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin
         # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}


### PR DESCRIPTION
Backport 999f5bea44aa3092b61541a40adf1be81c6490b9 from #10343.