### PR TITLE
fix(reports): always honor anonymous report toggle

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -122,7 +122,6 @@ local function execute(args)
       if conf.anonymous_reports then
         local kong_reports = require "kong.reports"
         kong_reports.configure_ping(conf)
-        kong_reports.toggle(true)
 
         local report = {
           decl_fmt_version = meta._format_version,

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -121,7 +121,7 @@ local function execute(args)
       -- send anonymous report if reporting is not disabled
       if conf.anonymous_reports then
         local kong_reports = require "kong.reports"
-        kong_reports.configure_ping(conf)
+        kong_reports.init(conf)
 
         local report = {
           decl_fmt_version = meta._format_version,

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -57,7 +57,7 @@ local REQUEST_ROUTE_CACHE_HITS_KEY_NEG = REQUEST_COUNT_KEY .. ":" .. ROUTE_CACHE
 
 local _buffer = {}
 local _ping_infos = {}
-local _enabled = kong and kong.configuration and kong.configuration.anonymous_reports or false
+local _enabled = false
 local _unique_str = utils.random_string()
 local _buffer_immutable_idx
 local _ssl_session
@@ -430,6 +430,7 @@ end
 return {
   -- plugin handler
   init_worker = function()
+    _enabled = kong and kong.configuration and kong.configuration.anonymous_reports or false
     if not _enabled then
       return
     end

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -57,7 +57,7 @@ local REQUEST_ROUTE_CACHE_HITS_KEY_NEG = REQUEST_COUNT_KEY .. ":" .. ROUTE_CACHE
 
 local _buffer = {}
 local _ping_infos = {}
-local _enabled = false
+local _enabled = kong and kong.configuration and kong.configuration.anonymous_reports or false
 local _unique_str = utils.random_string()
 local _buffer_immutable_idx
 local _ssl_session
@@ -114,7 +114,8 @@ end
 
 local function send_report(signal_type, t, host, port)
   if not _enabled then
-    return
+    -- false means we do nothing instead of sending report
+    return false
   elseif type(signal_type) ~= "string" then
     return error("signal_type (arg #1) must be a string", 2)
   end

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -114,8 +114,7 @@ end
 
 local function send_report(signal_type, t, host, port)
   if not _enabled then
-    -- false means we do nothing instead of sending report
-    return false
+    return nil, "disabled"
   elseif type(signal_type) ~= "string" then
     return error("signal_type (arg #1) must be a string", 2)
   end
@@ -149,21 +148,26 @@ local function send_report(signal_type, t, host, port)
   -- errors are not logged to avoid false positives for users
   -- who run Kong in an air-gapped environments
 
-  local ok = sock:connect(host, port)
+  local ok, err
+  ok, err = sock:connect(host, port)
   if not ok then
-    return
+    return nil, err
   end
 
-  local hs_ok, err = sock:sslhandshake(_ssl_session, nil, _ssl_verify)
-  if not hs_ok then
+  ok, err = sock:sslhandshake(_ssl_session, nil, _ssl_verify)
+  if not ok then
     log(DEBUG, "failed to complete SSL handshake for reports: ", err)
-    return
+    return nil, "failed to complete SSL handshake for reports: " .. err
   end
 
-  _ssl_session = hs_ok
+  _ssl_session = ok
 
-  sock:send(concat(_buffer, ";", 1, mutable_idx) .. "\n")
-  sock:setkeepalive()
+  -- send return nil plus err msg on failure
+  local bytes, err = sock:send(concat(_buffer, ";", 1, mutable_idx) .. "\n")
+  if bytes then
+    sock:setkeepalive()
+  end
+  return bytes, err
 end
 
 

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -430,11 +430,13 @@ do
   end
 end
 
-
 return {
+  init = function(kong_conf)
+    _enabled = kong_conf.anonymous_reports or false
+    configure_ping(kong_conf)
+  end,
   -- plugin handler
   init_worker = function()
-    _enabled = kong and kong.configuration and kong.configuration.anonymous_reports or false
     if not _enabled then
       return
     end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -911,9 +911,9 @@ return {
       end
 
       if kong.configuration.anonymous_reports then
-        reports.configure_ping(kong.configuration)
+        reports.init(kong.configuration)
         reports.add_ping_value("database_version", kong.db.infos.db_ver)
-        reports.init_worker()
+        reports.init_worker(kong.configuration)
       end
 
       update_lua_mem(true)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -913,7 +913,6 @@ return {
       if kong.configuration.anonymous_reports then
         reports.configure_ping(kong.configuration)
         reports.add_ping_value("database_version", kong.db.infos.db_ver)
-        reports.toggle(true)
         reports.init_worker()
       end
 

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -8,7 +8,7 @@ describe("reports", function()
   -- This test case may be run first, it aims to verify behavior of send()
   -- when the kong.configuration.anonymous_reports is unsetted
   it("send when kong.configuration.anonymous_reports = false", function ()
-    assert.False(reports.send())
+    assert.falsy(reports.send())
   end)
 
   describe("send()", function()

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -5,6 +5,12 @@ local cjson = require "cjson"
 
 
 describe("reports", function()
+  -- This test case may be run first, it aims to verify behavior of send()
+  -- when the kong.configuration.anonymous_reports is unsetted
+  it("send when kong.configuration.anonymous_reports = false", function ()
+    assert.False(reports.send())
+  end)
+
   describe("send()", function()
     lazy_setup(function()
       reports.toggle(true)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -104,6 +104,7 @@ describe("kong config", function()
 
     assert(helpers.kong_exec("config db_import " .. filename, {
       prefix = helpers.test_conf.prefix,
+      anonymous_reports = "on",
     }))
 
     local _, res = assert(thread:join())


### PR DESCRIPTION
### Summary

respect the kong.configuration.anonymous_reports when initializing the behavior of send_report.

The default behavior of send_report is initially determined by the configuration. However, it could still be toggled later, this means the caller is responsible for the actual behavior.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-4469
