### PR TITLE
Summary: chore(*): reconfigure automatic closing of issues and PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,10 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 14
+daysUntilStale: 21
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 7
-
-onlyLabels:
-  - "pending author feedback"
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -19,6 +16,14 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  This issue/PR has been automatically marked as stale because it has
+  not had recent activity.  It will be closed if no further activity
+  occurs.  Thank you for your contributions!
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue/PR has been automatically closed because it has not seen
+  any activity in a long time.  If you still want to pursue this
+  patch, please reopen the PR and try to address the issues that were
+  discussed to help the decision making process.  Thank you for your
+  contributions!


### PR DESCRIPTION
With this change, all PRs and issues are subject to automatic timeout after 28 days of inactivity.

KAG-875
