### PR TITLE
chore: remove unused busted tag

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -8,7 +8,7 @@ function red() {
     echo -e "\033[1;31m$*\033[0m"
 }
 
-export BUSTED_ARGS="--no-k -o htest -v --exclude-tags=flaky,ipv6"
+export BUSTED_ARGS="--no-k -o htest -v --exclude-tags=flaky"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"


### PR DESCRIPTION
### Summary

A grep through the codebase yields no '#ipv6' so this patch removes the tag from --exclude-tags.


### Checklist

- [x] The Pull Request has tests - N/A
- [x] There's an entry in the CHANGELOG - N/A
- [x] There is a user-facing docs PR - N/A