### PR TITLE
fix(plugin/rate-limiting): use `redis:eval()` to improve rate-limiting accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
   [#10836](https://github.com/Kong/kong/pull/10836)
 - **ACME**: Fixed sanity test can't work with "kong" storage in Hybrid mode
   [#10852](https://github.com/Kong/kong/pull/10852)
+- **rate-limiting**: Fixed an issue that impact the accuracy with the `redis` policy.
+  [#10559](https://github.com/Kong/kong/pull/10559)
 
 #### PDK
 

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -195,7 +195,7 @@ return {
       local periods = timestamp.get_timestamps(current_timestamp)
       local cache_key = get_local_key(conf, identifier, period, periods[period])
 
-      -- the usage of redis command incr insted of get is to avoid race condition in concurrent calls
+      -- the usage of redis command incr instead of get is to avoid race conditions in concurrent calls
       local current_metric, err = red:eval([[
         local cache_key, expiration = KEYS[1], ARGV[1]
         local result_incr = redis.call("incr", cache_key)

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -179,7 +179,8 @@ return {
   },
   ["redis"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
-      -- usage function alread increment the value of redis key to avoid race condition in concurrent calls
+            -- the usage function already incremented the value of redis key to avoid race condition in concurrent calls
+
       -- because of that we don't need to increment here
       return true
     end,
@@ -194,7 +195,6 @@ return {
       local periods = timestamp.get_timestamps(current_timestamp)
       local cache_key = get_local_key(conf, identifier, period, periods[period])
 
-      local current_metric, err = red:get(cache_key)
       -- the usage of redis command incr insted of get is to avoid race condition in concurrent calls
       local current_metric, err = red:eval([[
         local cache_key, expiration = KEYS[1], ARGV[1]

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -179,52 +179,8 @@ return {
   },
   ["redis"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
-      local red, err = get_redis_connection(conf)
-      if not red then
-        return nil, err
-      end
-
-      local keys = {}
-      local expiration = {}
-      local idx = 0
-      local periods = timestamp.get_timestamps(current_timestamp)
-      for period, period_date in pairs(periods) do
-        if limits[period] then
-          local cache_key = get_local_key(conf, identifier, period, period_date)
-          local exists, err = red:exists(cache_key)
-          if err then
-            kong.log.err("failed to query Redis: ", err)
-            return nil, err
-          end
-
-          idx = idx + 1
-          keys[idx] = cache_key
-          if not exists or exists == 0 then
-            expiration[idx] = EXPIRATION[period]
-          end
-
-          red:init_pipeline()
-          for i = 1, idx do
-            red:incrby(keys[i], value)
-            if expiration[i] then
-              red:expire(keys[i], expiration[i])
-            end
-          end
-        end
-      end
-
-      local _, err = red:commit_pipeline()
-      if err then
-        kong.log.err("failed to commit increment pipeline in Redis: ", err)
-        return nil, err
-      end
-
-      local ok, err = red:set_keepalive(10000, 100)
-      if not ok then
-        kong.log.err("failed to set Redis keepalive: ", err)
-        return nil, err
-      end
-
+      -- usage function alread increment the value of redis key to avoid race condition in concurrent calls
+      -- because of that we don't need to increment here
       return true
     end,
     usage = function(conf, identifier, period, current_timestamp)
@@ -239,6 +195,17 @@ return {
       local cache_key = get_local_key(conf, identifier, period, periods[period])
 
       local current_metric, err = red:get(cache_key)
+      -- the usage of redis command incr insted of get is to avoid race condition in concurrent calls
+      local current_metric, err = red:eval([[
+        local cache_key, expiration = KEYS[1], ARGV[1]
+        local result_incr = redis.call("incr", cache_key)
+        if result_incr == 1 then
+          redis.call("expire", cache_key, expiration)
+        end
+
+        return result_incr - 1
+      ]], 1, cache_key, EXPIRATION[period])
+
       if err then
         return nil, err
       end

--- a/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
@@ -166,6 +166,16 @@ describe("Plugin: rate-limiting (policies)", function()
     end)
 
     it("increase & usage", function()
+      --[[
+        Just a simple test:
+        - increase 1
+        - check usage == 1
+        - increase 1
+        - check usage == 2
+        - increase 1 (beyond the limit)
+        - check usage == 3
+      --]]
+
       local current_timestamp = 1424217600
       local periods = timestamp.get_timestamps(current_timestamp)
 

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -92,7 +92,7 @@ describe("Plugin: rate-limiting (integration)", function()
     describe("config.policy = redis #" .. strategy, function()
       -- Regression test for the following issue:
       -- https://github.com/Kong/kong/issues/3292
-  
+
       lazy_setup(function()
         flush_redis(red, REDIS_DB_1)
         flush_redis(red, REDIS_DB_2)
@@ -108,7 +108,7 @@ describe("Plugin: rate-limiting (integration)", function()
         }, {
           "rate-limiting"
         })
-  
+
         local route1 = assert(bp.routes:insert {
           hosts        = { "redistest1.com" },
         })
@@ -128,7 +128,7 @@ describe("Plugin: rate-limiting (integration)", function()
             redis_timeout     = 10000,
           },
         })
-  
+
         local route2 = assert(bp.routes:insert {
           hosts        = { "redistest2.com" },
         })
@@ -148,7 +148,7 @@ describe("Plugin: rate-limiting (integration)", function()
             redis_timeout     = 10000,
           },
         })
-  
+
         if red_version >= version("6.0.0") then
           local route3 = assert(bp.routes:insert {
             hosts        = { "redistest3.com" },
@@ -171,7 +171,7 @@ describe("Plugin: rate-limiting (integration)", function()
               redis_timeout     = 10000,
             },
           })
-  
+
           local route4 = assert(bp.routes:insert {
             hosts        = { "redistest4.com" },
           })
@@ -194,29 +194,29 @@ describe("Plugin: rate-limiting (integration)", function()
             },
           })
         end
-  
-  
+
+
         assert(helpers.start_kong({
           nginx_conf = "spec/fixtures/custom_nginx.template",
           lua_ssl_trusted_certificate = config.lua_ssl_trusted_certificate,
         }))
         client = helpers.proxy_client()
       end)
-  
+
       lazy_teardown(function()
         helpers.stop_kong()
         if red_version >= version("6.0.0") then
           remove_redis_user(red)
         end
       end)
-  
+
       it("connection pool respects database setting", function()
         assert(red:select(REDIS_DB_1))
         local size_1 = assert(red:dbsize())
-  
+
         assert(red:select(REDIS_DB_2))
         local size_2 = assert(red:dbsize())
-  
+
         assert.equal(0, tonumber(size_1))
         assert.equal(0, tonumber(size_2))
         if red_version >= version("6.0.0") then
@@ -224,7 +224,7 @@ describe("Plugin: rate-limiting (integration)", function()
           local size_3 = assert(red:dbsize())
           assert.equal(0, tonumber(size_3))
         end
-  
+
         local res = assert(client:send {
           method = "GET",
           path = "/status/200",
@@ -233,19 +233,19 @@ describe("Plugin: rate-limiting (integration)", function()
           }
         })
         assert.res_status(200, res)
-  
+
         -- Wait for async timer to increment the limit
-  
+
         ngx.sleep(SLEEP_TIME)
-  
+
         assert(red:select(REDIS_DB_1))
         size_1 = assert(red:dbsize())
-  
+
         assert(red:select(REDIS_DB_2))
         size_2 = assert(red:dbsize())
-  
+
         -- TEST: DB 1 should now have one hit, DB 2 and 3 none
-  
+
         assert.equal(1, tonumber(size_1))
         assert.equal(0, tonumber(size_2))
         if red_version >= version("6.0.0") then
@@ -253,7 +253,7 @@ describe("Plugin: rate-limiting (integration)", function()
           local size_3 = assert(red:dbsize())
           assert.equal(0, tonumber(size_3))
         end
-  
+
         -- rate-limiting plugin will reuses the redis connection
         local res = assert(client:send {
           method = "GET",
@@ -263,19 +263,19 @@ describe("Plugin: rate-limiting (integration)", function()
           }
         })
         assert.res_status(200, res)
-  
+
         -- Wait for async timer to increment the limit
-  
+
         ngx.sleep(SLEEP_TIME)
-  
+
         assert(red:select(REDIS_DB_1))
         size_1 = assert(red:dbsize())
-  
+
         assert(red:select(REDIS_DB_2))
         size_2 = assert(red:dbsize())
-  
+
         -- TEST: DB 1 and 2 should now have one hit, DB 3 none
-  
+
         assert.equal(1, tonumber(size_1))
         assert.equal(1, tonumber(size_2))
         if red_version >= version("6.0.0") then
@@ -283,7 +283,7 @@ describe("Plugin: rate-limiting (integration)", function()
           local size_3 = assert(red:dbsize())
           assert.equal(0, tonumber(size_3))
         end
-  
+
         if red_version >= version("6.0.0") then
           -- rate-limiting plugin will reuses the redis connection
           local res = assert(client:send {
@@ -294,30 +294,30 @@ describe("Plugin: rate-limiting (integration)", function()
             }
           })
           assert.res_status(200, res)
-  
+
           -- Wait for async timer to increment the limit
-  
+
           ngx.sleep(SLEEP_TIME)
-  
+
           assert(red:select(REDIS_DB_1))
           size_1 = assert(red:dbsize())
-  
+
           assert(red:select(REDIS_DB_2))
           size_2 = assert(red:dbsize())
-  
+
           assert(red:select(REDIS_DB_3))
           local size_3 = assert(red:dbsize())
-  
+
           -- TEST: All DBs should now have one hit, because the
           -- plugin correctly chose to select the database it is
           -- configured to hit
-  
+
           assert.is_true(tonumber(size_1) > 0)
           assert.is_true(tonumber(size_2) > 0)
           assert.is_true(tonumber(size_3) > 0)
         end
       end)
-  
+
       it("authenticates and executes with a valid redis user having proper ACLs", function()
         if red_version >= version("6.0.0") then
           local res = assert(client:send {
@@ -333,7 +333,7 @@ describe("Plugin: rate-limiting (integration)", function()
             "'authenticates and executes with a valid redis user having proper ACLs' will be skipped")
         end
       end)
-  
+
       it("fails to rate-limit for a redis user with missing ACLs", function()
         if red_version >= version("6.0.0") then
           local res = assert(client:send {
@@ -349,7 +349,7 @@ describe("Plugin: rate-limiting (integration)", function()
             "'fails to rate-limit for a redis user with missing ACLs' will be skipped")
         end
       end)
-  
+
     end)
   end
 

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -32,7 +32,7 @@ local function flush_redis(red, db)
 end
 
 local function add_redis_user(red)
-  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", "+exists", ">" .. REDIS_PASSWORD))
+  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "allcommands", ">" .. REDIS_PASSWORD))
   assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
 end
 


### PR DESCRIPTION
### Summary

fix rate-limiting accuracy reported on issue: https://github.com/Kong/kong/issues/5311
There is a low impact change to the current code and this implementation has better accuracy on redis policy

it is same fix made in PR https://github.com/Kong/kong/pull/8227, but I remove sliding-window feature. Kong have no plans to add a sliding window to this plugin, Sliding window is an enterprise-only feature at this point

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG

### Full changelog

[it removes the race condition problem getting keys on redis. it uses the return of the increment command as the usage counter ensuring atomicity, different from the current one, which allows multiple requests to get the same value of the redis key while the counter increment is done asynchronously]

[it has an even better performance than the current plugin using the redis policy, as it does only 1 operation per request in redis (eval) instead of the two operations per request that the current one (get and incrby)]

### Issue reference

Fix https://github.com/Kong/kong/issues/5311
KAG-981