### PR TITLE
chore(deps) bump luasec from 1.2.0 to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@
 - Bumped lua-resty-openssl from 0.8.17 to 0.8.20
   [#10463](https://github.com/Kong/kong/pull/10463)
   [#10476](https://github.com/Kong/kong/pull/10476)
+- Bumped LuaSec from 1.2.0 to 1.3.1
+  [#10528](https://github.com/Kong/kong/pull/10528)
 
 ## 3.2.0
 

--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -13,7 +13,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.3",
-  "luasec == 1.2.0",
+  "luasec == 1.3.1",
   "luasocket == 3.0-rc1",
   "penlight == 1.13.1",
   "lua-resty-http ~> 0.17",

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -129,7 +129,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
   Version Requirement:
-  - libc.so.6 (GLIBC_2.2.5, GLIBC_2.4)
+  - libc.so.6 (GLIBC_2.14, GLIBC_2.2.5, GLIBC_2.4)
   - libcrypto.so.1.1 (OPENSSL_1_1_0)
   - libssl.so.1.1 (OPENSSL_1_1_0, OPENSSL_1_1_1)
 


### PR DESCRIPTION
### Summary

#### LuaSec 1.3.1

* Fix: check if PSK is available

#### LuaSec 1.3.0

* Add :getlocalchain() + :getlocalcertificate() to mirror the peer methods (@mwild1)
* Add Pre-Shared Key (PSK) support (@jclab-joseph)