### PR TITLE
tests(*): fix db ttl cleanup flaky test

### DIFF
--- a/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
+++ b/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
@@ -6,6 +6,8 @@ for _, strategy in helpers.each_strategy() do
     describe("ttl cleanup timer #postgres", function()
       local bp, db, consumer1
       lazy_setup(function()
+        helpers.clean_logfile()
+
         bp, db = helpers.get_db_utils("postgres", {
           "routes",
           "services",
@@ -25,6 +27,7 @@ for _, strategy in helpers.each_strategy() do
 
         assert(helpers.start_kong({
           database = strategy,
+          log_level = "debug",
         }))
       end)
 
@@ -35,7 +38,7 @@ for _, strategy in helpers.each_strategy() do
 
       it("init_worker should run ttl cleanup in background timer", function ()
         helpers.pwait_until(function()
-          assert.errlog().has.line([[cleaning up expired rows from table ']] .. "keyauth_credentials" .. [[' took \d+\.\d+ seconds]], false, 2)
+          assert.errlog().has.line([[cleaning up expired rows from table ']] .. "keyauth_credentials" .. [[' took .+ seconds]], false, 2)
         end, 65)
 
         local ok, err = db.connector:query("SELECT * FROM keyauth_credentials")
@@ -47,7 +50,7 @@ for _, strategy in helpers.each_strategy() do
         assert.truthy(#names_of_table_with_ttl > 0)
 
         for _, name in ipairs(names_of_table_with_ttl) do
-          assert.errlog().has.line([[cleaning up expired rows from table ']] .. name .. [[' took \d+\.\d+ seconds]], false, 2)
+          assert.errlog().has.line([[cleaning up expired rows from table ']] .. name .. [[' took .+ seconds]], false, 2)
         end
       end)
     end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
It seems that sometimes the estimated time calculation will be 0 which violates the original expression so that the test may fail. Since we're only testing the fact that cleanup running, the time format is not what we care about.
```
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'cluster_events' took 0.026 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'clustering_data_planes' took 0.002 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'acme_storage' took 0.001 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'keyauth_credentials' took 0.001 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'oauth2_authorization_codes' took 0.001 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'oauth2_tokens' took 0.002 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'ratelimiting_metrics' took 0 seconds
kong_1   | 2023/03/16 07:22:41 [debug] 9263#0: *449 [lua] connector.lua:373: cleaning up expired rows from table 'sessions' took 0.001 seconds
```

I ran the test locally 20+ times and saw no failure now.


### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-921
