### PR TITLE
docs(changelog): bumped lua-resty-openssl to 0.8.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@
   [#10338](https://github.com/Kong/kong/pull/10338)
 - Bumped lua-protobuf from 0.3.3 to 0.4.2
   [#10137](https://github.com/Kong/kong/pull/10413)
+- Bumped lua-resty-openssl from 0.8.17 to 0.8.18
+  [#10463](https://github.com/Kong/kong/pull/10463)
 
 ## 3.2.0
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

#10463 missed the change log entry.


