### PR TITLE
revert "tests(templates): add `mock_upstream` fixture to data plane f…

### DIFF
--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -455,17 +455,12 @@ http {
     }
 > end -- role == "control_plane"
 
+> if role ~= "data_plane" then
     server {
         server_name mock_upstream;
 
-> if role ~= "data_plane" then
         listen 15555;
         listen 15556 ssl;
-
-> else
-        listen 16665;
-        listen 16666 ssl;
-> end -- role ~= "data_plane"
 
 > for i = 1, #ssl_cert do
         ssl_certificate     $(ssl_cert[i]);
@@ -711,6 +706,7 @@ http {
             }
         }
     }
+> end -- role ~= "data_plane"
 
     include '*.http_mock';
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -20,8 +20,6 @@ local MOCK_UPSTREAM_PORT = 15555
 local MOCK_UPSTREAM_SSL_PORT = 15556
 local MOCK_UPSTREAM_STREAM_PORT = 15557
 local MOCK_UPSTREAM_STREAM_SSL_PORT = 15558
-local MOCK_UPSTREAM_DP_PORT = 16665
-local MOCK_UPSTREAM_DP_SSL_PORT = 16666
 local GRPCBIN_HOST = os.getenv("KONG_SPEC_TEST_GRPCBIN_HOST") or "localhost"
 local GRPCBIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_PORT")) or 9000
 local GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) or 9001
@@ -1833,7 +1831,7 @@ local function wait_for_all_config_update(opts)
     if stream_enabled then
       pwait_until(function ()
         local proxy = proxy_client(proxy_client_timeout, stream_port, stream_ip)
-
+  
         res = proxy:get("/always_200")
         local ok, err = pcall(assert, res.status == 200)
         proxy:close()
@@ -3492,14 +3490,6 @@ end
 -- @field mock_upstream_ssl_host
 -- @field mock_upstream_ssl_port
 -- @field mock_upstream_ssl_url Base url constructed from the components
--- @field mock_upstream_dp_protocol
--- @field mock_upstream_dp_host
--- @field mock_upstream_dp_port
--- @field mock_upstream_dp_url Base url constructed from the components
--- @field mock_upstream_dp_ssl_protocol
--- @field mock_upstream_dp_ssl_host
--- @field mock_upstream_dp_ssl_port
--- @field mock_upstream_dp_ssl_url Base url constructed from the components
 -- @field mock_upstream_stream_port
 -- @field mock_upstream_stream_ssl_port
 -- @field mock_grpc_upstream_proto_path
@@ -3554,20 +3544,6 @@ end
   mock_upstream_ssl_url      = MOCK_UPSTREAM_SSL_PROTOCOL .. "://" ..
                                MOCK_UPSTREAM_HOST .. ':' ..
                                MOCK_UPSTREAM_SSL_PORT,
-
-  mock_upstream_dp_protocol  = MOCK_UPSTREAM_PROTOCOL,
-  mock_upstream_dp_host      = MOCK_UPSTREAM_HOST,
-  mock_upstream_dp_port      = MOCK_UPSTREAM_DP_PORT,
-  mock_upstream_dp_url       = MOCK_UPSTREAM_PROTOCOL .. "://" ..
-                               MOCK_UPSTREAM_HOST .. ':' ..
-                               MOCK_UPSTREAM_DP_PORT,
-
-  mock_upstream_dp_ssl_protocol = MOCK_UPSTREAM_SSL_PROTOCOL,
-  mock_upstream_dp_ssl_host     = MOCK_UPSTREAM_HOST,
-  mock_upstream_dp_ssl_port     = MOCK_UPSTREAM_DP_SSL_PORT,
-  mock_upstream_dp_ssl_url      = MOCK_UPSTREAM_SSL_PROTOCOL .. "://" ..
-                                  MOCK_UPSTREAM_HOST .. ':' ..
-                                  MOCK_UPSTREAM_DP_SSL_PORT,
 
   mock_upstream_stream_port     = MOCK_UPSTREAM_STREAM_PORT,
   mock_upstream_stream_ssl_port = MOCK_UPSTREAM_STREAM_SSL_PORT,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Revert "tests(templates): add `mock_upstream` fixture to data plane for RLA tests (#10224)"

Previous PR #10224 was desginated to improve RLA tests earlier, but now we prefer to add a
separate http mock upstream for each individual DP node, which has better isolation and is
less flaky. Check [EE PR 4819](https://github.com/Kong/kong-ee/pull/4819).

This reverts commit 6ad8bf399fe1c9b0587d28e33f8e2cb0caf7d226.

### Checklist

Since RLA now has abandoned the commit, we are safe to revert it.

- [ ] ~~The Pull Request has tests~~
- [ ] ~~There's an entry in the CHANGELOG~~
- [ ] ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

* This reverts commit https://github.com/Kong/kong/commit/6ad8bf399fe1c9b0587d28e33f8e2cb0caf7d226

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-4929]_


[FTI-4929]: https://konghq.atlassian.net/browse/FTI-4929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ