### PR TITLE
fix(utils): fix nginx binary path search sequence under the "venv" environment

### DIFF
--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -26,9 +26,9 @@ ffi.cdef([[
 
 local nginx_bin_name = "nginx"
 local nginx_search_paths = {
+  "",
   "/usr/local/openresty/nginx/sbin",
   "/opt/openresty/nginx/sbin",
-  ""
 }
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR fixes a problem that Kong uses the system's nginx binary instead of bazel built binary(which is what we expect to be used) under the venv environment.
![image](https://user-images.githubusercontent.com/39181969/231728261-190ac7d7-a885-4866-9aeb-66a744a2fd7d.png)

The root cause of this issue is that Kong tries to iterate through the path list defined in `nginx_search_paths`, and `/usr/local/openresty/nginx/sbin` and `/opt/openresty/nginx/sbin` always take precedence. 

https://github.com/Kong/kong/blob/22cba2328ac8939493699b22ab7926064bdb0175/kong/cmd/utils/nginx_signals.lua#L28-L32

https://github.com/Kong/kong/blob/22cba2328ac8939493699b22ab7926064bdb0175/kong/cmd/utils/nginx_signals.lua#L99-L116


This PR fixes the problem by putting the `""` path to the front of search paths, so Kong will first try to use the nginx binary according to the current PATH env var, and in the venv environment the nginx binary will be the one that is built by bazel, which is correct.




<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog



### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

