### PR TITLE
feat(conf) implement 'node_id' for configurable node ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
 - Add Postgres triggers on the core entites and entities in bundled plugins to delete the
   expired rows in an efficient and timely manner.
   [#10389](https://github.com/Kong/kong/pull/10389)
+- Support for configurable Node IDs
+  [#10385](https://github.com/Kong/kong/pull/10385)
 
 #### Admin API
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1899,3 +1899,8 @@
                                   # Setting this attribute disables the search
                                   # behavior and explicitly instructs Kong which
                                   # OpenResty installation to use.
+
+#node_id =                        # Node ID for the Kong node. Every Kong node
+                                  # in a Kong cluster must have a unique and
+                                  # valid UUID. When empty, node ID is
+                                  # automatically generated.

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1275,6 +1275,10 @@ local function check_and_parse(conf, opts)
     errors[#errors + 1] = "lua_max_post_args must be an integer between 1 and 1000"
   end
 
+  if conf.node_id and not utils.is_valid_uuid(conf.node_id) then
+    errors[#errors + 1] = "node_id must be a valid UUID"
+  end
+
   return #errors == 0, errors[1], errors
 end
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -20,6 +20,7 @@ error_template_html = NONE
 error_template_json = NONE
 error_template_xml = NONE
 error_template_plain = NONE
+node_id = NONE
 
 proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384
 stream_listen = off

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -667,6 +667,20 @@ describe("Configuration loader", function()
       assert.is_nil(err)
       assert.is_table(conf)
     end)
+    it("errors when node_id is not a valid uuid", function()
+      local conf, err = conf_loader(nil, {
+        node_id = "foobar",
+      })
+      assert.equal("node_id must be a valid UUID", err)
+      assert.is_nil(conf)
+    end)
+    it("accepts a valid UUID as node_id", function()
+      local conf, err = conf_loader(nil, {
+        node_id = "8b7de2ba-0477-4667-a811-8bca46073ca9",
+      })
+      assert.is_nil(err)
+      assert.equal("8b7de2ba-0477-4667-a811-8bca46073ca9", conf.node_id)
+    end)
     it("errors when the hosts file does not exist", function()
       local tmpfile = "/a_file_that_does_not_exist"
       local conf, err = conf_loader(nil, {


### PR DESCRIPTION
### Summary

Kong automatically generates node IDs for each node in a cluster. Node IDs are the only unique identifiers that exist to track a Kong node within a cluster (no assumption is made that hostname is unique across all Kong nodes).

When integrating closely with an orchestrator, a configurable node ID helps the operator to source the ID from the underlying orchestrator like Kubernetes instead of letting Kong generate one.

For most customers, letting Kong generate a Node ID will be sufficient.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR - Not applicable

### Full changelog

* introduce `node_id` configuration parameter