### PR TITLE
fix(cache): a typo of mlcache option `shm_set_tries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
 - Fix an issue where sorting function for traditional router sources/destinations lead to "invalid order
   function for sorting" error.
   [#10514](https://github.com/Kong/kong/pull/10514)
+- Fix a typo of mlcache option `shm_set_tries`.
+  [#10712](https://github.com/Kong/kong/pull/10712)
 
 #### Admin API
 

--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -97,7 +97,7 @@ function _M.new(opts)
   local mlcache, err = resty_mlcache.new(shm_name, shm_name, {
     shm_miss         = shm_miss_name,
     shm_locks        = "kong_locks",
-    shm_set_retries  = 3,
+    shm_set_tries    = 3,
     lru_size         = LRU_SIZE,
     ttl              = ttl,
     neg_ttl          = neg_ttl,


### PR DESCRIPTION
Fortunately, the default value of `shm_set_tries` is [3](https://github.com/thibaultcha/lua-resty-mlcache#new), so there is no change in behavior.