### PR TITLE
chore: add branch constrains on Workflow “Package & Release” Notifier

### DIFF
--- a/.github/workflows/release-fail-bot.yml
+++ b/.github/workflows/release-fail-bot.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Package & Release"]
     types:
       - completed
+    branches:
+      - master
 
 jobs:
   notify_failure:


### PR DESCRIPTION
## Desc

Only notify on given branches.

Fix KAG-1315