### PR TITLE
fix(makefile): remove `remove` target dependency to `dependencies` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,10 @@ fix-windows:
 # the following targets are kept for backwards compatibility
 # dev is renamed to dev-legacy
 remove:
-	$(warning 'remove' target is deprecated, please use `dev` instead)
+	$(warning 'remove' target is deprecated, please use `make dev` instead)
 	-@luarocks remove kong
 
-dependencies: bin/grpcurl remove
+dependencies: bin/grpcurl
 	$(warning 'dependencies' target is deprecated, this is now not needed when using `make dev`, but are kept for installation that are not built by Bazel)
 
 	for rock in $(DEV_ROCKS) ; do \
@@ -165,4 +165,4 @@ dependencies: bin/grpcurl remove
 install-legacy:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) YAML_DIR=$(YAML_DIR)
 
-dev-legacy: bin/grpcurl remove install-legacy dependencies
+dev-legacy: remove install-legacy dependencies


### PR DESCRIPTION

To preserve the previous behaviour.

This is a regression from https://github.com/Kong/kong/pull/10442 and https://github.com/Kong/kong/pull/10490.

Fixes https://github.com/Kong/kong-plugin/actions/runs/4421446482/jobs/7765323653

The previous dependency was:
```makefile
install:
	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) YAML_DIR=$(YAML_DIR)

remove:
	-@luarocks remove kong

dependencies: bin/grpcurl
	@for rock in $(DEV_ROCKS) ; do \
	  if luarocks list --porcelain $$rock | grep -q "installed" ; then \
	    echo $$rock already installed, skipping ; \
	  else \
	    echo $$rock not found, installing via luarocks... ; \
	    luarocks install $$rock OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) || exit 1; \
	  fi \
	done;

dev: remove install dependencies
```