### PR TITLE
feat(build): use managed cmake and system-wide make

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,6 @@ jobs:
         dnf config-manager --set-enabled powertools || true # enable devel packages on rockylinux:8
         yum install -y libyaml-devel
 
-    - name: Setup CMake
-      if: startsWith(matrix.label, 'centos-') || startsWith(matrix.label, 'rhel-')
-      uses: jwlawson/actions-setup-cmake@65b272e1213f99771fbba0c237e0b3312270e0c9 # v1.13
-      with:
-        cmake-version: '3.16.x'
-
     - name: Setup Amazon Linux
       if: startsWith(matrix.label, 'amazonlinux')
       run: |
@@ -206,7 +200,7 @@ jobs:
         export PATH="/opt/tools/bin:${PATH}"
         echo "/opt/tools/bin" >> $GITHUB_PATH
 
-        for tool in cmake git bazel; do
+        for tool in git bazel; do
           echo "${tool}: ($(which "$tool" || true)) $($tool --version)"
         done
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -93,7 +93,6 @@ sudo apt update \
     automake \
     build-essential \
     curl \
-    cmake \
     file \
     git \
     libyaml-dev \
@@ -113,7 +112,6 @@ Fedora/CentOS/RHEL:
 ```shell
 dnf install \
     automake \
-    cmake \
     gcc \
     gcc-c++ \
     git \
@@ -136,11 +134,8 @@ xcode-select --install
 # Install HomeBrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 # Build dependencies
-brew install libyaml cmake
+brew install libyaml
 ```
-
-`cmake` 3 is needed to build some targets, some distributions ship version 2 only. An updated cmake
-can be downloaded [here](https://cmake.org/download/).
 
 Finally, we start the build process:
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,10 +26,10 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 # This sets up some common toolchains for building targets. For more details, please see
 # https://bazelbuild.github.io/rules_foreign_cc/0.9.0/flatten.html#rules_foreign_cc_dependencies
-# TODO: select system `make` if installed, otherwise automatically build
 rules_foreign_cc_dependencies(
-    register_built_tools = False,
-    register_default_tools = False,
+    register_built_tools = False,  # don't build toolchains like make
+    register_default_tools = True,  # register cmake and ninja that are managed by bazel
+    register_preinstalled_tools = True,  # use preinstalled toolchains like make
 )
 
 load("//build/openresty:repositories.bzl", "openresty_repositories")


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Some distro ship old cmake that bazel doens't like; but we still use system installed make because bazel needs to compile it.

### Full changelog

* use managed cmake and system-wide make

### Issue reference

KAG-996
