### PR TITLE
fix(runloop): ssl request with invalid sni should not be logged as error

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -153,12 +153,12 @@ local function validate_sni(host)
     return nil, "invalid value: " .. host
   end
 
-  if res.type ~= "name" then
-    return nil, "must not be an IP"
-  end
-
   if err_or_port == "invalid port number" or type(res.port) == "number" then
     return nil, "must not have a port"
+  end
+
+  if res.type ~= "name" then
+    return nil, "must not be an IP"
   end
 
   return true
@@ -186,12 +186,12 @@ local function validate_wildcard_host(host)
     return nil, "invalid value: " .. host
   end
 
-  if res.type ~= "name" then
-    return nil, "must not be an IP"
-  end
-
   if err_or_port == "invalid port number" or type(res.port) == "number" then
     return nil, "must not have a port"
+  end
+
+  if res.type ~= "name" then
+    return nil, "must not be an IP"
   end
 
   return true

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -153,12 +153,12 @@ local function validate_sni(host)
     return nil, "invalid value: " .. host
   end
 
-  if err_or_port == "invalid port number" or type(res.port) == "number" then
-    return nil, "must not have a port"
+  if res and res.type ~= "name" then
+    return nil, "must not be an IP"
   end
 
-  if res.type ~= "name" then
-    return nil, "must not be an IP"
+  if err_or_port == "invalid port number" or type(res.port) == "number" then
+    return nil, "must not have a port"
   end
 
   return true
@@ -186,12 +186,12 @@ local function validate_wildcard_host(host)
     return nil, "invalid value: " .. host
   end
 
-  if err_or_port == "invalid port number" or type(res.port) == "number" then
-    return nil, "must not have a port"
+  if res and res.type ~= "name" then
+    return nil, "must not be an IP"
   end
 
-  if res.type ~= "name" then
-    return nil, "must not be an IP"
+  if err_or_port == "invalid port number" or type(res.port) == "number" then
+    return nil, "must not have a port"
   end
 
   return true

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -4,6 +4,7 @@ local mlcache = require "resty.mlcache"
 local new_tab = require "table.new"
 local openssl_x509_store = require "resty.openssl.x509.store"
 local openssl_x509 = require "resty.openssl.x509"
+local typedefs = require "kong.db.schema.typedefs"
 
 
 local ngx_log     = ngx.log
@@ -214,6 +215,13 @@ end
 local function find_certificate(sni)
   if not sni then
     log(DEBUG, "no SNI provided by client, serving default SSL certificate")
+    return default_cert_and_key
+  end
+
+  local res, err = typedefs.wildcard_host.custom_validator(sni)
+  if not res then
+    log(DEBUG, "invalid SNI '" .. sni .. "', " .. err ..
+               ", serving default SSL certificate")
     return default_cert_and_key
   end
 

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -238,7 +238,10 @@ local function find_certificate(sni)
     return nil, err
   end
 
-  for _, sni_new, err in mlcache.each_bulk_res(res) do
+  for _, new_sni, err in mlcache.each_bulk_res(res) do
+    if new_sni then
+      return get_certificate(new_sni.certificate, new_sni.name)
+    end
     if err then
       -- we choose to not call typedefs.wildcard_host.custom_validator(sni)
       -- in the front to reduce the cost in normal flow.
@@ -265,9 +268,6 @@ local function find_certificate(sni)
       else
         log(ERR, "failed to fetch SNI: ", err)
       end
-
-    elseif sni_new then
-      return get_certificate(sni_new.certificate, sni_new.name)
     end
   end
 

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -243,14 +243,23 @@ local function find_certificate(sni)
       -- we choose to not call typedefs.wildcard_host.custom_validator(sni)
       -- in the front to reduce the cost in normal flow.
       -- these error messages are from validate_wildcard_host()
-      local idx = err:find("must not have a port", nil, true) or
-                  err:find("must not be an IP", nil, true) or
-                  err:find("invalid value: ", nil, true) or
-                  err:find("only one wildcard must be specified", nil, true) or
-                  err:find("wildcard must be leftmost or rightmost character",
-                           nil, true)
-      if idx then
+      local patterns = {
+        "must not be an IP",
+        "must not have a port",
+        "invalid value: ",
+        "only one wildcard must be specified",
+        "wildcard must be leftmost or rightmost character",
+      }
+      local idx
 
+      for i, pat in ipairs(patterns) do
+        idx = err:find(pat, nil, true)
+        if idx then
+          break
+        end
+      end
+
+      if idx then
         kong.log.debug("invalid SNI '", sni, "', ", err:sub(idx),
                        ", serving default SSL certificate")
       else

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -252,7 +252,7 @@ local function find_certificate(sni)
       }
       local idx
 
-      for i, pat in ipairs(patterns) do
+      for _, pat in ipairs(patterns) do
         idx = err:find(pat, nil, true)
         if idx then
           break

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -243,11 +243,12 @@ local function find_certificate(sni)
       -- we choose to not call typedefs.wildcard_host.custom_validator(sni)
       -- in the front to reduce the cost in normal flow.
       -- these error messages are from validate_wildcard_host()
-      local idx = err:find("must not have a port") or
-                  err:find("must not be an IP") or
-                  err:find("invalid value: ") or
-                  err:find("only one wildcard must be specified") or
-                  err:find("wildcard must be leftmost or rightmost character")
+      local idx = err:find("must not have a port", nil, true) or
+                  err:find("must not be an IP", nil, true) or
+                  err:find("invalid value: ", nil, true) or
+                  err:find("only one wildcard must be specified", nil, true) or
+                  err:find("wildcard must be leftmost or rightmost character",
+                           nil, true)
       if idx then
 
         kong.log.debug("invalid SNI '", sni, "', ", err:sub(idx),

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -196,55 +196,6 @@ describe("Admin API: #" .. strategy, function()
         end
       end)
 
-      it("returns a conflict when a pre-existing sni on a different workspace is detected", function()
-        local n1 = get_name()
-        local n2 = get_name()
-        local res = client:post("/certificates", {
-          body    = {
-            cert  = ssl_fixtures.cert,
-            key   = ssl_fixtures.key,
-            snis  = { n1, n2 },
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        assert.res_status(201, res)
-
-        local res = client:post("/workspaces", {
-          body    = {
-            name  = "one",
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        assert.res_status(201, res)
-
-        local res = client:post("/one/certificates", {
-          body    = {
-            cert  = ssl_fixtures.cert,
-            key   = ssl_fixtures.key,
-            snis  = { n1, n2 },
-          },
-          headers = { ["Content-Type"] = "application/json" },
-        })
-        local body = assert.res_status(400, res)
-        local json = cjson.decode(body)
-        assert.matches("snis: " .. n1 .. " already associated with existing certificate", json.message)
-
-        -- make sure we didn't add the certificate, or any snis
-        local res  = client:get("/one/certificates")
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        for _, data in ipairs(json.data) do
-          assert(false) -- json.data should be empty table
-        end
-
-        local res  = client:get("/one/snis")
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        for _, data in ipairs(json.data) do
-          assert(false) -- json.data should be empty table
-        end
-      end)
-
       it_content_types("creates a certificate and returns it with the snis pseudo-property", function(content_type)
         return function()
           local n1 = get_name()

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -669,8 +669,6 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong {
         database    = strategy,
       })
-
-      ngx.sleep(0.01)
     end)
 
     lazy_teardown(function()


### PR DESCRIPTION
Currently, a ssl request with invalid sni will cause an error log as follows:

`2023/03/01 06:56:42 [error] 9398#0: *466 [lua] certificate.lua:51: log(): [ssl] failed to fetch SNI: failed to fetch '1.1.1.1' SNI: [postgres] must not be an IP, context: ssl_certificate_by_lua*, client: 127.0.0.1, server: 0.0.0.0:8443`

This is confusing. Customers may think it's related to db. As it's just an invalid request, change the log to debug level.

Fix [FTI-1716](https://konghq.atlassian.net/browse/FTI-1716)

[FTI-1716]: https://konghq.atlassian.net/browse/FTI-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ