### PR TITLE
chore(test): deprecate http_server

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1300,6 +1300,7 @@ end
 -- @return A thread object (from the `llthreads2` Lua package)
 -- @see kill_http_server
 local function http_server(port, opts)
+  print(debug.traceback("[warning] http_server is deprecated, use nginx fixtures.http_mock or helpers.http_mock instead.", 2))
   local threads = require "llthreads2.ex"
   opts = opts or {}
   local thread = threads.new({

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1300,7 +1300,7 @@ end
 -- @return A thread object (from the `llthreads2` Lua package)
 -- @see kill_http_server
 local function http_server(port, opts)
-  print(debug.traceback("[warning] http_server is deprecated, use nginx fixtures.http_mock or helpers.http_mock instead.", 2))
+  print(debug.traceback("[warning] http_server is deprecated, use helpers.start_kong's fixture parameter or helpers.http_mock instead.", 2))
   local threads = require "llthreads2.ex"
   opts = opts or {}
   local thread = threads.new({

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1300,7 +1300,8 @@ end
 -- @return A thread object (from the `llthreads2` Lua package)
 -- @see kill_http_server
 local function http_server(port, opts)
-  print(debug.traceback("[warning] http_server is deprecated, use helpers.start_kong's fixture parameter or helpers.http_mock instead.", 2))
+  print(debug.traceback("[warning] http_server is deprecated, " ..
+                        "use helpers.start_kong's fixture parameter or helpers.http_mock instead.", 2))
   local threads = require "llthreads2.ex"
   opts = opts or {}
   local thread = threads.new({

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1301,7 +1301,8 @@ end
 -- @see kill_http_server
 local function http_server(port, opts)
   print(debug.traceback("[warning] http_server is deprecated, " ..
-                        "use helpers.start_kong's fixture parameter or helpers.http_mock instead.", 2))
+                        "use helpers.start_kong's fixture parameter " ..
+                        "or helpers.http_mock instead.", 2))
   local threads = require "llthreads2.ex"
   opts = opts or {}
   local thread = threads.new({


### PR DESCRIPTION
Deprecate `http_server`. The comments could be ignored so we need to make a more noticeable warning.

KAG-1148