### PR TITLE
tests(tracing): add propagation integration test

### DIFF
--- a/spec/02-integration/14-tracing/02-propagation_spec.lua
+++ b/spec/02-integration/14-tracing/02-propagation_spec.lua
@@ -1,0 +1,79 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+local TCP_PORT = 35001
+for _, strategy in helpers.each_strategy() do
+  local proxy_client
+
+  describe("tracing propagation spec #" .. strategy, function()
+    describe("spans hierarchy", function ()
+
+      lazy_setup(function()
+        local bp, _ = assert(helpers.get_db_utils(strategy, {
+          "routes",
+          "plugins",
+        }, { "tcp-trace-exporter", "trace-propagator" }))
+
+        bp.routes:insert({
+          hosts = { "propagate.test" },
+        })
+
+        bp.plugins:insert({
+          name = "tcp-trace-exporter",
+          config = {
+            host = "127.0.0.1",
+            port = TCP_PORT,
+            custom_spans = false,
+          }
+        })
+
+        bp.plugins:insert({
+          name = "trace-propagator"
+        })
+
+        assert(helpers.start_kong {
+          database = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          plugins = "tcp-trace-exporter,trace-propagator",
+          tracing_instrumentations = "balancer",
+        })
+
+        proxy_client = helpers.proxy_client()
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("propagates the balancer span", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "propagate.test",
+          }
+        })
+        assert.res_status(200, r)
+        local body = r:read_body()
+        body = assert(body and cjson.decode(body))
+
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- expected spans are returned
+        local spans = cjson.decode(res)
+        assert.is_same(2, #spans, res)
+        local balancer_span = spans[2]
+        assert.is_same("balancer try #1", balancer_span.name)
+
+        local traceparent = assert(body.headers.traceparent)
+        local trace_id = balancer_span.trace_id
+        local span_id = balancer_span.span_id
+        -- traceparent contains correct trace id and the balancer span's id
+        assert.equals("00-" .. trace_id .. "-" .. span_id .. "-01", traceparent)
+      end)
+    end)
+  end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
@@ -1,0 +1,45 @@
+local propagation = require "kong.tracing.propagation"
+
+local ngx = ngx
+local kong = kong
+local propagation_parse = propagation.parse
+local propagation_set = propagation.set
+
+local _M = {
+  PRIORITY = 1001,
+  VERSION = "1.0",
+}
+
+
+function _M:access(conf)
+  local headers = ngx.req.get_headers()
+  local tracer = kong.tracing.new("trace-propagator")
+  local root_span = tracer.start_span("root")
+
+  local header_type, trace_id, span_id, parent_id = propagation_parse(headers)
+
+  if trace_id then
+    root_span.trace_id = trace_id
+  end
+
+  if span_id then
+    root_span.parent_id = span_id
+
+  elseif parent_id then
+    root_span.parent_id = parent_id
+  end
+
+  local new_span = ngx.ctx.last_try_balancer_span
+  if new_span == nil then
+    new_span = tracer.create_span(nil, {
+      span_kind = 3,
+      parent = root_span,
+    })
+    ngx.ctx.last_try_balancer_span = new_span
+  end
+
+  local type = header_type and "preserve" or "w3c"
+  propagation_set(type, header_type, new_span, "trace-propagator")
+end
+
+return _M

--- a/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/schema.lua
@@ -1,0 +1,11 @@
+return {
+  name = "trace-propagator",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = { }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Add tests for https://github.com/Kong/kong/pull/10583

Adds a test to confirm the span hierarchy is propagated correctly. The propagated span id must be that of the balancer span.

This test confirms that the whole flow available through https://github.com/Kong/kong/pull/10583 works:
- the custom plugin uses `tracer.create_span()` to create the balancer span in advance and propagate it
- the span is then correctly picked up in `instrumentation` and linked via `tracer.link_span()`

### Checklist

- [X] The Pull Request has tests
- [X] [not needed] There's an entry in the CHANGELOG
- [X] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-1040](https://konghq.atlassian.net/browse/KAG-1040)

[KAG-1040]: https://konghq.atlassian.net/browse/KAG-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ