### PR TITLE
feat(otel): add http_response_header_for_traceid config to add trace_id for downstream header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
   The plugin will set the corresponding header in the response
   if the field is specified with a string value.
   [#10379](https://github.com/Kong/kong/pull/10379)
+
 ### Dependencies
 
 - Bumped lua-resty-session from 4.0.2 to 4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,10 @@
 
 - **Request-Termination**: If the echo option was used, it would not return the uri-captures.
   [#10390](https://github.com/Kong/kong/pull/10390)
-
+- **OpenTelemetry**: add `http_response_header_for_traceid` field in OpenTelemetry plugin.
+  The plugin will set the corresponding header in the response
+  if the field is specified with a string value.
+  [#10379](https://github.com/Kong/kong/pull/10379)
 ### Dependencies
 
 - Bumped lua-resty-session from 4.0.2 to 4.0.3

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -62,7 +62,7 @@ return {
     },
     proxy_cache = {
       "ignore_uri_case",
-    }
+    },
     opentelemetry = {
       "http_response_header_for_traceid",
     },

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -63,5 +63,8 @@ return {
     proxy_cache = {
       "ignore_uri_case",
     }
+    opentelemetry = {
+      "http_response_header_for_traceid",
+    },
   },
 }

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -21,7 +21,6 @@ local null = ngx.null
 local encode_traces = otlp.encode_traces
 local translate_span_trace_id = otlp.translate_span
 local encode_span = otlp.transform_span
-local ctx = ngx.ctx
 
 local _log_prefix = "[otel] "
 
@@ -153,7 +152,7 @@ end
 
 function OpenTelemetryHandler:header_filter(conf)
   if conf.http_response_header_for_traceid then
-    local trace_id = ctx.plugin.trace_id
+    local trace_id = kong.ctx.plugin.trace_id
     if not trace_id then
       local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
       trace_id = root_span and root_span.trace_id

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -21,6 +21,7 @@ local null = ngx.null
 local encode_traces = otlp.encode_traces
 local translate_span_trace_id = otlp.translate_span
 local encode_span = otlp.transform_span
+local ctx = ngx.ctx
 
 local _log_prefix = "[otel] "
 

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -150,6 +150,17 @@ function OpenTelemetryHandler:access()
   propagation_set("preserve", header_type, translate_span_trace_id(root_span), "w3c")
 end
 
+function OpenTelemetryHandler:header_filter(conf)
+  if conf.http_response_header_for_traceid then
+    local trace_id = ctx.plugin.trace_id
+    if not trace_id then
+      local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
+      trace_id = root_span and root_span.trace_id
+    end
+    kong.response.add_header(conf.http_response_header_for_traceid, trace_id)
+  end
+end
+
 function OpenTelemetryHandler:log(conf)
   ngx_log(ngx_DEBUG, _log_prefix, "total spans in current request: ", ngx.ctx.KONG_SPANS and #ngx.ctx.KONG_SPANS)
 

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -49,6 +49,7 @@ return {
         { connect_timeout = typedefs.timeout { default = 1000 } },
         { send_timeout = typedefs.timeout { default = 5000 } },
         { read_timeout = typedefs.timeout { default = 5000 } },
+        { http_response_header_for_traceid = { type = "string", default = nil }},
       },
     }, },
   },

--- a/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
@@ -36,7 +36,7 @@ for _, strategy in helpers.each_strategy() do
                          protocols = { "http" },
                          paths = { "/" }})
 
-      route_traceid = bp.routes:insert({ service = http_srv,
+      local route_traceid = bp.routes:insert({ service = http_srv,
                          protocols = { "http" },
                          paths = { "/enable_response_header_traceid" }})
 
@@ -89,6 +89,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(err)
           assert.same(200, res.status)
         end
+        httpc:close()
       end)
 
       it("send traces with config http_response_header_for_traceid enable", function()
@@ -99,6 +100,7 @@ for _, strategy in helpers.each_strategy() do
           assert.same(200, res.status)
           assert.not_nil(res.headers["x-trace-id"])
         end
+        httpc:close()
       end)
 
       it("valid traces", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

add http_response_header_for_traceid config to add trace_id to the downstream header.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-4655
