### PR TITLE
disable-tracking-specific-routes-issue

### DIFF
--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -69,6 +69,17 @@ return {
           { http_response_header_for_traceid = { type = "string", default = nil }},
           { phase_duration_flavor = { type = "string", required = true, default = "annotations",
                                       one_of = { "annotations", "tags" } } },
+          { ignore_routes = { type = "array", elements = {
+            type = "record",
+            fields = {
+              { path = { type = "string" } },
+              { method = { type = "string", one_of = { "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS" } } },
+              },
+              entity_checks = {
+              { at_least_one_of = { "path", "method" } },
+              },
+            },
+          }, },                                                                  
         },
     }, },
   },


### PR DESCRIPTION

### Summary

This change is required because the current configuration option for the zipkin plugin requires configuring it for each route, which can be difficult to manage if there are many routes. The proposed change solves this problem by allowing the configuration of zipkin globally, while also providing the ability to disable tracing on specific routes through a small config list. This makes it easier to manage the configuration of the zipkin plugin.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->https://github.com/Kong/kong/issues/8120
Fix #_[8120]_
