### PR TITLE
fix(build): build wasmx support on macos

### DIFF
--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -74,7 +74,7 @@ def _load_vars(ctx):
         content += '"WASMER_ARCH": "amd64",'
         content += '"WASMTIME_ARCH": "x86_64",'
     elif ctx.os.arch == "aarch64":
-        content += '"V8_ARCH": "FIXME",' # no releases available atm
+        content += '"V8_ARCH": "FIXME",'  # no releases available atm
         content += '"WASMER_ARCH": "aarch64",'
         content += '"WASMTIME_ARCH": "aarch64",'
 

--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -59,6 +59,25 @@ def _load_vars(ctx):
 
     content += '"OPENRESTY_PATCHES": [%s],' % (", ".join(patches))
 
+    # wasm runtime options
+    if ctx.os.name == "mac os x":
+        content += '"V8_OS": "darwin",'
+        content += '"WASMER_OS": "darwin",'
+        content += '"WASMTIME_OS": "macos",'
+    elif ctx.os.name == "linux":
+        content += '"V8_OS": "linux",'
+        content += '"WASMER_OS": "linux",'
+        content += '"WASMTIME_OS": "linux",'
+
+    if ctx.os.arch == "amd64" or ctx.os.arch == "x86_64":
+        content += '"V8_ARCH": "x86_64",'
+        content += '"WASMER_ARCH": "amd64",'
+        content += '"WASMTIME_ARCH": "x86_64",'
+    elif ctx.os.arch == "aarch64":
+        content += '"V8_ARCH": "FIXME",' # no releases available atm
+        content += '"WASMER_ARCH": "aarch64",'
+        content += '"WASMTIME_ARCH": "aarch64",'
+
     ctx.file("BUILD.bazel", "")
     ctx.file("variables.bzl", "KONG_VAR = {\n" + content + "\n}")
 

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -10,6 +10,12 @@ def wasmx_repositories():
     wasmtime_version = KONG_VAR["WASMTIME_VERSION"]
     wasmer_version = KONG_VAR["WASMER_VERSION"]
     v8_version = KONG_VAR["V8_VERSION"]
+    wasmtime_os = KONG_VAR["WASMTIME_OS"]
+    wasmer_os = KONG_VAR["WASMER_OS"]
+    v8_os = KONG_VAR["V8_OS"]
+    wasmtime_arch = KONG_VAR["WASMTIME_ARCH"]
+    wasmer_arch = KONG_VAR["WASMER_ARCH"]
+    v8_arch = KONG_VAR["V8_ARCH"]
 
     maybe(
         new_git_repository,
@@ -41,9 +47,10 @@ filegroup(
         http_archive,
         name = "v8",
         urls = [
-            "https://github.com/Kong/ngx_wasm_runtimes/releases/download/latest/ngx_wasm_runtime-v8-" + v8_version + "-linux-x86_64.tar.gz",
+            "https://github.com/Kong/ngx_wasm_runtimes/releases/download/latest/ngx_wasm_runtime-v8-" +
+            v8_version + "-" + v8_os + "-" + v8_arch + ".tar.gz",
         ],
-        strip_prefix = "v8-" + v8_version + "-linux-x86_64",
+        strip_prefix = "v8-" + v8_version + "-" + v8_os + "-" + v8_arch,
         build_file_content = """
 filegroup(
     name = "all_srcs",
@@ -57,7 +64,8 @@ filegroup(
         http_archive,
         name = "wasmer",
         urls = [
-            "https://github.com/wasmerio/wasmer/releases/download/v" + wasmer_version + "/wasmer-linux-amd64.tar.gz",
+            "https://github.com/wasmerio/wasmer/releases/download/v" +
+            wasmer_version + "/wasmer-" + wasmer_os + "-" + wasmer_arch + ".tar.gz",
         ],
         build_file_content = """
 filegroup(
@@ -72,9 +80,10 @@ filegroup(
         http_archive,
         name = "wasmtime",
         urls = [
-            "https://github.com/bytecodealliance/wasmtime/releases/download/v" + wasmtime_version + "/wasmtime-v" + wasmtime_version + "-x86_64-linux-c-api.tar.xz",
+            "https://github.com/bytecodealliance/wasmtime/releases/download/v" +
+            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" +  wasmtime_os + "-c-api.tar.xz",
         ],
-        strip_prefix = "wasmtime-v" + wasmtime_version + "-x86_64-linux-c-api",
+        strip_prefix = "wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" + wasmtime_os + "-c-api",
         build_file_content = """
 filegroup(
     name = "all_srcs",

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -57,7 +57,7 @@ filegroup(
     srcs = glob(["include/**", "lib/**"]),
     visibility = ["//visibility:public"]
 )
-"""
+""",
     )
 
     maybe(
@@ -81,7 +81,7 @@ filegroup(
         name = "wasmtime",
         urls = [
             "https://github.com/bytecodealliance/wasmtime/releases/download/v" +
-            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" +  wasmtime_os + "-c-api.tar.xz",
+            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" + wasmtime_os + "-c-api.tar.xz",
         ],
         strip_prefix = "wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" + wasmtime_os + "-c-api",
         build_file_content = """

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -19,7 +19,7 @@ events {
 > end
 }
 
-> if #wasm_modules_parsed > 0 then
+> if wasm_modules_parsed and #wasm_modules_parsed > 0 then
 wasm {
   shm_kv kong_wasm_rate_limiting_counters 12m;
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -20,7 +20,7 @@ events {
 > end
 }
 
-> if #wasm_modules_parsed > 0 then
+> if wasm_modules_parsed and #wasm_modules_parsed > 0 then
 wasm {
   shm_kv kong_wasm_rate_limiting_counters 12m;
 


### PR DESCRIPTION
Set the needed vars to build on macos.

Will not work when using V8 and ARM at the same time.