### PR TITLE
chore(pdk): add comment so docs can be generated

### DIFF
--- a/kong/pdk/plugin.lua
+++ b/kong/pdk/plugin.lua
@@ -6,6 +6,15 @@
 local _plugin = {}
 
 
+---
+-- Returns the instance ID of the running plugin.
+--
+-- @function kong.plugin.get_id
+-- @phases init_worker, rewrite, access, header_filter, response, body_filter, log
+-- @treturn string The ID of the running plugin
+-- @usage
+--
+-- kong.request.get_id() -- "123e4567-e89b-12d3-a456-426614174000"
 function _plugin.get_id(self)
   return ngx.ctx.plugin_id
 end

--- a/kong/pdk/plugin.lua
+++ b/kong/pdk/plugin.lua
@@ -7,10 +7,10 @@ local _plugin = {}
 
 
 ---
--- Returns the instance ID of the running plugin.
+-- Returns the instance ID of the plugin.
 --
 -- @function kong.plugin.get_id
--- @phases init_worker, rewrite, access, header_filter, response, body_filter, log
+-- @phases rewrite, access, header_filter, response, body_filter, log
 -- @treturn string The ID of the running plugin
 -- @usage
 --


### PR DESCRIPTION
I missed the comment for the usage of the `kong.plugin.get_id()`.