### PR TITLE
fix(build): add rpm signing related env var into repository rule environ list (#4647)

### DIFF
--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -74,5 +74,7 @@ load_bindings = repository_rule(
     environ = [
         "BUILD_NAME",
         "INSTALL_DESTDIR",
+        "RPM_SIGNING_KEY_FILE",
+        "NFPM_RPM_PASSPHRASE",
     ],
 )


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Cherry-picking EE fix for adding rpm signing related env var into repository rule environ list

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-744
