### PR TITLE
chore(deps): bump lua-protobuf to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
 - Bumped lua-resty-session from 4.0.2 to 4.0.3
   [#10338](https://github.com/Kong/kong/pull/10338)
+- Bumped lua-protobuf from 0.3.3 to 0.4.2
+  [#10137](https://github.com/Kong/kong/pull/10413)
 
 ## 3.2.0
 

--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.3.3",
+  "lua-protobuf == 0.4.2",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.6.2",
   "lua-resty-mlcache == 2.6.0",

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -90,8 +90,8 @@ local function get_proto_info(fname)
   local grpc_tools_instance = grpc_tools.new()
   grpc_tools_instance:each_method(fname, function(parsed, srvc, mthd)
     local options_bindings =  {
-      safe_access(mthd, "options", "options", "google.api.http"),
-      safe_access(mthd, "options", "options", "google.api.http", "additional_bindings")
+      safe_access(mthd, "options", "google.api.http"),
+      safe_access(mthd, "options", "google.api.http", "additional_bindings")
     }
     for _, options in ipairs(options_bindings) do
       for http_method, http_path in pairs(options) do

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -205,7 +205,7 @@ local function load_service()
   for i, s in ipairs(parsed.service) do
     for j, m in ipairs(s.method) do
       local method_name = s.name .. '.' .. m.name
-      local lower_name = m.options and m.options.options and m.options.options.MethodName
+      local lower_name = m.options and m.options.MethodName
           or method_name
                 :gsub('_', '.')
                 :gsub('([a-z]%d*)([A-Z])', '%1_%2')

--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -41,6 +41,7 @@ end
 
 local function set_hooks()
   pb.option("enable_hooks")
+  pb.option("enable_enchooks")
 
   safe_set_type_hook(".google.protobuf.Timestamp", function (t)
     if type(t) ~= "table" then

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -153,9 +153,9 @@ for _, strategy in helpers.each_strategy() do
         -- default resource attributes
         assert.same("service.instance.id", res_attr[1].key)
         assert.same("service.name", res_attr[2].key)
-        assert.same({string_value = "kong"}, res_attr[2].value)
+        assert.same({string_value = "kong", value = "string_value"}, res_attr[2].value)
         assert.same("service.version", res_attr[3].key)
-        assert.same({string_value = kong.version}, res_attr[3].value)
+        assert.same({string_value = kong.version, value = "string_value"}, res_attr[3].value)
 
         local scope_spans = decoded.resource_spans[1].scope_spans
         assert.is_true(#scope_spans > 0, scope_spans)
@@ -272,12 +272,12 @@ for _, strategy in helpers.each_strategy() do
         sort_by_key(res_attr)
         -- resource attributes
         assert.same("os.version", res_attr[1].key)
-        assert.same({string_value = "debian"}, res_attr[1].value)
+        assert.same({string_value = "debian", value = "string_value"}, res_attr[1].value)
         assert.same("service.instance.id", res_attr[2].key)
         assert.same("service.name", res_attr[3].key)
-        assert.same({string_value = "kong_oss"}, res_attr[3].value)
+        assert.same({string_value = "kong_oss", value = "string_value"}, res_attr[3].value)
         assert.same("service.version", res_attr[4].key)
-        assert.same({string_value = kong.version}, res_attr[4].value)
+        assert.same({string_value = kong.version, value = "string_value"}, res_attr[4].value)
 
         local scope_spans = decoded.resource_spans[1].scope_spans
         assert.is_true(#scope_spans > 0, scope_spans)
@@ -441,13 +441,13 @@ for _, strategy in helpers.each_strategy() do
         local attr = span.attributes
         sort_by_key(attr)
         assert.same({
-          { key = "http.flavor", value = { string_value = "1.1" } },
-          { key = "http.host", value = { string_value = "0.0.0.0" } },
-          { key = "http.method", value = { string_value = "GET" } },
-          { key = "http.scheme", value = { string_value = "http" } },
-          { key = "http.status_code", value = { int_value = 200 } },
-          { key = "http.url", value = { string_value = "http://0.0.0.0/" } },
-          { key = "net.peer.ip", value = { string_value = "127.0.0.1" } },
+          { key = "http.flavor", value = { string_value = "1.1", value = "string_value" } },
+          { key = "http.host", value = { string_value = "0.0.0.0", value = "string_value" } },
+          { key = "http.method", value = { string_value = "GET", value = "string_value" } },
+          { key = "http.scheme", value = { string_value = "http", value = "string_value" } },
+          { key = "http.status_code", value = { int_value = 200, value = "int_value" } },
+          { key = "http.url", value = { string_value = "http://0.0.0.0/", value = "string_value" } },
+          { key = "net.peer.ip", value = { string_value = "127.0.0.1", value = "string_value" } },
         }, attr)
       end)
     end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Bump `lua-protobuf` from `0.3.3` to `0.4.2`.



It has been confirmed that the `lua-protobuf` under version 0.4.2 causes the Segmentation fault(core dump) while used with `lpeg`. The issue was found in another PR(https://github.com/Kong/kong/pull/10055).


Here is the proof in the core dump file on GitHub action runner.


<details>
    <summary>Backtrace from the core dump</summary>

```
gdb /home/runner/work/kong/kong/bazel-bin/build/kong-dev/openresty/nginx/sbin/nginx /tmp/cores/core.nginx.30260

GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1                                                                                                                                                                                                                  │····
Copyright (C) 2022 Free Software Foundation, Inc.                                                                                                                                                                                                          │····
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>                                                                                                                                                                              │····
This is free software: you are free to change and redistribute it.                                                                                                                                                                                         │····
There is NO WARRANTY, to the extent permitted by law.                                                                                                                                                                                                      │····
Type "show copying" and "show warranty" for details.                                                                                                                                                                                                       │····
This GDB was configured as "x86_64-linux-gnu".                                                                                                                                                                                                             │····
Type "show configuration" for configuration details.                                                                                                                                                                                                       │····
For bug reporting instructions, please see:                                                                                                                                                                                                                │····
<https://www.gnu.org/software/gdb/bugs/>.                                                                                                                                                                                                                  │····
Find the GDB manual and other documentation resources online at:                                                                                                                                                                                           │····
    <http://www.gnu.org/software/gdb/documentation/>.                                                                                                                                                                                                      │····
                                                                                                                                                                                                                                                           │····
For help, type "help".                                                                                                                                                                                                                                     │····
Type "apropos word" to search for commands related to "word"...                                                                                                                                                                                            │····
Reading symbols from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/openresty/nginx/sbin/nginx...                                                                                                                                                    │····
                                                                                                                                                                                                                                                           │····
warning: Can't open file /dev/zero (deleted) during file-backed mapping note processing                                                                                                                                                                    │····
[New LWP 30260]                                                                                                                                                                                                                                            │····
[Thread debugging using libthread_db enabled]                                                                                                                                                                                                              │····
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".                                                                                                                                                                                 │····
Core was generated by `nginx: worker process                                                         '.                                                                                                                                                    │····
Program terminated with signal SIGSEGV, Segmentation fault.                                                                                                                                                                                                │····
#0  0x00007f98a3b9c1de in pb_free.part () from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/lib/lua/5.1/pb.so                                                                                                                                      │····
(gdb) backtrace                                                                                                                                                                                                                                            │····
#0  0x00007f98a3b9c1de in pb_free.part () from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/lib/lua/5.1/pb.so                                                                                                                                      │····
#1  0x00007f98a3b9cded in Lpb_delete () from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/lib/lua/5.1/pb.so                                                                                                                                        │····
#2  0x00007f98b8b5bb93 in lj_BC_FUNCC () from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/openresty/luajit/lib/libluajit-5.1.so.2                                                                                                                 │····
#3  0x00007f98b8b5e39f in gc_call_finalizer (g=0x561f8b098d10, L=L@entry=0x561f8b098ca0, mo=<optimized out>, o=0x561f8b4c70e0) at lj_gc.c:520                                                                                                              │····
#4  0x00007f98b8b5e688 in gc_finalize (L=L@entry=0x561f8b098ca0) at lj_gc.c:567                                                                                                                                                                            │····
#5  0x00007f98b8b5fe78 in lj_gc_finalize_udata (L=L@entry=0x561f8b098ca0) at lj_gc.c:574                                                                                                                                                                   │····
#6  0x00007f98b8b69a6e in cpfinalize (L=0x561f8b098ca0, dummy=<optimized out>, ud=<optimized out>) at lj_state.c:273                                                                                                                                       │····
#7  0x00007f98b8b5bf89 in lj_vm_cpcall () from /home/runner/work/kong/kong/bazel-bin/build/kong-dev/openresty/luajit/lib/libluajit-5.1.so.2                                                                                                                │····
#8  0x00007f98b8b69e58 in lua_close (L=0x561f8b098ca0) at lj_state.c:299                                                                                                                                                                                   │····
#9  0x0000561f89fffec7 in ngx_http_lua_cleanup_vm ()                                                                                                                                                                                                       │····
#10 0x0000561f89f14536 in ngx_destroy_pool ()                                                                                                                                                                                                              │····
#11 0x0000561f89f3f653 in ngx_worker_process_exit ()                                                                                                                                                                                                       │····
#12 0x0000561f89f3f863 in ngx_worker_process_cycle ()                                                                                                                                                                                                      │····
#13 0x0000561f89f3dbf6 in ngx_spawn_process ()                                                                                                                                                                                                             │····
#14 0x0000561f89f3eae8 in ngx_start_worker_processes ()                                                                                                                                                                                                    │····
#15 0x0000561f89f4053a in ngx_master_process_cycle ()                                                                                                                                                                                                      │····
#16 0x0000561f89f11ed5 in main () 

```

 </details>