### PR TITLE
feat(opentelemetry): Allow header_type to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   [#10562](https://github.com/Kong/kong/pull/10562)
 - **OpenTelemetry**: spans are now correctly correlated in downstream Datadog traces.
   [10531](https://github.com/Kong/kong/pull/10531)
+- **OpenTelemetry**: add `header_type` field in OpenTelemetry plugin.
+  Previously, the `header_type` was hardcoded to `preserve`, now it can be set to one of the
+  following values: `preserve`, `ignore`, `b3`, `b3-single`, `w3c`, `jaeger`, `ot`.
+  [#10620](https://github.com/Kong/kong/pull/10620)
 
 #### PDK
 

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -66,6 +66,7 @@ return {
     opentelemetry = {
       "http_response_header_for_traceid",
       "queue",
+      "header_type",
     },
     http_log = {
       "queue",

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -90,8 +90,7 @@ local function http_export(conf, spans)
   return ok, err
 end
 
-
-function OpenTelemetryHandler:access()
+function OpenTelemetryHandler:access(conf)
   local headers = ngx_get_headers()
   local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
 
@@ -104,7 +103,7 @@ function OpenTelemetryHandler:access()
     kong.ctx.plugin.should_sample = false
   end
 
-  local header_type, trace_id, span_id, parent_id, should_sample, _ = propagation_parse(headers)
+  local header_type, trace_id, span_id, parent_id, should_sample, _ = propagation_parse(headers, conf.header_type)
   if should_sample == false then
     root_span.should_sample = should_sample
   end
@@ -124,7 +123,7 @@ function OpenTelemetryHandler:access()
     root_span.parent_id = parent_id
   end
 
-  propagation_set("preserve", header_type, root_span, "w3c")
+  propagation_set(conf.header_type, header_type, root_span, "w3c")
 end
 
 

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -52,7 +52,7 @@ return {
         { send_timeout = typedefs.timeout { default = 5000 } },
         { read_timeout = typedefs.timeout { default = 5000 } },
         { http_response_header_for_traceid = { type = "string", default = nil }},
-        { header_type = { type = "string", required = true, default = "preserve",
+        { header_type = { type = "string", required = false, default = "preserve",
                           one_of = { "preserve", "ignore", "b3", "b3-single", "w3c", "jaeger", "ot" } } },
       },
       entity_checks = {

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -52,6 +52,8 @@ return {
         { send_timeout = typedefs.timeout { default = 5000 } },
         { read_timeout = typedefs.timeout { default = 5000 } },
         { http_response_header_for_traceid = { type = "string", default = nil }},
+        { header_type = { type = "string", required = true, default = "preserve",
+                          one_of = { "preserve", "ignore", "b3", "b3-single", "w3c", "jaeger", "ot" } } },
       },
       entity_checks = {
         { custom_entity_check = {

--- a/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
@@ -24,21 +24,44 @@ describe("propagation tests #" .. strategy, function()
   lazy_setup(function()
     local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
 
-    -- enable opentelemetry plugin globally pointing to mock server
+    service = bp.services:insert()
+
     bp.plugins:insert({
       name = "opentelemetry",
+      route = {id = bp.routes:insert({
+        service = service,
+        hosts = { "http-route" },
+      }).id},
       config = {
         -- fake endpoint, request to backend will sliently fail
         endpoint = "http://localhost:8080/v1/traces",
       }
     })
 
-    service = bp.services:insert()
+    bp.plugins:insert({
+      name = "opentelemetry",
+      route = {id = bp.routes:insert({
+        service = service,
+        hosts = { "http-route-ignore" },
+      }).id},
+      config = {
+        -- fake endpoint, request to backend will sliently fail
+        endpoint = "http://localhost:8080/v1/traces",
+        header_type = "ignore",
+      }
+    })
 
-    -- kong (http) mock upstream
-    bp.routes:insert({
-      service = service,
-      hosts = { "http-route" },
+    bp.plugins:insert({
+      name = "opentelemetry",
+      route = {id = bp.routes:insert({
+        service = service,
+        hosts = { "http-route-w3c" },
+      }).id},
+      config = {
+        -- fake endpoint, request to backend will sliently fail
+        endpoint = "http://localhost:8080/v1/traces",
+        header_type = "w3c",
+      }
     })
 
     helpers.start_kong({
@@ -120,6 +143,54 @@ describe("propagation tests #" .. strategy, function()
       headers = {
         traceparent = fmt("00-%s-%s-01", trace_id, parent_id),
         host = "http-route"
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    assert.matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+  end)
+
+  it("defaults to w3c without propagating when header_type set to ignore and w3c headers sent", function()
+    local trace_id = gen_trace_id()
+    local parent_id = gen_span_id()
+
+    local r = proxy_client:get("/", {
+      headers = {
+        traceparent = fmt("00-%s-%s-01", trace_id, parent_id),
+        host = "http-route-ignore"
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    assert.is_not_nil(json.headers.traceparent)
+    -- incoming trace id is ignored
+    assert.not_matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+  end)
+
+  it("defaults to w3c without propagating when header_type set to ignore and b3 headers sent", function()
+    local trace_id = gen_trace_id()
+    local r = proxy_client:get("/", {
+      headers = {
+        ["x-b3-sampled"] = "1",
+        ["x-b3-traceid"] = trace_id,
+        host  = "http-route-ignore",
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    assert.is_not_nil(json.headers.traceparent)
+    -- incoming trace id is ignored
+    assert.not_matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+  end)
+
+  it("propagates w3c tracing headers when header_type set to w3c", function()
+    local trace_id = gen_trace_id()
+    local parent_id = gen_span_id()
+
+    local r = proxy_client:get("/", {
+      headers = {
+        traceparent = fmt("00-%s-%s-01", trace_id, parent_id),
+        host = "http-route-w3c"
       },
     })
     local body = assert.response(r).has.status(200)


### PR DESCRIPTION
### Summary

At the moment the opentelemtry plugin sets the `default_header_type` for propigations:

https://github.com/Kong/kong/blob/master/kong/plugins/opentelemetry/handler.lua#L150

However, doesn't allow the modification of `header_type` in the `schema`, so it always defaults to `preserve`. However, based on the function it's calling:

https://github.com/Kong/kong/blob/master/kong/tracing/propagation.lua#L432

> -- If conf_header_type is set to `preserve`, found_header_type is used over default_header_type;

The above means the `default_header_type` is never used. We want the `default_header_type` to be used, and we want to ignore the incoming header type. 

I am not implmenting the ability to modify the `default_header_type` as opentelemetry notes it should default to `w3c` which it currently is:

https://opentelemetry.io/docs/concepts/signals/traces/#context-propagation

### Checklist

- [X] The Pull Request has tests
- [N/A] There's an entry in the CHANGELOG **note, it specifically says not to edit this: https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#submitting-a-patch**
- [?] Can submit documentation if needed

### Full changelog

* Implement the ability to set `header_type` for the opentelemetry plugin

### Issue reference

Fix https://github.com/Kong/kong/issues/10246


