### PR TITLE
tests(certificates): reduce cert PATCH test flakiness

### DIFF
--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -74,7 +74,12 @@ describe("Admin API: #" .. strategy, function()
   local function get_certificates()
     local res  = client:get("/certificates")
     local body = assert.res_status(200, res)
-    return cjson.decode(body)
+    local json = cjson.decode(body)
+    for _, cert in ipairs(json.data) do
+      cert.updated_at = nil
+    end
+
+    return json
   end
 
   local bp, db


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR reduces the flakiness of a certificate PATCH test.

A failure example can be found at https://github.com/Kong/kong/actions/runs/4443688330/jobs/7801199951?pr=10475, it can be found from the result that when comparing two certificates lists, the `updated_at` field is marked as different.

```
...
*[updated_at] = 1679021891 }

...

*[updated_at] = 1679021890 }
```

This could happen if the PATCH action happens in the next second of the creation, which may cause this test result flaky.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
