### PR TITLE
chore(db): only enable posgres cleanup timer on nodes that have admin listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@
 - Bumped lua-resty-session from 4.0.2 to 4.0.3
   [#10338](https://github.com/Kong/kong/pull/10338)
 
+### Changed
+
+#### Core
+
+- Postgres TTL cleanup timer will now only run on traditional and control plane nodes that have enabled the Admin API.
+
 ## 3.2.0
 
 ### Breaking Changes

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -315,8 +315,7 @@ end
 
 
 function _mt:init_worker(strategies)
-  if ngx.worker.id() == 0 then
-
+  if ngx.worker.id() == 0 and #kong.configuration.admin_listeners > 0 then
     local table_names = get_names_of_tables_with_ttl(strategies)
     local ttl_escaped = self:escape_identifier("ttl")
     local expire_at_escaped = self:escape_identifier("expire_at")


### PR DESCRIPTION
### Summary

PR #10389 and #10331 pursued different ways to improve our situation with cleanup timers.

This PR makes it so that it only happens on nodes that have admin listeners. Fairly simple but may already cover the majority of problem space.