### PR TITLE
tests: fix spelling `ngx.ctx.rewite` -> `ngx.ctx.rewrite`

### DIFF
--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -173,7 +173,7 @@ headers have already been sent
             local pdk = PDK.new()
 
             pdk.response.exit(200)
-            ngx.ctx.rewite = true
+            ngx.ctx.rewrite = true
         }
 
         access_by_lua_block {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Fix spelling in `t/01-pdk/08-response/11-exit.t` fixes the test

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
