### PR TITLE
tests(helpers) fix flaky hybrid mode test

### DIFF
--- a/kong/cmd/utils/kill.lua
+++ b/kong/cmd/utils/kill.lua
@@ -2,7 +2,7 @@ local pl_path = require "pl.path"
 local pl_utils = require "pl.utils"
 local log = require "kong.cmd.utils.log"
 
-local cmd_tmpl = [[kill %s `cat %s` >/dev/null 2>&1]]
+local cmd_tmpl = [[kill %s `cat %s 2>&1` >/dev/null 2>&1]]
 
 local function kill(pid_file, args)
   log.debug("sending signal to pid at: %s", pid_file)

--- a/spec/02-integration/02-cmd/12-hybrid_spec.lua
+++ b/spec/02-integration/02-cmd/12-hybrid_spec.lua
@@ -129,13 +129,11 @@ for _, strategy in helpers.each_strategy() do
           cluster_control_plane = "127.0.0.1:9005",
           proxy_listen = "0.0.0.0:9002",
         }))
-
-        helpers.wait_for_file_contents("servroot/pids/nginx.pid")
-        helpers.wait_for_file_contents("servroot2/pids/nginx.pid")
       end)
 
       lazy_teardown(function()
-        helpers.kill_all()
+        helpers.stop_kong("servroot")
+        helpers.stop_kong("servroot2")
       end)
 
       it("quits gracefully", function()


### PR DESCRIPTION
This PR fixes the following flaky test:
```
        __________
        FAILED  spec/02-integration/02-cmd/12-hybrid_spec.lua:141: kong hybrid with #cassandra backend quits gracefully
spec/02-integration/02-cmd/12-hybrid_spec.lua:150: Expected objects to be equal.
Passed in:
(string) 'cat: /home/runner/work/kong/kong/servroot2/pids/nginx.pid: No such file or directory
'
Expected:
(string) ''

stack traceback:
	spec/02-integration/02-cmd/12-hybrid_spec.lua:150: in function <spec/02-integration/02-cmd/12-hybrid_spec.lua:141>
```

If the inner command substitution failed with a "file not found", the
error would be reported, even though the outer command has a
redirection. This happens because the substitution is evaluated first,
and the outer redirection does not apply to it. This fixes a flakiness
in the hybrid mode tests for `kong quit`. This commit also does some
minor cleanups in said tests.
