### PR TITLE
style(queue): remove unused upvalues

### DIFF
--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -61,8 +61,6 @@ local table_new = require("table.new")
 
 
 local string_format = string.format
-local rawset = rawset
-local rawget = rawget
 local assert = assert
 local select = select
 local pairs = pairs


### PR DESCRIPTION
Master is red: https://github.com/Kong/kong/actions/runs/4791115533/jobs/8521126234

```
busted 2.1.2 already installed, skipping
busted-htest 1.0.0 already installed, skipping
luacheck 1.1.0 already installed, skipping
lua-llthreads2 0.1.6 already installed, skipping
http 0.4 already installed, skipping
ldoc 1.4.6 already installed, skipping
Checking kong/tools/queue.lua                     2 warnings

    kong/tools/queue.lua:64:7: unused variable rawset
    kong/tools/queue.lua:65:7: unused variable rawget

Total: 2 warnings / 0 errors in 905 files
make: *** [Makefile:[11](https://github.com/Kong/kong/actions/runs/4791115533/jobs/8521126234#step:8:12)6: lint] Error 1
Error: Process completed with exit code 2.
```