### PR TITLE
feat(conf): configurable max for request headers, response headers, uri args, post args and decode args for lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   [#10400](https://github.com/Kong/kong/pull/10400)
 - Allow configuring custom error templates
   [#10374](https://github.com/Kong/kong/pull/10374)
+- The maximum number of request headers, response headers, uri args, and post args that are
+  parsed by default can now be configured with a new configuration parameters:
+  `lua_max_req_headers`, `lua_max_resp_headers`, `lua_max_uri_args` and `lua_max_post_args`
+  [#10443](https://github.com/Kong/kong/pull/10443)
 
 #### Admin API
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1653,6 +1653,44 @@
                                  #   This flavor of router will be removed in the next
                                  #   major release of Kong.
 
+#lua_max_req_headers = 100       # Maximum number of request headers to parse by default.
+                                 #
+                                 # This argument can be set to an integer between 1 and 1000.
+                                 #
+                                 # When proxying the Kong sends all the request headers
+                                 # and this setting does not have any effect. It is used
+                                 # to limit Kong and its plugins from reading too many
+                                 # request headers.
+
+#lua_max_resp_headers = 100      # Maximum number of response headers to parse by default.
+                                 #
+                                 # This argument can be set to an integer between 1 and 1000.
+                                 #
+                                 # When proxying, Kong returns all the response headers
+                                 # and this setting does not have any effect. It is used
+                                 # to limit Kong and its plugins from reading too many
+                                 # response headers.
+
+#lua_max_uri_args = 100          # Maximum number of request uri arguments to parse by
+                                 # default.
+                                 #
+                                 # This argument can be set to an integer between 1 and 1000.
+                                 #
+                                 # When proxying, Kong sends all the request query
+                                 # arguments and this setting does not have any effect.
+                                 # It is used to limit Kong and its plugins from reading
+                                 # too many query arguments.
+
+#lua_max_post_args = 100         # Maximum number of request post arguments to parse by
+                                 # default.
+                                 #
+                                 # This argument can be set to an integer between 1 and 1000.
+                                 #
+                                 # When proxying, Kong sends all the request post
+                                 # arguments and this setting does not have any effect.
+                                 # It is used to limit Kong and its plugins from reading
+                                 # too many post arguments.
+
 #------------------------------------------------------------------------------
 # MISCELLANEOUS
 #------------------------------------------------------------------------------
@@ -1844,4 +1882,3 @@
                                   # Setting this attribute disables the search
                                   # behavior and explicitly instructs Kong which
                                   # OpenResty installation to use.
-

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -450,6 +450,11 @@ local CONF_PARSERS = {
   },
   worker_state_update_frequency = { typ = "number" },
 
+  lua_max_req_headers = { typ = "number" },
+  lua_max_resp_headers = { typ = "number" },
+  lua_max_uri_args = { typ = "number" },
+  lua_max_post_args = { typ = "number" },
+
   ssl_protocols = {
     typ = "string",
     directives = {
@@ -1226,6 +1231,30 @@ local function check_and_parse(conf, opts)
     if conf.tracing_sampling_rate < 0 or conf.tracing_sampling_rate > 1 then
       errors[#errors + 1] = "tracing_sampling_rate must be between 0 and 1"
     end
+  end
+
+  if conf.lua_max_req_headers < 1 or conf.lua_max_req_headers > 1000
+  or conf.lua_max_req_headers ~= floor(conf.lua_max_req_headers)
+  then
+    errors[#errors + 1] = "lua_max_req_headers must be an integer between 1 and 1000"
+  end
+
+  if conf.lua_max_resp_headers < 1 or conf.lua_max_resp_headers > 1000
+  or conf.lua_max_resp_headers ~= floor(conf.lua_max_resp_headers)
+  then
+    errors[#errors + 1] = "lua_max_resp_headers must be an integer between 1 and 1000"
+  end
+
+  if conf.lua_max_uri_args < 1 or conf.lua_max_uri_args > 1000
+  or conf.lua_max_uri_args ~= floor(conf.lua_max_uri_args)
+  then
+    errors[#errors + 1] = "lua_max_uri_args must be an integer between 1 and 1000"
+  end
+
+  if conf.lua_max_post_args < 1 or conf.lua_max_post_args > 1000
+  or conf.lua_max_post_args ~= floor(conf.lua_max_post_args)
+  then
+    errors[#errors + 1] = "lua_max_post_args must be an integer between 1 and 1000"
   end
 
   return #errors == 0, errors[1], errors

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -80,6 +80,14 @@ local function new(self)
   local X_FORWARDED_PATH       = "X-Forwarded-Path"
   local X_FORWARDED_PREFIX     = "X-Forwarded-Prefix"
 
+  local is_trusted_ip do
+    local is_trusted = self.ip.is_trusted
+    local get_ip = self.client.get_ip
+    is_trusted_ip = function()
+      return is_trusted(get_ip())
+    end
+  end
+
 
   ---
   -- Returns the scheme component of the request's URL. The returned value is
@@ -158,7 +166,7 @@ local function new(self)
   function _REQUEST.get_forwarded_scheme()
     check_phase(PHASES.request)
 
-    if self.ip.is_trusted(self.client.get_ip()) then
+    if is_trusted_ip() then
       local scheme = _REQUEST.get_header(X_FORWARDED_PROTO)
       if scheme then
         return lower(scheme)
@@ -193,7 +201,7 @@ local function new(self)
   function _REQUEST.get_forwarded_host()
     check_phase(PHASES.request)
 
-    if self.ip.is_trusted(self.client.get_ip()) then
+    if is_trusted_ip() then
       local host = _REQUEST.get_header(X_FORWARDED_HOST)
       if host then
         local s = find(host, "@", 1, true)
@@ -240,8 +248,8 @@ local function new(self)
   function _REQUEST.get_forwarded_port()
     check_phase(PHASES.request)
 
-    if self.ip.is_trusted(self.client.get_ip()) then
-      local port = tonumber(_REQUEST.get_header(X_FORWARDED_PORT))
+    if is_trusted_ip() then
+      local port = tonumber(_REQUEST.get_header(X_FORWARDED_PORT), 10)
       if port and port >= MIN_PORT and port <= MAX_PORT then
         return port
       end
@@ -295,7 +303,7 @@ local function new(self)
   function _REQUEST.get_forwarded_path()
     check_phase(PHASES.request)
 
-    if self.ip.is_trusted(self.client.get_ip()) then
+    if is_trusted_ip() then
       local path = _REQUEST.get_header(X_FORWARDED_PATH)
       if path then
         return path
@@ -338,7 +346,7 @@ local function new(self)
     check_phase(PHASES.request)
 
     local prefix
-    if self.ip.is_trusted(self.client.get_ip()) then
+    if is_trusted_ip() then
       prefix = _REQUEST.get_header(X_FORWARDED_PREFIX)
       if prefix then
         return prefix

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -573,7 +573,8 @@ local function new(self)
       end
     end
 
-    if ngx.ctx.KONG_UNEXPECTED and _REQUEST.get_http_version() < 2 then
+    local ctx = ngx.ctx
+    if ctx.KONG_UNEXPECTED and _REQUEST.get_http_version() < 2 then
       local req_line = var.request
       local qidx = find(req_line, "?", 1, true)
       if not qidx then
@@ -589,7 +590,12 @@ local function new(self)
       return decode_args(sub(req_line, qidx + 1, eidx - 1), max_args)
     end
 
-    return get_uri_args(max_args)
+    local uri_args, err = get_uri_args(max_args, ctx.uri_args)
+    if uri_args then
+      ctx.uri_args = uri_args
+    end
+
+    return uri_args, err
   end
 
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -117,66 +117,66 @@ local function new(self, major_version)
     [16] = "Unauthenticated",
   }
 
-local get_http_error_message
-do
-  local HTTP_ERROR_MESSAGES = {
-    [400] = "Bad request",
-    [401] = "Unauthorized",
-    [402] = "Payment required",
-    [403] = "Forbidden",
-    [404] = "Not found",
-    [405] = "Method not allowed",
-    [406] = "Not acceptable",
-    [407] = "Proxy authentication required",
-    [408] = "Request timeout",
-    [409] = "Conflict",
-    [410] = "Gone",
-    [411] = "Length required",
-    [412] = "Precondition failed",
-    [413] = "Payload too large",
-    [414] = "URI too long",
-    [415] = "Unsupported media type",
-    [416] = "Range not satisfiable",
-    [417] = "Expectation failed",
-    [418] = "I'm a teapot",
-    [421] = "Misdirected request",
-    [422] = "Unprocessable entity",
-    [423] = "Locked",
-    [424] = "Failed dependency",
-    [425] = "Too early",
-    [426] = "Upgrade required",
-    [428] = "Precondition required",
-    [429] = "Too many requests",
-    [431] = "Request header fields too large",
-    [451] = "Unavailable for legal reasons",
-    [494] = "Request header or cookie too large",
-    [500] = "An unexpected error occurred",
-    [501] = "Not implemented",
-    [502] = "An invalid response was received from the upstream server",
-    [503] = "The upstream server is currently unavailable",
-    [504] = "The upstream server is timing out",
-    [505] = "HTTP version not supported",
-    [506] = "Variant also negotiates",
-    [507] = "Insufficient storage",
-    [508] = "Loop detected",
-    [510] = "Not extended",
-    [511] = "Network authentication required",
-  }
+  local get_http_error_message
+  do
+    local HTTP_ERROR_MESSAGES = {
+      [400] = "Bad request",
+      [401] = "Unauthorized",
+      [402] = "Payment required",
+      [403] = "Forbidden",
+      [404] = "Not found",
+      [405] = "Method not allowed",
+      [406] = "Not acceptable",
+      [407] = "Proxy authentication required",
+      [408] = "Request timeout",
+      [409] = "Conflict",
+      [410] = "Gone",
+      [411] = "Length required",
+      [412] = "Precondition failed",
+      [413] = "Payload too large",
+      [414] = "URI too long",
+      [415] = "Unsupported media type",
+      [416] = "Range not satisfiable",
+      [417] = "Expectation failed",
+      [418] = "I'm a teapot",
+      [421] = "Misdirected request",
+      [422] = "Unprocessable entity",
+      [423] = "Locked",
+      [424] = "Failed dependency",
+      [425] = "Too early",
+      [426] = "Upgrade required",
+      [428] = "Precondition required",
+      [429] = "Too many requests",
+      [431] = "Request header fields too large",
+      [451] = "Unavailable for legal reasons",
+      [494] = "Request header or cookie too large",
+      [500] = "An unexpected error occurred",
+      [501] = "Not implemented",
+      [502] = "An invalid response was received from the upstream server",
+      [503] = "The upstream server is currently unavailable",
+      [504] = "The upstream server is timing out",
+      [505] = "HTTP version not supported",
+      [506] = "Variant also negotiates",
+      [507] = "Insufficient storage",
+      [508] = "Loop detected",
+      [510] = "Not extended",
+      [511] = "Network authentication required",
+    }
 
 
-  function get_http_error_message(status)
-    local msg = HTTP_ERROR_MESSAGES[status]
+    function get_http_error_message(status)
+      local msg = HTTP_ERROR_MESSAGES[status]
 
-    if msg then
+      if msg then
+        return msg
+      end
+
+      msg = fmt("The upstream server responded with %d", status)
+      HTTP_ERROR_MESSAGES[status] = msg
+
       return msg
     end
-
-    msg = fmt("The upstream server responded with %d", status)
-    HTTP_ERROR_MESSAGES[status] = msg
-
-    return msg
   end
-end
 
 
   ---

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -63,7 +63,6 @@ local function new(self, major_version)
   local _RESPONSE = {}
 
   local MIN_HEADERS          = 1
-  local MAX_HEADERS_DEFAULT  = 100
   local MAX_HEADERS          = 1000
 
   local MIN_STATUS_CODE      = 100
@@ -268,9 +267,10 @@ local function new(self, major_version)
   -- headers as the client would see them upon reception, including headers
   -- added by Kong itself.
   --
-  -- By default, this function returns up to **100** headers. The optional
-  -- `max_headers` argument can be specified to customize this limit, but must
-  -- be greater than **1** and equal to or less than **1000**.
+  -- By default, this function returns up to **100** headers (or what has been
+  -- configured using `lua_max_resp_headers`). The optional `max_headers` argument
+  -- can be specified to customize this limit, but must be greater than **1** and
+  -- equal to or less than **1000**.
   --
   -- @function kong.response.get_headers
   -- @phases header_filter, response, body_filter, log, admin_api
@@ -295,7 +295,7 @@ local function new(self, major_version)
     check_phase(header_body_log)
 
     if max_headers == nil then
-      return ngx.resp.get_headers(MAX_HEADERS_DEFAULT)
+      return ngx.resp.get_headers()
     end
 
     if type(max_headers) ~= "number" then

--- a/kong/pdk/service/response.lua
+++ b/kong/pdk/service/response.lua
@@ -135,6 +135,7 @@ local function new(pdk, major_version)
   local MIN_HEADERS            = 1
   local MAX_HEADERS_DEFAULT    = 100
   local MAX_HEADERS            = 1000
+  local MAX_HEADERS_CONFIGURED
 
 
   ---
@@ -200,10 +201,13 @@ local function new(pdk, major_version)
 
     if max_headers == nil then
       if buffered_headers then
-        return attach_buffered_headers_mt(buffered_headers, MAX_HEADERS_DEFAULT)
+        if not MAX_HEADERS_CONFIGURED then
+          MAX_HEADERS_CONFIGURED = pdk and pdk.configuration and pdk.configuration.lua_max_resp_headers
+        end
+        return attach_buffered_headers_mt(buffered_headers, MAX_HEADERS_CONFIGURED or MAX_HEADERS_DEFAULT)
       end
 
-      return attach_resp_headers_mt(ngx.resp.get_headers(MAX_HEADERS_DEFAULT))
+      return attach_resp_headers_mt(ngx.resp.get_headers())
     end
 
     if type(max_headers) ~= "number" then

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -406,6 +406,7 @@ function ProxyCacheHandler:header_filter(conf)
 
   -- if this is a cacheable request, gather the headers and mark it so
   if cacheable_response(conf, cc) then
+    -- TODO: should this use the kong.conf configured limit?
     proxy_cache.res_headers = resp_get_headers(0, true)
     proxy_cache.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -32,7 +32,6 @@ local ngx_log       = ngx.log
 local get_phase     = ngx.get_phase
 local get_method    = ngx.req.get_method
 local get_headers   = ngx.req.get_headers
-local ngx_WARN      = ngx.WARN
 local ngx_ERR       = ngx.ERR
 
 
@@ -45,7 +44,6 @@ local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 local route_match_stat     = utils.route_match_stat
 
 
-local MAX_REQ_HEADERS  = 100
 local DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
@@ -522,10 +520,13 @@ function _M:exec(ctx)
   local headers, headers_key
   if self.match_headers then
     local err
-    headers, err = get_headers(MAX_REQ_HEADERS)
+    headers, err = get_headers()
     if err == "truncated" then
-      ngx_log(ngx_WARN, "retrieved ", MAX_REQ_HEADERS, " headers for evaluation ",
-                        "(max) but request had more; other headers will be ignored")
+      local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
+      ngx_log(ngx_ERR, "router: not all request headers were read in order to determine the route as ",
+                       "the request contains more than ", lua_max_req_headers, " headers, route selection ",
+                       "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",
+                       "(currently at ", lua_max_req_headers, ")")
     end
 
     headers["host"] = nil

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -205,7 +205,6 @@ local MATCH_SUBRULES = {
 
 
 local EMPTY_T = {}
-local MAX_REQ_HEADERS = 100
 
 
 local match_route
@@ -1694,10 +1693,13 @@ function _M.new(routes, cache, cache_neg)
       local headers
       if match_headers then
         local err
-        headers, err = get_headers(MAX_REQ_HEADERS)
+        headers, err = get_headers()
         if err == "truncated" then
-          log(WARN, "retrieved ", MAX_REQ_HEADERS, " headers for evaluation ",
-                    "(max) but request had more; other headers will be ignored")
+          local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
+          log(ERR, "router: not all request headers were read in order to determine the route as ",
+                    "the request contains more than ", lua_max_req_headers, " headers, route selection ",
+                    "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",
+                    "(currently at ", lua_max_req_headers, ")")
         end
 
         headers["host"] = nil

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -48,7 +48,6 @@ local get_query_arg
 do
   local sort = table.sort
   local get_uri_args = ngx.req.get_uri_args
-  local limit = 100
 
   -- OpenResty allows us to reuse the table that it populates with the request
   -- query args. The table is cleared by `ngx.req.get_uri_args` on each use, so
@@ -56,15 +55,22 @@ do
   --
   -- @see https://github.com/openresty/lua-resty-core/pull/288
   -- @see https://github.com/openresty/lua-resty-core/blob/3c3d0786d6e26282e76f39f4fe5577d316a47a09/lib/resty/core/request.lua#L196-L208
-  local cache = require("table.new")(0, limit)
-
+  local cache
+  local limit
 
   function get_query_arg(name)
+    if not limit then
+      limit = kong and kong.configuration and kong.configuration.lua_max_uri_args or 100
+      cache = require("table.new")(0, limit)
+    end
+
     local query, err = get_uri_args(limit, cache)
 
     if err == "truncated" then
       log(WARN, "could not fetch all query string args for request, ",
-                "hash value may be empty/incomplete")
+                "hash value may be empty/incomplete, please consider ",
+                 "increasing the value of 'lua_max_uri_args' ",
+                 "(currently at ",  limit, ")")
 
     elseif not query then
       log(ERR, "failed fetching query string args: ", err or "unknown error")

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -307,8 +307,8 @@ local function build_phases(plugin)
           serialize_data = kong.log.serialize(),
           ngx_ctx = clone(ngx.ctx),
           ctx_shared = kong.ctx.shared,
-          request_headers = req_get_headers(100),
-          response_headers = resp_get_headers(100),
+          request_headers = req_get_headers(),
+          response_headers = resp_get_headers(),
           response_status = ngx.status,
           req_start_time = req_start_time(),
         })

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -180,6 +180,11 @@ lua_ssl_protocols = TLSv1.1 TLSv1.2 TLSv1.3
 lua_package_path = ./?.lua;./?/init.lua;
 lua_package_cpath = NONE
 
+lua_max_req_headers = 100
+lua_max_resp_headers = 100
+lua_max_uri_args = 100
+lua_max_post_args = 100
+
 role = traditional
 kic = off
 pluginserver_names = NONE

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1835,4 +1835,67 @@ describe("Configuration loader", function()
       assert.equal("foo#bar", conf.pg_password)
     end)
   end)
+
+  describe("lua max limits for request/response headers and request uri/post args", function()
+    it("are accepted", function()
+      local conf, err = assert(conf_loader(nil, {
+        lua_max_req_headers = 1,
+        lua_max_resp_headers = 100,
+        lua_max_uri_args = 500,
+        lua_max_post_args = 1000,
+      }))
+
+      assert.is_nil(err)
+
+      assert.equal(1, conf.lua_max_req_headers)
+      assert.equal(100, conf.lua_max_resp_headers)
+      assert.equal(500, conf.lua_max_uri_args)
+      assert.equal(1000, conf.lua_max_post_args)
+    end)
+
+    it("are not accepted with limits below 1", function()
+      local _, err = conf_loader(nil, {
+        lua_max_req_headers = 0,
+      })
+      assert.equal("lua_max_req_headers must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_resp_headers = 0,
+      })
+      assert.equal("lua_max_resp_headers must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_uri_args = 0,
+      })
+      assert.equal("lua_max_uri_args must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_post_args = 0,
+      })
+      assert.equal("lua_max_post_args must be an integer between 1 and 1000", err)
+    end)
+
+    it("are not accepted with limits above 1000", function()
+      local _, err = conf_loader(nil, {
+        lua_max_req_headers = 1001,
+      })
+      assert.equal("lua_max_req_headers must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_resp_headers = 1001,
+      })
+      assert.equal("lua_max_resp_headers must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_uri_args = 1001,
+      })
+      assert.equal("lua_max_uri_args must be an integer between 1 and 1000", err)
+
+      local _, err = conf_loader(nil, {
+        lua_max_post_args = 1001,
+      })
+      assert.equal("lua_max_post_args must be an integer between 1 and 1000", err)
+    end)
+  end)
+
 end)

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -409,7 +409,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       before_each(function()
-        os.execute("echo -n '' > " .. FILE_LOG_PATH)
+        helpers.clean_logfile(FILE_LOG_PATH)
         os.execute("chmod 0777 " .. FILE_LOG_PATH)
       end)
 
@@ -749,7 +749,7 @@ for _, strategy in helpers.each_strategy() do
 
       before_each(function()
         proxy_client = helpers.proxy_client()
-        os.execute("echo -n '' > " .. FILE_LOG_PATH)
+        helpers.clean_logfile(FILE_LOG_PATH)
         os.execute("chmod 0777 " .. FILE_LOG_PATH)
       end)
 

--- a/spec/02-integration/05-proxy/30-max-args_spec.lua
+++ b/spec/02-integration/05-proxy/30-max-args_spec.lua
@@ -1,0 +1,248 @@
+local helpers = require "spec.helpers"
+local clone = require "table.clone"
+
+
+local encode_args = ngx.encode_args
+local tostring = tostring
+local assert = assert
+local ipairs = ipairs
+
+
+local lazy_teardown = lazy_teardown
+local before_each = before_each
+local after_each = after_each
+local lazy_setup = lazy_setup
+local describe = describe
+local it = it
+
+
+local HOST = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_port
+
+
+local function get_parameters(n)
+  local query = {}
+
+  for i = 1, n do
+    query["a" .. i] = "v" .. i
+  end
+
+  local body = encode_args(query)
+  local headers = clone(query)
+  headers["a1"] = nil
+  headers["a2"] = nil
+  headers["a3"] = nil
+  headers["a4"] = nil
+
+  headers["content-length"] = tostring(#body)
+  headers["content-type"] = "application/x-www-form-urlencoded"
+  headers["user-agent"] = "kong"
+  headers["host"] = HOST
+
+  return {
+    query = query,
+    headers = headers,
+    body = body,
+  }
+end
+
+
+local function get_response_headers(n)
+  local headers = {}
+
+  for i = 1, n - 2 do
+    headers["a" .. i] = "v" .. i
+  end
+
+  headers["content-length"] = "0"
+  headers["connection"] = "keep-alive"
+
+  return headers
+end
+
+
+local function validate(client_args_count, params, body, headers)
+  assert.is.equal(client_args_count, body.client_args_count)
+
+  assert.same(params.query, body.kong.uri_args)
+  assert.same(params.query, body.ngx.uri_args)
+
+  assert.same(params.headers, body.kong.request_headers)
+  assert.same(params.headers, body.ngx.request_headers)
+
+  local response_headers = get_response_headers(client_args_count)
+
+  assert.same(response_headers, body.kong.response_headers)
+  assert.same(response_headers, body.ngx.response_headers)
+
+  headers["Content-Length"] = nil
+  headers["Connection"] = nil
+  headers["Content-Type"] = nil
+  headers["Date"] = nil
+  headers["Server"] = nil
+  headers["X-Kong-Response-Latency"] = nil
+
+  response_headers["content-length"] = nil
+  response_headers["connection"] = nil
+
+  assert.same(response_headers, headers)
+
+  assert.same(params.query, body.kong.post_args)
+  assert.same(params.query, body.ngx.post_args)
+
+  assert.logfile().has.no.line("request headers truncated", true, 0.5)
+  assert.logfile().has.no.line("uri args truncated", true, 0.1)
+  assert.logfile().has.no.line("post args truncated", true, 0.1)
+  assert.logfile().has.no.line("response headers truncated", true, 0.1)
+end
+
+
+local function validate_truncated(client_args_count, params, body, headers)
+  assert.is.equal(client_args_count, body.client_args_count)
+
+  assert.is_not.same(params.query, body.kong.uri_args)
+  assert.is_not.same(params.query, body.ngx.uri_args)
+
+  assert.is_not.same(params.headers, body.kong.request_headers)
+  assert.is_not.same(params.headers, body.ngx.request_headers)
+
+  assert.is_not.same(get_response_headers(client_args_count), body.kong.response_headers)
+  assert.is_not.same(get_response_headers(client_args_count), body.ngx.response_headers)
+
+  local response_headers = get_response_headers(client_args_count)
+
+  headers["Content-Length"] = nil
+  headers["Connection"] = nil
+  headers["Content-Type"] = nil
+  headers["Date"] = nil
+  headers["Server"] = nil
+  headers["X-Kong-Response-Latency"] = nil
+
+  response_headers["content-length"] = nil
+  response_headers["connection"] = nil
+
+  assert.same(response_headers, headers)
+
+  assert.is_not.same(params.query, body.kong.post_args)
+  assert.is_not.same(params.query, body.ngx.post_args)
+
+  assert.logfile().has.line("request headers truncated", true, 0.5)
+  assert.logfile().has.line("uri args truncated", true, 0.1)
+  assert.logfile().has.line("post args truncated", true, 0.1)
+  assert.logfile().has.line("response headers truncated", true, 0.1)
+end
+
+
+local function validate_proxy(params, body)
+  assert.same(params.query, body.uri_args)
+
+  local request_headers = body.headers
+
+  request_headers["connection"] = nil
+  request_headers["x-forwarded-for"] = nil
+  request_headers["x-forwarded-host"] = nil
+  request_headers["x-forwarded-path"] = nil
+  request_headers["x-forwarded-port"] = nil
+  request_headers["x-forwarded-prefix"] = nil
+  request_headers["x-forwarded-proto"] = nil
+  request_headers["x-real-ip"] = nil
+
+  assert.same(params.headers, request_headers)
+  assert.same(params.query, body.uri_args)
+  assert.same(params.query, body.post_data.params)
+
+  assert.logfile().has.no.line("truncated", true, 0.5)
+end
+
+
+for _, strategy in helpers.each_strategy() do
+  for _, n in ipairs({ 50, 100, 200 }) do
+    describe("max args [#" .. strategy .. "] (" .. n .. " parameters)", function()
+      local client
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "plugins",
+          "routes",
+          "services",
+        }, {
+          "max-args"
+        })
+
+        local service = assert(bp.services:insert({
+          url = helpers.mock_upstream_url
+        }))
+
+        bp.routes:insert({
+          service = service,
+          paths = { "/proxy" }
+        })
+
+        local route = bp.routes:insert({
+          paths = { "/max-args" }
+        })
+
+        assert(bp.plugins:insert({
+          name = "max-args",
+          route = { id = route.id },
+        }))
+
+        helpers.start_kong({
+          database = strategy,
+          plugins = "bundled, max-args",
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          lua_max_resp_headers = n ~= 100 and n or nil,
+          lua_max_req_headers = n ~= 100 and n or nil,
+          lua_max_uri_args = n ~= 100 and n or nil,
+          lua_max_post_args = n ~= 100 and n or nil,
+          log_level = "debug",
+        })
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      before_each(function()
+        helpers.clean_logfile()
+        client = helpers.proxy_client()
+      end)
+
+      after_each(function()
+        if client then
+          client:close()
+        end
+      end)
+
+      it("no truncation when using " .. n .. " parameters", function()
+        local params = get_parameters(n)
+        local res = client:post("/max-args", params)
+        assert.response(res).has.status(200)
+        local body = assert.response(res).has.jsonbody()
+        validate(n, params, body, res.headers)
+      end)
+
+      it("truncation when using " .. n + 1 .. " parameters", function()
+        local params = get_parameters(n + 1)
+        local res = client:post("/max-args", params)
+        assert.response(res).has.status(200)
+        local body = assert.response(res).has.jsonbody()
+        validate_truncated(n + 1, params, body, res.headers)
+      end)
+
+      it("no truncation when using " .. n .. " parameters when proxying", function()
+        local params = get_parameters(n)
+        local res = client:post("/proxy", params)
+        assert.response(res).has.status(200)
+        local body = assert.response(res).has.jsonbody()
+        validate_proxy(params, body, res.headers)
+      end)
+
+      it("no truncation when using " .. n + 1 .. " parameters when proxying", function()
+        local params = get_parameters(n + 1)
+        local res = client:post("/proxy", params)
+        assert.response(res).has.status(200)
+        local body = assert.response(res).has.jsonbody()
+        validate_proxy(params, body, res.headers)
+      end)
+    end)
+  end
+end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -554,7 +554,7 @@ http {
             }
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response({}, ngx.req.get_uri_args())
+                return mu.send_default_json_response({}, ngx.req.get_uri_args(0))
             }
         }
 

--- a/spec/fixtures/custom_plugins/kong/plugins/max-args/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/max-args/handler.lua
@@ -1,0 +1,72 @@
+local nkeys = require "table.nkeys"
+
+
+local kong = kong
+local ngx = ngx
+
+
+
+local function get_response_headers(n)
+  local headers = {}
+
+  for i = 1, n - 2 do
+    headers["a" .. i] = "v" .. i
+  end
+
+  --headers["content-length"] = "0" (added by nginx/kong)
+  --headers["connection"] = "keep-alive" (added by nginx/kong)
+
+  return headers
+end
+
+
+local MaxArgsHandler = {
+  VERSION = "0.1-t",
+  PRIORITY = 1000,
+}
+
+
+function MaxArgsHandler:access(conf)
+  local client_args_count = nkeys(ngx.req.get_uri_args(0))
+
+  ngx.req.read_body()
+
+  kong.ctx.plugin.data = {
+    client_args_count = client_args_count,
+    kong = {
+      request_headers = kong.request.get_headers(),
+      uri_args = kong.request.get_query(),
+      post_args = kong.request.get_body() or {},
+    },
+    ngx = {
+      request_headers = ngx.req.get_headers(),
+      uri_args = ngx.req.get_uri_args(),
+      post_args = ngx.req.get_post_args(),
+    },
+  }
+
+  return kong.response.exit(200, "", get_response_headers(client_args_count))
+end
+
+
+function MaxArgsHandler:header_filter(conf)
+  local data = kong.ctx.plugin.data
+  return kong.response.exit(200, {
+    client_args_count = data.client_args_count,
+    kong = {
+      request_headers = data.kong.request_headers,
+      response_headers = kong.response.get_headers(),
+      uri_args = data.kong.uri_args,
+      post_args = data.kong.post_args,
+    },
+    ngx = {
+      request_headers = data.ngx.request_headers,
+      response_headers = ngx.resp.get_headers(),
+      uri_args = data.ngx.uri_args,
+      post_args = data.ngx.post_args,
+    }
+  })
+end
+
+
+return MaxArgsHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/max-args/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/max-args/schema.lua
@@ -1,0 +1,18 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  name = "max-args",
+  fields = {
+    {
+      protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } },
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}

--- a/spec/fixtures/mock_upstream.lua
+++ b/spec/fixtures/mock_upstream.lua
@@ -123,7 +123,7 @@ end
 
 local function filter_access_by_basic_auth(expected_username,
                                            expected_password)
-   local headers = ngx.req.get_headers()
+   local headers = ngx.req.get_headers(0)
 
    local username, password =
    find_http_credentials(headers["proxy-authorization"])
@@ -200,7 +200,7 @@ local function get_post_data(content_type)
     if content_type:find("application/x-www-form-urlencoded", nil, true) then
 
       kind        = "form"
-      params, err = ngx.req.get_post_args()
+      params, err = ngx.req.get_post_args(0)
 
     elseif content_type:find("multipart/form-data", nil, true) then
       kind        = "multipart-form"
@@ -232,7 +232,7 @@ local function get_default_json_response()
     post_data = get_post_data(headers["Content-Type"]),
     url       = ("%s://%s:%s%s"):format(vars.scheme, vars.host,
                                         vars.server_port, vars.request_uri),
-    uri_args  = ngx.req.get_uri_args(),
+    uri_args  = ngx.req.get_uri_args(0),
     vars      = vars,
   }
 end
@@ -321,7 +321,7 @@ local function store_log(logname)
     entries = { entries }
   end
 
-  local log_req_headers = ngx.req.get_headers()
+  local log_req_headers = ngx.req.get_headers(0)
 
   for i = 1, #entries do
     local store = {

--- a/spec/fixtures/mock_webserver_tpl.lua
+++ b/spec/fixtures/mock_webserver_tpl.lua
@@ -19,7 +19,7 @@ http {
 
     _G.log_record = function(ngx_req)
       local cjson = require("cjson")
-      local args, err = ngx_req.get_uri_args()
+      local args, err = ngx_req.get_uri_args(0)
       local key = args['key'] or "default"
       local log_locks = _G.log_locks
 
@@ -36,7 +36,7 @@ http {
           time = ngx.now(),
           -- path = "/log",
           method = ngx_req.get_method(),
-          headers = ngx_req.get_headers(),
+          headers = ngx_req.get_headers(0),
         }
 
         logs = cjson.decode(logs)
@@ -111,7 +111,7 @@ http {
 
     location = /healthy {
       access_by_lua_block {
-        local host = ngx.req.get_headers()["host"] or "localhost"
+        local host = ngx.req.get_headers(0)["host"] or "localhost"
         local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
         if host_no_port == nil then
           return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
@@ -134,7 +134,7 @@ http {
 
     location = /unhealthy {
       access_by_lua_block {
-        local host = ngx.req.get_headers()["host"] or "localhost"
+        local host = ngx.req.get_headers(0)["host"] or "localhost"
         local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
         if host_no_port == nil then
           return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
@@ -180,8 +180,8 @@ http {
       access_by_lua_block {
         _G.log_record(ngx.req)
         local i = require 'inspect'
-        ngx.log(ngx.ERR, "INSPECT status (headers): ", i(ngx.req.get_headers()))
-        local host = ngx.req.get_headers()["host"] or "localhost"
+        ngx.log(ngx.ERR, "INSPECT status (headers): ", i(ngx.req.get_headers(0)))
+        local host = ngx.req.get_headers(0)["host"] or "localhost"
         local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
         if host_no_port == nil then
           return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
@@ -213,7 +213,7 @@ http {
           _G.log_record(ngx.req)
           local cjson = require("cjson")
           local server_values = ngx.shared.server_values
-          local host = ngx.req.get_headers()["host"] or "localhost"
+          local host = ngx.req.get_headers(0)["host"] or "localhost"
           local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
           if host_no_port == nil then
             return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
### Summary

Adds new `kong.conf` configuration settings:

- `lua_max_req_headers` (affects `kong.request.get_headers()` and `ngx.req.get_headers()`, does not affect proxying)
- `lua_max_resp_headers` (affects `kong.response.get_headers()` and `kong.service.response.get_headers()` and `ngx.resp.get_headers()`, does not affect proxying)
- `lua_max_uri_args` (affects `kong.request.get_query()`, `kong.request.get_query_arg()`, `ngx.req.get_uri_args()`, does not affect proxying)
- `lua_max_post_args` (affects `kong.request.get_body()` and `ngx.req.get_post_args()`, does not affect proxying)

And changes Kong to use those defaults.

This PR also contains some style/perf commits. I suggest this to be reviewed `commit-by-commit`.

KAG-715

### Issues Resolved

Fix #10324