### PR TITLE
fix(cd): remove detection of unused tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,9 +206,7 @@ jobs:
         export PATH="/opt/tools/bin:${PATH}"
         echo "/opt/tools/bin" >> $GITHUB_PATH
 
-        rustup default stable
-
-        for tool in cmake git yq rootlesskit bazel cargo; do
+        for tool in cmake git bazel; do
           echo "${tool}: ($(which "$tool" || true)) $($tool --version)"
         done
 


### PR DESCRIPTION
rustup/cargo are not exposed to PATH since bazel manages its own rust toolchain.

Fixes failures at https://github.com/Kong/kong/actions/runs/4309201395