### PR TITLE
fix(gha): Set Package Architecture when Uploading to Pulp (#10339)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,8 +469,19 @@ jobs:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
 
+    - name: Set package architecture
+      id: pkg-arch
+      run: |
+        arch='amd64'
+        if [[ '${{ matrix.label }}' == *'arm64' ]]; then
+          arch='arm64'
+        fi
+        echo "arch=$arch"
+        echo "arch=$arch" >> $GITHUB_OUTPUT
+
     - name: Upload Packages to PULP
       env:
+        ARCHITECTURE: ${{ steps.pkg-arch.outputs.arch }}
         OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
         PULP_HOST: https://api.download.konghq.com
         PULP_USERNAME: admin


### PR DESCRIPTION
* fix(gha): set package arch for upload

* Update .github/workflows/release.yml

Co-authored-by: Tyler Ball <2481463+tyler-ball@users.noreply.github.com>

---------

Co-authored-by: Tyler Ball <2481463+tyler-ball@users.noreply.github.com>
(cherry picked from commit 35c4b7a22d266262e4165fa9869a73c21202c677)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Manual backport of https://github.com/Kong/kong/pull/10339

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
