### PR TITLE
chore(actions): do not allow "backport master" labels

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -11,3 +11,6 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
+    - name: backport master label found
+      run: echo "Please do not backport into master, instead, create a PR targeting master and backport from it instead."; exit 1
+      if: ${{ contains(github.event.*.labels.*.name, 'backport master') }}


### PR DESCRIPTION
This is a bad practice which could cause merge conflicts and is against our backport policy.

Tested and works:
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/1131072/223039595-9abc1ea1-d055-4fb1-a16b-446d648777eb.png">
