### PR TITLE
chore(dev): prioritize .lua over .ljbc in LUA_PATH

### DIFF
--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -25,7 +25,13 @@ rocks_trees = {
 export LUAROCKS_CONFIG="$ROCKS_CONFIG"
 
 # duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
-export LUA_PATH="./?.lua;./?/init.lua;$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;;"
+export LUA_PATH="$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;;"
+# support custom plugin
+if [ -n $KONG_PLUGIN_PATH ] ; then
+    LUA_PATH="$KONG_PLUGIN_PATH/?.lua;$KONG_PLUGIN_PATH/?/init.lua;$LUA_PATH"
+fi
+# append the default
+LUA_PATH="./?.lua;./?/init.lua;$LUA_PATH"
 
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
 export KONG_PREFIX="$KONG_VENV/kong/servroot"

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -25,7 +25,7 @@ rocks_trees = {
 export LUAROCKS_CONFIG="$ROCKS_CONFIG"
 
 # duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
-export LUA_PATH="./?.lua;./?/init.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?/init.lua;;"
+export LUA_PATH="./?.lua;./?/init.lua;$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;;"
 
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
 export KONG_PREFIX="$KONG_VENV/kong/servroot"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

chore(dev): prioritize `.lua` over `.ljbc` in `LUA_PATH`

We may edit Lua files in place for debug.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Place `.lua` in front of `.ljbc` in `LUA_PATH`.
* Support custom pluin `KONG_PLUGIN_PATH`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5013]_


[FTI-5013]: https://konghq.atlassian.net/browse/FTI-5013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ