### PR TITLE
chore: run label based jobs on other events

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,7 @@
 name: Pull Request Label Checker
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, edited, synchronize, labeled, unlabeled]
 jobs:
   check-labels:
     name: prevent merge labels

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -1,7 +1,7 @@
 name: Pull Request Label Checker
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, edited, synchronize, labeled, unlabeled]
 jobs:
   schema-change-labels:
     if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"


### PR DESCRIPTION
It seems that Github Actions is not running these jobs even once even though the PRs are labelled at least once. This patch runs these jobs on other related PR activity.
