### PR TITLE
chore(tests): add http2 smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,6 +492,7 @@ jobs:
 
     env:
       KONG_ADMIN_URI: http://localhost:8001
+      KONG_ADMIN_HTTP2_URI: https://localhost:8444
       KONG_PROXY_URI: http://localhost:8000
 
     steps:
@@ -507,9 +508,9 @@ jobs:
       # always pull the latest image to ensure we're testing the latest version.
       run: |
         docker run \
-          -p 8000:8000 -p 8001:8001 \
+          -p 8000:8000 -p 8001:8001 -p 8444:8444\
           -e KONG_PG_PASSWORD=kong \
-          -e KONG_ADMIN_LISTEN=0.0.0.0:8001 \
+          -e KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl http2 \
           -e KONG_ANONYMOUS_REPORTS=off \
           --name kong \
           --restart always \
@@ -529,6 +530,11 @@ jobs:
       env:
         VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
       run: build/tests/02-admin-api.sh
+
+    - name: Smoke Tests - HTTP2 Admin API
+      env:
+        VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
+      run: build/tests/03-http2-admin-api.sh
 
   release-packages:
     name: Release Packages - ${{ matrix.label }} - ${{ needs.metadata.outputs.release-desc }}

--- a/build/tests/03-http2-admin-api.sh
+++ b/build/tests/03-http2-admin-api.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ -n "${VERBOSE:-}" ]; then
+    set -x
+fi
+
+source .requirements
+source build/tests/util.sh
+
+service_name="$(random_string)"
+route_name="$(random_string)"
+
+kong_ready
+
+msg_test "Check if cURL supports HTTP/2"
+if ! curl --version | grep -i "http2" > /dev/null; then
+  msg_yellow "local cURL does not support HTTP/2, bypass HTTP/2 tests"
+  exit 0
+fi
+
+msg_test "Check HTTP/2 Admin API response is valid"
+admin_api_http2_validity


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds a simple smoke test to check if the HTTP/2 listening port can respond with valid response data.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-854
