### PR TITLE
fix(request-terminator): add the missing captures in the echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@
 - Fix an issue where validation to regex routes may be skipped when the old-fashioned config is used for DB-less Kong.
   [#10348](https://github.com/Kong/kong/pull/10348)
 
+#### PDK
+
+- `request.get_uri_captures` now returns the unnamed part tagged as an array (for jsonification).
+  [#10390](https://github.com/Kong/kong/pull/10390)
+
+#### Plugins
+
+- **Request-Termination**: If the echo option was used, it would not return the uri-captures.
+  [#10390](https://github.com/Kong/kong/pull/10390)
+
 ## 3.2.0
 
 ### Breaking Changes

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -850,17 +850,17 @@ local function new(self)
       local typ = type(k)
       if typ == "number" then
         unnamed_captures[k] = v
-  
+
       elseif typ == "string" then
         named_captures[k] = v
-  
+
       else
         kong.log.err("unknown capture key type: ", typ)
       end
     end
-  
+
     return {
-      unnamed = unnamed_captures,
+      unnamed = setmetatable(unnamed_captures, cjson.array_mt),
       named = named_captures,
     }
   end

--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -52,6 +52,7 @@ function RequestTerminationHandler:access(conf)
         raw_body = kong.request.get_raw_body(),
         method = kong.request.get_method(),
         path = kong.request.get_path(),
+        uri_captures = kong.request.get_uri_captures(),
       },
       matched_route = kong.router.get_route(),
       matched_service = kong.router.get_service(),

--- a/spec/03-plugins/14-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/14-request-termination/02-access_spec.lua
@@ -343,6 +343,10 @@ for _, strategy in helpers.each_strategy() do
           },
           raw_body = 'cool body',
           scheme = 'http',
+          uri_captures = {
+            named = {},
+            unnamed = {}
+          },
         }, json.request)
       end)
       it("doesn't echo a request if the trigger is set but not specified", function()
@@ -387,6 +391,10 @@ for _, strategy in helpers.each_strategy() do
           },
           raw_body = 'cool body',
           scheme = 'http',
+          uri_captures = {
+            named = {},
+            unnamed = {}
+          },
         }, json.request)
       end)
       it("echos a request if the trigger is specified as a query parameter", function()

--- a/spec/03-plugins/14-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/14-request-termination/02-access_spec.lua
@@ -52,6 +52,8 @@ for _, strategy in helpers.each_strategy() do
 
       local route9 = bp.routes:insert({
         hosts = { "api9.request-termination.com" },
+        strip_path = false,
+        paths = { "~/(?<parameter>[^#?/]+)/200" }
       })
 
       local route10 = bp.routes:insert({
@@ -344,8 +346,8 @@ for _, strategy in helpers.each_strategy() do
           raw_body = 'cool body',
           scheme = 'http',
           uri_captures = {
-            named = {},
-            unnamed = {}
+            named = { parameter = "status" },
+            unnamed = { "status" }
           },
         }, json.request)
       end)
@@ -429,6 +431,10 @@ for _, strategy in helpers.each_strategy() do
           },
           raw_body = 'cool body',
           scheme = 'http',
+          uri_captures = {
+            named = {},
+            unnamed = {}
+          },
         }, json.request)
       end)
     end)

--- a/t/01-pdk/04-request/21-get_uri_captures.t
+++ b/t/01-pdk/04-request/21-get_uri_captures.t
@@ -17,7 +17,7 @@ __DATA__
     access_by_lua_block {
       local PDK = require "kong.pdk"
       local pdk = PDK.new()
-      
+
       local m = ngx.re.match(ngx.var.uri, [[^\/t((\/\d+)(?P<tag>\/\w+))?]], "jo")
 
       ngx.ctx.router_matches = {
@@ -28,6 +28,9 @@ __DATA__
       ngx.say("uri_captures: ", "tag: ", captures.named["tag"],
               ", 0: ", captures.unnamed[0], ", 1: ", captures.unnamed[1],
               ", 2: ", captures.unnamed[2], ", 3: ", captures.unnamed[3])
+
+      array_mt = assert(require("cjson").array_mt, "expected array_mt to be truthy")
+      assert(getmetatable(captures.unnamed) == array_mt, "expected the 'unnamed' captures to be an array")
     }
   }
 --- request


### PR DESCRIPTION
### Summary

request terminator 'echo' option would not return the uri-captures. And when  it did, the array part was not returned as an array.

