### PR TITLE
chore(ci) track enterprise schema changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -174,6 +174,8 @@ schema-change-noteworthy:
 - kong/db/schema/entities/**/*
 - kong/**/schema.lua
 - kong/plugins/**/daos.lua
+- plugins-ee/**/daos.lua
+- plugins-ee/**/schema.lua
 
 build/bazel:
 - '**/*.bazel'


### PR DESCRIPTION
### Summary

This patch updates the labeler configuration to track schema changes for Enterprise code as part of the public open-source code.


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests - Not applicable
- [x] There's an entry in the CHANGELOG - Not applicable
- [x] There is a user-facing docs PR  - Not applicable
