### PR TITLE
fix(plugin/datadog): Make datadog fields referenceable. 

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -73,7 +73,7 @@ return {
     { config = {
         type = "record",
         fields = {
-          { host = typedefs.host({ default = "localhost" }), },
+          { host = typedefs.host({ default = "localhost", referenceable = true }), },
           { port = typedefs.port({ default = 8125 }), },
           { prefix = { type = "string", default = "kong" }, },
           { service_name_tag = { type = "string", default = "name" }, },


### PR DESCRIPTION
### Summary

This PR addresses an issue reported in https://github.com/Kong/kong/issues/7954 and it's makes the fields referencable with environment variables using Kong Vault feature.

Bug:  setting to null doesn't work in Kubernetes.



### Issue reference
https://github.com/Kong/kong/issues/7954 
FTI-4910