### PR TITLE
fix(balancer) use local target cache

### DIFF
--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -102,6 +102,7 @@ local function create_balancer_exclusive(upstream)
   local health_threshold = upstream.healthchecks and
     upstream.healthchecks.threshold or nil
 
+  targets.clean_targets_cache(upstream)
   local targets_list, err = targets.fetch_targets(upstream)
   if not targets_list then
     return nil, "failed fetching targets:" .. err

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -38,6 +38,8 @@ local GLOBAL_QUERY_OPTS = { workspace = null, show_ws_id = true }
 local renewal_heap = require("binaryheap").minUnique()
 local renewal_weak_cache = setmetatable({}, { __mode = "v" })
 
+local targets_by_upstream_id = {}
+
 local targets_M = {}
 
 -- forward local declarations
@@ -126,9 +128,17 @@ end
 function targets_M.fetch_targets(upstream)
   local targets_cache_key = "balancer:targets:" .. upstream.id
 
-  return kong.core_cache:get(
-      targets_cache_key, nil,
-      load_targets_into_memory, upstream.id)
+  if targets_by_upstream_id[targets_cache_key] == nil then
+    targets_by_upstream_id[targets_cache_key] = load_targets_into_memory(upstream.id)
+  end
+
+  return targets_by_upstream_id[targets_cache_key]
+end
+
+
+function targets_M.clean_targets_cache(upstream)
+  local targets_cache_key = "balancer:targets:" .. upstream.id
+  targets_by_upstream_id[targets_cache_key] = nil
 end
 
 
@@ -157,7 +167,14 @@ function targets_M.on_target_event(operation, target)
   log(DEBUG, "target ", operation, " for upstream ", upstream_id,
     upstream_name and " (" .. upstream_name ..")" or "")
 
-  kong.core_cache:invalidate_local("balancer:targets:" .. upstream_id)
+  targets_by_upstream_id["balancer:targets:" .. upstream_id] = nil
+
+  local upstream = upstreams.get_upstream_by_id(upstream_id)
+  if not upstream then
+    log(ERR, "target ", operation, ": upstream not found for ", upstream_id,
+      upstream_name and " (" .. upstream_name ..")" or "")
+    return
+  end
 
   -- cancel DNS renewal
   if operation ~= "create" then

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -187,13 +187,6 @@ function targets_M.on_target_event(operation, target)
     end
   end
 
-  local upstream = upstreams.get_upstream_by_id(upstream_id)
-  if not upstream then
-    log(ERR, "target ", operation, ": upstream not found for ", upstream_id,
-      upstream_name and " (" .. upstream_name ..")" or "")
-    return
-  end
-
 -- move this to upstreams?
   local balancer = balancers.get_balancer_by_id(upstream_id)
   if not balancer then

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -191,11 +191,6 @@ local function do_upstream_event(operation, upstream_data)
     end
 
   elseif operation == "delete" or operation == "update" then
-    local target_cache_key = "balancer:targets:" .. upstream_id
-    if kong.db.strategy ~= "off" then
-      kong.core_cache:invalidate_local(target_cache_key)
-    end
-
     local balancer = balancers.get_balancer_by_id(upstream_id)
     if balancer then
       healthcheckers.stop_healthchecker(balancer, CLEAR_HEALTH_STATUS_DELAY)


### PR DESCRIPTION
### Summary

The target's global cache was caching more data than it should: it kept data retrieved from the database and DNS name resolution, which has its own cache.

As a result, when config reloads were done, some processes were skipped (such as setting the upstream as healthy) because the load-balancer never identified the data as new if it was the same as cached (highly probable with DNS name resolution).

This change makes the target cache local to the worker. 

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Make the target cache local to the worker.
* This PR has no tests. This is a race condition, almost impossible to automate. 

### Issue reference

FTI-3172
Fix #8517
Fix #10020
