### PR TITLE
chore(deps): pin to latest resty-http 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,8 @@
 - Bumped lua-resty-openssl from 0.8.17 to 0.8.20
   [#10463](https://github.com/Kong/kong/pull/10463)
   [#10476](https://github.com/Kong/kong/pull/10476)
+- Bumped lua-resty-http from 0.17.0.beta.1 to 0.17.1
+  [#10547](https://github.com/Kong/kong/pull/10547)
 - Bumped LuaSec from 1.2.0 to 1.3.1
   [#10528](https://github.com/Kong/kong/pull/10528)
 

--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "luasec == 1.3.1",
   "luasocket == 3.0-rc1",
   "penlight == 1.13.1",
-  "lua-resty-http ~> 0.17",
+  "lua-resty-http == 0.17.1",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",
   "multipart == 0.5.9",


### PR DESCRIPTION
### Summary

The 0.17.0 is not beta anymore as the 0.17.1 was released as non-beta, so lets start pinning the resty.http again.

#### What's Changed

Documentation is clearer about using same connection for multiple requests via 'request' function by @alexdowad in #282

- fix 100 response with headers by @catbro666
- fix: no trailing \"?\" for empty query table by @StarlightIbuki

#### New Contributors

@chronolaw made their first contribution
@alexdowad made their first contribution
@catbro666 made their first contribution
@StarlightIbuki made their first contribution