### PR TITLE
fix(db/declarative): store and verify kong version in lmdb cache

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -204,6 +204,8 @@ local constants = {
   DECLARATIVE_HASH_KEY = "declarative_config:hash",
   DECLARATIVE_EMPTY_CONFIG_HASH = string.rep("0", 32),
 
+  LMDB_KONG_VERSION_KEY = "lmdb:kong:version",
+
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 
   CLUSTERING_SYNC_STATUS = {

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -130,7 +130,8 @@ end
 local function get_current_hash()
   local v, err = lmdb_get(LMDB_KONG_VERSION_KEY)
   if v ~= KONG_VERSION or err then
-    return nil, err or "Kong version mismatch"
+    ngx.log(ngx.WARN, "current Kong v", KONG_VERSION, " mismatch cache v", v)
+    return nil, err
   end
 
   return lmdb_get(DECLARATIVE_HASH_KEY)

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -33,7 +33,7 @@ local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
 local KONG_VERSION = meta.version
-local LMDB_KONG_VERSION_KEY = "lmdb:kong:version"
+local LMDB_KONG_VERSION_KEY = constants.LMDB_KONG_VERSION_KEY
 
 
 local function find_or_create_current_workspace(name)

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -25,6 +25,7 @@ local get_phase = ngx.get_phase
 local ngx_socket_tcp = ngx.socket.tcp
 local yield = utils.yield
 local sha256 = utils.sha256_hex
+local lmdb_get = lmdb.get
 
 
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
@@ -126,7 +127,7 @@ end
 
 
 local function get_current_hash()
-  return lmdb.get(DECLARATIVE_HASH_KEY)
+  return lmdb_get(DECLARATIVE_HASH_KEY)
 end
 
 

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -129,9 +129,14 @@ end
 
 local function get_current_hash()
   local v, err = lmdb_get(LMDB_KONG_VERSION_KEY)
-  if v ~= KONG_VERSION or err then
-    ngx.log(ngx.WARN, "current Kong v", KONG_VERSION, " mismatch cache v", v)
+
+  if err then
     return nil, err
+  end
+
+  if v ~= KONG_VERSION then
+    ngx.log(ngx.WARN, "current Kong v", KONG_VERSION, " mismatches cache v", v)
+    return nil
   end
 
   return lmdb_get(DECLARATIVE_HASH_KEY)

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -135,7 +135,9 @@ local function get_current_hash()
   end
 
   if v ~= KONG_VERSION then
-    ngx.log(ngx.WARN, "current Kong v", KONG_VERSION, " mismatches cache v", v)
+    ngx.log(ngx.WARN,
+            "current Kong v", KONG_VERSION,
+            " mismatches cache v", v or " unknown")
     return nil
   end
 

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -1,5 +1,6 @@
 local lmdb = require("resty.lmdb")
 local txn = require("resty.lmdb.transaction")
+local meta = require("kong.meta")
 local constants = require("kong.constants")
 local workspaces = require("kong.workspaces")
 local utils = require("kong.tools.utils")

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -31,6 +31,10 @@ local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
+local KONG_VERSION = meta.version
+local LMDB_KONG_VERSION_KEY = "lmdb:kong:version"
+
+
 local function find_or_create_current_workspace(name)
   name = name or "default"
 
@@ -425,6 +429,9 @@ local function load_into_cache(entities, meta, hash)
 
   t:set("tags||@list", tags)
   t:set(DECLARATIVE_HASH_KEY, hash)
+
+  -- for compatibility check
+  t:set(LMDB_KONG_VERSION_KEY, KONG_VERSION)
 
   kong.default_workspace = default_workspace
 

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -128,6 +128,11 @@ end
 
 
 local function get_current_hash()
+  local v, err = lmdb_get(LMDB_KONG_VERSION_KEY)
+  if v ~= KONG_VERSION or err then
+    return nil, err or "Kong version mismatch"
+  end
+
   return lmdb_get(DECLARATIVE_HASH_KEY)
 end
 

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -46,7 +46,6 @@ do
   origin_lmdb_get = lmdb.get
 
   lmdb_get = function(key, db)
-    --return origin_lmdb_get(key, db)
     local v, err = origin_lmdb_get(LMDB_KONG_VERSION_KEY, db)
     if v ~= KONG_VERSION or err then
       return nil, err or "Kong version mismatch"

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -19,6 +19,7 @@ local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
 local null = ngx.null
 local unmarshall = marshaller.unmarshall
+local lmdb_get = lmdb.get
 local get_workspace_id = workspaces.get_workspace_id
 
 
@@ -33,29 +34,6 @@ local off = {}
 
 local _mt = {}
 _mt.__index = _mt
-
-
-local lmdb_get
-do
-  local meta = require("kong.meta")
-  local constants = require("kong.constants")
-
-  local KONG_VERSION = meta.version
-  local LMDB_KONG_VERSION_KEY = constants.LMDB_KONG_VERSION_KEY
-
-  origin_lmdb_get = lmdb.get
-
-  lmdb_get = function(key, db)
-    local v, err = origin_lmdb_get(LMDB_KONG_VERSION_KEY, db)
-    if v ~= KONG_VERSION or err then
-      return nil, err or "Kong version mismatch"
-    end
-
-    lmdb_get = origin_lmdb_get
-
-    return origin_lmdb_get(key, db)
-  end
-end
 
 
 local function ws(schema, options)

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -37,6 +37,9 @@ _mt.__index = _mt
 
 local lmdb_get
 do
+  local meta = require("kong.meta")
+  local constants = require("kong.constants")
+
   local KONG_VERSION = meta.version
   local LMDB_KONG_VERSION_KEY = constants.LMDB_KONG_VERSION_KEY
 

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -127,6 +127,8 @@ describe("dbless persistence with a declarative config #off", function()
     assert.res_status(401, res)
 
     proxy_client:close()
+
+    verify_lmdb_kong_version()
   end)
 
   after_each(function()

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -2,6 +2,8 @@ local helpers = require "spec.helpers"
 
 local fmt = string.format
 
+local KONG_VERSION = require("kong.meta").version
+
 local SERVICE_YML = [[
 - name: my-service-%d
   url: https://example%d.dev
@@ -17,7 +19,6 @@ local verify_lmdb_kong_version
 local set_lmdb_kong_version
 do
   local TEST_CONF = helpers.test_conf
-  local KONG_VERSION = require("kong.meta").version
   local LMDB_KONG_VERSION_KEY = require("kong.constants").LMDB_KONG_VERSION_KEY
 
   verify_lmdb_kong_version = function()
@@ -62,6 +63,8 @@ describe("dbless persistence #off", function()
 
     admin_client = assert(helpers.admin_client())
     proxy_client = assert(helpers.proxy_client())
+
+    assert.logfile().has.line("current Kong v" .. KONG_VERSION .. " mismatches cache v1.0")
   end)
 
   lazy_teardown(function()

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -61,10 +61,10 @@ describe("dbless persistence #off", function()
       database   = "off",
     }))
 
+    assert.logfile().has.line("current Kong v" .. KONG_VERSION .. " mismatches cache v1.0")
+
     admin_client = assert(helpers.admin_client())
     proxy_client = assert(helpers.proxy_client())
-
-    assert.logfile().has.line("current Kong v" .. KONG_VERSION .. " mismatches cache v1.0")
   end)
 
   lazy_teardown(function()
@@ -129,6 +129,9 @@ describe("dbless persistence with a declarative config #off", function()
         database   = "off",
         declarative_config = yaml_file,
     }))
+
+    assert.logfile().has.line("current Kong v" .. KONG_VERSION .. " mismatches cache v unknown")
+
     admin_client = assert(helpers.admin_client())
     proxy_client = assert(helpers.proxy_client())
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

If kong's version mismatches the version stored in the lmdb cache, 
the function `get_current_hash` will log a warning message and return `nil`,
then kong will load an empty declarative config, which means cache is cleared.

KAG-798

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]


