### PR TITLE
tests(postgres): reduce ttl cleanup test time usage

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -360,7 +360,7 @@ local CONF_PARSERS = {
   pg_keepalive_timeout = { typ = "number" },
   pg_pool_size = { typ = "number" },
   pg_backlog = { typ = "number" },
-  pg_ttl_cleanup_interval = { typ = "number" },
+  _debug_pg_ttl_cleanup_interval = { typ = "number" },
 
   pg_ro_port = { typ = "number" },
   pg_ro_timeout = { typ = "number" },

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -360,6 +360,7 @@ local CONF_PARSERS = {
   pg_keepalive_timeout = { typ = "number" },
   pg_pool_size = { typ = "number" },
   pg_backlog = { typ = "number" },
+  pg_ttl_cleanup_interval = { typ = "number" },
 
   pg_ro_port = { typ = "number" },
   pg_ro_timeout = { typ = "number" },

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -947,7 +947,7 @@ function _M.new(kong_config)
     --- not used directly by pgmoon, but used internally in connector to set the keepalive timeout
     keepalive_timeout = kong_config.pg_keepalive_timeout,
     --- non user-faced parameters
-    ttl_cleanup_interval = kong_config.pg_ttl_cleanup_interval or 60,
+    ttl_cleanup_interval = kong_config._debug_pg_ttl_cleanup_interval or 60,
   }
 
   local refs = kong_config["$refs"]

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -339,7 +339,7 @@ ORDER BY %s LIMIT 50000 FOR UPDATE SKIP LOCKED)
    WHERE ctid IN (TABLE rows);]], table_name_escaped, column_name, column_name, table_name_escaped):gsub("CURRENT_TIMESTAMP", "TO_TIMESTAMP(%%s)")
     end
 
-    return timer_every(60, function(premature)
+    return timer_every(self.config.ttl_cleanup_interval, function(premature)
       if premature then
         return
       end
@@ -946,6 +946,8 @@ function _M.new(kong_config)
 
     --- not used directly by pgmoon, but used internally in connector to set the keepalive timeout
     keepalive_timeout = kong_config.pg_keepalive_timeout,
+    --- non user-faced parameters
+    ttl_cleanup_interval = kong_config.pg_ttl_cleanup_interval or 60,
   }
 
   local refs = kong_config["$refs"]

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -114,7 +114,7 @@ pg_semaphore_timeout = 60000
 pg_keepalive_timeout = NONE
 pg_pool_size = NONE
 pg_backlog = NONE
-pg_ttl_cleanup_interval = 60
+_debug_pg_ttl_cleanup_interval = 60
 
 pg_ro_host = NONE
 pg_ro_port = NONE

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -114,6 +114,7 @@ pg_semaphore_timeout = 60000
 pg_keepalive_timeout = NONE
 pg_pool_size = NONE
 pg_backlog = NONE
+pg_ttl_cleanup_interval = 60
 
 pg_ro_host = NONE
 pg_ro_port = NONE

--- a/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
+++ b/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
@@ -28,6 +28,7 @@ for _, strategy in helpers.each_strategy() do
         assert(helpers.start_kong({
           database = strategy,
           log_level = "debug",
+          pg_ttl_cleanup_interval = 3,
         }))
       end)
 
@@ -39,7 +40,7 @@ for _, strategy in helpers.each_strategy() do
       it("init_worker should run ttl cleanup in background timer", function ()
         helpers.pwait_until(function()
           assert.errlog().has.line([[cleaning up expired rows from table ']] .. "keyauth_credentials" .. [[' took .+ seconds]], false, 2)
-        end, 65)
+        end, 5)
 
         local ok, err = db.connector:query("SELECT * FROM keyauth_credentials")
         assert.is_nil(err)

--- a/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
+++ b/spec/02-integration/03-db/20-ttl-cleanup_spec.lua
@@ -28,7 +28,7 @@ for _, strategy in helpers.each_strategy() do
         assert(helpers.start_kong({
           database = strategy,
           log_level = "debug",
-          pg_ttl_cleanup_interval = 3,
+          _debug_pg_ttl_cleanup_interval = 3,
         }))
       end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR tries to reduce the  time usage of TTL cleanup integration test, by adding a configurable option `pg_ttl_cleanup_interval` for adjusting when doing tests.



### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-921
