### PR TITLE
fix(clustering): add missing aws-lambda plugin new option in removed fields

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -61,6 +61,9 @@ return {
       "account_key",
       "storage_config.redis.namespace",
     },
+    aws_lambda = {
+      "disable_https",
+    },
     proxy_cache = {
       "ignore_uri_case",
     },


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds the missing new config field `disable_https` in the aws-lambda plugin, to the removed field so that clustering compat can work normally.
<!--- Why is this change required? What problem does it solve? -->

Related feature PR: https://github.com/Kong/kong/pull/9799

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
