### PR TITLE
chore(release): bump version number to 3.3.0

### DIFF
--- a/kong-3.3.0-0.rockspec
+++ b/kong-3.3.0-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong"
-version = "3.2.1-0"
+version = "3.3.0-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git+https://github.com/Kong/kong.git",
-  tag = "3.2.1"
+  tag = "3.3.0"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 3,
-  minor = 2,
-  patch = 1,
+  minor = 3,
+  patch = 0,
   --suffix = "-alpha.13"
 }, {
   -- our Makefile during certain releases adjusts this line. Any changes to


### PR DESCRIPTION
This should have been done in master as part of the release of Kong 3.2.0.

The step is now included in our new release checklist.

### Checklist

- <del>[ ] The Pull Request has tests</del>
- <del>[ ] There's an entry in the CHANGELOG</del>
- <del>[ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE</del>
