### PR TITLE
docs(contribute): we may dropping `ngx.` for OpenResty APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,6 +464,12 @@ practices:
   end
   ```
 
+  For OpenResty built-in APIs we may drop `ngx.` in the localized version
+
+  ```lua
+  local req_get_post_args = ngx.req.get_post_args
+  ```
+
   Non-hot paths are localization optional
 
   ```lua


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


