### PR TITLE
chore(manifest): fix manifest update after luasec bump

### DIFF
--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -139,7 +139,7 @@
   - libc.so.6
   Rpath     : /usr/local/kong/lib
   Version Requirement:
-  - libc.so.6 (GLIBC_2.2.5)
+  - libc.so.6 (GLIBC_2.14, GLIBC_2.2.5)
   - libcrypto.so.1.1 (OPENSSL_1_1_0)
   - libssl.so.1.1 (OPENSSL_1_1_0, OPENSSL_1_1_1)
 

--- a/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
@@ -135,7 +135,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
   Version Requirement:
-  - libc.so.6 (GLIBC_2.2.5, GLIBC_2.4)
+  - libc.so.6 (GLIBC_2.14, GLIBC_2.2.5, GLIBC_2.4)
   - libcrypto.so.1.1 (OPENSSL_1_1_0)
   - libssl.so.1.1 (OPENSSL_1_1_0, OPENSSL_1_1_1)
 

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -135,7 +135,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
   Version Requirement:
-  - libc.so.6 (GLIBC_2.2.5, GLIBC_2.4)
+  - libc.so.6 (GLIBC_2.14, GLIBC_2.2.5, GLIBC_2.4)
   - libcrypto.so.1.1 (OPENSSL_1_1_0)
   - libssl.so.1.1 (OPENSSL_1_1_0, OPENSSL_1_1_1)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Follow up of https://github.com/Kong/kong/pull/10528. This adds the missing manifest change required after luasec bump.

### Checklist

- [x] The Pull Request has tests
- [NA] There's an entry in the CHANGELOG
- [NA] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* chore(manifest): fix manifest update after luasec bump

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
