### PR TITLE
chore(dev): bump grpcurl to 1.8.7 to provide arm64 on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
-GRPCURL_VERSION ?= 1.8.5
+GRPCURL_VERSION ?= 1.8.7
 BAZLISK_VERSION ?= 1.16.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
@@ -105,9 +105,11 @@ install: dev
 	@$(VENV) luarocks make
 
 clean: check-bazel
+	rm -f bin/bazel bin/grpcurl
 	$(BAZEL) clean
 
 expunge: check-bazel
+	rm -f bin/bazel bin/grpcurl
 	$(BAZEL) clean --expunge
 
 lint: dev

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,12 @@ install: dev
 	@$(VENV) luarocks make
 
 clean: check-bazel
-	rm -f bin/bazel bin/grpcurl
 	$(BAZEL) clean
+	rm -f bin/bazel bin/grpcurl
 
 expunge: check-bazel
-	rm -f bin/bazel bin/grpcurl
 	$(BAZEL) clean --expunge
+	rm -f bin/bazel bin/grpcurl
 
 lint: dev
 	@$(VENV) luacheck -q .

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -594,7 +594,7 @@ if limit_by == "ip" then
         local ok, res = helpers.proxy_client_grpc(){
           service = "hello.HelloService.SayHello",
           opts = {
-            ["-v"] = true,
+            ["-vv"] = true,
           },
         }
 
@@ -616,9 +616,14 @@ if limit_by == "ip" then
       local ok, res = helpers.proxy_client_grpc(){
         service = "hello.HelloService.SayHello",
         opts = {
-          ["-v"] = true,
+          ["-vv"] = true,
         },
       }
+      -- print("sleep")
+      -- ngx.sleep(123213213)
+
+      -- debug
+      print(res)
       assert.falsy(ok)
       assert.matches("Code: ResourceExhausted", res)
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1112,6 +1112,7 @@ local function grpc_client(host, port, opts)
       end
 
       local opts = gen_grpcurl_opts(pl_tablex.merge(t.opts, args.opts, true))
+      print(string.format(t.cmd_template, opts, service))
       local ok, _, out, err = exec(string.format(t.cmd_template, opts, service), true)
 
       if ok then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary


Bump grpcurl to 1.8.7 to provide arm64 on macOS; was seeing some failure in rate limit plugin, open PR to figure out why.

### Checklist

- [na] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* bump grpcurl to 1.8.7 to provide arm64 on macOS
