### PR TITLE
chore(dep): bump `lua-resty-timer-ng` from `0.2.4` to `0.2.5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,8 +173,9 @@
   [#10338](https://github.com/Kong/kong/pull/10338)
 - Bumped lua-protobuf from 0.3.3 to 0.4.2
   [#10137](https://github.com/Kong/kong/pull/10413)
-- Bumped lua-resty-timer-ng from 0.2.3 to 0.2.4
+- Bumped lua-resty-timer-ng from 0.2.3 to 0.2.5
   [#10419](https://github.com/Kong/kong/pull/10419)
+  [10664](https://github.com/Kong/kong/pull/10664)
 - Bumped lua-resty-openssl from 0.8.17 to 0.8.20
   [#10463](https://github.com/Kong/kong/pull/10463)
   [#10476](https://github.com/Kong/kong/pull/10476)
@@ -186,8 +187,6 @@
   [#10562](https://github.com/Kong/kong/pull/10562)
 - Bumped lua-resty-events from 0.1.3 to 0.1.4
   [#10634](https://github.com/Kong/kong/pull/10634)
-- Bumped lua-resty-timer-ng from 0.2.4 to 0.2.5
-  [10664](https://github.com/Kong/kong/pull/10664)
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@
   [#10137](https://github.com/Kong/kong/pull/10413)
 - Bumped lua-resty-timer-ng from 0.2.3 to 0.2.5
   [#10419](https://github.com/Kong/kong/pull/10419)
-  [10664](https://github.com/Kong/kong/pull/10664)
+  [#10664](https://github.com/Kong/kong/pull/10664)
 - Bumped lua-resty-openssl from 0.8.17 to 0.8.20
   [#10463](https://github.com/Kong/kong/pull/10463)
   [#10476](https://github.com/Kong/kong/pull/10476)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,8 @@
   [#10562](https://github.com/Kong/kong/pull/10562)
 - Bumped lua-resty-events from 0.1.3 to 0.1.4
   [#10634](https://github.com/Kong/kong/pull/10634)
+- Bumped lua-resty-timer-ng from 0.2.4 to 0.2.5
+  [10664](https://github.com/Kong/kong/pull/10664)
 
 ## 3.2.0
 

--- a/kong-3.3.0-0.rockspec
+++ b/kong-3.3.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.11.0",
   "lua-resty-session == 4.0.3",
-  "lua-resty-timer-ng == 0.2.4",
+  "lua-resty-timer-ng == 0.2.5",
   "lpeg == 1.0.2",
 }
 build = {


### PR DESCRIPTION
## What's Changed
* fix: fix log flooding by @ADD-SP in https://github.com/Kong/lua-resty-timer-ng/pull/14


**Full Changelog**: https://github.com/Kong/lua-resty-timer-ng/compare/0.2.4...0.2.5

[KAG-1131]

[KAG-1131]: https://konghq.atlassian.net/browse/KAG-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ