### PR TITLE
fix(router): traditional router could error with "invalid order function for sorting"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@
 - Fixed an issue where dangling Unix sockets would prevent Kong from restarting in
   Docker containers if it was not cleanly stopped.
   [#10468](https://github.com/Kong/kong/pull/10468)
+- Fix an issue where sorting function for traditional router sources/destinations lead to "invalid order
+  function for sorting" error.
+  [#10514](https://github.com/Kong/kong/pull/10514)
 
 #### Admin API
 

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -163,6 +163,71 @@ for _, strategy in helpers.each_strategy() do
           service = service,
         })
 
+        assert(bp.routes:insert {
+          protocols = { "tcp" },
+          service   = service,
+          destinations = {
+            { ip = "0.0.0.0", port = 19004 },
+            { ip = "0.0.0.0", port = 19005 },
+            { ip = "0.0.0.0", port = 19006 },
+            { ip = "0.0.0.0", port = 19007 },
+            { ip = "0.0.0.0" },
+            { port = 19004 },
+          }
+        })
+
+        assert(bp.routes:insert {
+          protocols = { "tcp" },
+          service   = service,
+          destinations = {
+            { ip = "0.0.0.0", port = 19004 },
+            { ip = "0.0.0.0", port = 19005 },
+            { ip = "0.0.0.0", port = 19006 },
+            { ip = "0.0.0.0", port = 19007 },
+            { ip = "0.0.0.0" },
+            { port = 19004 },
+          }
+        })
+
+        assert(bp.routes:insert {
+          protocols = { "tcp" },
+          service   = service,
+          destinations = {
+            { ip = "0.0.0.0", port = 19004 },
+            { ip = "0.0.0.0", port = 19005 },
+            { ip = "0.0.0.0", port = 19006 },
+            { ip = "0.0.0.0", port = 19007 },
+            { ip = "0.0.0.0" },
+            { port = 19004 },
+          }
+        })
+
+        assert(bp.routes:insert {
+          protocols = { "tcp" },
+          service   = service,
+          destinations = {
+            { ip = "0.0.0.0", port = 19004 },
+            { ip = "0.0.0.0", port = 19005 },
+            { ip = "0.0.0.0", port = 19006 },
+            { ip = "0.0.0.0", port = 19007 },
+            { ip = "0.0.0.0" },
+            { port = 19004 },
+          }
+        })
+
+        assert(bp.routes:insert {
+          protocols = { "tcp" },
+          service   = service,
+          destinations = {
+            { ip = "0.0.0.0", port = 19004 },
+            { ip = "0.0.0.0", port = 19005 },
+            { ip = "0.0.0.0", port = 19006 },
+            { ip = "0.0.0.0", port = 19007 },
+            { ip = "0.0.0.0" },
+            { port = 19004 },
+          }
+        })
+
         assert(helpers.start_kong({
           database      = strategy,
           stream_listen = helpers.get_proxy_ip(false) .. ":19000, " ..
@@ -209,6 +274,10 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("connection reset by peer", err)
         end
         assert(tcp_client:close())
+      end)
+
+      it("destinations has more than 3 items", function()
+        assert.logfile().has.no.line("invalid order function for sorting", true)
       end)
     end)
   end


### PR DESCRIPTION
### Summary

The same route may have been added multiple times to `routes_by_sources[<ip|port>]` or `routes_by_destination[<ip|port>]` which lead to "invalid order function for sorting" when we tried to sort the routes. There was also sorting issue when multiple routes sorted the same. This fixes the issue.

KAG-918

### Issues Resolved

Fix #10446
Close #10470