### PR TITLE
tests(connection-pool): address flakiness

### DIFF
--- a/spec/02-integration/03-db/15-connection_pool_spec.lua
+++ b/spec/02-integration/03-db/15-connection_pool_spec.lua
@@ -1,125 +1,72 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("#postgres Postgres connection pool", function()
-  local client
+for pool_size, backlog_size in ipairs({ 0, 3 }) do
+  describe("#postgres Postgres connection pool with pool=" .. pool_size .. "and backlog=" .. backlog_size, function()
+    local client
+    lazy_setup(function()
+      local bp = helpers.get_db_utils("postgres", {
+        "plugins",
+      }, {
+        "slow-query"
+      })
 
-  setup(function()
-    local bp = helpers.get_db_utils("postgres", {
-      "plugins",
-    }, {
-      "slow-query"
-    })
+      bp.plugins:insert({
+        name = "slow-query",
+      })
 
-    bp.plugins:insert({
-      name = "slow-query",
-    })
+      assert(helpers.start_kong({
+        database = "postgres",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "slow-query",
+        nginx_worker_processes = 1,
+        pg_pool_size = pool_size,
+        pg_backlog = backlog_size,
+      }))
+      client = helpers.admin_client()
+    end)
 
-    assert(helpers.start_kong({
-      database = "postgres",
-      nginx_conf = "spec/fixtures/custom_nginx.template",
-      plugins = "slow-query",
-      nginx_worker_processes = 1,
-      pg_pool_size = 1,
-      pg_backlog = 0,
-    }))
-    client = helpers.admin_client()
-  end)
+    lazy_teardown(function()
+      if client then
+        client:close()
+      end
+      helpers.stop_kong()
+    end)
 
-  teardown(function()
-    if client then
-      client:close()
-    end
-    helpers.stop_kong()
-  end)
+    it("results in query error too many waiting connect operations when pool and backlog sizes are exceeded", function()
+      helpers.wait_timer("slow-query", true, "all-finish", 10)
 
-  it("results in query error too many waiting connect operations", function()
-    helpers.wait_timer("slow-query", true, "all-finish", 10)
+      local delay = 4
+      assert
+        .with_timeout(10)
+        -- wait for any ongoing query to finish before retrying
+        .with_step(delay)
+        .ignore_exceptions(true)
+        .eventually(function()
+          local ok = true
+          for _ = 1, pool_size + backlog_size do
+            local res = assert(client:send {
+              method = "GET",
+              path = "/slow-resource?prime=true&delay=" .. delay,
+              headers = { ["Content-Type"] = "application/json" }
+            })
+            res:read_body()
+            ok = ok and res.status == 204
+          end
+          return ok
+        end)
+        .is_truthy("expected both requests to succeed with empty pool and backlog")
 
-    helpers.wait_until(function()
+      ngx.sleep(2)
+
       local res = assert(client:send {
         method = "GET",
-        path = "/slow-resource?prime=true",
+        path = "/slow-resource?delay=-1",
         headers = { ["Content-Type"] = "application/json" }
       })
-      res:read_body()
-      return res.status == 204
-    end, 10)
-
-    helpers.wait_timer("slow-query", true, "any-running")
-
-    local res = assert(client:send {
-      method = "GET",
-      path = "/slow-resource",
-      headers = { ["Content-Type"] = "application/json" }
-    })
-    local body = assert.res_status(500 , res)
-    local json = cjson.decode(body)
-    assert.same({ error = "too many waiting connect operations" }, json)
+      local body = assert.res_status(500, res)
+      local json = cjson.decode(body)
+      assert.same({ error = "too many waiting connect operations" }, json)
+    end)
   end)
-end)
-
-describe("#postgres Postgres connection pool with backlog", function()
-  local client
-
-  setup(function()
-    local bp = helpers.get_db_utils("postgres", {
-      "plugins",
-    }, {
-      "slow-query"
-    })
-
-    bp.plugins:insert({
-      name = "slow-query",
-    })
-
-    assert(helpers.start_kong({
-      database = "postgres",
-      nginx_conf = "spec/fixtures/custom_nginx.template",
-      plugins = "slow-query",
-      nginx_worker_processes = 1,
-      pg_pool_size = 1,
-      pg_backlog = 1,
-    }))
-    client = helpers.admin_client()
-  end)
-
-  teardown(function()
-    if client then
-      client:close()
-    end
-    helpers.stop_kong()
-  end)
-
-  it("results in query error too many waiting connect operations when backlog exceeds", function()
-    helpers.wait_timer("slow-query", true, "all-finish", 10)
-
-    -- send 2 requests, both should succeed as pool size is 1 and backlog is 1
-    helpers.wait_until(function()
-      local ok = true
-      for _ = 0, 1 do
-        local res = assert(client:send {
-          method = "GET",
-          path = "/slow-resource?prime=true",
-          headers = { ["Content-Type"] = "application/json" }
-        })
-        res:read_body()
-        ok = ok and res.status == 204
-      end
-      return ok
-    end, 10)
-
-    -- make sure both the timers are running
-    helpers.wait_timer("slow-query", true, "all-running")
-
-    -- now the request should fail as both pool and backlog is full
-    local res = assert(client:send {
-      method = "GET",
-      path = "/slow-resource",
-      headers = { ["Content-Type"] = "application/json" }
-    })
-    local body = assert.res_status(500 , res)
-    local json = cjson.decode(body)
-    assert.same({ error = "too many waiting connect operations" }, json)
-  end)
-end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/slow-query/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/slow-query/api.lua
@@ -1,9 +1,11 @@
 return {
   ["/slow-resource"] = {
     GET = function(self)
+      local delay = self.params.delay or 1
+
       if self.params.prime then
         ngx.timer.at(0, function()
-          local _, err = kong.db.connector:query("SELECT pg_sleep(1)")
+          local _, err = kong.db.connector:query("SELECT pg_sleep(" .. delay .. ")")
           if err then
             ngx.log(ngx.ERR, err)
           end
@@ -12,7 +14,7 @@ return {
         return kong.response.exit(204)
       end
 
-      local _, err = kong.db.connector:query("SELECT pg_sleep(1)")
+      local _, err = kong.db.connector:query("SELECT pg_sleep(" .. delay .. ")")
       if err then
         return kong.response.exit(500, { error = err })
       end


### PR DESCRIPTION
### Summary

The test was flaky due to incorrect waiting assertions, that were not ensuring the connection queues to be filled properly/all the time. This change also removes some duplicate code.

### Checklist

- [X] The Pull Request has tests
- [x] [no need] There's an entry in the CHANGELOG
- [X] [no need] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
KAG-1215