### PR TITLE
feat(serverless-functions): isolate sandbox cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+#### Plugins
+
+- **Serverless Functions**: `kong.cache` now points to a cache instance that is dedicated to the
+  Serverless Functions plugins: it does not provide access to the global kong cache. Access to
+  certain fields in kong.configuration has also been restricted.
+
 ### Additions
 
 #### Core

--- a/kong/plugins/pre-function/_handler.lua
+++ b/kong/plugins/pre-function/_handler.lua
@@ -4,38 +4,18 @@ local kong_meta = require "kong.meta"
 
 -- handler file for both the pre-function and post-function plugin
 
-local CONF_SENSITIVE = {
-  pg_password = true,
-  pg_ro_password = true,
-  cassandra_password = true,
-  proxy_server = true,
-}
 
 local config_cache do
 
   local no_op = function() end
 
   local shm_name = "kong_db_cache"
-  local cache = resty_mlcache.new(shm_name, shm_name, { lru_size = 1e4 })
-  local sandbox_kong = setmetatable({}, {
-    __index = function(self, k)
-      if k == "cache" then
-        rawset(self, k, cache)
-        return cache
-      end
-      if k == "configuration" then
-        return setmetatable({}, {
-          __index = function(_, conf_k)
-            if CONF_SENSITIVE[conf_k] then
-              return "[redacted]"
-            end
-            return kong.configuration[conf_k]
-          end
-        })
-      end
-      return kong[k]
-    end
-  })
+  local cache_name = "serverless_" .. shm_name
+  local cache = resty_mlcache.new(cache_name, shm_name, { lru_size = 1e4 })
+  local sandbox_kong = setmetatable({
+    cache = cache,
+    configuration = kong.configuration.remove_sensitive()
+  }, { __index = kong })
 
   local sandbox_opts = { env = { kong = sandbox_kong, ngx = ngx } }
 

--- a/spec/03-plugins/33-serverless-functions/02-access_spec.lua
+++ b/spec/03-plugins/33-serverless-functions/02-access_spec.lua
@@ -490,7 +490,7 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
           })
           local body = assert.res_status(200, res)
           assert.is_not_nil(body)
-          assert.equal("[redacted]", body)
+          assert.match("%*+", body)
         end)
       end)
 

--- a/spec/03-plugins/33-serverless-functions/02-access_spec.lua
+++ b/spec/03-plugins/33-serverless-functions/02-access_spec.lua
@@ -58,6 +58,38 @@ local mock_fn_ten = [[
   ngx.var.args = nil
 ]]
 
+-- cache is accessible
+local mock_fn_eleven = [[
+  local ok, err = kong.cache:get("foo", nil, function() return "val" end)
+  if err then
+    ngx.exit(500)
+  end
+  local v = kong.cache:get("foo")
+  ngx.status = 200
+  ngx.say(v)
+  ngx.exit(ngx.status)
+]]
+
+-- cache does not allow access to gateway information
+local mock_fn_twelve = [[
+  ngx.status = 200
+  ngx.say(tostring(kong.cache.cluster_events))
+  ngx.exit(ngx.status)
+]]
+
+-- configuration is accessible
+local mock_fn_thirteen = [[
+  ngx.status = 200
+  ngx.say(kong.configuration.plugins[1])
+  ngx.exit(ngx.status)
+]]
+
+-- configuration restricts access to properties
+local mock_fn_fourteen = [[
+  ngx.status = 200
+  ngx.say(kong.configuration.pg_password)
+  ngx.exit(ngx.status)
+]]
 
 
 describe("Plugin: serverless-functions", function()
@@ -138,6 +170,26 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
           hosts   = { "ten." .. plugin_name .. ".com" },
         }
 
+        local route11 = bp.routes:insert {
+          service = { id = service.id },
+          hosts   = { "eleven." .. plugin_name .. ".com" },
+        }
+
+        local route12 = bp.routes:insert {
+          service = { id = service.id },
+          hosts   = { "twelve." .. plugin_name .. ".com" },
+        }
+
+        local route13 = bp.routes:insert {
+          service = { id = service.id },
+          hosts   = { "thirteen." .. plugin_name .. ".com" },
+        }
+
+        local route14 = bp.routes:insert {
+          service = { id = service.id },
+          hosts   = { "fourteen." .. plugin_name .. ".com" },
+        }
+
         bp.plugins:insert {
           name    = plugin_name,
           route   = { id = route1.id },
@@ -190,6 +242,30 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
           name    = plugin_name,
           route   = { id = route10.id },
           config  = get_conf { mock_fn_ten },
+        }
+
+        bp.plugins:insert {
+          name    = plugin_name,
+          route   = { id = route11.id },
+          config  = get_conf { mock_fn_eleven },
+        }
+
+        bp.plugins:insert {
+          name    = plugin_name,
+          route   = { id = route12.id },
+          config  = get_conf { mock_fn_twelve },
+        }
+
+        bp.plugins:insert {
+          name    = plugin_name,
+          route   = { id = route13.id },
+          config  = get_conf { mock_fn_thirteen },
+        }
+
+        bp.plugins:insert {
+          name    = plugin_name,
+          route   = { id = route14.id },
+          config  = get_conf { mock_fn_fourteen },
         }
 
         assert(helpers.start_kong({
@@ -361,6 +437,60 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
           end
 
           assert.equal(10, count)
+        end)
+      end)
+
+      describe("sandbox access", function()
+        it("can access cache", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/status/200",
+            headers = {
+              ["Host"] = "eleven." .. plugin_name .. ".com",
+            },
+          })
+          local body = assert.res_status(200, res)
+          assert.is_not_nil(body)
+          assert.equal("val", body)
+        end)
+
+        it("cannot access gateway information through the cache", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/status/200",
+            headers = {
+              ["Host"] = "twelve." .. plugin_name .. ".com",
+            },
+          })
+          local body = assert.res_status(200, res)
+          assert.is_not_nil(body)
+          assert.equal("nil", body)
+        end)
+
+        it("can access kong.configuration fields", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/status/200",
+            headers = {
+              ["Host"] = "thirteen." .. plugin_name .. ".com",
+            },
+          })
+          local body = assert.res_status(200, res)
+          assert.is_not_nil(body)
+          assert.equal("bundled", body)
+        end)
+
+        it("redacts sensitive configuration fields", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/status/200",
+            headers = {
+              ["Host"] = "fourteen." .. plugin_name .. ".com",
+            },
+          })
+          local body = assert.res_status(200, res)
+          assert.is_not_nil(body)
+          assert.equal("[redacted]", body)
         end)
       end)
 


### PR DESCRIPTION
### Summary

Isolate the kong.cache instance available to the serverless functions
Limit access to kong.configuration fields

### Checklist

- [X] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

[KAG-364]

[KAG-364]: https://konghq.atlassian.net/browse/KAG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ