### PR TITLE
chore(ci): Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           cd kong
           output="$(git branch --show-current)"
-          echo "::set-output name=name::$output"
+          echo "name=$output" >> $GITHUB_OUTPUT
 
       - name: Show Docs status
         run: |


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Update `.github/workflows/autodocs.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=name::$output"
```

**TO-BE**

```yml
echo "name=$output" >> $GITHUB_OUTPUT
```

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Resolve #10551
