### PR TITLE
fix(*): move previous `dev` targets to `dev-legacy`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [8000, 8001, "db:5432"],
 
-    "postCreateCommand": "make dev",
+    "postCreateCommand": "make dev-legacy",
 
     // Set *default* container specific settings.json values on container create.
     // "settings": {},

--- a/scripts/test-upgrade-path.sh
+++ b/scripts/test-upgrade-path.sh
@@ -85,7 +85,7 @@ function build_containers() {
     gojira up -t $OLD_VERSION --network $NETWORK_NAME --$DATABASE
     gojira run -t $OLD_VERSION -- make dev
     gojira up -t $NEW_VERSION --alone --network $NETWORK_NAME --$DATABASE
-    gojira run -t $NEW_VERSION -- make dev
+    gojira run -t $NEW_VERSION -- make dev-legacy
 }
 
 function initialize_test_list() {

--- a/scripts/test-upgrade-path.sh
+++ b/scripts/test-upgrade-path.sh
@@ -85,6 +85,7 @@ function build_containers() {
     gojira up -t $OLD_VERSION --network $NETWORK_NAME --$DATABASE
     gojira run -t $OLD_VERSION -- make dev
     gojira up -t $NEW_VERSION --alone --network $NETWORK_NAME --$DATABASE
+    # Kong version >= 3.3 moved non Bazel-built dev setup to make dev-legacy
     gojira run -t $NEW_VERSION -- make dev-legacy
 }
 


### PR DESCRIPTION
Follow up of https://github.com/Kong/kong/pull/10442.
This should fix the failing Upgrade Tests.
Also open to suggestions to let `make dev` works both in a bazel built venv and in a released docker container