### PR TITLE
chore(test): prevent potential sni names collision across different test files

### DIFF
--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -520,6 +520,8 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       bp = bu.get_db_utils_for_dc_and_admin_api(strategy, {
+        "snis",
+        "certificates",
         "services",
         "routes",
         "upstreams",


### PR DESCRIPTION
The `certificates` admin API is used directly in this test block without truncating the tables, if the same sni name is created in another spec file, then collision will occur.

[FTI-4846](https://konghq.atlassian.net/browse/FTI-4846)

[FTI-4846]: https://konghq.atlassian.net/browse/FTI-4846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ