### PR TITLE
chore(workflows): allow errors in schema-change-labels job

### DIFF
--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -9,5 +9,6 @@ jobs:
     steps:
     - name: Schema change label found
       uses: rtCamp/action-slack-notify@v2
+      continue-on-error: true
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}


### PR DESCRIPTION
### Summary

Allow failure for the schema-change-labels job.
This will make the job fail silently on fork PRs, since they are unable to access the secret that is required to complete this workflow.

Please feel free to propose better alternatives.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
