### PR TITLE
feat(proxy-cache): add ignore_uri_case to configuring cache-key uri to be handled as lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,8 @@
 
 - **ACME**: acme plugin now supports configuring an `account_key` in `keys` and `key_sets`
   [#9746](https://github.com/Kong/kong/pull/9746)
-- **Proxy-Cache**: add `cache_lowercase_uri` to configuring cache-key uri to be handled as lowercase [#10453](https://github.com/Kong/kong/pull/10453)
+- **Proxy-Cache**: add `ignore_uri_case` to configuring cache-key uri to be handled as lowercase
+  [#10453](https://github.com/Kong/kong/pull/10453)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 
 - **ACME**: acme plugin now supports configuring an `account_key` in `keys` and `key_sets`
   [#9746](https://github.com/Kong/kong/pull/9746)
+- **Proxy-Cache**: add `cache_lowercase_uri` to configuring cache-key uri to be handled as lowercase [#10453](https://github.com/Kong/kong/pull/10453)
 
 ### Fixes
 

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -59,6 +59,9 @@ return {
   [3003000000] = {
     acme = {
       "account_key",
+    },
+    proxy_cache = {
+      "ignore_uri_case",
     }
   },
 }

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -287,6 +287,12 @@ function ProxyCacheHandler:access(conf)
   local consumer = kong.client.get_consumer()
   local route = kong.router.get_route()
   local uri = ngx_re_sub(ngx.var.request, "\\?.*", "", "oj")
+
+  -- if we want the cache-key uri only to be lowercase
+  if conf.cache_lowercase_uri then
+    uri = lower(uri)
+  end
+
   local cache_key, err = cache_key.build_cache_key(consumer and consumer.id,
                                                    route    and route.id,
                                                    kong.request.get_method(),

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -289,7 +289,7 @@ function ProxyCacheHandler:access(conf)
   local uri = ngx_re_sub(ngx.var.request, "\\?.*", "", "oj")
 
   -- if we want the cache-key uri only to be lowercase
-  if conf.cache_lowercase_uri then
+  if conf.ignore_uri_case then
     uri = lower(uri)
   end
 

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -58,7 +58,7 @@ return {
             default = false,
             required = true,
           }},
-          { cache_lowercase_uri = {
+          { ignore_uri_case = {
             type = "boolean",
             default = false,
             required = false,

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -58,6 +58,11 @@ return {
             default = false,
             required = true,
           }},
+          { cache_lowercase_uri = {
+            type = "boolean",
+            default = false,
+            required = false,
+          }},
           { storage_ttl = {
             type = "integer",
           }},

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -198,7 +198,6 @@ do
           content_type = { "text/plain", "application/json" },
           [policy] = policy_config,
           cache_control = true,
-          cache_lowercase_uri = true,
           storage_ttl = 600,
         },
       })

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -1421,7 +1421,6 @@ do
       })
 
       -- here 404 is return by upstream
-      local body1 = assert.res_status(404, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
       local cache_key1 = res.headers["X-Cache-Key"]
@@ -1437,7 +1436,6 @@ do
       }
 
       -- here 404 is return by upstream
-      local body2 = assert.res_status(404, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
       local cache_key2 = res.headers["X-Cache-Key"]
       assert.not_same(cache_key1, cache_key2)

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -1386,7 +1386,6 @@ do
         },
       })
 
-      -- here 404 is return by upstream
       local body1 = assert.res_status(404, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
@@ -1402,7 +1401,6 @@ do
         },
       }
 
-      -- here 404 is return by upstream
       local body2 = assert.res_status(404, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
       local cache_key2 = res.headers["X-Cache-Key"]
@@ -1420,7 +1418,6 @@ do
         },
       })
 
-      -- here 404 is return by upstream
       assert.same("Miss", res.headers["X-Cache-Status"])
 
       local cache_key1 = res.headers["X-Cache-Key"]
@@ -1435,7 +1432,6 @@ do
         },
       }
 
-      -- here 404 is return by upstream
       assert.same("Miss", res.headers["X-Cache-Status"])
       local cache_key2 = res.headers["X-Cache-Key"]
       assert.not_same(cache_key1, cache_key2)

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -71,21 +71,21 @@ do
       local route14 = assert(bp.routes:insert {
         hosts = { "route-14.com" },
       })
-      local route15 = assert(bp.routes:insert({
+      local route15 = assert(bp.routes:insert {
         hosts = { "route-15.com" },
-      }))
-      local route16 = assert(bp.routes:insert({
+      })
+      local route16 = assert(bp.routes:insert {
         hosts = { "route-16.com" },
-      }))
-      local route17 = assert(bp.routes:insert({
+      })
+      local route17 = assert(bp.routes:insert {
         hosts = { "route-17.com" },
-      }))
-      local route18 = assert(bp.routes:insert({
+      })
+      local route18 = assert(bp.routes:insert {
         hosts = { "route-18.com" },
-      }))
-      local route19 = assert(bp.routes:insert({
+      })
+      local route19 = assert(bp.routes:insert {
         hosts = { "route-19.com" },
-      }))
+      })
       local route20 = assert(bp.routes:insert {
         hosts = { "route-20.com" },
       })

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -87,7 +87,7 @@ do
         hosts = { "route-19.com" },
       }))
       local route20 = assert(bp.routes:insert {
-        paths = { "/my-route/" },
+        hosts = { "route-20.com" },
       })
 
 
@@ -1365,7 +1365,10 @@ do
     it("ignore uri case in cache_key", function()
       local res = assert(client:send {
         method = "GET",
-        path = "/my-route/kong",
+        path = "/ignore-case/kong",
+        headers = {
+          host = "route-20.com",
+        },
       })
 
       -- here 404 is return by upstream
@@ -1378,7 +1381,10 @@ do
 
       local res = client:send {
         method = "GET",
-        path = "/my-route/KONG",
+        path = "/ignore-case/KONG",
+        headers = {
+          host = "route-20.com",
+        },
       }
 
       -- here 404 is return by upstream

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -1418,22 +1418,25 @@ do
         },
       })
 
-      assert.same("Miss", res.headers["X-Cache-Status"])
+      assert.res_status(404, res)
+      local x_cache_status = assert.response(res).has_header("X-Cache-Status")
+      assert.same("Miss", x_cache_status)
 
       local cache_key1 = res.headers["X-Cache-Key"]
       assert.matches("^[%w%d]+$", cache_key1)
       assert.equals(64, #cache_key1)
 
-      local res = client:send {
+      res = assert(client:send {
         method = "GET",
         path = "/acknowledge-case/KONG",
         headers = {
           host = "route-21.com",
         },
-      }
+      })
 
-      assert.same("Miss", res.headers["X-Cache-Status"])
-      local cache_key2 = res.headers["X-Cache-Key"]
+      x_cache_status = assert.response(res).has_header("X-Cache-Status")
+      local cache_key2 = assert.response(res).has_header("X-Cache-Key")
+      assert.same("Miss", x_cache_status)
       assert.not_same(cache_key1, cache_key2)
     end)
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -86,6 +86,9 @@ do
       local route19 = assert(bp.routes:insert({
         hosts = { "route-19.com" },
       }))
+      local route20 = assert(bp.routes:insert {
+        paths = { "/my-route/" },
+      })
 
 
       local consumer1 = assert(bp.consumers:insert {
@@ -279,6 +282,18 @@ do
           strategy = policy,
           [policy] = policy_config,
           content_type = { "application/xml;" }, -- invalid content_type
+        },
+      })
+
+      assert(bp.plugins:insert {
+        name = "proxy-cache",
+        route = { id = route20.id },
+        config = {
+          strategy = policy,
+          response_code = {404},
+          ignore_uri_case = true,
+          content_type = { "text/plain", "application/json" },
+          [policy] = policy_config,
         },
       })
 
@@ -1346,5 +1361,34 @@ do
         assert.same("Bypass", res.headers["X-Cache-Status"])
       end)
     end)
+
+    it("ignore uri case in cache_key", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/my-route/kong",
+      })
+
+      -- here 404 is return by upstream
+      local body1 = assert.res_status(404, res)
+      assert.same("Miss", res.headers["X-Cache-Status"])
+
+      local cache_key1 = res.headers["X-Cache-Key"]
+      assert.matches("^[%w%d]+$", cache_key1)
+      assert.equals(64, #cache_key1)
+
+      local res = client:send {
+        method = "GET",
+        path = "/my-route/KONG",
+      }
+
+      -- here 404 is return by upstream
+      local body2 = assert.res_status(404, res)
+      assert.same("Hit", res.headers["X-Cache-Status"])
+      local cache_key2 = res.headers["X-Cache-Key"]
+      assert.same(cache_key1, cache_key2)
+
+      assert.same(body1, body2)
+    end)
+
   end)
 end

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -89,6 +89,9 @@ do
       local route20 = assert(bp.routes:insert {
         hosts = { "route-20.com" },
       })
+      local route21 = assert(bp.routes:insert {
+        hosts = { "route-21.com" },
+      })
 
 
       local consumer1 = assert(bp.consumers:insert {
@@ -292,6 +295,18 @@ do
           strategy = policy,
           response_code = {404},
           ignore_uri_case = true,
+          content_type = { "text/plain", "application/json" },
+          [policy] = policy_config,
+        },
+      })
+
+      assert(bp.plugins:insert {
+        name = "proxy-cache",
+        route = { id = route21.id },
+        config = {
+          strategy = policy,
+          response_code = {404},
+          ignore_uri_case = false,
           content_type = { "text/plain", "application/json" },
           [policy] = policy_config,
         },
@@ -1394,6 +1409,38 @@ do
       assert.same(cache_key1, cache_key2)
 
       assert.same(body1, body2)
+    end)
+
+    it("acknowledge uri case in cache_key", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/acknowledge-case/kong",
+        headers = {
+          host = "route-21.com",
+        },
+      })
+
+      -- here 404 is return by upstream
+      local body1 = assert.res_status(404, res)
+      assert.same("Miss", res.headers["X-Cache-Status"])
+
+      local cache_key1 = res.headers["X-Cache-Key"]
+      assert.matches("^[%w%d]+$", cache_key1)
+      assert.equals(64, #cache_key1)
+
+      local res = client:send {
+        method = "GET",
+        path = "/acknowledge-case/KONG",
+        headers = {
+          host = "route-21.com",
+        },
+      }
+
+      -- here 404 is return by upstream
+      local body2 = assert.res_status(404, res)
+      assert.same("Miss", res.headers["X-Cache-Status"])
+      local cache_key2 = res.headers["X-Cache-Key"]
+      assert.not_same(cache_key1, cache_key2)
     end)
 
   end)

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -198,6 +198,7 @@ do
           content_type = { "text/plain", "application/json" },
           [policy] = policy_config,
           cache_control = true,
+          cache_lowercase_uri = true,
           storage_ttl = 600,
         },
       })


### PR DESCRIPTION
### Summary

The proxy-cache plugin uri input is taken straight from `ngx.var.request` and when incoming requests are randomized with lowercase and uppercase letters, all requests are handled as new ones.

The issue with this is that the proxy-cache sees then as unique requests, even if the backend request response is exactly the same and the cache-key should therefore be possible to set to lowercase that upstream servers are not receiving unnecessary requests.

Example of requests being randomized and handled as unique cache entries:
* `/api/greeting/tobias`
* `/api/greeting/Tobias`
* `/api/greeting/tObIaS`

Default of the `ignore_uri_case` is `false` and the cache-key will be based on the actual `ngx.var.request`, but when setting the parameter to `true` instead, it will be lowercased instead.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/5270

### Full changelog

* Implementing new parameter called `ignore_uri_case` for the proxy-cache plugin to lowercase the request and use that for cache-key calculation.

### Discussion reference

Rel #7821 & #10425
