### PR TITLE
feat(http-log): support charset in content-type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@
   [#9746](https://github.com/Kong/kong/pull/9746)
 - **Proxy-Cache**: add `ignore_uri_case` to configuring cache-key uri to be handled as lowercase
   [#10453](https://github.com/Kong/kong/pull/10453)
+- **HTTP-Log**: add `application/json; charset=utf-8` option for the `Content-Type` header
+  in the http-log plugin, for log collectors that require that character set declaration.
+  [#x](https://github.com/Kong/kong/pull/x)
 
 #### PDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
   [#10453](https://github.com/Kong/kong/pull/10453)
 - **HTTP-Log**: add `application/json; charset=utf-8` option for the `Content-Type` header
   in the http-log plugin, for log collectors that require that character set declaration.
-  [#x](https://github.com/Kong/kong/pull/x)
+  [#10533](https://github.com/Kong/kong/pull/10533)
 
 #### PDK
 

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -11,7 +11,7 @@ return {
           -- NOTE: any field added here must be also included in the handler's get_queue_id method
           { http_endpoint = typedefs.url({ required = true, encrypted = true, referenceable = true }) }, -- encrypted = true is a Kong-Enterprise exclusive feature, does nothing in Kong CE
           { method = { type = "string", default = "POST", one_of = { "POST", "PUT", "PATCH" }, }, },
-          { content_type = { type = "string", default = "application/json", one_of = { "application/json" }, }, },
+          { content_type = { type = "string", default = "application/json", one_of = { "application/json", "application/json; charset=utf-8" }, }, },
           { timeout = { type = "number", default = 10000 }, },
           { keepalive = { type = "number", default = 60000 }, },
           { retry_count = { type = "integer", default = 10 }, },

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -38,25 +38,49 @@ for _, strategy in helpers.each_strategy() do
         }
       }
 
-      local service1 = bp.services:insert{
+      local service1_2 = bp.services:insert{
         protocol = "http",
         host     = helpers.mock_upstream_host,
         port     = helpers.mock_upstream_port,
       }
 
-      local route1 = bp.routes:insert {
-        hosts   = { "http_logging.test" },
-        service = service1
+      local route1_2 = bp.routes:insert {
+        hosts   = { "content_type_application_json_http_logging.test" },
+        service = service1_2
       }
 
       bp.plugins:insert {
-        route = { id = route1.id },
+        route = { id = route1_2.id },
         name     = "http-log",
         config   = {
           http_endpoint = "http://" .. helpers.mock_upstream_host
                                     .. ":"
                                     .. helpers.mock_upstream_port
-                                    .. "/post_log/http"
+                                    .. "/post_log/http2",
+          content_type = "application/json"
+        }
+      }
+
+      local service1_3 = bp.services:insert{
+        protocol = "http",
+        host     = helpers.mock_upstream_host,
+        port     = helpers.mock_upstream_port,
+      }
+
+      local route1_3 = bp.routes:insert {
+        hosts   = { "content_type_application_json_charset_utf_8_http_logging.test" },
+        service = service1_3
+      }
+
+      bp.plugins:insert {
+        route = { id = route1_3.id },
+        name     = "http-log",
+        config   = {
+          http_endpoint = "http://" .. helpers.mock_upstream_host
+                                    .. ":"
+                                    .. helpers.mock_upstream_port
+                                    .. "/post_log/http3",
+          content_type = "application/json; charset=utf-8"
         }
       }
 
@@ -293,6 +317,68 @@ for _, strategy in helpers.each_strategy() do
 
         if #body.entries == 1 then
           assert.same("127.0.0.1", body.entries[1].client_ip)
+          return true
+        end
+      end, 10)
+    end)
+
+    it("logs to HTTP with content-type 'application/json'", function()
+      local res = assert(proxy_client:send({
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "content_type_application_json_http_logging.test"
+        }
+      }))
+      assert.res_status(200, res)
+
+      helpers.wait_until(function()
+        local client = assert(helpers.http_client(helpers.mock_upstream_host,
+                                                  helpers.mock_upstream_port))
+        local res = assert(client:send {
+          method  = "GET",
+          path    = "/read_log/http2",
+          headers = {
+            Accept = "application/json"
+          }
+        })
+        local raw = assert.res_status(200, res)
+        local body = cjson.decode(raw)
+
+        if #body.entries == 1 then
+          assert.same("127.0.0.1", body.entries[1].client_ip)
+          assert.same(body.entries[1].log_req_headers['content-type'] or "", "application/json")
+          return true
+        end
+      end, 10)
+    end)
+
+    it("logs to HTTP with content-type 'application/json; charset=utf-8'", function()
+      local res = assert(proxy_client:send({
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "content_type_application_json_charset_utf_8_http_logging.test"
+        }
+      }))
+      assert.res_status(200, res)
+
+      helpers.wait_until(function()
+        local client = assert(helpers.http_client(helpers.mock_upstream_host,
+                                                  helpers.mock_upstream_port))
+        local res = assert(client:send {
+          method  = "GET",
+          path    = "/read_log/http3",
+          headers = {
+            Accept = "application/json"
+          }
+        })
+        local raw = assert.res_status(200, res)
+        local body = cjson.decode(raw)
+
+        if #body.entries == 1 then
+          assert.same("127.0.0.1", body.entries[1].client_ip)
+          assert.same(body.entries[1].log_req_headers['content-type'] or "", "application/json; charset=utf-8")
           return true
         end
       end, 10)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com -https://github.com/Kong/docs.konghq.com/pull/5326

### Full changelog

* adds `application/json; charset=utf-8` option for the `Content-Type` header  in the http-log plugin, for log collectors that require that character set declaration.

### Issue reference

Reported in FTI 4931.