### PR TITLE
tests(integration): reduce targets admin API tests flakiness

### DIFF
--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -947,6 +947,7 @@ describe("Admin API #" .. strategy, function()
         local res
         assert
           .with_timeout(10)
+          .ignore_exceptions(true)
           .eventually(function()
             res = admin_client:patch("/upstreams/" .. upstream.name .. "/targets/" .. target.target, {
               body = {
@@ -954,9 +955,9 @@ describe("Admin API #" .. strategy, function()
               },
               headers = { ["Content-Type"] = "application/json" }
             })
-            return res and res.status == 200
+            assert.response(res).has.status(200)
           end)
-          .is_truthy()
+          .has_no_error()
         local json = assert.response(res).has.jsonbody()
         assert.is_string(json.id)
         assert.are.equal(target.target, json.target)

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -943,19 +943,26 @@ describe("Admin API #" .. strategy, function()
       end)
 
       it("is allowed and works", function()
-        ngx.sleep(1)
-        local res = client:patch("/upstreams/" .. upstream.name .. "/targets/" .. target.target, {
-          body = {
-            weight = 659,
-          },
-          headers = { ["Content-Type"] = "application/json" }
-        })
-        assert.response(res).has.status(200)
+        local admin_client = assert(helpers.admin_client())
+        local res
+        assert
+          .with_timeout(10)
+          .eventually(function()
+            res = admin_client:patch("/upstreams/" .. upstream.name .. "/targets/" .. target.target, {
+              body = {
+                weight = 659,
+              },
+              headers = { ["Content-Type"] = "application/json" }
+            })
+            return res and res.status == 200
+          end)
+          .is_truthy()
         local json = assert.response(res).has.jsonbody()
         assert.is_string(json.id)
         assert.are.equal(target.target, json.target)
         assert.are.equal(659, json.weight)
         assert.truthy(target.updated_at < json.updated_at)
+        admin_client:close()
 
         local res = assert(client:send {
           method = "GET",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`spec/02-integration/04-admin_api/08-targets_routes_spec.lua` test has been flaky for some time. This file uses `ngx.sleep()` instead of `wait_until()` or `assert.eventually()` in several tests. When the host is busy, the `ngx.sleep()` time may be not enough.

This change actually waits for the most flaky request in the file to finish instead of relying on `ngx.sleep()`. A lot more still to be done.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Change a `ngx.sleep()` call to a `assert.eventually()`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
