### PR TITLE
feat(build): support fish, add PS1, move venv scripts to template

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -180,20 +180,14 @@ Verify the three new containers are up and running with `docker ps` on a separat
 
 Now you can start Kong:
 
-For Zsh/Bash:
-
 ```shell
 # active the venv into your shell envirnoment
+# For Zsh/Bash:
 . bazel-bin/build/kong-dev-venv.sh
+# For Fish Shell:
+. bazel-bin/build/kong-dev-venv.fish
 # Start Kong!
 kong start
-```
-
-For Fish:
-
-```shell
-# Start Kong!
-bazel-bin/build/kong-dev-venv.sh kong start
 ```
 
 ### Install Development Dependencies

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
-load("//build:build_system.bzl", "kong_directory_genrule")
+load("//build:build_system.bzl", "kong_directory_genrule", "kong_rules_group", "kong_template_file")
 
 exports_files([
     "package/nfpm.yaml",
@@ -127,66 +127,39 @@ kong_directory_genrule(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+kong_template_file(
+    name = "venv.sh",
+    output = "%s-venv.sh" % KONG_VAR["BUILD_NAME"],
+    substitutions = {
+        "{{build_name}}": KONG_VAR["BUILD_NAME"],
+        "{{workspace_path}}": KONG_VAR["WORKSPACE_PATH"],
+    },
+    template = "//build:templates/venv.sh",
+)
+
+kong_template_file(
+    name = "venv.fish",
+    output = "%s-venv.fish" % KONG_VAR["BUILD_NAME"],
+    substitutions = {
+        "{{build_name}}": KONG_VAR["BUILD_NAME"],
+        "{{workspace_path}}": KONG_VAR["WORKSPACE_PATH"],
+    },
+    template = "//build:templates/venv.fish",
+)
+
+kong_template_file(
+    name = "venv-commons",
+    is_executable = True,
+    output = "%s/venv/lib/venv-commons" % KONG_VAR["BUILD_NAME"],
+    template = "//build:templates/venv-commons",
+)
+
+kong_rules_group(
     name = "venv",
-    srcs = [
-        ":kong",
+    propagates = [
+        ":venv.sh",
+        ":venv.fish",
+        ":venv-commons",
     ],
-    outs = [
-        "%s-venv.sh" % KONG_VAR["BUILD_NAME"],
-    ],
-    cmd = """
-    workspace_path={workspace_path}
-    build_name={build_name}
-    """.format(
-        build_name = KONG_VAR["BUILD_NAME"],
-        workspace_path = KONG_VAR["WORKSPACE_PATH"],
-    ) + """
-
-        cat << EOF > $@
-#!/bin/bash
-
-INSTALL_ROOT=$${workspace_path}/bazel-bin/build/$${build_name}
-ROCKS_CONFIG="\\$$INSTALL_ROOT/rocks_config"
-ROCKS_ROOT="\\$$INSTALL_ROOT"
-
-chmod -R a+rw "\\$$INSTALL_ROOT"
-
-export LD_LIBRARY_PATH=\\$$INSTALL_ROOT/kong/lib
-mkdir -p \\$$INSTALL_ROOT/venv/bin
-
-echo '#!/bin/bash
-'\\$$INSTALL_ROOT/openresty/bin/resty -I \\$$INSTALL_ROOT/openresty/site/lualib -I \\$$INSTALL_ROOT/openresty/lualib --nginx \\$$INSTALL_ROOT/openresty/nginx/sbin/nginx' "\\$$@"
-' > \\$$INSTALL_ROOT/venv/bin/resty
-chmod +x \\$$INSTALL_ROOT/venv/bin/resty
-
-export PATH="\\$$INSTALL_ROOT/venv/bin:\\$$INSTALL_ROOT/openresty/bin:\\$$INSTALL_ROOT/openresty/nginx/sbin:\\$$INSTALL_ROOT/openresty/luajit/bin:\\$$INSTALL_ROOT/luarocks/bin:\\$$INSTALL_ROOT/bin:$${workspace_path}/bin:\\$$PATH"
-
-echo "
-rocks_trees = {
-{ name = [[system]], root = [[\\$$ROCKS_ROOT]] }
-}
-
-" > \\$$ROCKS_CONFIG
-
-export LUAROCKS_CONFIG=\\$$ROCKS_CONFIG
-
-# duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
-export LUA_PATH="./?.lua;./?/init.lua;\\$$INSTALL_ROOT/openresty/site/lualib/?.ljbc;\\$$INSTALL_ROOT/openresty/site/lualib/?/init.ljbc;\\$$INSTALL_ROOT/openresty/lualib/?.ljbc;\\$$INSTALL_ROOT/openresty/lualib/?/init.ljbc;\\$$INSTALL_ROOT/openresty/site/lualib/?.lua;\\$$INSTALL_ROOT/openresty/site/lualib/?/init.lua;\\$$INSTALL_ROOT/openresty/lualib/?.lua;\\$$INSTALL_ROOT/openresty/lualib/?/init.lua;\\$$INSTALL_ROOT/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;\\$$ROCKS_ROOT/share/lua/5.1/?.ljbc;\\$$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;\\$$ROCKS_ROOT/share/lua/5.1/?.lua;\\$$ROCKS_ROOT/share/lua/5.1/?/init.lua;;"
-
-export LUA_CPATH="\\$$INSTALL_ROOT/openresty/site/lualib/?.so;\\$$INSTALL_ROOT/openresty/lualib/?.so;./?.so;\\$$INSTALL_ROOT/lib/lua/5.1/?.so;\\$$INSTALL_ROOT/openresty/luajit/lib/lua/5.1/?.so;\\$$ROCKS_ROOT/lib/lua/5.1/?.so;;"
-export KONG_PREFIX="\\$$INSTALL_ROOT/kong/servroot"
-export LIBRARY_PREFIX="\\$$INSTALL_ROOT/kong" # let "make dev" happy
-export OPENSSL_DIR="\\$$INSTALL_ROOT/kong" # let "make dev" happy
-
-# can be used as a wrapper
-if [ ! -z "\\$$*" ]; then
-    exec \\$$@
-fi
-EOF
-
-        echo \\* Please run ". $@" to activate the "$${build_name}" environment
-    """,
-    executable = True,
     visibility = ["//visibility:public"],
 )

--- a/build/build_system.bzl
+++ b/build/build_system.bzl
@@ -45,3 +45,30 @@ kong_rules_group = rule(
         "propagates": attr.label_list(),
     },
 )
+
+def _kong_template_file_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = ctx.outputs.output,
+        substitutions = ctx.attr.substitutions,
+        is_executable = ctx.attr.is_executable,
+    )
+
+    return [
+        DefaultInfo(files = depset([ctx.outputs.output])),
+    ]
+
+kong_template_file = rule(
+    implementation = _kong_template_file_impl,
+    attrs = {
+        "template": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "output": attr.output(
+            mandatory = True,
+        ),
+        "substitutions": attr.string_dict(),
+        "is_executable": attr.bool(default = False),
+    },
+)

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -1,0 +1,33 @@
+
+test -z "$KONG_VENV" && exit 1
+
+# use env vars to let Fish shell happy, we will unset them later
+export ROCKS_CONFIG="$KONG_VENV/rocks_config"
+export ROCKS_ROOT="$KONG_VENV"
+
+chmod -R a+rw "$KONG_VENV"
+
+mkdir -p "$KONG_VENV/venv/bin"
+
+echo "#!/bin/bash
+$KONG_VENV/openresty/bin/resty -I $KONG_VENV/openresty/site/lualib -I $KONG_VENV/openresty/lualib --nginx $KONG_VENV/openresty/nginx/sbin/nginx \"\$@\"
+" > "$KONG_VENV/venv/bin/resty"
+chmod +x "$KONG_VENV/venv/bin/resty"
+
+export PATH="$KONG_VENV/venv/bin:$KONG_VENV/openresty/bin:$KONG_VENV/openresty/nginx/sbin:$KONG_VENV/openresty/luajit/bin:$KONG_VENV/luarocks/bin:$KONG_VENV/bin:$workspace_path/bin:$PATH"
+
+echo "
+rocks_trees = {
+    { name = [[system]], root = [[$ROCKS_ROOT]] }
+}
+" > "$ROCKS_CONFIG"
+
+export LUAROCKS_CONFIG="$ROCKS_CONFIG"
+
+# duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
+export LUA_PATH="./?.lua;./?/init.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?/init.lua;;"
+
+export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
+export KONG_PREFIX="$KONG_VENV/kong/servroot"
+export LIBRARY_PREFIX="$KONG_VENV/kong" # let "make dev" happy
+export OPENSSL_DIR="$KONG_VENV/kong" # let "make dev" happy

--- a/build/templates/venv.fish
+++ b/build/templates/venv.fish
@@ -1,0 +1,79 @@
+#!/usr/bin/env fish
+
+# template variables starts
+set build_name "{{build_name}}"
+set workspace_path "{{workspace_path}}"
+# template variables ends
+
+if test (echo $FISH_VERSION | head -c 1) -lt 3
+    echo "Fish version 3.0.0 or higher is required."
+end
+
+# Modified from virtualenv: https://github.com/pypa/virtualenv/blob/main/src/virtualenv/activation/fish/activate.fish
+
+set -xg KONG_VENV "$workspace_path/bazel-bin/build/$build_name"
+
+# set PATH
+if test -n "$_OLD_KONG_VENV_PATH"
+    # restore old PATH first, if this script is called multiple times
+    echo "restored old path $_OLD_KONG_VENV_PATH"
+    set -gx PATH $_OLD_KONG_VENV_PATH
+else
+    set _OLD_KONG_VENV_PATH $PATH
+end
+
+function deactivate -d 'Exit Kong\'s venv and return to the normal environment.'
+
+    # reset old environment variables
+    if test -n "$_OLD_KONG_VENV_PATH"
+        set -gx PATH $_OLD_KONG_VENV_PATH
+        set -e _OLD_KONG_VENV_PATH
+    end
+
+    if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
+       and functions -q _old_fish_prompt
+        # Set an empty local `$fish_function_path` to allow the removal of `fish_prompt` using `functions -e`.
+        set -l fish_function_path
+
+        # Erase virtualenv's `fish_prompt` and restore the original.
+        functions -e fish_prompt
+        functions -c _old_fish_prompt fish_prompt
+        functions -e _old_fish_prompt
+        set -e _OLD_FISH_PROMPT_OVERRIDE
+    end
+
+    set -e KONG_VENV
+    set -e ROCKS_CONFIG ROCKS_ROOT LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
+    functions -e deactivate
+end
+
+# actually set env vars
+source $KONG_VENV/venv/lib/venv-commons
+set -xg PATH "$PATH"
+
+# set shell prompt
+if test -z "$KONG_VENV_DISABLE_PROMPT"
+    # Copy the current `fish_prompt` function as `_old_fish_prompt`.
+    functions -c fish_prompt _old_fish_prompt
+
+    function fish_prompt
+        # Run the user's prompt first; it might depend on (pipe)status.
+        set -l prompt (_old_fish_prompt)
+
+        # Prompt override provided?
+        # If not, just prepend the environment name.
+        if test -n ''
+            printf '(%s) ' ''
+        else
+            printf '(%s) ' "$build_name"
+        end
+
+        string join -- \n $prompt # handle multi-line prompts
+    end
+
+    set -gx _OLD_FISH_PROMPT_OVERRIDE "$KONG_VENV"
+end
+
+if test -n "$argv"
+    exec $argv
+end

--- a/build/templates/venv.sh
+++ b/build/templates/venv.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# template variables starts
+build_name="{{build_name}}"
+workspace_path="{{workspace_path}}"
+# template variables ends
+
+KONG_VENV="$workspace_path/bazel-bin/build/$build_name"
+export KONG_VENV
+
+# set PATH
+if [ -n "${_OLD_KONG_VENV_PATH}" ]; then
+    # restore old PATH first, if this script is called multiple times
+    PATH="${_OLD_KONG_VENV_PATH}"
+else
+    _OLD_KONG_VENV_PATH="${PATH}"
+fi
+export PATH
+
+deactivate () {
+    export PATH="${_OLD_KONG_VENV_PATH}"
+    export PS1="${_OLD_KONG_VENV_PS1}"
+    unset KONG_VENV
+    unset _OLD_KONG_VENV_PATH _OLD_KONG_VENV_PS1
+    unset ROCKS_CONFIG ROCKS_ROOT LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
+    unset -f deactivate
+}
+
+# actually set env vars
+. $KONG_VENV/venv/lib/venv-commons
+
+# set shell prompt
+if [ -z "${KONG_VENV_DISABLE_PROMPT-}" ] ; then
+    if [ -n "${_OLD_KONG_VENV_PS1}" ]; then
+        # prepend the old PS1 if this script is called multiple times
+        PS1="(${build_name}) ${_OLD_KONG_VENV_PS1}"
+    else
+        _OLD_KONG_VENV_PS1="${PS1-}"
+        PS1="(${build_name}) ${PS1-}"
+    fi
+    export PS1
+fi
+
+# check wrapper
+test -n "$*" && exec "$@" || true


### PR DESCRIPTION

### Summary

This PR adds official support of Fish shell to venv; and add PS1 prompt to bash/zsh/fish.
Also we starts to move shell scripts into template to make it `shellcheck`-able.

### Checklist


### Full changelog

- feat(build): support fish, add PS1, move venv scripts to template

Pretty demo:

[![asciicast](https://asciinema.org/a/2mc7LG1e5fDFfzc1f5uADf8DB.svg)](https://asciinema.org/a/2mc7LG1e5fDFfzc1f5uADf8DB)
