### PR TITLE
fix: change opentelemetry plugin version to match core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   Serverless Functions plugins: it does not provide access to the global kong cache. Access to
   certain fields in kong.configuration has also been restricted.
   [#10417](https://github.com/Kong/kong/pull/10417)
+- **Opentelemetry**: plugin version has been updated to match Kong's version
+  [#10646](https://github.com/Kong/kong/pull/10646)
+
 
 ### Additions
 
@@ -114,7 +117,7 @@
 - **Request Transformer**: honor value of untrusted_lua configuration parameter
   [#10327](https://github.com/Kong/kong/pull/10327)
 - **OAuth2**: fix an issue that OAuth2 token was being cached to nil while access to the wrong service first.
-  [#10522](https://github.com/Kong/kong/pull/10522)  
+  [#10522](https://github.com/Kong/kong/pull/10522)
 
 #### PDK
 

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -3,6 +3,7 @@ local http = require "resty.http"
 local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
+local kong_meta = require "kong.meta"
 
 
 local ngx = ngx
@@ -28,7 +29,7 @@ local _log_prefix = "[otel] "
 
 
 local OpenTelemetryHandler = {
-  VERSION = "0.1.0",
+  VERSION = kong_meta.version,
   PRIORITY = 14,
 }
 

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -9,6 +9,7 @@ local plugins_definition = require "kong.db.schema.entities.plugins"
 local dao_plugins = require "kong.db.dao.plugins"
 local certificates_definition = require "kong.db.schema.entities.certificates"
 local constants = require "kong.constants"
+local kong_meta = require "kong.meta"
 
 describe("plugins", function()
   local Plugins
@@ -312,6 +313,13 @@ describe("plugins", function()
           end
         end
         assert.is_true(has_protocols_field, "bundled plugin " .. plugin_name .. " missing required field: protocols")
+      end
+    end)
+    it("ensure every bundled plugin version is same as core version", function()
+      for plugin_name, _ in pairs(constants.BUNDLED_PLUGINS) do
+        local handler = require("kong.plugins." .. plugin_name .. ".handler")
+        local plugin_version = handler.VERSION
+        assert.equal(kong_meta.version, plugin_version)
       end
     end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Plugin versions are the same as the core version for the bundled plugin. OpenTelemetry plugin didn't follow this invariant and now it does.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR - N/A