### PR TITLE
fix(instrumentation): span hierarchy

### DIFF
--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -121,20 +121,12 @@ setmetatable(noop_span, {
   __newindex = NOOP,
 })
 
-local function new_span(tracer, name, options)
-  if type(tracer) ~= "table" then
-    error("invalid tracer", 2)
-  end
-
-  if type(name) ~= "string" or #name == 0 then
-    error("invalid span name", 2)
-  end
-
-  if options ~= nil and type(options) ~= "table" then
-    error("invalid options type", 2)
-  end
-
+local function validate_span_options(options)
   if options ~= nil then
+    if type(options) ~= "table" then
+      error("invalid options type", 2)
+    end
+
     if options.start_time_ns ~= nil and type(options.start_time_ns) ~= "number" then
       error("invalid start time", 2)
     end
@@ -151,53 +143,57 @@ local function new_span(tracer, name, options)
       error("invalid attributes", 2)
     end
   end
+end
 
+local function create_span(tracer, options)
+  validate_span_options(options)
   options = options or {}
 
-  -- get parent span from ctx
-  -- the ctx could either be stored in ngx.ctx or kong.ctx
-  local parent_span = options.parent or tracer.active_span()
+  local span = tablepool_fetch(POOL_SPAN, 0, 12)
 
-  local trace_id = parent_span and parent_span.trace_id
+  span.parent = options.parent or tracer and tracer.active_span()
+
+  local trace_id = span.parent and span.parent.trace_id
       or options.trace_id
       or generate_trace_id()
-
-  local sampled = parent_span and parent_span.should_sample
+  local sampled = span.parent and span.parent.should_sample
       or options.should_sample
-      or tracer.sampler(trace_id)
+      or tracer and tracer.sampler(trace_id)
 
   if not sampled then
     return noop_span
   end
 
-  -- avoid reallocate
-  -- we will release the span table at the end of log phase
-  local span = tablepool_fetch(POOL_SPAN, 0, 12)
-  -- cache tracer ref, to get hooks / span processer
-  -- tracer ref will not be cleared when the span table released
-  span.tracer = tracer
-
-  span.name = name
-  span.trace_id = trace_id
-  span.span_id = generate_span_id()
-  span.parent_id = parent_span and parent_span.span_id
+  span.parent_id = span.parent and span.parent.span_id
       or options.parent_id
-
-  -- specify span start time manually
-  span.start_time_ns = options.start_time_ns or ffi_time_unix_nano()
+  span.tracer = span.tracer or tracer
+  span.span_id = generate_span_id()
+  span.trace_id = trace_id
   span.kind = options.span_kind or SPAN_KIND.INTERNAL
-  span.attributes = options.attributes
-
   -- indicates whether the span should be reported
-  span.should_sample = parent_span and parent_span.should_sample
+  span.should_sample = span.parent and span.parent.should_sample
       or options.should_sample
       or sampled
 
-  -- parent ref, some cases need access to parent span
-  span.parent = parent_span
-
-  -- inherit metatable
   setmetatable(span, span_mt)
+  return span
+end
+
+local function link_span(tracer, span, name, options)
+  if tracer and type(tracer) ~= "table" then
+    error("invalid tracer", 2)
+  end
+  validate_span_options(options)
+
+  options = options or {}
+
+  -- cache tracer ref, to get hooks / span processer
+  -- tracer ref will not be cleared when the span table released
+  span.tracer = span.tracer or tracer
+  -- specify span start time
+  span.start_time_ns = options.start_time_ns or ffi_time_unix_nano()
+  span.attributes = options.attributes
+  span.name = name
 
   -- insert the span to ctx
   local ctx = ngx.ctx
@@ -211,6 +207,21 @@ local function new_span(tracer, name, options)
   local len = spans[0] + 1
   spans[len] = span
   spans[0] = len
+
+  return span
+end
+
+local function new_span(tracer, name, options)
+  if type(tracer) ~= "table" then
+    error("invalid tracer", 2)
+  end
+
+  if type(name) ~= "string" or #name == 0 then
+    error("invalid span name", 2)
+  end
+
+  local span = create_span(tracer, options)
+  link_span(tracer, span, name, options)
 
   return span
 end
@@ -370,6 +381,8 @@ local tracer_memo = setmetatable({}, { __mode = "k" })
 local noop_tracer = {}
 noop_tracer.name = "noop"
 noop_tracer.start_span = function() return noop_span end
+noop_tracer.create_span = function() return noop_span end
+noop_tracer.link_span = NOOP
 noop_tracer.active_span = NOOP
 noop_tracer.set_active_span = NOOP
 noop_tracer.process_span = NOOP
@@ -440,6 +453,14 @@ local function new_tracer(name, options)
     end
 
     return new_span(self, ...)
+  end
+
+  function self.create_span(...)
+    return create_span(...)
+  end
+
+  function self.link_span(...)
+    return link_span(...)
   end
 
   --- Batch process spans

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -81,10 +81,11 @@ function _M.balancer(ctx)
   local balancer_tries = balancer_data.tries
   local try_count = balancer_data.try_count
   local upstream_connect_time = split(var.upstream_connect_time, ", ", "jo")
+
   for i = 1, try_count do
     local try = balancer_tries[i]
-
-    local options = {
+    local span_name = "balancer try #" .. i
+    local span_options = {
       span_kind = 3, -- client
       start_time_ns = try.balancer_start * 1e6,
       attributes = {
@@ -93,36 +94,34 @@ function _M.balancer(ctx)
       }
     }
 
-    -- last try: load the last span (already created/propagated)
-    if i == try_count and try.state == nil then
-      span = ctx.last_try_balancer_span
-      if span then
-        tracer:link_span(span, "balancer try #" .. i, options)
+    -- one of the unsuccessful tries
+    if i < try_count or try.state ~= nil or not ctx.last_try_balancer_span then
+      span = tracer.start_span(span_name, span_options)
+
+      if try.state then
+        span:set_attribute("http.status_code", try.code)
+        span:set_status(2)
       end
-    end
-    -- no the last try: create a new span
-    if not span then
-      span = tracer.start_span("balancer try #" .. i, options)
-    end
 
-    if try.state then
-      span:set_attribute("http.status_code", try.code)
-      span:set_status(2)
-    end
-
-    -- last try
-    if i == try_count and try.state == nil then
-      local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
-      span:finish(upstream_finish_time)
-
-    else
-      -- retrying
       if try.balancer_latency ~= nil then
         local try_upstream_connect_time = (tonumber(upstream_connect_time[i], 10) or 0) * 1000
         span:finish((try.balancer_start + try.balancer_latency + try_upstream_connect_time) * 1e6)
       else
         span:finish()
       end
+
+    else
+      -- last try: load the last span (already created/propagated)
+      span = ctx.last_try_balancer_span
+      tracer:link_span(span, span_name, span_options)
+
+      if try.state then
+        span:set_attribute("http.status_code", try.code)
+        span:set_status(2)
+      end
+
+      local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
+      span:finish(upstream_finish_time)
     end
   end
 end


### PR DESCRIPTION
### Summary

**This is a recreated PR for a temporary/experimental PR, originally created by @samugi**

Fix the hierarchy of spans incorrectly reported to DataDog with balancer spans appearing always last in the flame graph.

### Problem

The DataDog tracing plugin was always propagating the root span, which means the receiver of the propagation header will set their parent to the ID of the root span (that represents the root http request) instead of the balancer span, which is the real "caller" of the upstream.

### Solution

To fix this it's necessary that the balancer span (not the root span) is propagated at the end of the request. This is challenging because the balancer spans are generated after the balancer data is available (after the header propagation already occurred).

This solution expands the tracing PDK interface to expose two additional functions: `create_span`, `link_span`.
These functions consist of the logic previously handled by `new_span`, split so that `create_span` can be used to create a deactivated/unlinked span and `link_span` can be used to actually submit the span and add it to KONG_SPANS.
The `new_span` function was kept for compatibility, but it internally just calls these 2 functions now.

The plugin's handlers can now use `create_span` to create the last-try balancer span "in advance", and propagate its information. Later, the span is automatically populated with the balancer information (name, attributes, ...) and linked via `link_span`.

#### Testing
This PR adds no changes to the existing logic, testing should be done on the plugins that will take advantage of the newly added functions.

### Checklist

- [x] [not needed] The Pull Request has tests (see above)
- [X] [not needed] There's an entry in the CHANGELOG
- [X] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
- [x] Cherry-pick to EE and implement the Datadog part

### Full changelog

* [Implement ...]

### Issue reference

KAG-1040