### PR TITLE
chore(ci) notify slack on PRs performing schema changes

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -11,3 +11,11 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
+  schema-change-labels:
+    if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Schema change label found
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}


### PR DESCRIPTION
### Summary


With this patch, CI will notify a Kong Inc internal slack channel on every PR that performs a schema change.

### Checklist

- [x] The Pull Request has tests - Not applicable
- [x] There's an entry in the CHANGELOG - Not applicable
- [x] There is a user-facing docs PR - Not applicable
