### PR TITLE
feat(proxy): error templates customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 
 - Make runloop and init error response content types compliant with Accept header value
   [#10366](https://github.com/Kong/kong/pull/10366)
+- Allow configuring custom error templates
+  [#10374](https://github.com/Kong/kong/pull/10374)
 
 ### Fixes
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -234,6 +234,18 @@ G# -----------------------
                                  # `proxy_server` is in HTTPS.
                                  # See the `lua_ssl_trusted_certificate`
                                  # setting to specify a certificate authority.
+
+#error_template_html =           # Path to the custom html error template to
+                                 # override the default html kong error template
+
+#error_template_json =           # Path to the custom json error template to
+                                 # override the default json kong error template
+
+#error_template_xml =            # Path to the custom xml error template to
+                                 # override the default xml kong error template
+
+#error_template_plain =          # Path to the custom plain error template to
+                                 # override the default plain kong error template
 #------------------------------------------------------------------------------
 # HYBRID MODE
 #------------------------------------------------------------------------------

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -577,6 +577,11 @@ local CONF_PARSERS = {
 
   proxy_server = { typ = "string" },
   proxy_server_ssl_verify = { typ = "boolean" },
+
+  error_template_html = { typ = "string" },
+  error_template_json = { typ = "string" },
+  error_template_xml = { typ = "string" },
+  error_template_plain = { typ = "string" },
 }
 
 

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -63,7 +63,7 @@ return function(ctx)
     message = { message = message }
 
   else
-    local mime_type = utils.get_mime_type(accept_header)
+    local mime_type = utils.get_response_type(accept_header)
     message = fmt(utils.get_error_template(mime_type), message)
     headers = { [CONTENT_TYPE] = mime_type }
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -16,6 +16,10 @@ host_ports = NONE
 anonymous_reports = on
 proxy_server = NONE
 proxy_server_ssl_verify = on
+error_template_html = NONE
+error_template_json = NONE
+error_template_xml = NONE
+error_template_plain = NONE
 
 proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384
 stream_listen = off

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -32,6 +32,7 @@ local lower         = string.lower
 local fmt           = string.format
 local find          = string.find
 local gsub          = string.gsub
+local join          = pl_stringx.join
 local split         = pl_stringx.split
 local re_find       = ngx.re.find
 local re_match      = ngx.re.match
@@ -1245,6 +1246,7 @@ end
 
 
 local get_mime_type
+local get_response_type
 local get_error_template
 do
   local CONTENT_TYPE_JSON    = "application/json"
@@ -1324,6 +1326,45 @@ do
     end
   })
 
+
+  get_response_type = function(accept_header)
+    local content_type = MIME_TYPES[CONTENT_TYPE_DEFAULT]
+    if type(accept_header) == "table" then
+      accept_header = join(",", accept_header)
+    end
+
+    if accept_header ~= nil then
+      local pattern = [[
+        ((?:[a-z0-9][a-z0-9-!#$&^_+.]+|\*) \/ (?:[a-z0-9][a-z0-9-!#$&^_+.]+|\*))
+        (?:
+          \s*;\s*
+          q = ( 1(?:\.0{0,3}|) | 0(?:\.\d{0,3}|) )
+          | \s*;\s* [a-z0-9][a-z0-9-!#$&^_+.]+ (?:=[^;]*|)
+        )*
+      ]]
+      local accept_values = split(accept_header, ",")
+      local max_quality = 0
+
+      for _, accept_value in ipairs(accept_values) do
+        accept_value = _M.strip(accept_value)
+        local matches = ngx.re.match(accept_value, pattern, "ajoxi")
+
+        if matches then
+          local media_type = matches[1]
+          local q = tonumber(matches[2]) or 1
+
+          if q > max_quality then
+            max_quality = q
+            content_type = get_mime_type(media_type) or content_type
+          end
+        end
+      end
+    end
+
+    return content_type
+  end
+
+
   get_mime_type = function(content_header, use_default)
     use_default = use_default == nil or use_default
     content_header = _M.strip(content_header)
@@ -1334,7 +1375,7 @@ do
     if #entries > 1 then
       if entries[2] == CONTENT_TYPE_ANY then
         if entries[1] == CONTENT_TYPE_ANY then
-          mime_type = MIME_TYPES["default"]
+          mime_type = MIME_TYPES[CONTENT_TYPE_DEFAULT]
         else
           mime_type = MIME_TYPES[entries[1]]
         end
@@ -1344,7 +1385,7 @@ do
     end
 
     if mime_type or use_default then
-      return mime_type or MIME_TYPES["default"]
+      return mime_type or MIME_TYPES[CONTENT_TYPE_DEFAULT]
     end
 
     return nil, "could not find MIME type"
@@ -1374,6 +1415,7 @@ do
 
 end
 _M.get_mime_type = get_mime_type
+_M.get_response_type = get_response_type
 _M.get_error_template = get_error_template
 
 

--- a/spec/02-integration/05-proxy/12-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_default_type_spec.lua
@@ -307,6 +307,37 @@ for _, strategy in helpers.each_strategy() do
           local xml_message = string.format(custom_template, RESPONSE_MESSAGE)
           assert.equal(xml_message, body)
         end)
+
+        describe("with q-values", function()
+          it("defaults to 1 when q-value is not specified", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/",
+              headers = {
+                accept = "application/json;q=0.9,text/html,text/plain;q=0.9",
+              }
+            })
+
+            local body = assert.res_status(RESPONSE_CODE, res)
+            local custom_template = pl_file.read(html_template_path)
+            local html_message = string.format(custom_template, RESPONSE_MESSAGE)
+            assert.equal(html_message, body)
+          end)
+
+          it("picks highest q-value (json)", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/",
+              headers = {
+                accept = "text/plain;q=0.7,application/json;q=0.8,text/html;q=0.5",
+              }
+            })
+
+            local body = assert.res_status(RESPONSE_CODE, res)
+            local json = cjson.decode(body)
+            assert.equal(RESPONSE_MESSAGE, json.custom_template_message)
+          end)
+        end)
       end)
     end)
   end)

--- a/spec/02-integration/05-proxy/12-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_default_type_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson   = require "cjson"
+local pl_file = require "pl.file"
 
 
 local XML_TEMPLATE = [[
@@ -192,6 +193,118 @@ for _, strategy in helpers.each_strategy() do
 
           local body = assert.res_status(RESPONSE_CODE, res)
           local xml_message = string.format(XML_TEMPLATE, RESPONSE_MESSAGE)
+          assert.equal(xml_message, body)
+        end)
+      end)
+    end)
+
+    describe("Custom error templates", function()
+      local html_template_path  = "spec/fixtures/error_templates/error_template.html"
+      local plain_template_path = "spec/fixtures/error_templates/error_template.plain"
+      local json_template_path  = "spec/fixtures/error_templates/error_template.json"
+      local xml_template_path   = "spec/fixtures/error_templates/error_template.xml"
+
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+        })
+
+        local service = bp.services:insert {
+          name            = "api-1",
+          protocol        = "http",
+          host            = helpers.blackhole_host,
+          port            = 81,
+          connect_timeout = 1,
+        }
+
+        bp.routes:insert {
+          methods = { "GET", "HEAD" },
+          service = service,
+        }
+
+        assert(helpers.start_kong {
+          database             = strategy,
+          prefix               = helpers.test_conf.prefix,
+          nginx_conf           = "spec/fixtures/custom_nginx.template",
+          error_template_html  = html_template_path,
+          error_template_plain = plain_template_path,
+          error_template_json  = json_template_path,
+          error_template_xml   = xml_template_path,
+        })
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      before_each(function()
+        proxy_client = helpers.proxy_client()
+      end)
+
+      after_each(function()
+        if proxy_client then
+          proxy_client:close()
+        end
+      end)
+
+      describe("Accept header modified Content-Type", function()
+        it("text/html", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              accept = "text/html",
+            }
+          })
+
+          local body = assert.res_status(RESPONSE_CODE, res)
+          local custom_template = pl_file.read(html_template_path)
+          local html_message = string.format(custom_template, RESPONSE_MESSAGE)
+          assert.equal(html_message, body)
+        end)
+
+        it("text/plain", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              accept = "text/plain",
+            }
+          })
+
+          local body = assert.res_status(RESPONSE_CODE, res)
+          local custom_template = pl_file.read(plain_template_path)
+          local html_message = string.format(custom_template, RESPONSE_MESSAGE)
+          assert.equal(html_message, body)
+        end)
+
+        it("application/json", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              accept = "application/json",
+            }
+          })
+
+          local body = assert.res_status(RESPONSE_CODE, res)
+          local json = cjson.decode(body)
+          assert.equal(RESPONSE_MESSAGE, json.custom_template_message)
+        end)
+
+        it("application/xml", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              accept = "application/xml",
+            }
+          })
+
+          local body = assert.res_status(RESPONSE_CODE, res)
+          local custom_template = pl_file.read(xml_template_path)
+          local xml_message = string.format(custom_template, RESPONSE_MESSAGE)
           assert.equal(xml_message, body)
         end)
       end)

--- a/spec/fixtures/error_templates/error_template.html
+++ b/spec/fixtures/error_templates/error_template.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Custom template</title>
+  </head>
+  <body>
+    <h1>Not the default</h1>
+    <p>%s.</p>
+  </body>
+</html>

--- a/spec/fixtures/error_templates/error_template.json
+++ b/spec/fixtures/error_templates/error_template.json
@@ -1,0 +1,3 @@
+{
+  "custom_template_message":"%s"
+}

--- a/spec/fixtures/error_templates/error_template.plain
+++ b/spec/fixtures/error_templates/error_template.plain
@@ -1,0 +1,1 @@
+custom plain template: %s\n

--- a/spec/fixtures/error_templates/error_template.xml
+++ b/spec/fixtures/error_templates/error_template.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <message>custom template</message>
+  <message>%s</message>
+</error>

--- a/t/01-pdk/08-response/13-error.t
+++ b/t/01-pdk/08-response/13-error.t
@@ -444,3 +444,43 @@ grpc-status: 8
 grpc-message: ResourceExhausted
 --- no_error_log
 [error]
+
+
+=== TEST 15: service.response.error() honors values of multiple Accept headers
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+            return pdk.response.error(502)
+        }
+    }
+
+--- request
+GET /t
+--- more_headers
+Accept: text/plain;q=0.2, text/*;q=0.1
+Accept: text/css;q=0.7, text/html;q=0.9, */*;q=0.5
+Accept: application/xml;q=0.2, application/json;q=0.3
+--- error_code: 502
+--- response_headers_like
+Content-Type: text/html; charset=utf-8
+--- response_body
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Kong Error</title>
+  </head>
+  <body>
+    <h1>Kong Error</h1>
+    <p>An invalid response was received from the upstream server.</p>
+  </body>
+</html>
+--- no_error_log
+[error]

--- a/t/01-pdk/08-response/13-error.t
+++ b/t/01-pdk/08-response/13-error.t
@@ -16,6 +16,10 @@ __DATA__
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(502)
@@ -43,6 +47,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(400)
@@ -68,6 +76,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(400)
@@ -95,6 +107,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             local headers = {
@@ -127,6 +143,10 @@ Content-Type: application/xml
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(502)
@@ -164,6 +184,10 @@ Content-Type: text/html; charset=utf-8
     location = /error_handler {
         internal;
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.exit(200, "nothing happened")
@@ -172,6 +196,10 @@ Content-Type: text/html; charset=utf-8
 
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(500)
@@ -197,6 +225,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(419, "I'm not a teapot")
@@ -224,6 +256,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(500, "oh no")
@@ -251,6 +287,10 @@ Content-Type: application/json; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(502, { ["a field"] = "not a default message" })
@@ -279,6 +319,10 @@ Content-Type: application/xml; charset=utf-8
 --- config
     location = /t {
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             return pdk.response.error(410)


### PR DESCRIPTION
### Summary

Allow customizing error templates via kong.configuration parameters

### Checklist

- [X] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7093

[KAG-723](https://konghq.atlassian.net/browse/KAG-723)
[KAG-751]


[KAG-751]: https://konghq.atlassian.net/browse/KAG-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KAG-723]: https://konghq.atlassian.net/browse/KAG-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ