### PR TITLE
fix(clustering): version compatibility for acme

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -59,6 +59,7 @@ return {
   [3003000000] = {
     acme = {
       "account_key",
+      "storage_config.redis.namespace",
     },
     proxy_cache = {
       "ignore_uri_case",


### PR DESCRIPTION
## Summary

fix version compatibility for acme. The [original PR](https://github.com/Kong/kong/pull/10562) missed to add the field into removed_fields.lua

[KAG-615](https://konghq.atlassian.net/browse/KAG-615)


[KAG-615]: https://konghq.atlassian.net/browse/KAG-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ