### PR TITLE
fix(tracing/core): sampled flags and propagation

### DIFF
--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -427,6 +427,11 @@ end
 
 
 local function set(conf_header_type, found_header_type, proxy_span, conf_default_header_type)
+  if proxy_span.is_recording == false then
+    kong.log.debug("skipping propagation of noop span")
+    return
+  end
+
   local set_header = kong.service.request.set_header
 
   -- If conf_header_type is set to `preserve`, found_header_type is used over default_header_type;

--- a/spec/02-integration/14-tracing/02-propagation_spec.lua
+++ b/spec/02-integration/14-tracing/02-propagation_spec.lua
@@ -1,47 +1,59 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local utils = require "kong.tools.utils"
+local to_hex = require("resty.string").to_hex
+
+local rand_bytes = utils.get_rand_bytes
 
 local TCP_PORT = 35001
+
+local function gen_id(len)
+  return to_hex(rand_bytes(len))
+end
+
 for _, strategy in helpers.each_strategy() do
   local proxy_client
 
   describe("tracing propagation spec #" .. strategy, function()
+    lazy_setup(function()
+      local bp, _ = assert(helpers.get_db_utils(strategy, {
+        "routes",
+        "plugins",
+      }, { "tcp-trace-exporter", "trace-propagator" }))
+
+      bp.routes:insert({
+        hosts = { "propagate.test" },
+      })
+
+      bp.plugins:insert({
+        name = "tcp-trace-exporter",
+        config = {
+          host = "127.0.0.1",
+          port = TCP_PORT,
+          custom_spans = false,
+        }
+      })
+
+      bp.plugins:insert({
+        name = "trace-propagator"
+      })
+    end)
+
     describe("spans hierarchy", function ()
-
       lazy_setup(function()
-        local bp, _ = assert(helpers.get_db_utils(strategy, {
-          "routes",
-          "plugins",
-        }, { "tcp-trace-exporter", "trace-propagator" }))
-
-        bp.routes:insert({
-          hosts = { "propagate.test" },
-        })
-
-        bp.plugins:insert({
-          name = "tcp-trace-exporter",
-          config = {
-            host = "127.0.0.1",
-            port = TCP_PORT,
-            custom_spans = false,
-          }
-        })
-
-        bp.plugins:insert({
-          name = "trace-propagator"
-        })
-
         assert(helpers.start_kong {
           database = strategy,
           nginx_conf = "spec/fixtures/custom_nginx.template",
           plugins = "tcp-trace-exporter,trace-propagator",
           tracing_instrumentations = "balancer",
         })
-
         proxy_client = helpers.proxy_client()
       end)
 
       lazy_teardown(function()
+        if proxy_client then
+          proxy_client:close()
+        end
         helpers.stop_kong()
       end)
 
@@ -73,6 +85,80 @@ for _, strategy in helpers.each_strategy() do
         local span_id = balancer_span.span_id
         -- traceparent contains correct trace id and the balancer span's id
         assert.equals("00-" .. trace_id .. "-" .. span_id .. "-01", traceparent)
+      end)
+    end)
+
+    describe("parsing incoming headers", function ()
+      local trace_id = gen_id(16)
+      local span_id = gen_id(8)
+
+      lazy_setup(function()
+        assert(helpers.start_kong {
+          database = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          plugins = "tcp-trace-exporter,trace-propagator",
+          tracing_instrumentations = "request,router,balancer,plugin_access,plugin_header_filter",
+        })
+        proxy_client = helpers.proxy_client()
+      end)
+
+      lazy_teardown(function()
+        if proxy_client then
+          proxy_client:close()
+        end
+        helpers.stop_kong()
+      end)
+
+      it("enables sampling when incoming header has sampled enabled", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "propagate.test",
+            traceparent = string.format("00-%s-%s-01", trace_id, span_id),
+          }
+        })
+        assert.res_status(200, r)
+        local body = r:read_body()
+        body = assert(body and cjson.decode(body))
+
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- all spans are returned
+        local spans = cjson.decode(res)
+        assert.is_same(6, #spans, res)
+
+        local traceparent = assert(body.headers.traceparent)
+        assert.matches("00%-" .. trace_id .. "%-%x+%-01", traceparent)
+      end)
+
+      it("disables sampling when incoming header has sampled disabled", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "propagate.test",
+            traceparent = string.format("00-%s-%s-00", trace_id, span_id),
+          }
+        })
+        assert.res_status(200, r)
+        local body = r:read_body()
+        body = assert(body and cjson.decode(body))
+
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- no spans are returned
+        local spans = cjson.decode(res)
+        assert.is_same(0, #spans, res)
+
+        local traceparent = assert(body.headers.traceparent)
+        assert.equals("00-" .. trace_id .. "-" .. span_id .. "-00", traceparent)
       end)
     end)
   end)

--- a/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
@@ -104,6 +104,9 @@ function _M:log(config)
 
   local spans = {}
   local process_span = function (span)
+    if span.should_sample == false then
+      return
+    end
     local s = table.clone(span)
     s.tracer = nil
     s.parent = nil

--- a/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
@@ -16,7 +16,11 @@ function _M:access(conf)
   local tracer = kong.tracing.new("trace-propagator")
   local root_span = tracer.start_span("root")
 
-  local header_type, trace_id, span_id, parent_id = propagation_parse(headers)
+  local header_type, trace_id, span_id, parent_id, should_sample = propagation_parse(headers)
+
+  if should_sample == false then
+    tracer:set_should_sample(should_sample)
+  end
 
   if trace_id then
     root_span.trace_id = trace_id


### PR DESCRIPTION
### Summary

fix an issue where incoming propagation headers with disabled sampling (sampled flag = 0) produced invalid propagation of noop spans and broken traces

This fix:
* ensures propagation is not attempted on noop spans
* ensures no span is sampled when sampling is disabled in the incoming headers
* propagates the correct header when sampling is disabled in the incoming headers

### Checklist

- [X] The Pull Request has tests
- [x] [not needed] There's an entry in the CHANGELOG
- [x] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

https://konghq.atlassian.net/browse/KAG-1184
https://konghq.atlassian.net/browse/KAG-1176