### PR TITLE
chore(auto-assignee): exclude PR opened from fork

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -8,5 +8,8 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0
+      - name: assign-author
+        # ignore the pull requests opened from PR because token is not correct
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0
 


### PR DESCRIPTION

### Summary

Fix the failing tests like in https://github.com/Kong/kong/actions/runs/4717539509/jobs/8366244956

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* chore(auto-assignee): exclude PR opened from fork
