### PR TITLE
Fix/plugin server release lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@
   [#10514](https://github.com/Kong/kong/pull/10514)
 - Fix a typo of mlcache option `shm_set_tries`.
   [#10712](https://github.com/Kong/kong/pull/10712)
+- Fix an issue where slow start up of Go plugin server causes dead lock.
+  [#10561](https://github.com/Kong/kong/pull/10561)
 
 #### Admin API
 

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -40,6 +40,9 @@ else
   resp_get_headers = NOOP
 end
 
+local SLEEP_STEP = 0.1
+local WAIT_TIME = 10
+local MAX_WAIT_STEPS = WAIT_TIME / SLEEP_STEP
 
 --- keep request data a bit longer, into the log timer
 local save_for_later = {}
@@ -192,18 +195,15 @@ function get_instance_id(plugin_name, conf)
   local key = type(conf) == "table" and kong.plugin.get_id() or plugin_name
   local instance_info = running_instances[key]
 
-  local sleep_time = 0
   local wait_count = 0
   while instance_info and not instance_info.id do
     -- some other thread is already starting an instance
     -- prevent busy-waiting
-    ngx_sleep(sleep_time)
+    ngx_sleep(SLEEP_STEP)
   
     -- to prevent a potential dead loop when someone failed to release the ID
     wait_count = wait_count + 1
-    if wait_count > 10 then
-      sleep_time = 1
-    elseif wait_count > 20 then
+    if wait_count > MAX_WAIT_STEPS then
       return nil, "Could not claim instance_id for " .. plugin_name .. " (key: " .. key .. ")"
     end
     instance_info = running_instances[key]

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -336,6 +336,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
 
   if err then
     if err == "not ready" then
+      self.reset_instance(plugin_name, conf)
       return handle_not_ready(plugin_name)
     end
     if err and str_find(err:lower(), "no plugin instance", 1, true) then

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -401,6 +401,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
 
   if not res or res == "" then
     if err == "not ready" then
+      self.reset_instance(plugin_name, conf)
       return handle_not_ready(plugin_name)
     end
     if err and (str_find(err:lower(), "no plugin instance", 1, true)


### PR DESCRIPTION
### Summary

NOTE: when merging, please make sure all changes are included in the message.

When the plugin server sock is not ready and a request comes, the "not ready" error will leak lock, fail to release the instance, and cause the CPU to reach 100%.

### Checklist

- [x] There's an entry in the CHANGELOG
- [ ] <s>The Pull Request has tests N/A.</s> This is hard to test with CI.
- [ ] <s>There is a user-facing docs PR</s> N/A

### Issue reference

[KAG-1204](https://konghq.atlassian.net/browse/KAG-1204)

[KAG-1204]: https://konghq.atlassian.net/browse/KAG-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ