### PR TITLE
chore(actions): use release tag for `scan-docker-image`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,7 @@ jobs:
     - name: Scan AMD64 Image digest
       id: sbom_action_amd64
       if: steps.image_manifest_metadata.outputs.amd64_sha != ''
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v1
       with:
         asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-amd64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.amd64_sha }}
@@ -468,7 +468,7 @@ jobs:
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
       id: sbom_action_arm64
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@b2e4a29d30382e1cceeda8df1e8b8bee65bef39b
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v1
       with:
         asset_prefix: kong-${{ github.sha }}-${{ matrix.label }}-linux-arm64
         image: ${{env.IMAGE}}@${{ steps.image_manifest_metadata.outputs.arm64_sha }}


### PR DESCRIPTION
These actions are released and controlled by the company, so we do not need to pin them by hash.

KAG-1073
