### PR TITLE
fix(tracing): balancer span precision

### DIFF
--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -87,7 +87,7 @@ function _M.balancer(ctx)
     local span_name = "balancer try #" .. i
     local span_options = {
       span_kind = 3, -- client
-      start_time_ns = try.balancer_start * 1e6,
+      start_time_ns = try.balancer_start_ns,
       attributes = {
         ["net.peer.ip"] = try.ip,
         ["net.peer.port"] = try.port,
@@ -103,9 +103,9 @@ function _M.balancer(ctx)
         span:set_status(2)
       end
 
-      if try.balancer_latency ~= nil then
+      if try.balancer_latency_ns ~= nil then
         local try_upstream_connect_time = (tonumber(upstream_connect_time[i], 10) or 0) * 1000
-        span:finish((try.balancer_start + try.balancer_latency + try_upstream_connect_time) * 1e6)
+        span:finish(try.balancer_start_ns + try.balancer_latency_ns + try_upstream_connect_time * 1e6)
       else
         span:finish()
       end


### PR DESCRIPTION
### Summary

use nanosecond precision to track balancer span's start and end times

### Checklist

- [x] [not needed] The Pull Request has tests
- [x] [postponed] There's an entry in the CHANGELOG
- [x] [not needed] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-1112
