### PR TITLE
Revert "fix(key-auth): return unauthorized if api key includes non-ascii symbols (#10171)"

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -30,7 +30,6 @@ local _realm = 'Key realm="' .. _KONG._NAME .. '"'
 
 local ERR_DUPLICATE_API_KEY   = { status = 401, message = "Duplicate API key found" }
 local ERR_NO_API_KEY          = { status = 401, message = "No API key found in request" }
-local ERR_INVALID_API_KEY     = { status = 401, message = "Invalid symbol(s) found in API key" }
 local ERR_INVALID_AUTH_CRED   = { status = 401, message = "Invalid authentication credentials" }
 local ERR_INVALID_PLUGIN_CONF = { status = 500, message = "Invalid plugin configuration" }
 local ERR_UNEXPECTED          = { status = 500, message = "An unexpected error occurred" }
@@ -169,12 +168,6 @@ local function do_authentication(conf)
   if not key or key == "" then
     kong.response.set_header("WWW-Authenticate", _realm)
     return nil, ERR_NO_API_KEY
-  end
-
-  -- this request contains invalid symbol in API key, HTTP 401
-  if not key:find("^[%w%-%_]+$") then
-    kong.response.set_header("WWW-Authenticate", _realm)
-    return nil, ERR_INVALID_API_KEY
   end
 
   -- retrieve our consumer linked to this API key

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -245,19 +245,6 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.same({ message = "No API key found in request" }, json)
       end)
-      it("returns Unauthorized on invalid symbol in key header", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200",
-          headers = {
-            ["Host"] = "key-auth1.com",
-            ["apikey"] = "5SRmk6gý",
-          }
-        })
-        local body = assert.res_status(401, res)
-        local json = cjson.decode(body)
-        assert.same({ message = "Invalid symbol(s) found in API key" }, json)
-      end)
       it("returns WWW-Authenticate header on missing credentials", function()
         local res = assert(proxy_client:send {
           method  = "GET",


### PR DESCRIPTION
This reverts commit d10101955bc554e9e453d5968392babbdf1bf4f9 (#10171).

The fix is too restrictive on the key syntax due to a misunderstanding on my end.  Before reimplementing, we need a reproduction case that demonstrates the problem, as we may need to fix the issue at another level.

https://konghq.atlassian.net/browse/KAG-721