### PR TITLE
fix(bazel): add alt url for older zlib releases

### DIFF
--- a/build/cross_deps/zlib/repositories.bzl
+++ b/build/cross_deps/zlib/repositories.bzl
@@ -8,7 +8,10 @@ def zlib_repositories():
 
     http_archive(
         name = "cross_deps_zlib",
-        url = "https://zlib.net/zlib-1.2.13.tar.gz",
+        urls = [
+            "https://zlib.net/zlib-1.2.13.tar.gz",
+            "https://zlib.net/fossils/zlib-1.2.13.tar.gz",
+        ],
         sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
         strip_prefix = "zlib-1.2.13",
         build_file = "//build/cross_deps/zlib:BUILD.zlib.bazel",


### PR DESCRIPTION
### Summary

This PR will mean that when the current version of zlib gets moved into the site's "fossils" repo, we won't have a broken build.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference
