### PR TITLE
fix(resty.dns.client): fix the UDP sockets leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@
 - Fix an issue where sorting function for traditional router sources/destinations lead to "invalid order
   function for sorting" error.
   [#10514](https://github.com/Kong/kong/pull/10514)
+- Fix the UDP socket leak caused by frequent DNS queries.
+  [#10691](https://github.com/Kong/kong/pull/10691)
 - Fix a typo of mlcache option `shm_set_tries`.
   [#10712](https://github.com/Kong/kong/pull/10712)
 

--- a/build/openresty/patches/lua-resty-dns-0.22_01-destory_resolver.patch
+++ b/build/openresty/patches/lua-resty-dns-0.22_01-destory_resolver.patch
@@ -1,11 +1,11 @@
 diff --git a/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua b/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
-index a67b3c1..ec4aa28 100644
+index a67b3c1..0305485 100644
 --- a/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
 +++ b/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
-@@ -99,6 +99,31 @@ for i = 2, 64, 2 do
+@@ -99,6 +99,26 @@ for i = 2, 64, 2 do
      arpa_tmpl[i] = DOT_CHAR
  end
- 
+
 +local function udp_socks_close(self)
 +    if self.socks == nil then
 +        return
@@ -26,52 +26,21 @@ index a67b3c1..ec4aa28 100644
 +    self.tcp_sock:close()
 +    self.tcp_sock = nil
 +end
-+
-+local actions = {
-+    ["udp"] = udp_socks_close,
-+    ["tcp"] = tcp_socks_close,
-+}
- 
+
  function _M.new(class, opts)
      if not opts then
-@@ -161,6 +186,16 @@ function _M.new(class, opts)
+@@ -161,6 +181,14 @@ function _M.new(class, opts)
                  }, mt)
  end
- 
+
 +function _M:destroy()
 +    udp_socks_close(self)
-+    self.socks = nil
 +    tcp_socks_close(self)
-+    self.tcp_sock = nil
 +    self.cur = nil
 +    self.servers = nil
 +    self.retrans = nil
 +    self.no_recurse = nil
 +end
- 
+
  local function pick_sock(self, socks)
      local cur = self.cur
-@@ -978,5 +1013,23 @@ function _M.reverse_query(self, addr)
-                       {qtype = self.TYPE_PTR})
- end
- 
-+function _M.socks_cleanup(self, sock_typs)
-+    if type(sock_typs) ~= 'table' then
-+        return nil, "sock_typs must be an array"
-+    end
-+
-+    local opts = { sock_typs[1], sock_typs[2] }
-+    for _, typ in ipairs(opts) do
-+        if type(actions[typ]) == 'function' then
-+            actions[typ](self)
-+            if typ == 'udp' then
-+                self.socks = nil
-+
-+            else
-+                self.tcp_sock = nil
-+            end
-+        end
-+    end
-+end
- 
- return _M

--- a/build/openresty/patches/lua-resty-dns-0.22_01-destory_resolver.patch
+++ b/build/openresty/patches/lua-resty-dns-0.22_01-destory_resolver.patch
@@ -1,0 +1,77 @@
+diff --git a/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua b/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
+index a67b3c1..ec4aa28 100644
+--- a/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
++++ b/bundle/lua-resty-dns-0.22/lib/resty/dns/resolver.lua
+@@ -99,6 +99,31 @@ for i = 2, 64, 2 do
+     arpa_tmpl[i] = DOT_CHAR
+ end
+ 
++local function udp_socks_close(self)
++    if self.socks == nil then
++        return
++    end
++
++    for _, sock in ipairs(self.socks) do
++        sock:close()
++    end
++
++    self.socks = nil
++end
++
++local function tcp_socks_close(self)
++    if self.tcp_sock == nil then
++        return
++    end
++
++    self.tcp_sock:close()
++    self.tcp_sock = nil
++end
++
++local actions = {
++    ["udp"] = udp_socks_close,
++    ["tcp"] = tcp_socks_close,
++}
+ 
+ function _M.new(class, opts)
+     if not opts then
+@@ -161,6 +186,16 @@ function _M.new(class, opts)
+                 }, mt)
+ end
+ 
++function _M:destroy()
++    udp_socks_close(self)
++    self.socks = nil
++    tcp_socks_close(self)
++    self.tcp_sock = nil
++    self.cur = nil
++    self.servers = nil
++    self.retrans = nil
++    self.no_recurse = nil
++end
+ 
+ local function pick_sock(self, socks)
+     local cur = self.cur
+@@ -978,5 +1013,23 @@ function _M.reverse_query(self, addr)
+                       {qtype = self.TYPE_PTR})
+ end
+ 
++function _M.socks_cleanup(self, sock_typs)
++    if type(sock_typs) ~= 'table' then
++        return nil, "sock_typs must be an array"
++    end
++
++    local opts = { sock_typs[1], sock_typs[2] }
++    for _, typ in ipairs(opts) do
++        if type(actions[typ]) == 'function' then
++            actions[typ](self)
++            if typ == 'udp' then
++                self.socks = nil
++
++            else
++                self.tcp_sock = nil
++            end
++        end
++    end
++end
+ 
+ return _M

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -727,14 +727,13 @@ local function individualQuery(qname, r_opts, try_list)
 
   local result
   result, err = r:query(qname, r_opts)
+  close_socks(r)
   if not result then
-    close_socks(r)
     return result, err, try_list
   end
 
   parseAnswer(qname, r_opts.qtype, result, try_list)
 
-  close_socks(r)
   return result, nil, try_list
 end
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -734,6 +734,7 @@ local function individualQuery(qname, r_opts, try_list)
 
   parseAnswer(qname, r_opts.qtype, result, try_list)
 
+  close_socks(r)
   return result, nil, try_list
 end
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -729,7 +729,6 @@ local function individualQuery(qname, r_opts, try_list)
   result, err = r:query(qname, r_opts)
   if not result then
     close_socks(r)
-    r = nil
     return result, err, try_list
   end
 
@@ -777,7 +776,6 @@ local function executeQuery(premature, item)
   ngx.sleep(0)
   -- 3) release the resolver
   close_socks(r)
-  r = nil
 end
 
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -703,7 +703,7 @@ local function parseAnswer(qname, qtype, answers, try_list)
 end
 
 local function close_socks(resolver)
-  for _, sock in ipairs(resolver.socks or {}) do
+  for _, sock in ipairs(resolver.socks or EMPTY) do
     sock:close()
   end
   if resolver.tcp_sock then

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -702,15 +702,6 @@ local function parseAnswer(qname, qtype, answers, try_list)
   return true
 end
 
-local function close_socks(resolver)
-  for _, sock in ipairs(resolver.socks or EMPTY) do
-    sock:close()
-  end
-  if resolver.tcp_sock then
-    resolver.tcp_sock:close()
-  end
-end
-
 -- executes 1 individual query.
 -- This query will not be synchronized, every call will be 1 query.
 -- @param qname the name to query for
@@ -727,7 +718,7 @@ local function individualQuery(qname, r_opts, try_list)
 
   local result
   result, err = r:query(qname, r_opts)
-  close_socks(r)
+  r:destroy()
   if not result then
     return result, err, try_list
   end
@@ -774,8 +765,8 @@ local function executeQuery(premature, item)
   item.semaphore:post(math_max(item.semaphore:count() * -1, 1))
   item.semaphore = nil
   ngx.sleep(0)
-  -- 3) release the resolver
-  close_socks(r)
+  -- 3) destroy the resolver
+  r:destroy()
 end
 
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -718,6 +718,12 @@ local function individualQuery(qname, r_opts, try_list)
 
   local result
   result, err = r:query(qname, r_opts)
+  -- Manually destroy the resolver.
+  -- When resovler is initialized, some socket resources are also created inside
+  -- resolver. As the resolver is created in timer-ng, the socket resources are
+  -- not released automatically, we have to destroy the resolver manually.
+  -- resolver:destroy is patched in build phase, more information can be found in
+  -- build/openresty/patches/lua-resty-dns-0.22_01-destory_resolver.patch
   r:destroy()
   if not result then
     return result, err, try_list
@@ -765,7 +771,7 @@ local function executeQuery(premature, item)
   item.semaphore:post(math_max(item.semaphore:count() * -1, 1))
   item.semaphore = nil
   ngx.sleep(0)
-  -- 3) destroy the resolver
+  -- 3) destroy the resolver -- ditto in individualQuery
   r:destroy()
 end
 

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -175,7 +175,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("release", function()
-        assert.logfile().has.line("servin '".. domain_name .. "' from mocks", true, 30)
+        assert.logfile().has.line("serving '".. domain_name .. "' from mocks", true, 30)
         local ok, stderr, stdout = helpers.execute("netstat -n | grep 53 | grep udp | wc -l")
         assert.truthy(ok, stderr)
         assert.equals(0, assert(tonumber(stdout)))

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -145,6 +145,12 @@ for _, strategy in helpers.each_strategy() do
         assert.response(r).has.status(503)
       end)
     end)
+
+    -- lua-resty-dns is used for DNS query. It will create some UDP sockets
+    -- during initialization. These sockets should be released after Query finish.
+    -- The release is done by explicitly calling a destory method that we patch.
+    -- This test case is to check the UDP sockets are released after the DNS query
+    -- is done.
     describe("udp sockets", function()
       local domain_name = "www.example.com"
       local address = "127.0.0.10"

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -152,6 +152,7 @@ for _, strategy in helpers.each_strategy() do
 
       lazy_setup(function()
         local bp = helpers.get_db_utils(strategy, {
+          "routes",
           "services",
         })
 

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -152,7 +152,7 @@ for _, strategy in helpers.each_strategy() do
     -- This test case is to check the UDP sockets are released after the DNS query
     -- is done.
     describe("udp sockets", function()
-      local domain_name = "www.example.com"
+      local domain_name = "www.example.test"
       local address = "127.0.0.10"
       local proxy_client
 

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -181,7 +181,7 @@ for _, strategy in helpers.each_strategy() do
         if proxy_client then
           proxy_client:close()
         end
-        helpers.stop_kong()
+        assert(helpers.stop_kong())
       end)
 
       it("release", function()


### PR DESCRIPTION
### Summary

In `resty.dns.client` module when `resolver:new()` is called, a UDP socket is created. In 2.x, the UDP socket is released quickly, while in 3.x, it has to take several seconds to release. If the ttl of dns responses is shorter than the time it waits, the leak will happen. In this PR, a forcible release is added.

FTI-4962

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-4962
