### PR TITLE
fix(dockerfiles): clean up dangling sockets on startup (#10468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@
 - Bumped lua-resty-session from 4.0.2 to 4.0.3
   [#10338](https://github.com/Kong/kong/pull/10338)
 
+### Fixes
+
+#### Core
+
+- Fixed an issue where dangling Unix sockets would prevent Kong from restart in
+  Docker containers if it was not cleanly stopped.
+  [#10481](https://github.com/Kong/kong/pull/10481)
+
+
 ### 3.2.1
 
 #### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 
 #### Core
 
-- Fixed an issue where dangling Unix sockets would prevent Kong from restart in
+- Fixed an issue where dangling Unix sockets would prevent Kong from restarting in
   Docker containers if it was not cleanly stopped.
   [#10481](https://github.com/Kong/kong/pull/10481)
 

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -44,6 +44,22 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     kong prepare -p "$PREFIX" "$@"
 
+    # remove all dangling sockets in $PREFIX dir before starting Kong
+    LOGGED_SOCKET_WARNING=0
+    for localfile in "$PREFIX"/*; do
+      if [ -S "$localfile" ]; then
+        if (( LOGGED_SOCKET_WARNING == 0 )); then
+          printf >&2 'WARN: found dangling unix sockets in the prefix directory '
+          printf >&2 '(%q) ' "$PREFIX"
+          printf >&2 'while preparing to start Kong. This may be a sign that Kong '
+          printf >&2 'was previously shut down uncleanly or is in an unknown state '
+          printf >&2 'and could require further investigation.\n'
+          LOGGED_SOCKET_WARNING=1
+        fi
+        rm -f "$localfile"
+      fi
+    done
+
     ln -sfn /dev/stdout $PREFIX/logs/access.log
     ln -sfn /dev/stdout $PREFIX/logs/admin_access.log
     ln -sfn /dev/stderr $PREFIX/logs/error.log


### PR DESCRIPTION
FTI-4525

(cherry picked from commit a6fe3703e7e564aa0634f36d0f6d60ad395e2a03)

### Summary

This change adds a clean-up step to remove all sockets that a previous Kong run may have left in `$PREFIX` directory.

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

Dangling unix sockets have been a pain point in recent Kong versions and was dealt in traditional Kong in #9254, but the kong script is not called when starting Kong inside a container, so a similar change to `dockerfiles/entrypoint.sh` was added here.

### Issue reference

FTI-4525