### PR TITLE
fix(tracing): http_client span

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -593,6 +593,8 @@ return function(options)
       instrumentation.set_patch_dns_query_fn(toip, function(wrap)
         toip = wrap
       end)
+      -- patch request_uri to record http_client spans
+      instrumentation.http_client()
     end
   end
 

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -159,8 +159,8 @@ for _, strategy in helpers.each_strategy() do
 
         -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(4, #spans, res)
-        assert.is_same("GET /", spans[1].name)
+        assert.is_same(5, #spans, res)
+        assert.matches("HTTP GET", spans[3].name)
       end)
     end)
 
@@ -314,7 +314,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- Making sure it's alright
         local spans = cjson.decode(res)
-        local expected_span_num = 12
+        local expected_span_num = 13
         -- cassandra has different db query implementation
         if strategy == "cassandra" then
           expected_span_num = expected_span_num + 4


### PR DESCRIPTION
### Summary

global patch for http_client spans was missing
this fix adds it and fixes the test to ensure http_client spans are created as expected

### Checklist

- [X] The Pull Request has tests
- [X] [postponed] There's an entry in the CHANGELOG
- [X] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-1111
