### PR TITLE
fix(schema): nested record shorthand type check

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1704,7 +1704,11 @@ function Schema:process_auto_fields(data, context, nulls, opts)
       end
     end
 
-    value = adjust_field_for_context(field, value, context, nulls, opts)
+    local err
+    value, err = adjust_field_for_context(field, value, context, nulls, opts)
+    if err then
+      return nil, err
+    end
 
     if is_select then
       local vtype = type(value)

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -873,6 +873,30 @@ describe("schema", function()
       assert.falsy(Test:validate({ f = { r = { a = 2, b = "foo" }}}))
     end)
 
+    it("validates shorthands type check with nested records", function()
+      local Test = Schema.new({
+        fields = {
+          { r = {
+              type = "record",
+              fields = {
+                { a = { type = "string" } },
+                { b = { type = "number" } } },
+              shorthand_fields = {
+                {
+                  username = {
+                    type = "string",
+                    func = function(value)
+                      return {
+                        b = value
+                      }
+                    end,
+                  }}}}}}})
+      local input =  { r = { username = 123 }}
+      local ok, err = Test:process_auto_fields(input)
+      assert.falsy(ok)
+      assert.same({ username = "expected a string" }, err)
+    end)
+
     it("validates an integer", function()
       local Test = Schema.new({
         fields = {


### PR DESCRIPTION
### Summary

When a schema shorthand type check validation failed in a nested record, the error was not handled correctly, producing failures in setting the configuration that were hard to idenfity due to the missing error.

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

KAG-851