### PR TITLE
chore(rockspec): bump `lua-resty-timer-ng` from 0.2.3 to 0.2.4

### DIFF
--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
   "lua-resty-session == 4.0.3",
-  "lua-resty-timer-ng == 0.2.3",
+  "lua-resty-timer-ng == 0.2.4",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
## What's Changed
* fix(logs): fix too many NOTICE logs when creating a timer by @ADD-SP in https://github.com/Kong/lua-resty-timer-ng/pull/13


**Full Changelog**: https://github.com/Kong/lua-resty-timer-ng/compare/0.2.3...0.2.4