### PR TITLE
chore: auto-assign PR author as assignee

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -1,0 +1,12 @@
+name: Add assignee to PRs
+on:
+  pull_request:
+    types: [ opened, reopened ]
+permissions:
+  pull-requests: write
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0
+


### PR DESCRIPTION
### Summary

I'm working on setting up some automation for better project tracking using Github Projects and that requires the 'Assignees' field to be populated with PR author. This action adds automation for that.

### Checklist

- [x] The Pull Request has tests - N/A
- [x] There's an entry in the CHANGELOG - N/A
- [x] There is a user-facing docs PR - N/A