### PR TITLE
fix(tests): use openssl API version instead of BoringSSL git sha in tests

### DIFF
--- a/build/tests/01-base.sh
+++ b/build/tests/01-base.sh
@@ -109,7 +109,7 @@ assert_exec 0 'root' "/usr/local/openresty/bin/resty -e 'print(jit.version)' | g
 # check which ssl openresty is using
 if docker_exec root '/usr/local/openresty/bin/openresty -V 2>&1' | grep 'BoringSSL'; then
     msg_test 'openresty binary uses expected boringssl version'
-    assert_exec 0 'root' "/usr/local/openresty/bin/openresty -V 2>&1 | grep '${RESTY_BORINGSSL_VERSION}'"
+    assert_exec 0 'root' "/usr/local/openresty/bin/openresty -V 2>&1 | grep '1.1.0'"
 else
     msg_test 'openresty binary uses expected openssl version'
     assert_exec 0 'root' "/usr/local/openresty/bin/openresty -V 2>&1 | grep '${RESTY_OPENSSL_VERSION}'"


### PR DESCRIPTION
string to be tested was `built with OpenSSL 1.1.0 (compatible; BoringSSL) (running with BoringSSL)` not including the git sha