### PR TITLE
fix(queues): use explicit workspace in registry key

### DIFF
--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -75,18 +75,11 @@ local function make_queue_key(name)
 end
 
 
-local queues = setmetatable({}, {
-  __newindex = function (self, name, queue)
-    return rawset(self, make_queue_key(name), queue)
-  end,
-  __index = function (self, name)
-    return rawget(self, make_queue_key(name))
-  end
-})
+local queues = {}
 
 
 function Queue.exists(name)
-  return queues[name] and true or false
+  return queues[make_queue_key(name)] and true or false
 end
 
 -------------------------------------------------------------------------------
@@ -97,8 +90,9 @@ end
 local function get_or_create_queue(queue_conf, handler, handler_conf)
 
   local name = assert(queue_conf.name)
+  local key = make_queue_key(name)
 
-  local queue = queues[name]
+  local queue = queues[key]
   if queue then
     queue:log_debug("queue exists")
     -- We always use the latest configuration that we have seen for a queue and handler.
@@ -109,6 +103,7 @@ local function get_or_create_queue(queue_conf, handler, handler_conf)
   queue = {
     -- Queue parameters from the enqueue call
     name = name,
+    key = key,
     handler = handler,
     handler_conf = handler_conf,
 
@@ -130,16 +125,16 @@ local function get_or_create_queue(queue_conf, handler, handler_conf)
 
   queue = setmetatable(queue, Queue_mt)
 
-  kong.timer:named_at("queue " .. name, 0, function(_, q)
+  kong.timer:named_at("queue " .. key, 0, function(_, q)
     while q:count() > 0 do
       q:log_debug("processing queue")
       q:process_once()
     end
     q:log_debug("done processing queue")
-    queues[name] = nil
+    queues[key] = nil
   end, queue)
 
-  queues[name] = queue
+  queues[key] = queue
 
   queue:log_debug("queue created")
 
@@ -375,7 +370,7 @@ end
 -- For testing, the _exists() function is provided to allow a test to wait for the
 -- queue to have been completely processed.
 function Queue._exists(name)
-  local queue = queues[name]
+  local queue = queues[make_queue_key(name)]
   return queue and queue:count() > 0
 end
 

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -35,13 +35,13 @@ describe("plugin queue", function()
   lazy_setup(function()
     kong.timer = timerng.new()
     kong.timer:start()
-    -- make sure our workspace is nil to begin with to prevent leakage from
-    -- other tests
-    ngx.ctx.workspace = nil
+    -- make sure our workspace is explicitly set so that we test behavior in the presence of workspaces
+    ngx.ctx.workspace = "queue-tests"
   end)
 
   lazy_teardown(function()
     kong.timer:destroy()
+    ngx.ctx.workspace = nil
   end)
 
   before_each(function()


### PR DESCRIPTION
### Summary

This fixes an issue in the queue implementation in EE that made queues fail to work after the first entry was processed.  This was caused by the 'smart' way to isolate the queues in each workspace from those in other workspaces by using __index and __newindex to automatically combine the workspace name into the key used as index into the table of queues.  This approach failed to work when the queue had to be deleted as that happens from the timer context in which no ngx.context is not set.

### Checklist

- [X] The Pull Request has tests (test adapted accordingly)
- [ ] There's an entry in the CHANGELOG N/A (unreleased)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com N/A (unreleased)

### Issue reference

Fixes KAG-1292
