### PR TITLE
fix(db): didn't consider all workspaces when doing sni name collision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@
   [#10352](https://github.com/Kong/kong/pull/10352)
 - Fix an issue where validation to regex routes may be skipped when the old-fashioned config is used for DB-less Kong.
   [#10348](https://github.com/Kong/kong/pull/10348)
+- Fix an issue with dao API `_SNIs:check_list_is_new` which may cause the
+  endpoint `certificates` post request to fail without reverting to the
+  original state when a sni name already exists in another workspace.
+  [#10365](https://github.com/Kong/kong/pull/10365)
 
 ## 3.2.0
 

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -6,6 +6,7 @@ local setmetatable = setmetatable
 local tostring = tostring
 local ipairs = ipairs
 local table = table
+local null = ngx.null
 
 
 local function invalidate_cache(self, old_entity, err, err_t)
@@ -25,9 +26,11 @@ local _SNIs = {}
 -- associated to the given certificate
 -- if the cert id is nil, all encountered snis will return an error
 function _SNIs:check_list_is_new(name_list, valid_cert_id)
+  -- sni names should be unique across workspaces
+  local options = { workspace = null }
   for i=1, #name_list do
     local name = name_list[i]
-    local row, err, err_t = self:select_by_name(name)
+    local row, err, err_t = self:select_by_name(name, options)
     if err then
       return nil, err, err_t
     end

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -196,55 +196,6 @@ describe("Admin API: #" .. strategy, function()
         end
       end)
 
-      it("returns a conflict when a pre-existing sni on a different workspace is detected", function()
-        local n1 = get_name()
-        local n2 = get_name()
-        local res = client:post("/certificates", {
-          body    = {
-            cert  = ssl_fixtures.cert,
-            key   = ssl_fixtures.key,
-            snis  = { n1, n2 },
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        assert.res_status(201, res)
-
-        local res = client:post("/workspaces", {
-          body    = {
-            name  = "one",
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        assert.res_status(201, res)
-
-        local res = client:post("/one/certificates", {
-          body    = {
-            cert  = ssl_fixtures.cert,
-            key   = ssl_fixtures.key,
-            snis  = { n1, n2 },
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        local body = assert.res_status(400, res)
-        local json = cjson.decode(body)
-        assert.matches("snis: " .. n1 .. " already associated with existing certificate", json.message)
-
-        -- make sure we didn't add the certificate, or any snis
-        local res  = client:get("/one/certificates")
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        for _, data in ipairs(json.data) do
-          assert(false) -- json.data should be empty table
-        end
-
-        local res  = client:get("/one/snis")
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        for _, data in ipairs(json.data) do
-          assert(false) -- json.data should be empty table
-        end
-      end)
-
       it_content_types("creates a certificate and returns it with the snis pseudo-property", function(content_type)
         return function()
           local n1 = get_name()


### PR DESCRIPTION
### Summary

As sni names should be unique across workspaces, so collision check should be done across all workspaces.

This affects admin API `certificates`. The post request may fail without reverting to the original state when a sni name already exists in another workspace.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* fix an issue with dao API `_SNIs:check_list_is_new` which may cause the endpoint `certificates` post request to fail without reverting to the original state when a sni name already exists in another workspace.

### Issue reference

Fix FTI-4846