### PR TITLE
[KAG-1076] fix(gha): add container version sanity test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,6 +531,21 @@ jobs:
         sleep 3
         docker logs kong
 
+    - name: Smoke Tests - Version Test
+      run: |
+        workflow_version="$(
+          echo '${{ steps.metadata.outputs.kong-version }}' \
+            | sed -e 's@\.@\\\.@g'
+        )"
+
+        # confirm workflow's version and built container version match with
+        # dots escaped, and end-line delimited
+        if ! docker exec kong kong version | grep -E "${workflow_version}$"; then
+          echo "Built container's 'kong version' didn't match workflow's."
+          echo "Ensure that versions in the meta.lua files are as expected."
+          exit 1
+        fi
+
     - name: Smoke Tests - Base Tests
       env:
         VERBOSE: ${{ runner.debug == '1' && '1' || '' }}


### PR DESCRIPTION
### Summary

This provides a basic sanity/smoke test of the output of `kong version` compared to the workflow value of `steps.metadata.outputs.kong-version`.
Notably, this comparison is done using a trailing `$` and using shell-escaped dots (`\.`) to exclude "dot-all" matches (grep's default behaviour).

This is remediation from the 2.8.4.0 release.

### Checklist

- [x] The Pull Request ~~has~~ is tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-1076]_


[KAG-1076]: https://konghq.atlassian.net/browse/KAG-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ