### PR TITLE
fix(tracing): fix span name high cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@
 
 - `request.get_uri_captures` now returns the unnamed part tagged as an array (for jsonification).
   [#10390](https://github.com/Kong/kong/pull/10390)
+- Tracing PDK now accepts resource as an parameter.
+  [#10477](https://github.com/Kong/kong/pull/10477)
 
 #### Plugins
 

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -55,6 +55,8 @@ local SPAN_KIND = {
   CONSUMER = 5,
 }
 
+local EMPTY = {}
+
 --- Generate trace ID
 local function generate_trace_id()
   return rand_bytes(16)
@@ -149,7 +151,7 @@ local function new_span(tracer, name, options)
     end
   end
 
-  options = options or {}
+  options = options or EMPTY
 
   -- get parent span from ctx
   -- the ctx could either be stored in ngx.ctx or kong.ctx
@@ -175,6 +177,7 @@ local function new_span(tracer, name, options)
   span.tracer = tracer
 
   span.name = name
+  span.resource = options.resource
   span.trace_id = trace_id
   span.span_id = generate_span_id()
   span.parent_id = parent_span and parent_span.span_id

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -250,7 +250,8 @@ for _, strategy in helpers.each_strategy() do
         -- Making sure it's alright
         local spans = cjson.decode(res)
         assert.is_same(2, #spans, res)
-        assert.is_same("header_filter phase: " .. tcp_trace_plugin_name, spans[2].name)
+        assert.is_same("plugin", spans[2].name)
+        assert.is_same("header_filter phase: " .. tcp_trace_plugin_name, spans[2].resource)
       end)
     end)
 
@@ -284,7 +285,7 @@ for _, strategy in helpers.each_strategy() do
 
         local found
         for _, span in ipairs(spans) do
-          if span.name == "DNS: konghq.com" then
+          if span.name == "DNS" and span.resource == "DNS 127.0.0.1" then
             found = true
           end
         end

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -102,7 +102,7 @@ for _, strategy in helpers.each_strategy() do
           expected_span_num = 4
         end
         assert.is_same(expected_span_num, #spans, res)
-        assert.is_same("query", spans[2].name)
+        assert.is_same("DB_query", spans[2].name)
       end)
     end)
 
@@ -160,7 +160,8 @@ for _, strategy in helpers.each_strategy() do
         -- Making sure it's alright
         local spans = cjson.decode(res)
         assert.is_same(4, #spans, res)
-        assert.is_same("GET /", spans[1].name)
+        assert.is_same("API_gateway", spans[1].name)
+        assert.is_same("GET /", spans[1].resource)
       end)
     end)
 
@@ -189,7 +190,8 @@ for _, strategy in helpers.each_strategy() do
         -- Making sure it's alright
         local spans = cjson.decode(res)
         assert.is_same(2, #spans, res)
-        assert.is_same("balancer try #1", spans[2].name)
+        assert.is_same("balancer", spans[2].name)
+        assert.is_same("balancer try #1", spans[2].resource)
       end)
     end)
 
@@ -218,7 +220,8 @@ for _, strategy in helpers.each_strategy() do
         -- Making sure it's alright
         local spans = cjson.decode(res)
         assert.is_same(2, #spans, res)
-        assert.is_same("rewrite phase: " .. tcp_trace_plugin_name, spans[2].name)
+        assert.is_same("plugin", spans[2].name)
+        assert.is_same("rewrite phase: " .. tcp_trace_plugin_name, spans[2].resource)
       end)
     end)
 


### PR DESCRIPTION
### Summary

Service, operation name, and then resource are the three levels of grouping in DataDog.

The operation name(also called span name) is used to filter Datadog APM/service board. High cardinality makes it unusable.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix FTI-4882
