### PR TITLE
chore(dev): prioritize EE plugins .lua over .ljbc

### DIFF
--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -40,9 +40,7 @@ if [ -d "./plugins-ee" ] ; then
     for p in ./plugins-ee/*/; do
         p_name=$(basename "$p")
         p_target="${plugins_ee}/kong/plugins/${p_name}"
-        if ! [ -L "$p_target" ]; then
-            ln -s "$(realpath "${p}"/kong/plugins/"${p_name}")" "$p_target"
-        fi
+        ln -s "$(realpath "${p}"/kong/plugins/"${p_name}")" "$p_target"
     done
     LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
 fi

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -35,21 +35,19 @@ $KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;\
 $KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
 # XXX EE
 if [ -d "./plugins-ee" ] ; then
-    plugins_ee="${workspace_path}/bazel-bin/build/ee/plugins-ee"
-    rm -rf "$plugins_ee/kong/plugins"
-    mkdir -p "$plugins_ee/kong/plugins"
-    for p in ./plugins-ee/*/; do
-        p_name=$(basename "$p")
-        p_target="${plugins_ee}/kong/plugins/${p_name}"
-        ln -s "$(realpath "${p}"/kong/plugins/"${p_name}")" "$p_target"
+    links_dir="${workspace_path}/bazel-bin/build/ee/plugins-ee"
+    rm -rf "$links_dir/kong/plugins"
+    mkdir -p "$links_dir/kong/plugins"
+    for plugin in ./plugins-ee/*/; do
+        ln -s "$(realpath "./plugins-ee/${plugin}/kong/plugins/${plugin}")" "${links_dir}/kong/plugins/${plugin}"
     done
-    LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
+    LUA_PATH="$links_dir/?.lua;$links_dir/init/?.lua;$LUA_PATH"
 fi
 # support custom plugin development
 if [ -n $KONG_PLUGIN_PATH ] ; then
     LUA_PATH="$KONG_PLUGIN_PATH/?.lua;$KONG_PLUGIN_PATH/?/init.lua;$LUA_PATH"
 fi
-# default; duplicate of 'lua_package_path' in kong.conf and 'nginx_kong.lua'
+# default; duplicate of 'lua_package_path' in kong.conf and nginx_kong.lua
 LUA_PATH="./?.lua;./?/init.lua;$LUA_PATH;;"
 
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -35,11 +35,14 @@ $KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;\
 $KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
 # XXX EE
 if [ -d "./plugins-ee" ] ; then
-    plugins_ee="$workspace_path/bazel-bin/build/ee/plugins-ee"
+    plugins_ee="${workspace_path}/bazel-bin/build/ee/plugins-ee"
     mkdir -p "$plugins_ee/kong/plugins"
-    for p in $(ls -d ./plugins-ee/*/); do
-        p_name=$(basename $p)
-        ln -s "$(realpath ${p}/kong/plugins/${p_name})" "$plugins_ee/kong/plugins/${p_name}"
+    for p in ./plugins-ee/*/; do
+        p_name=$(basename "$p")
+        p_target="${plugins_ee}/kong/plugins/${p_name}"
+        if ! [ -L "$p_target" ]; then
+            ln -s "$(realpath "${p}"/kong/plugins/"${p_name}")" "$p_target"
+        fi
     done
     LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
 fi

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -33,14 +33,16 @@ $KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/i
 $KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;\
 $KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;\
 $KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
-# EE plugins
-plugins_ee="$workspace_path/bazel-bin/build/ee/plugins-ee"
-mkdir -p "$plugins_ee/kong/plugins"
-for p in $(ls -d ./plugins-ee/*/); do
-    p_name=$(basename $p)
-    ln -s "$(realpath ${p}/kong/plugins/${p_name})" "$plugins_ee/kong/plugins/${p_name}"
-done
-LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
+# XXX EE
+if [ -d "./plugins-ee" ] ; then
+    plugins_ee="$workspace_path/bazel-bin/build/ee/plugins-ee"
+    mkdir -p "$plugins_ee/kong/plugins"
+    for p in $(ls -d ./plugins-ee/*/); do
+        p_name=$(basename $p)
+        ln -s "$(realpath ${p}/kong/plugins/${p_name})" "$plugins_ee/kong/plugins/${p_name}"
+    done
+    LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
+fi
 # support custom plugin development
 if [ -n $KONG_PLUGIN_PATH ] ; then
     LUA_PATH="$KONG_PLUGIN_PATH/?.lua;$KONG_PLUGIN_PATH/?/init.lua;$LUA_PATH"

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -25,13 +25,28 @@ rocks_trees = {
 export LUAROCKS_CONFIG="$ROCKS_CONFIG"
 
 # duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
-export LUA_PATH="$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;$ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/init.ljbc;$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;;"
-# support custom plugin
+export LUA_PATH="\
+$ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;\
+$ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;\
+$KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;\
+$KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/init.ljbc;\
+$KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;\
+$KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;\
+$KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
+# EE plugins
+plugins_ee="$workspace_path/bazel-bin/build/ee/plugins-ee"
+mkdir -p "$plugins_ee/kong/plugins"
+for p in $(ls -d ./plugins-ee/*/); do
+    p_name=$(basename $p)
+    ln -s "$(realpath ${p}/kong/plugins/${p_name})" "$plugins_ee/kong/plugins/${p_name}"
+done
+LUA_PATH="$plugins_ee/?.lua;$plugins_ee/init/?.lua;$LUA_PATH"
+# support custom plugin development
 if [ -n $KONG_PLUGIN_PATH ] ; then
     LUA_PATH="$KONG_PLUGIN_PATH/?.lua;$KONG_PLUGIN_PATH/?/init.lua;$LUA_PATH"
 fi
-# append the default
-LUA_PATH="./?.lua;./?/init.lua;$LUA_PATH"
+# default; duplicate of 'lua_package_path' in kong.conf and 'nginx_kong.lua'
+LUA_PATH="./?.lua;./?/init.lua;$LUA_PATH;;"
 
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
 export KONG_PREFIX="$KONG_VENV/kong/servroot"

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -36,6 +36,7 @@ $KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
 # XXX EE
 if [ -d "./plugins-ee" ] ; then
     plugins_ee="${workspace_path}/bazel-bin/build/ee/plugins-ee"
+    rm -rf "$plugins_ee/kong/plugins"
     mkdir -p "$plugins_ee/kong/plugins"
     for p in ./plugins-ee/*/; do
         p_name=$(basename "$p")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

#10693 prioritizes `.lua` over `.ljbc` in general, within `venv`. This PR applies the rule to EE plugins as well.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add all EE plugins in Kong repo to `LUA_PATH`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5013]_


[FTI-5013]: https://konghq.atlassian.net/browse/FTI-5013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

KAG-1235