### PR TITLE
feat(proxy): Allow to remove the proxy cache headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,8 @@
 - Tracing: tracing_sampling_rate defaults to 0.01 (trace one of every 100 requests) instead of the previous 1
   (trace all requests). Tracing all requests is inappropriate for most production systems
   [#10774](https://github.com/Kong/kong/pull/10774)
+- **Proxy Cache**: Add option to remove the proxy cache headers from the response
+  [#10445](https://github.com/Kong/kong/pull/10445)
 
 ### Additions
 

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -92,5 +92,8 @@ return {
     rate_limiting = {
       "sync_rate",
     },
+    proxy_cache = {
+      "response_headers",
+    },
   },
 }

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -56,9 +56,21 @@ local function overwritable_header(header)
      and not ngx_re_match(n_header, "ratelimit-remaining")
 end
 
-local function set_header(header, value)
-  if ngx.var.http_kong_debug then
+local function set_header(conf, header, value)
+  if ngx.var.http_kong_debug or conf.response_headers[header] then
     kong.response.set_header(header, value)
+  end
+end
+
+local function reset_res_header(res)
+  res.headers["Age"] = nil
+  res.headers["X-Cache-Status"] = nil
+  res.headers["X-Cache-Key"] = nil
+end
+
+local function set_res_header(res, header, value, conf)
+  if ngx.var.http_kong_debug or conf.response_headers[header] then
+    res.headers[header] = value
   end
 end
 
@@ -224,11 +236,11 @@ end
 
 
 -- indicate that we should attempt to cache the response to this request
-local function signal_cache_req(ctx, cache_key, cache_status)
+local function signal_cache_req(ctx, conf, cache_key, cache_status)
   ctx.proxy_cache = {
     cache_key = cache_key,
   }
-  set_header("X-Cache-Status", cache_status or "Miss")
+  set_header(conf, "X-Cache-Status", cache_status or "Miss")
 end
 
 
@@ -284,7 +296,7 @@ function ProxyCacheHandler:access(conf)
 
   -- if we know this request isnt cacheable, bail out
   if not cacheable_request(conf, cc) then
-    set_header("X-Cache-Status", "Bypass")
+    set_header(conf, "X-Cache-Status", "Bypass")
     return
   end
 
@@ -309,7 +321,7 @@ function ProxyCacheHandler:access(conf)
     return
   end
 
-  set_header("X-Cache-Key", cache_key)
+  set_header(conf, "X-Cache-Key", cache_key)
 
   -- try to fetch the cached object from the computed cache key
   local strategy = require(STRATEGY_PATH)({
@@ -332,7 +344,7 @@ function ProxyCacheHandler:access(conf)
     -- this request is cacheable but wasn't found in the data store
     -- make a note that we should store it in cache later,
     -- and pass the request upstream
-    return signal_cache_req(ctx, cache_key)
+    return signal_cache_req(ctx, conf, cache_key)
 
   elseif err then
     kong.log.err(err)
@@ -342,29 +354,29 @@ function ProxyCacheHandler:access(conf)
   if res.version ~= CACHE_VERSION then
     kong.log.notice("cache format mismatch, purging ", cache_key)
     strategy:purge(cache_key)
-    return signal_cache_req(ctx, cache_key, "Bypass")
+    return signal_cache_req(ctx, conf, cache_key, "Bypass")
   end
 
   -- figure out if the client will accept our cache value
   if conf.cache_control then
     if cc["max-age"] and time() - res.timestamp > cc["max-age"] then
-      return signal_cache_req(ctx, cache_key, "Refresh")
+      return signal_cache_req(ctx, conf, cache_key, "Refresh")
     end
 
     if cc["max-stale"] and time() - res.timestamp - res.ttl > cc["max-stale"]
     then
-      return signal_cache_req(ctx, cache_key, "Refresh")
+      return signal_cache_req(ctx, conf, cache_key, "Refresh")
     end
 
     if cc["min-fresh"] and res.ttl - (time() - res.timestamp) < cc["min-fresh"]
     then
-      return signal_cache_req(ctx, cache_key, "Refresh")
+      return signal_cache_req(ctx, conf, cache_key, "Refresh")
     end
 
   else
     -- don't serve stale data; res may be stored for up to `conf.storage_ttl` secs
     if time() - res.timestamp > conf.cache_ttl then
-      return signal_cache_req(ctx, cache_key, "Refresh")
+      return signal_cache_req(ctx, conf, cache_key, "Refresh")
     end
   end
 
@@ -390,14 +402,10 @@ function ProxyCacheHandler:access(conf)
   end
 
 
-  if ngx.var.http_kong_debug then
-    res.headers["Age"] = floor(time() - res.timestamp)
-    res.headers["X-Cache-Status"] = "Hit"
-  else
-    res.headers["Age"] = nil
-    res.headers["X-Cache-Status"] = nil
-    res.headers["X-Cache-Key"] = nil
-  end
+  reset_res_header(res)
+  set_res_header(res, "Age", floor(time() - res.timestamp), conf)
+  set_res_header(res, "X-Cache-Status", "Hit", conf)
+  set_res_header(res, "X-Cache-Key", cache_key, conf)
 
   return kong.response.exit(res.status, res.body, res.headers)
 end
@@ -422,7 +430,7 @@ function ProxyCacheHandler:header_filter(conf)
     proxy_cache.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
 
   else
-    set_header("X-Cache-Status", "Bypass")
+    set_header(conf, "X-Cache-Status", "Bypass")
     ctx.proxy_cache = nil
   end
 

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -74,6 +74,16 @@ return {
           { vary_headers = { description = "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.", type = "array",
             elements = { type = "string" },
           }},
+          { response_headers = {
+            type = "record",
+            fields = {
+              { age  = {type = "boolean",  default = true} },
+              { ["X-Cache-Status"]  = {type = "boolean",  default = true} },
+              { ["X-Cache-Key"]  = {type = "boolean",  default = true} },
+            },
+          }},
+
+
         },
       }
     },

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -344,13 +344,11 @@ do
     end)
 
     it("caches a simple request", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -365,13 +363,11 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      local res = client:send {
-        method = "GET",
-        path = "/get",
+      local res = client:get("/get", {
         headers = {
           host = "route-1.com",
         }
-      }
+      })
 
       local body2 = assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -386,13 +382,12 @@ do
     end)
 
     it("respects cache ttl", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
       })
+      )
 
       --local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -403,13 +398,11 @@ do
       --  return strategy:fetch(cache_key2) ~= nil
       --end, TIMEOUT)
 
-      res = client:send {
-        method = "GET",
-        path = "/get",
+      res = client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      }
+      })
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -427,13 +420,11 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -444,25 +435,21 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
       -- examine the behavior of keeping cache in memory for longer than ttl
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -473,13 +460,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -498,37 +483,31 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Refresh", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
     end)
 
     it("respects cache ttl via cache control", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      local res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -539,13 +518,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -561,13 +538,11 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -577,36 +552,30 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
       -- assert that max-age=0 never results in caching
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/0",
+      res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Bypass", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/0",
+      res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -615,26 +584,22 @@ do
     it("public not present in Cache-Control, but max-age is", function()
       -- httpbin's /cache endpoint always sets "Cache-Control: public"
       -- necessary to set it manually using /response-headers instead
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers?Cache-Control=max-age%3D604800",
+      local res = assert(client:get("/response-headers?Cache-Control=max-age%3D604800", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
     end)
 
     it("Cache-Control contains s-maxage only", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers?Cache-Control=s-maxage%3D604800",
+      local res = assert(client:get("/response-headers?Cache-Control=s-maxage%3D604800", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -642,14 +607,12 @@ do
 
     it("Expires present, Cache-Control absent", function()
       local httpdate = ngx.escape_uri(os.date("!%a, %d %b %Y %X %Z", os.time()+5000))
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers",
+      local res = assert(client:get("/response-headers", {
         query = "Expires=" .. httpdate,
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -658,28 +621,24 @@ do
     describe("respects cache-control", function()
       it("min-fresh", function()
         -- bypass via unsatisfied min-fresh
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "min-fresh=30",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("max-age", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        local res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -690,14 +649,12 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -714,27 +671,23 @@ do
         --  return ngx.time() - obj.timestamp > 2
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("max-stale", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -745,13 +698,11 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -767,41 +718,35 @@ do
         --  return ngx.time() - obj.timestamp - obj.ttl > 2
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "max-stale=1",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("only-if-cached", function()
-        local res = assert(client:send {
-          method = "GET",
-          path   = "/get?not=here",
+        local res = assert(client:get("/get?not=here", {
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "only-if-cached",
           }
-        })
+        }))
 
         assert.res_status(504, res)
       end)
     end)
 
     it("caches a streaming request", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/stream/3",
+      local res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -813,13 +758,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/stream/3",
+      res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body2 = assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -827,25 +770,21 @@ do
     end)
 
     it("uses a separate cache key for the same consumer between routes", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-13.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key1 = res.headers["X-Cache-Key"]
 
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-14.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key2 = res.headers["X-Cache-Key"]
 
@@ -853,25 +792,21 @@ do
     end)
 
     it("uses a separate cache key for the same consumer between routes/services", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-15.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key1 = res.headers["X-Cache-Key"]
 
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-16.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key2 = res.headers["X-Cache-Key"]
 
@@ -879,13 +814,11 @@ do
     end)
 
     it("uses an separate cache key between routes-specific and a global plugin", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-3.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -894,13 +827,11 @@ do
       assert.matches("^[%w%d]+$", cache_key1)
       assert.equals(64, #cache_key1)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-4.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
@@ -910,13 +841,11 @@ do
     end)
 
     it("differentiates caches between instances", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -930,13 +859,11 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
         }
-      })
+      }))
 
       local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -945,69 +872,57 @@ do
     end)
 
     it("uses request params as part of the cache key", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get?a=b&b=c",
+      local res = assert(client:get("/get?a=b&b=c", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a=c",
+      res = assert(client:get("/get?a=c", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?b=c&a=b",
+      res = assert(client:get("/get?b=c&a=b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a&b",
+      res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a&b",
+      res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
     end)
 
     it("can focus only in a subset of the query arguments", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get?foo=b&b=c",
+      local res = assert(client:get("/get?foo=b&b=c", {
         headers = {
           host = "route-12.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -1019,13 +934,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?b=d&foo=b",
+      res = assert(client:get("/get?b=d&foo=b", {
         headers = {
           host = "route-12.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
@@ -1033,14 +946,12 @@ do
     end)
 
     it("uses headers if instructed to do so", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "bar",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
       --local cache_key = res.headers["X-Cache-Key"]
@@ -1050,88 +961,74 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "bar",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "baz",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
     end)
 
     describe("handles authenticated routes", function()
       it("by ignoring cache if the request is unauthenticated", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
           }
-        })
+        }))
 
         assert.res_status(401, res)
         assert.is_nil(res.headers["X-Cache-Status"])
       end)
 
       it("by maintaining a separate cache per consumer", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "bob",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "bob",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
 
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "alice",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "alice",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1141,9 +1038,7 @@ do
 
     describe("bypasses cache for uncacheable requests: ", function()
       it("request method", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        local res = assert(client:post("/post", {
           headers = {
             host = "route-1.com",
             ["Content-Type"] = "application/json",
@@ -1151,7 +1046,7 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -1160,26 +1055,22 @@ do
 
     describe("bypasses cache for uncacheable responses:", function()
       it("response status", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/status/418",
+        local res = assert(client:get("/status/418", {
           headers = {
             host = "route-1.com",
           },
-        })
+        }))
 
         assert.res_status(418, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
       end)
 
       it("response content type", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/xml",
+        local res = assert(client:get("/xml", {
           headers = {
             host = "route-1.com",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -1188,9 +1079,7 @@ do
 
     describe("caches non-default", function()
       it("request methods", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        local res = assert(client:post("/post", {
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
@@ -1198,7 +1087,7 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -1209,9 +1098,7 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        res = assert(client:post("/post", {
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
@@ -1219,31 +1106,27 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
       end)
 
       it("response status", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/status/417",
+        local res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
           },
-        })
+        }))
 
         assert.res_status(417, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/status/417",
+        res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
           },
-        })
+        }))
 
         assert.res_status(417, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1253,25 +1136,21 @@ do
 
     describe("displays Kong core headers:", function()
       it("X-Kong-Proxy-Latency", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=proxy-latency",
+        local res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
         assert.matches("^%d+$", res.headers["X-Kong-Proxy-Latency"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=proxy-latency",
+        res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1279,13 +1158,11 @@ do
       end)
 
       it("X-Kong-Upstream-Latency", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=upstream-latency",
+        local res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -1297,13 +1174,11 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=upstream-latency",
+        res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -347,6 +347,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -366,6 +367,7 @@ do
       local res = client:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       })
 
@@ -385,6 +387,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       })
       )
@@ -401,6 +404,7 @@ do
       res = client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       })
 
@@ -423,6 +427,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -438,6 +443,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -448,6 +454,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -463,6 +470,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -486,6 +494,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -495,6 +504,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -506,6 +516,7 @@ do
       local res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -521,6 +532,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -541,6 +553,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -555,6 +568,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -565,6 +579,7 @@ do
       res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -574,6 +589,7 @@ do
       res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -587,6 +603,7 @@ do
       local res = assert(client:get("/response-headers?Cache-Control=max-age%3D604800", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -598,6 +615,7 @@ do
       local res = assert(client:get("/response-headers?Cache-Control=s-maxage%3D604800", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -611,6 +629,7 @@ do
         query = "Expires=" .. httpdate,
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -625,6 +644,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "min-fresh=30",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -637,6 +657,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -653,6 +674,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -675,6 +697,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -686,6 +709,7 @@ do
         local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -701,6 +725,7 @@ do
         res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -722,6 +747,7 @@ do
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "max-stale=1",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -734,6 +760,7 @@ do
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "only-if-cached",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -745,6 +772,7 @@ do
       local res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -761,6 +789,7 @@ do
       res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -774,6 +803,7 @@ do
         headers = {
           host = "route-13.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -783,6 +813,7 @@ do
         headers = {
           host = "route-14.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -796,6 +827,7 @@ do
         headers = {
           host = "route-15.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -805,6 +837,7 @@ do
         headers = {
           host = "route-16.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -817,6 +850,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-3.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -830,6 +864,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-4.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -844,6 +879,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -862,6 +898,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -875,6 +912,7 @@ do
       local res = assert(client:get("/get?a=b&b=c", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -884,6 +922,7 @@ do
       res = assert(client:get("/get?a=c", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -894,6 +933,7 @@ do
       res = assert(client:get("/get?b=c&a=b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -903,6 +943,7 @@ do
       res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -911,6 +952,7 @@ do
       res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -921,6 +963,7 @@ do
       local res = assert(client:get("/get?foo=b&b=c", {
         headers = {
           host = "route-12.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -937,6 +980,7 @@ do
       res = assert(client:get("/get?b=d&foo=b", {
         headers = {
           host = "route-12.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -950,6 +994,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "bar",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -965,6 +1010,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "bar",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -974,6 +1020,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "baz",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -985,6 +1032,7 @@ do
         local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -997,6 +1045,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "bob",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1007,6 +1056,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "bob",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1017,6 +1067,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "alice",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1027,6 +1078,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "alice",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1042,6 +1094,7 @@ do
           headers = {
             host = "route-1.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -1058,6 +1111,7 @@ do
         local res = assert(client:get("/status/418", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1069,6 +1123,7 @@ do
         local res = assert(client:get("/xml", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1083,6 +1138,7 @@ do
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -1102,6 +1158,7 @@ do
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -1116,6 +1173,7 @@ do
         local res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1125,6 +1183,7 @@ do
         res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1139,6 +1198,7 @@ do
         local res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1149,6 +1209,7 @@ do
         res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1161,6 +1222,7 @@ do
         local res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1177,6 +1239,7 @@ do
         res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1193,6 +1256,7 @@ do
           path = "/xml",
           headers = {
             host = "route-17.com",
+            ["kong-debug"] = 1,
           },
         }
 
@@ -1213,6 +1277,7 @@ do
           path = "/xml",
           headers = {
             host = "route-18.com",
+            ["kong-debug"] = 1,
           },
         })
 
@@ -1228,6 +1293,7 @@ do
           path = "/response-headers?Content-Type=application/xml;",
           headers = {
             host = "route-18.com",
+            ["kong-debug"] = 1,
           },
         })
 
@@ -1242,6 +1308,7 @@ do
           path = "/xml",
           headers = {
             host = "route-19.com",
+            ["kong-debug"] = 1,
           },
         }
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -663,7 +663,7 @@ do
           path = "/cache/2",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "min-fresh=30"
+            ["Cache-Control"] = "min-fresh=30",
           }
         })
 
@@ -677,7 +677,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -695,7 +695,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -719,7 +719,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -1038,7 +1038,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "bar"
+          foo = "bar",
         }
       })
       assert.res_status(200, res)
@@ -1055,7 +1055,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "bar"
+          foo = "bar",
         }
       })
       assert.res_status(200, res)
@@ -1066,7 +1066,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "baz"
+          foo = "baz",
         }
       })
       assert.res_status(200, res)

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -71,9 +71,7 @@ describe("Plugin: proxy-cache", function()
     local body
 
     it("accepts an array of numbers as strings", function()
-      local res = assert(admin_client:send {
-        method = "POST",
-        path = "/plugins",
+      local res = assert(admin_client:post("/plugins", {
         body = {
           name = "proxy-cache",
           config = {
@@ -90,7 +88,7 @@ describe("Plugin: proxy-cache", function()
         headers = {
           ["Content-Type"] = "application/json",
         },
-      })
+      }))
       body = assert.res_status(201, res)
     end)
     it("casts an array of response_code values to number types", function()
@@ -205,13 +203,11 @@ describe("Plugin: proxy-cache", function()
   describe("(API)", function()
     describe("DELETE", function()
       it("delete a cache entry", function()
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -222,13 +218,11 @@ describe("Plugin: proxy-cache", function()
         assert.equals(64, #cache_key1)
         cache_key = cache_key1
 
-        res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -236,61 +230,47 @@ describe("Plugin: proxy-cache", function()
         assert.same(cache_key1, cache_key2)
 
         -- delete the key
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        res = assert(admin_client:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
         -- delete directly, having to look up all proxy-cache instances
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        res = assert(admin_client:delete("/proxy-cache/" .. cache_key))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
       end)
       it("purge all the cache entries", function()
         -- make a `Hit` request to `route-1`
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
 
         -- make a `Miss` request to `route-2`
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -301,13 +281,11 @@ describe("Plugin: proxy-cache", function()
         assert.equals(64, #cache_key1)
 
         -- make a `Hit` request to `route-1`
-        res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -315,109 +293,76 @@ describe("Plugin: proxy-cache", function()
         assert.same(cache_key1, cache_key2)
 
         -- delete all the cache keys
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
       end)
       it("delete a non-existing cache key", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. "123",
-        })
+        local res = assert(admin_client:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. "123"))
         assert.res_status(404, res)
       end)
       it("delete a non-existing plugins's cache key", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. route1.id .. "/caches/" .. "123",
-        })
+        local res = assert(admin_client:delete("/proxy-cache/" .. route1.id .. "/caches/" .. "123"))
         assert.res_status(404, res)
       end)
     end)
     describe("GET", function()
       it("get a non-existing cache", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         assert.res_status(404, res)
 
         -- attempt to list an entry directly via cache key
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. cache_key))
         assert.res_status(404, res)
       end)
       it("get a existing cache", function()
         -- add request to cache
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
         assert.res_status(200, res)
 
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         local body = assert.res_status(200, res)
         local json_body = cjson.decode(body)
         assert.same(cache_key, json_body.headers["X-Cache-Key"])
 
         -- list an entry directly via cache key
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" ..  cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" ..  cache_key))
         local body = assert.res_status(200, res)
         local json_body = cjson.decode(body)
         assert.same(cache_key, json_body.headers["X-Cache-Key"])

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -206,6 +206,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -221,6 +222,7 @@ describe("Plugin: proxy-cache", function()
         res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -236,6 +238,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -249,6 +252,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -260,6 +264,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
         assert.res_status(200, res)
@@ -269,6 +274,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -284,6 +290,7 @@ describe("Plugin: proxy-cache", function()
         res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
         }))
 

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -115,6 +115,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -125,6 +126,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -135,6 +137,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -146,6 +149,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -157,6 +161,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -166,6 +171,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -189,6 +195,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -198,6 +205,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -112,125 +112,101 @@ describe("proxy-cache invalidations via: " .. strategy, function()
 
     setup(function()
       -- prime cache entries on both instances
-      local res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      local res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key = res_1.headers["X-Cache-Key"]
 
-      local res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
       assert.same(cache_key, res_2.headers["X-Cache-Key"])
 
-      res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-2.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key2 = res_1.headers["X-Cache-Key"]
       assert.not_same(cache_key, cache_key2)
 
-      res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-2.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
     end)
 
     it("propagates purges via cluster events mechanism", function()
-      local res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      local res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Hit", res_1.headers["X-Cache-Status"])
 
-      local res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Hit", res_2.headers["X-Cache-Status"])
 
       -- now purge the entry
-      local res = assert(admin_client_1:send {
-        method = "DELETE",
-        path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-      })
+      local res = assert(admin_client_1:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
 
       assert.res_status(204, res)
 
       helpers.wait_until(function()
         -- assert that the entity was purged from the second instance
-        res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        res = assert(admin_client_2:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
 
       -- refresh and purge with our second endpoint
-      res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
 
-      res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
       assert.same(cache_key, res_2.headers["X-Cache-Key"])
 
       -- now purge the entry
-      res = assert(admin_client_1:send {
-        method = "DELETE",
-        path = "/proxy-cache/" .. cache_key,
-      })
+      res = assert(admin_client_1:delete("/proxy-cache/" .. cache_key))
 
       assert.res_status(204, res)
 
@@ -239,55 +215,42 @@ describe("proxy-cache invalidations via: " .. strategy, function()
 
       helpers.wait_until(function()
         -- assert that the entity was purged from the second instance
-        res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        res = assert(admin_client_2:get("/proxy-cache/" .. cache_key, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
     end)
 
     it("does not affect cache entries under other plugin instances", function()
-      local res = assert(admin_client_1:send {
-        method = "GET",
-        path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-      })
+      local res = assert(admin_client_1:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+      }))
 
       assert.res_status(200, res)
 
-      res = assert(admin_client_2:send {
-        method = "GET",
-        path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-      })
+      res = assert(admin_client_2:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+      }))
 
       assert.res_status(200, res)
     end)
 
     it("propagates global purges", function()
       do
-        local res = assert(admin_client_1:send {
-          method = "DELETE",
-          path = "/proxy-cache/",
-        })
-  
+        local res = assert(admin_client_1:delete("/proxy-cache/"))
+
         assert.res_status(204, res)
       end
 
       helpers.wait_until(function()
-        local res = assert(admin_client_1:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-        })
+        local res = assert(admin_client_1:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
 
       helpers.wait_until(function()
-        local res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-        })
+        local res = assert(admin_client_2:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)


### PR DESCRIPTION
Update of #7829 

### Summary
Adding Miss/Hit, Age and cache key to answer shouldn't be the default behavior.
Add option to remove the proxy cache headers from the response.
If the kong debug is set keep the headers

### Full changelog
The following headers:

- `X-Cache-Status`
- `X-Cache-Key`
- `Age`

can be now be removed from the answer via the `response_headers` option,
for example to remove all:
```
        config = {
          [...]
          response_headers = {
            age = false,
            ["X-Cache-Status"] = false,
            ["X-Cache-Key"]  = false
          }
```
Default behavior to have all the header set is kept for retro compatibility reason.

Refactor test to remove duplicated lines and use get, post and delete helpers instead of send
