### PR TITLE
chore: split schema change job

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,7 @@
 name: Pull Request Label Checker
 on:
   pull_request:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [labeled, unlabeled]
 jobs:
   check-labels:
     name: prevent merge labels
@@ -11,11 +11,3 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
-  schema-change-labels:
-    if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Schema change label found
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -1,0 +1,13 @@
+name: Pull Request Label Checker
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+jobs:
+  schema-change-labels:
+    if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Schema change label found
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}


### PR DESCRIPTION
### Summary

It seems that if the do not merge label job is skipped then the second job doesn't run either:
https://github.com/Kong/kong/actions/runs/4307151445/jobs/7511859202

This change splits the job into two and narrows down the events on which these jobs are triggered since the only meaninful input are the labels on the PR.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->


<!--- Why is this change required? What problem does it solve? --