### PR TITLE
fix(router): fix incorrectly calculated priorities in traditional_compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ### Breaking Changes
 
+#### Core
+
+- The `traditional_compat` router mode has been made more compatible with the
+  behavior of `traditional` mode by splitting routes with multiple paths into
+  multiple atc routes with separate priorities.  Since the introduction of the new
+  router in Kong Gateway 3.0, `traditional_compat` mode assigned only one priority
+  to each route, even if different prefix path lengths and regular expressions
+  were mixed in a route. This was not how multiple paths were handled in the
+  `traditional` router and the behavior has now been changed so that a separate
+  priority value is assigned to each path in a route.
+  [#10615](https://github.com/Kong/kong/pull/10615)
+
 #### Plugins
 
 - **Serverless Functions**: `kong.cache` now points to a cache instance that is dedicated to the
@@ -57,6 +69,7 @@
   [#10288](https://github.com/Kong/kong/pull/10288)
 - Added new span attribute `http.client_ip` to capture the client IP when behind a proxy.
   [#10723](https://github.com/Kong/kong/pull/10723)
+  [#10204](https://github.com/Kong/kong/pull/10204)
 
 #### Admin API
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -373,7 +373,6 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
                    src_ip, src_port,
                    dst_ip, dst_port,
                    sni, req_headers)
-
   check_select_params(req_method, req_uri, req_host, req_scheme,
                       src_ip, src_port,
                       dst_ip, dst_port,
@@ -443,6 +442,9 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
   local service = self.services[uuid]
   local matched_route = self.routes[uuid]
+  if matched_route.original_route then
+    matched_route = matched_route.original_route
+  end
 
   local service_protocol, _,  --service_type
         service_host, service_port,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -441,10 +441,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
   local uuid, matched_path, captures = c:get_result("http.path")
 
   local service = self.services[uuid]
-  local matched_route = self.routes[uuid]
-  if matched_route.original_route then
-    matched_route = matched_route.original_route
-  end
+  local matched_route = self.routes[uuid].original_route or self.routes[uuid]
 
   local service_protocol, _,  --service_type
         service_host, service_port,

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -358,9 +358,9 @@ end
 
 
 local function split_routes_and_services_by_path(routes_and_services)
-  local routes_and_services_split = {}
-  for _, route_and_service in ipairs(routes_and_services) do
-    split_route_by_path_into(route_and_service, routes_and_services_split)
+  local routes_and_services_split = tb_new(#routes_and_services, 0)
+  for i = 1, #routes_and_services do
+    split_route_by_path_into(routes_and_services[i], routes_and_services_split)
   end
   return routes_and_services_split
 end

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -357,18 +357,24 @@ local function split_route_by_path_into(route_and_service, routes_and_services_s
 end
 
 
+local function split_routes_and_services_by_path(routes_and_services)
+  local routes_and_services_split = {}
+  for _, route_and_service in ipairs(routes_and_services) do
+    split_route_by_path_into(route_and_service, routes_and_services_split)
+  end
+  return routes_and_services_split
+end
+
+
 function _M.new(routes_and_services, cache, cache_neg, old_router)
   -- route_and_service argument is a table with [route] and [service]
   if type(routes_and_services) ~= "table" then
     return error("expected arg #1 routes to be a table", 2)
   end
 
-  local routes_and_services_split = {}
-  for _, route_and_service in ipairs(routes_and_services) do
-    split_route_by_path_into(route_and_service, routes_and_services_split)
-  end
+  routes_and_services = split_routes_and_services_by_path(routes_and_services)
 
-  return atc.new(routes_and_services_split, cache, cache_neg, old_router, get_exp_and_priority)
+  return atc.new(routes_and_services, cache, cache_neg, old_router, get_exp_and_priority)
 end
 
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -33,16 +33,16 @@ local service = {
   protocol = "http",
 }
 
-  local headers_mt = {
-    __index = function(t, k)
-      local u = rawget(t, string.upper(k))
-      if u then
-        return u
-      end
-
-      return rawget(t, string.lower(k))
+local headers_mt = {
+  __index = function(t, k)
+    local u = rawget(t, string.upper(k))
+    if u then
+      return u
     end
-  }
+
+    return rawget(t, string.lower(k))
+  end
+}
 
 for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
   describe("Router (flavor = " .. flavor .. ")", function()
@@ -2181,14 +2181,23 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         lazy_setup(function()
           use_case = {
-            -- percent encoding with unreserved char, route should be plain text
+            -- plain
+            {
+              service = service,
+              route   = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8100",
+                paths = {
+                  "/plain/a.b.c", -- /plain/a.b.c
+                },
+              },
+            },
+            -- percent encoding with unreserved char, route should not be normalized
             {
               service = service,
               route   = {
                 id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
                 paths = {
-                  "/plain/a.b.c", -- /plain/a.b.c
-                  "/plain/a.b%25c", -- /plain/a.b.c
+                  "/plain/a.b%58c", -- /plain/a.bXc
                 },
               },
             },
@@ -2230,11 +2239,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           assert.same(use_case[1].route, match_t.route)
 
           -- route no longer normalize user configured path
-          match_t = router:select("GET", "/plain/a.b c", "example.com")
+          match_t = router:select("GET", "/plain/a.bXc", "example.com")
           assert.falsy(match_t)
-          match_t = router:select("GET", "/plain/a.b%25c", "example.com")
+          match_t = router:select("GET", "/plain/a.b%58c", "example.com")
           assert.truthy(match_t)
-          assert.same(use_case[1].route, match_t.route)
+          assert.same(use_case[2].route, match_t.route)
 
           match_t = router:select("GET", "/plain/aab.c", "example.com")
           assert.falsy(match_t)
@@ -2246,7 +2255,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
           match_t = router:select("GET", "/reg%65x/123", "example.com")
           assert.truthy(match_t)
-          assert.same(use_case[2].route, match_t.route)
+          assert.same(use_case[3].route, match_t.route)
 
           match_t = router:select("GET", "/regex/\\d+", "example.com")
           assert.falsy(match_t)
@@ -2261,7 +2270,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
           match_t = router:select("GET", "/regex-meta/%5Cd+%2E", "example.com")
           assert.truthy(match_t)
-          assert.same(use_case[3].route, match_t.route)
+          assert.same(use_case[4].route, match_t.route)
         end)
 
         it("leave reserved characters alone in regex paths", function()
@@ -2270,7 +2279,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
           match_t = router:select("GET", "/regex-reserved%2Fabc", "example.com")
           assert.truthy(match_t)
-          assert.same(use_case[4].route, match_t.route)
+          assert.same(use_case[5].route, match_t.route)
         end)
       end)
 
@@ -3524,7 +3533,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             service      = service,
             route        = {
               id         = uuid(),
-              paths      = { "/my-route", "/this-route" },
+              paths      = { "/my-route", "/xx-route" }, -- need to have same length for get_priority to work
               strip_path = true
             }
           },
@@ -3534,7 +3543,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             route        = {
               id         = uuid(),
               methods    = { "POST" },
-              paths      = { "/my-route", "/this-route" },
+              paths      = { "/my-route", "/xx-route" }, -- need to have same length for get_priority to work
               strip_path = false,
             },
           },
@@ -3630,11 +3639,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           assert.equal("/my-route", match_t.prefix)
           assert.equal("/", match_t.upstream_uri)
 
-          _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
+          _ngx = mock_ngx("GET", "/xx-route", { host = "domain.org" })
           router._set_ngx(_ngx)
           match_t = router:exec()
           assert.same(use_case_routes[1].route, match_t.route)
-          assert.equal("/this-route", match_t.prefix)
+          assert.equal("/xx-route", match_t.prefix)
           assert.equal("/", match_t.upstream_uri)
 
           _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
@@ -3644,11 +3653,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           assert.equal("/my-route", match_t.prefix)
           assert.equal("/", match_t.upstream_uri)
 
-          _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
+          _ngx = mock_ngx("GET", "/xx-route", { host = "domain.org" })
           router._set_ngx(_ngx)
           match_t = router:exec()
           assert.same(use_case_routes[1].route, match_t.route)
-          assert.equal("/this-route", match_t.prefix)
+          assert.equal("/xx-route", match_t.prefix)
           assert.equal("/", match_t.upstream_uri)
         end)
 
@@ -4619,3 +4628,106 @@ describe("[both regex and prefix with regex_priority]", function()
   end)
 
 end)
+
+
+for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
+  describe("Router (flavor = " .. flavor .. ")", function()
+    reload_router(flavor)
+
+    describe("[both regex and prefix]", function()
+      local use_case, router
+
+      lazy_setup(function()
+        use_case = {
+          -- regex + prefix
+          {
+            service = service,
+            route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+              paths = {
+                "~/some/thing/else",
+                "/foo",
+              },
+              hosts = {
+                "domain-1.org",
+              },
+            },
+          },
+          -- prefix
+          {
+            service = service,
+            route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+              paths = {
+                "/foo/bar"
+              },
+              hosts = {
+                "domain-1.org",
+              },
+            },
+          },
+        }
+
+        router = assert(new_router(use_case))
+      end)
+
+      it("[assigns different priorities to regex and non-regex path]", function()
+        local match_t = router:select("GET", "/some/thing/else", "domain-1.org")
+        assert.truthy(match_t)
+        assert.same(use_case[1].route, match_t.route)
+        local match_t = router:select("GET", "/foo/bar", "domain-1.org")
+        assert.truthy(match_t)
+        assert.same(use_case[2].route, match_t.route)
+      end)
+
+    end)
+
+    describe("[overlapping prefixes]", function()
+      local use_case, router
+
+      lazy_setup(function()
+        use_case = {
+          -- regex + prefix
+          {
+            service = service,
+            route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+              paths = {
+                "/foo",
+                "/foo/bar/baz"
+              },
+              hosts = {
+                "domain-1.org",
+              },
+            },
+          },
+          -- prefix
+          {
+            service = service,
+            route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+              paths = {
+                "/foo/bar"
+              },
+              hosts = {
+                "domain-1.org",
+              },
+            },
+          },
+        }
+
+        router = assert(new_router(use_case))
+      end)
+
+      it("[assigns different priorities to each path]", function()
+        local match_t = router:select("GET", "/foo", "domain-1.org")
+        assert.truthy(match_t)
+        assert.same(use_case[1].route, match_t.route)
+        local match_t = router:select("GET", "/foo/bar", "domain-1.org")
+        assert.truthy(match_t)
+        assert.same(use_case[2].route, match_t.route)
+      end)
+
+    end)
+  end)
+end


### PR DESCRIPTION
### Summary

When prefix and regex routes were mixed or prefixes of different lengths were specified in one route, traditional_compat assigned the highest priority of all paths to the route for all paths, causing unexpected routing matches that were incompatible with the traditional router.

With this fix, each multi-path route is split into multiple routes with separate priorities.

### Checklist

- [X] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing [docs PR](https://github.com/Kong/docs.konghq.com/pull/5402)

### Issue reference

KAG-727
[KAG-1446](https://konghq.atlassian.net/browse/KAG-1446)

[KAG-1446]: https://konghq.atlassian.net/browse/KAG-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ