### PR TITLE
tests(plugins-iterator): precedence tests

### DIFF
--- a/spec/02-integration/15-plugins-iterator/01-precedence_spec.lua
+++ b/spec/02-integration/15-plugins-iterator/01-precedence_spec.lua
@@ -1,0 +1,470 @@
+local helpers = require "spec.helpers"
+local conf_loader = require "kong.conf_loader"
+local insert = table.insert
+local factories = require "spec.fixtures.factories.plugins"
+
+local PluginFactory = factories.PluginFactory
+local EntitiesFactory = factories.EntitiesFactory
+
+for _, strategy in helpers.each_strategy() do
+  describe("Plugins Iterator - Triple Scoping - #Consumer #Route #Service on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      -- to authenticate as `alice`
+      -- scoped to consumer, route, and service
+      expected_header = pf:consumer_route_service()
+
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to Consumer, Route
+      insert(must_not_have_headers, (pf:consumer_route()))
+      -- scoped to Consumer, Service
+      insert(must_not_have_headers, (pf:consumer_service()))
+      -- scoped to Route, Service
+      insert(must_not_have_headers, (pf:route_service()))
+
+      -- scoped to route
+      insert(must_not_have_headers, (pf:route()))
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to consumer
+      insert(must_not_have_headers, (pf:consumer()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 7)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Dual Scoping - #Consumer #Route on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:consumer_route()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to Consumer, Service
+      insert(must_not_have_headers, (pf:consumer_service()))
+      -- scoped to Route, Service
+      insert(must_not_have_headers, (pf:route_service()))
+
+      -- scoped to route
+      insert(must_not_have_headers, (pf:route()))
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to consumer
+      insert(must_not_have_headers, (pf:consumer()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 6)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Dual Scoping - #Consumer #Service on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:consumer_service()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to Route, Service
+      insert(must_not_have_headers, (pf:route_service()))
+
+      -- scoped to route
+      insert(must_not_have_headers, (pf:route()))
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to consumer
+      insert(must_not_have_headers, (pf:consumer()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 5)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Dual Scoping - #Route #Service on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:route_service()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to route
+      insert(must_not_have_headers, (pf:route()))
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to consumer
+      insert(must_not_have_headers, (pf:consumer()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 4)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Single coping - #Consumer on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:consumer()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to route
+      insert(must_not_have_headers, (pf:route()))
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 3)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Single coping - #Route on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:route()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to serive
+      insert(must_not_have_headers, (pf:service()))
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 2)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Single scoping - #single #Service on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:service()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      -- scoped to global
+      insert(must_not_have_headers, (pf:global()))
+
+      assert.is_equal(#must_not_have_headers, 1)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+
+  describe("Plugins Iterator - Global scoping on #" .. strategy, function()
+    local proxy_client, expected_header, must_not_have_headers
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+    end)
+
+    lazy_setup(function()
+      proxy_client = helpers.proxy_client
+      helpers.stop_kong()
+      helpers.kill_all()
+      assert(conf_loader(nil, {}))
+
+      local ef = EntitiesFactory:setup(strategy)
+      local pf = PluginFactory:setup(ef)
+
+      expected_header = pf:global()
+      -- adding header-names of plugins that should _not_ be executed
+      -- this assits with tracking if a plugin was executed or not
+      must_not_have_headers = {}
+
+      assert.is_equal(#must_not_have_headers, 0)
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+    end)
+
+    it("verify precedence", function()
+      local r = proxy_client():get("/anything", {
+        headers = {
+          host = "route.test",
+          -- authenticate as `alice`
+          apikey = "alice",
+        },
+      })
+      assert.response(r).has.status(200)
+      -- verify that the expected plugin was executed
+      assert.request(r).has_header(expected_header)
+      -- verify that no other plugin was executed that had lesser scopes configured
+      for _, header in pairs(must_not_have_headers) do
+        assert.request(r).has_no_header(header)
+      end
+    end)
+  end)
+end

--- a/spec/fixtures/factories/plugins.lua
+++ b/spec/fixtures/factories/plugins.lua
@@ -1,0 +1,154 @@
+local helpers = require "spec.helpers"
+
+local EntitiesFactory = {}
+
+function EntitiesFactory:setup(strategy)
+	local bp, _ = helpers.get_db_utils(strategy,
+		{ "plugins",
+			"routes",
+			"services",
+			"consumers", },
+		{ "key-auth", "request-transformer" })
+
+
+	local alice = assert(bp.consumers:insert {
+		custom_id = "alice"
+	})
+
+	local bob = assert(bp.consumers:insert {
+		username = "bob",
+	})
+
+	local eve = assert(bp.consumers:insert{
+		username = "eve"
+	})
+
+	assert(bp.keyauth_credentials:insert {
+		key      = "bob",
+		consumer = { id = bob.id },
+	})
+	assert(bp.keyauth_credentials:insert {
+		key = "alice",
+		consumer = { id = alice.id },
+	})
+	assert(bp.keyauth_credentials:insert {
+		key = "eve",
+		consumer = { id = eve.id },
+	})
+
+	local service = assert(bp.services:insert {
+		path = "/anything",
+	})
+
+	local route = assert(bp.routes:insert {
+		service = { id = service.id },
+		hosts = { "route.test" },
+	})
+	assert(bp.key_auth_plugins:insert())
+
+	self.bp = bp
+	self.alice_id = alice.id
+	self.bob_id = bob.id
+	self.eve_id = eve.id
+	self.route_id = route.id
+	self.service_id = service.id
+	return self
+end
+
+local PluginFactory = {}
+function PluginFactory:setup(ef)
+	self.bp = ef.bp
+	self.bob_id = ef.bob_id
+	self.alice_id = ef.alice_id
+	self.eve_id = ef.eve_id
+	self.route_id = ef.route_id
+	self.service_id = ef.service_id
+	return self
+end
+
+function PluginFactory:produce(header_name, plugin_scopes)
+	local plugin_cfg = {
+		name = "request-transformer",
+		config = {
+			add = {
+				headers = { ("%s:true"):format(header_name) }
+			}
+		}
+	}
+	for k, v in pairs(plugin_scopes) do
+		plugin_cfg[k] = v
+	end
+	return assert(self.bp.plugins:insert(plugin_cfg))
+end
+
+function PluginFactory:consumer_route_service()
+	local header_name = "x-consumer-and-service-and-route"
+	self:produce(header_name, {
+		consumer = { id = self.alice_id },
+		service = { id = self.service_id },
+		route = { id = self.route_id },
+	})
+	return header_name
+end
+
+function PluginFactory:consumer_route()
+	local header_name = "x-consumer-and-route"
+	self:produce(header_name, {
+		consumer = { id = self.alice_id },
+		route = { id = self.route_id },
+	})
+	return header_name
+end
+
+function PluginFactory:consumer_service()
+	local header_name = "x-consumer-and-service"
+	self:produce(header_name, {
+		consumer = { id = self.alice_id },
+		service = { id = self.service_id },
+	})
+	return header_name
+end
+
+function PluginFactory:route_service()
+	local header_name = "x-route-and-service"
+	self:produce(header_name, {
+		route = { id = self.route_id },
+		service = { id = self.service_id },
+	})
+	return header_name
+end
+
+function PluginFactory:consumer()
+	local header_name = "x-consumer"
+	self:produce(header_name, {
+		consumer = { id = self.alice_id }
+	})
+	return header_name
+end
+
+function PluginFactory:route()
+	local header_name = "x-route"
+	self:produce(header_name, {
+		route = { id = self.route_id }
+	})
+	return header_name
+end
+
+function PluginFactory:service()
+	local header_name = "x-service"
+	self:produce(header_name, {
+		service = { id = self.service_id }
+	})
+	return header_name
+end
+
+function PluginFactory:global()
+	local header_name = "x-global"
+	self:produce(header_name, {})
+	return header_name
+end
+
+return {
+	PluginFactory = PluginFactory,
+	EntitiesFactory = EntitiesFactory
+}


### PR DESCRIPTION
### Summary

Add precedence tests to ensure plugins are executed in the right order according to their scoping (route, service, consumer)

### Checklist

- [X] The Pull Request has tests
- [x] [not needed] There's an entry in the CHANGELOG
- [X] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

KAG-1127
