### PR TITLE
chore(*): remove redundant changelog FTI-4889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,11 +83,6 @@
 - **ACME**: acme plugin now supports configuring an `account_key` in `keys` and `key_sets`
   [#9746](https://github.com/Kong/kong/pull/9746)
 
-### Dependencies
-
-- Bumped lua-resty-session from 4.0.2 to 4.0.3
-  [#10338](https://github.com/Kong/kong/pull/10338)
-
 ### Fixes
 
 #### Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Remove redundant changelog, avoid CE2EE merge conflict.