### PR TITLE
refactor(DAO): introduce validate and fix check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,7 +284,8 @@
   leads to the corruption of chunk-encoded response data.
   [#10816](https://github.com/Kong/kong/pull/10816)
   [#10824](https://github.com/Kong/kong/pull/10824)
-
+- Fix protocol detection of default values.
+  [#10736](https://github.com/Kong/kong/pull/10736)
 
 #### Admin API
 

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -471,6 +471,11 @@ local function check_insert(self, entity, options)
     entity_to_insert.cache_key = self:cache_key(entity_to_insert)
   end
 
+  local validate_ok, err, err_t = self:validate(entity_to_insert, options)
+  if not validate_ok then
+    return nil, err, err_t
+  end
+
   return entity_to_insert
 end
 
@@ -547,6 +552,11 @@ local function check_update(self, key, entity, options, name)
     entity_to_update.cache_key = self:cache_key(entity_to_update)
   end
 
+  local validate_ok, err, err_t = self:validate(entity_to_update, options)
+  if not validate_ok then
+    return nil, nil, err, err_t
+  end
+
   return entity_to_update, rbw_entity
 end
 
@@ -613,6 +623,11 @@ local function check_upsert(self, key, entity, options, name)
 
   if self.schema.cache_key and #self.schema.cache_key > 1 then
     entity_to_upsert.cache_key = self:cache_key(entity_to_upsert)
+  end
+
+  local validate_ok, err, err_t = self:validate(entity_to_upsert, options)
+  if not validate_ok then
+    return nil, nil, err, err_t
   end
 
   return entity_to_upsert, rbw_entity
@@ -1100,6 +1115,14 @@ function DAO:each(size, options)
   end
 
   return iteration.by_row(self, pager, size, options)
+end
+
+
+-- allow custom validations
+-- return true if valid, or nil/false + err(string) + err_t(table)
+-- stub implementation
+function DAO:validate(entity, options)
+  return true
 end
 
 

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -8,50 +8,52 @@ local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x
 
 
 for _, strategy in helpers.each_strategy() do
-  describe("kong.db [#" .. strategy .. "]", function()
-    local db, bp, service, route
-    local global_plugin
+  for _, default in ipairs{ false, true } do
+    describe("kong.db [#" .. strategy .. "]" .. (default and ", with default protocol" or ""), function()
+      local db, bp, service, route
+      local global_plugin
 
-    lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-      })
+      lazy_setup(function()
+        bp, db = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+          "plugins",
+        })
 
-      global_plugin = db.plugins:insert({ name = "key-auth",
-                                          protocols = { "http" },
-                                        })
-      assert.truthy(global_plugin)
+        global_plugin = assert(db.plugins:insert({ name = "key-auth",
+                                            protocols = (not default) and { "http" } or nil,
+                                          }))
 
-    end)
-
-    describe("Plugins #plugins", function()
-
-      before_each(function()
-        service = bp.services:insert()
-        route = bp.routes:insert({ service = { id = service.id },
-                                   protocols = { "tcp" },
-                                   sources = { { ip = "127.0.0.1" } },
-                                 })
       end)
 
-      describe(":insert()", function()
-        it("checks composite uniqueness", function()
-          local route = bp.routes:insert({ methods = {"GET"} })
+      describe("Plugins #plugins", function()
 
-          local plugin, err, err_t = db.plugins:insert({
-            name = "key-auth",
-            route = { id = route.id },
+        before_each(function()
+          service = bp.services:insert({
+            protocol = "tcp",
           })
-          assert.is_nil(err_t)
-          assert.is_nil(err)
+          route = bp.routes:insert({ service = { id = service.id },
+                                    protocols = { "tcp" },
+                                    sources = { { ip = "127.0.0.1" } },
+                                  })
+        end)
 
-          assert.matches(UUID_PATTERN, plugin.id)
-          assert.is_number(plugin.created_at)
-          plugin.id = nil
-          plugin.created_at = nil
-          plugin.updated_at = nil
+        describe(":insert()", function()
+          it("checks composite uniqueness", function()
+            local route = bp.routes:insert({ methods = {"GET"} })
+
+            local plugin, err, err_t = db.plugins:insert({
+              name = "key-auth",
+              route = { id = route.id },
+            })
+            assert.is_nil(err_t)
+            assert.is_nil(err)
+
+            assert.matches(UUID_PATTERN, plugin.id)
+            assert.is_number(plugin.created_at)
+            plugin.id = nil
+            plugin.created_at = nil
+            plugin.updated_at = nil
 
           assert.same({
             config = {
@@ -70,239 +72,239 @@ for _, strategy in helpers.each_strategy() do
             },
           }, plugin)
 
-          plugin, err, err_t = db.plugins:insert({
-            name = "key-auth",
-            route = route,
-          })
+            plugin, err, err_t = db.plugins:insert({
+              name = "key-auth",
+              route = route,
+            })
 
-          assert.falsy(plugin)
-          assert.match("UNIQUE violation", err)
-          assert.same("unique constraint violation", err_t.name)
-          assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
-                      [[route={id="]] .. route.id ..
-                      [["},service=null}']], err_t.message)
+            assert.falsy(plugin)
+            assert.match("UNIQUE violation", err)
+            assert.same("unique constraint violation", err_t.name)
+            assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
+                        [[route={id="]] .. route.id ..
+                        [["},service=null}']], err_t.message)
+          end)
+
+          it("does not validate when associated to an incompatible route, or a service with only incompatible routes", function()
+            local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
+                                                        protocols = { "http" },
+                                                        route = { id = route.id },
+                                                      })
+            assert.is_nil(plugin)
+            assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
+
+            local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
+                                                        protocols = { "http" },
+                                                        service = { id = service.id },
+                                                      })
+            assert.is_nil(plugin)
+            assert.equals(err_t.fields.protocols,
+                          "must match the associated service's protocol")
+          end)
+
+          it("validates when associated to a service with no routes", function()
+            local service_with_no_routes = bp.services:insert()
+            local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
+                                                        protocols = { "http" },
+                                                        service = { id = service_with_no_routes.id },
+                                                      })
+            assert.truthy(plugin)
+            assert.is_nil(err_t)
+          end)
         end)
 
-        it("does not validate when associated to an incompatible route, or a service with only incompatible routes", function()
-          local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
-                                                       protocols = { "http" },
-                                                       route = { id = route.id },
-                                                     })
-          assert.is_nil(plugin)
+        describe(":update()", function()
+          it("checks composite uniqueness", function()
+            local route = bp.routes:insert({ methods = {"GET"} })
+
+            local plugin, err, err_t = db.plugins:insert({
+              name = "key-auth",
+              route = { id = route.id },
+            })
+            assert.is_nil(err_t)
+            assert.is_nil(err)
+
+            assert.matches(UUID_PATTERN, plugin.id)
+            assert.is_number(plugin.created_at)
+            plugin.id = nil
+            plugin.created_at = nil
+            plugin.updated_at = nil
+
+          assert.same({
+            config = {
+              hide_credentials = false,
+              run_on_preflight = true,
+              key_in_header = true,
+              key_in_query = true,
+              key_in_body = false,
+              key_names = { "apikey" },
+            },
+            protocols = { "grpc", "grpcs", "http", "https" },
+            enabled = true,
+            name = "key-auth",
+            route = {
+              id = route.id,
+            },
+          }, plugin)
+
+            plugin, err, err_t = db.plugins:insert({
+              name = "key-auth",
+              route = route,
+            })
+
+            assert.falsy(plugin)
+            assert.match("UNIQUE violation", err)
+            assert.same("unique constraint violation", err_t.name)
+            assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
+                        [[route={id="]] .. route.id ..
+                        [["},service=null}']], err_t.message)
+          end)
+        end)
+
+        it("returns an error when updating mismatched plugins", function()
+          local p, _, err_t = db.plugins:update({ id = global_plugin.id },
+                                                { route = { id = route.id } })
+          assert.is_nil(p)
           assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
 
-          local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
-                                                       protocols = { "http" },
-                                                       service = { id = service.id },
-                                                     })
-          assert.is_nil(plugin)
+
+          local p, _, err_t = db.plugins:update({ id = global_plugin.id },
+                                                { service = { id = service.id } })
+          assert.is_nil(p)
           assert.equals(err_t.fields.protocols,
-                        "must match the protocols of at least one route pointing to this Plugin's service")
-        end)
-
-        it("validates when associated to a service with no routes", function()
-          local service_with_no_routes = bp.services:insert()
-          local plugin, _, err_t = db.plugins:insert({ name = "key-auth",
-                                                       protocols = { "http" },
-                                                       service = { id = service_with_no_routes.id },
-                                                     })
-          assert.truthy(plugin)
-          assert.is_nil(err_t)
+                        "must match the associated service's protocol")
         end)
       end)
 
-      describe(":update()", function()
-        it("checks composite uniqueness", function()
-          local route = bp.routes:insert({ methods = {"GET"} })
+      describe(":upsert()", function()
+        it("returns an error when upserting mismatched plugins", function()
+          local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
+                                                { name = "key-auth", route = { id = route.id }, protocols = { "http" } })
+          assert.is_nil(p)
+          assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
 
-          local plugin, err, err_t = db.plugins:insert({
-            name = "key-auth",
-            route = { id = route.id },
+
+          local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
+                                                { name = "key-auth", service = { id = service.id }, protocols = { "http" } })
+          assert.is_nil(p)
+          assert.equals(err_t.fields.protocols,
+                        "must match the associated service's protocol")
+        end)
+      end)
+
+      describe(":load_plugin_schemas()", function()
+        it("loads custom entities with specialized methods", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["plugin-with-custom-dao"] = true,
           })
-          assert.is_nil(err_t)
           assert.is_nil(err)
+          assert.truthy(ok)
 
-          assert.matches(UUID_PATTERN, plugin.id)
-          assert.is_number(plugin.created_at)
-          plugin.id = nil
-          plugin.created_at = nil
-          plugin.updated_at = nil
-
-          assert.same({
-            config = {
-              hide_credentials = false,
-              run_on_preflight = true,
-              key_in_header = true,
-              key_in_query = true,
-              key_in_body = false,
-              key_names = { "apikey" },
-            },
-            protocols = { "grpc", "grpcs", "http", "https" },
-            enabled = true,
-            name = "key-auth",
-            route = {
-              id = route.id,
-            },
-          }, plugin)
-
-          plugin, err, err_t = db.plugins:insert({
-            name = "key-auth",
-            route = route,
-          })
-
-          assert.falsy(plugin)
-          assert.match("UNIQUE violation", err)
-          assert.same("unique constraint violation", err_t.name)
-          assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
-                      [[route={id="]] .. route.id ..
-                      [["},service=null}']], err_t.message)
-        end)
-      end)
-
-      it("returns an error when updating mismatched plugins", function()
-        local p, _, err_t = db.plugins:update({ id = global_plugin.id },
-                                              { route = { id = route.id } })
-        assert.is_nil(p)
-        assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
-
-
-        local p, _, err_t = db.plugins:update({ id = global_plugin.id },
-                                              { service = { id = service.id } })
-        assert.is_nil(p)
-        assert.equals(err_t.fields.protocols,
-                      "must match the protocols of at least one route pointing to this Plugin's service")
-      end)
-    end)
-
-    describe(":upsert()", function()
-      it("returns an error when upserting mismatched plugins", function()
-        local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
-                                              { route = { id = route.id }, protocols = { "http" } })
-        assert.is_nil(p)
-        assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
-
-
-        local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
-                                              { service = { id = service.id }, protocols = { "http" } })
-        assert.is_nil(p)
-        assert.equals(err_t.fields.protocols,
-                      "must match the protocols of at least one route pointing to this Plugin's service")
-      end)
-    end)
-
-    describe(":load_plugin_schemas()", function()
-      it("loads custom entities with specialized methods", function()
-        local ok, err = db.plugins:load_plugin_schemas({
-          ["plugin-with-custom-dao"] = true,
-        })
-        assert.is_nil(err)
-        assert.truthy(ok)
-
-        assert.same("I was implemented for " .. strategy, db.custom_dao:custom_method())
-      end)
-
-      it("reports failure with missing plugins", function()
-        local ok, err = db.plugins:load_plugin_schemas({
-          ["missing"] = true,
-        })
-        assert.falsy(ok)
-        assert.match("missing plugin is enabled but not installed", err, 1, true)
-      end)
-
-      describe("with bad PRIORITY fails; ", function()
-        setup(function()
-          local schema = {}
-          package.loaded["kong.plugins.NaN_priority.schema"] = schema
-          package.loaded["kong.plugins.NaN_priority.handler"] = { PRIORITY = 0/0, VERSION = "1.0" }
-          package.loaded["kong.plugins.huge_negative.schema"] = schema
-          package.loaded["kong.plugins.huge_negative.handler"] = { PRIORITY = -math.huge, VERSION = "1.0" }
-          package.loaded["kong.plugins.string_priority.schema"] = schema
-          package.loaded["kong.plugins.string_priority.handler"] = { PRIORITY = "abc", VERSION = "1.0" }
+          assert.same("I was implemented for " .. strategy, db.custom_dao:custom_method())
         end)
 
-        teardown(function()
-          package.loaded["kong.plugins.NaN_priority.schema"] = nil
-          package.loaded["kong.plugins.NaN_priority.handler"] = nil
-          package.loaded["kong.plugins.huge_negative.schema"] = nil
-          package.loaded["kong.plugins.huge_negative.handler"] = nil
-          package.loaded["kong.plugins.string_priority.schema"] = nil
-          package.loaded["kong.plugins.string_priority.handler"] = nil
-        end)
-
-        it("NaN", function()
+        it("reports failure with missing plugins", function()
           local ok, err = db.plugins:load_plugin_schemas({
-            ["NaN_priority"] = true,
+            ["missing"] = true,
           })
           assert.falsy(ok)
-          assert.match('Plugin "NaN_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "nan"', err, 1, true)
+          assert.match("missing plugin is enabled but not installed", err, 1, true)
         end)
 
-        it("-math.huge", function()
-          local ok, err = db.plugins:load_plugin_schemas({
-            ["huge_negative"] = true,
-          })
-          assert.falsy(ok)
-          assert.match('Plugin "huge_negative" cannot be loaded because its PRIORITY field is not a valid integer number, got: "-inf"', err, 1, true)
+        describe("with bad PRIORITY fails; ", function()
+          setup(function()
+            local schema = {}
+            package.loaded["kong.plugins.NaN_priority.schema"] = schema
+            package.loaded["kong.plugins.NaN_priority.handler"] = { PRIORITY = 0/0, VERSION = "1.0" }
+            package.loaded["kong.plugins.huge_negative.schema"] = schema
+            package.loaded["kong.plugins.huge_negative.handler"] = { PRIORITY = -math.huge, VERSION = "1.0" }
+            package.loaded["kong.plugins.string_priority.schema"] = schema
+            package.loaded["kong.plugins.string_priority.handler"] = { PRIORITY = "abc", VERSION = "1.0" }
+          end)
+
+          teardown(function()
+            package.loaded["kong.plugins.NaN_priority.schema"] = nil
+            package.loaded["kong.plugins.NaN_priority.handler"] = nil
+            package.loaded["kong.plugins.huge_negative.schema"] = nil
+            package.loaded["kong.plugins.huge_negative.handler"] = nil
+            package.loaded["kong.plugins.string_priority.schema"] = nil
+            package.loaded["kong.plugins.string_priority.handler"] = nil
+          end)
+
+          it("NaN", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["NaN_priority"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "NaN_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "nan"', err, 1, true)
+          end)
+
+          it("-math.huge", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["huge_negative"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "huge_negative" cannot be loaded because its PRIORITY field is not a valid integer number, got: "-inf"', err, 1, true)
+          end)
+
+          it("string", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["string_priority"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "string_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "abc"', err, 1, true)
+          end)
+
         end)
 
-        it("string", function()
-          local ok, err = db.plugins:load_plugin_schemas({
-            ["string_priority"] = true,
-          })
-          assert.falsy(ok)
-          assert.match('Plugin "string_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "abc"', err, 1, true)
+        describe("with bad VERSION fails; ", function()
+          setup(function()
+            local schema = {}
+            package.loaded["kong.plugins.no_version.schema"] = schema
+            package.loaded["kong.plugins.no_version.handler"] = { PRIORITY = 1000, VERSION = nil }
+            package.loaded["kong.plugins.too_many.schema"] = schema
+            package.loaded["kong.plugins.too_many.handler"] = { PRIORITY = 1000, VERSION = "1.0.0.0" }
+            package.loaded["kong.plugins.number.schema"] = schema
+            package.loaded["kong.plugins.number.handler"] = { PRIORITY = 1000, VERSION = 123 }
+          end)
+
+          teardown(function()
+            package.loaded["kong.plugins.no_version.schema"] = nil
+            package.loaded["kong.plugins.no_version.handler"] = nil
+            package.loaded["kong.plugins.too_many.schema"] = nil
+            package.loaded["kong.plugins.too_many.handler"] = nil
+            package.loaded["kong.plugins.number.schema"] = nil
+            package.loaded["kong.plugins.number.handler"] = nil
+          end)
+
+          it("without version", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["no_version"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "no_version" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "nil"', err, 1, true)
+          end)
+
+          it("too many components", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["too_many"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "too_many" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "1.0.0.0"', err, 1, true)
+          end)
+
+          it("number", function()
+            local ok, err = db.plugins:load_plugin_schemas({
+              ["number"] = true,
+            })
+            assert.falsy(ok)
+            assert.match('Plugin "number" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "123"', err, 1, true)
+          end)
+
         end)
 
       end)
 
-      describe("with bad VERSION fails; ", function()
-        setup(function()
-          local schema = {}
-          package.loaded["kong.plugins.no_version.schema"] = schema
-          package.loaded["kong.plugins.no_version.handler"] = { PRIORITY = 1000, VERSION = nil }
-          package.loaded["kong.plugins.too_many.schema"] = schema
-          package.loaded["kong.plugins.too_many.handler"] = { PRIORITY = 1000, VERSION = "1.0.0.0" }
-          package.loaded["kong.plugins.number.schema"] = schema
-          package.loaded["kong.plugins.number.handler"] = { PRIORITY = 1000, VERSION = 123 }
-        end)
-
-        teardown(function()
-          package.loaded["kong.plugins.no_version.schema"] = nil
-          package.loaded["kong.plugins.no_version.handler"] = nil
-          package.loaded["kong.plugins.too_many.schema"] = nil
-          package.loaded["kong.plugins.too_many.handler"] = nil
-          package.loaded["kong.plugins.number.schema"] = nil
-          package.loaded["kong.plugins.number.handler"] = nil
-        end)
-
-        it("without version", function()
-          local ok, err = db.plugins:load_plugin_schemas({
-            ["no_version"] = true,
-          })
-          assert.falsy(ok)
-          assert.match('Plugin "no_version" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "nil"', err, 1, true)
-        end)
-
-        it("too many components", function()
-          local ok, err = db.plugins:load_plugin_schemas({
-            ["too_many"] = true,
-          })
-          assert.falsy(ok)
-          assert.match('Plugin "too_many" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "1.0.0.0"', err, 1, true)
-        end)
-
-        it("number", function()
-          local ok, err = db.plugins:load_plugin_schemas({
-            ["number"] = true,
-          })
-          assert.falsy(ok)
-          assert.match('Plugin "number" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "123"', err, 1, true)
-        end)
-
-      end)
-
-    end)
-
-  end) -- kong.db [strategy]
-
+    end) -- kong.db [strategy]
+  end
 end

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -380,23 +380,25 @@ do
       paths = rproto ~= "tcp" and rpaths or nil,
     })
 
-    bp.plugins:insert({
-      name = "post-function",
-      service = { id = service_id },
-      config = {
-        header_filter = {[[
-          local value = ngx.ctx and
-                        ngx.ctx.balancer_data and
-                        ngx.ctx.balancer_data.hash_value
-          if value == "" or value == nil then
-            value = "NONE"
-          end
-
-          ngx.header["x-balancer-hash-value"] = value
-          ngx.header["x-uri"] = ngx.var.request_uri
-        ]]},
-      },
-    })
+    if sproto ~= "tcp" and rproto ~= "udp" then
+      bp.plugins:insert({
+        name = "post-function",
+        service = { id = service_id },
+        config = {
+          header_filter = {[[
+            local value = ngx.ctx and
+                          ngx.ctx.balancer_data and
+                          ngx.ctx.balancer_data.hash_value
+            if value == "" or value == nil then
+              value = "NONE"
+            end
+  
+            ngx.header["x-balancer-hash-value"] = value
+            ngx.header["x-uri"] = ngx.var.request_uri
+          ]]},
+        },
+      })
+    end
 
     return route_host, service_id, route_id
   end


### PR DESCRIPTION
## **DO NOT MERGE!**

This PR causes a breaking change. We planed this for 4.0.

### Review Note

Please check "Hide whitespace" when reviewing.

### Summary

@flrgh:
> 1. This has_common_protocol_with_service() validation function is a liar and does not actually check the service protocol.
> 2. For both routes and services, the protocol checks happen before the input is populated with default values, so a plugin payload with an explicit { "protocols": [ "http" ] } will [correctly] result in a validation error, but a plugin payload with protocols omitted will be [erroneously] accepted.

We want validation to be after default values are populated.

I noticed that insert/update/upsert shares code. It seems reasonable to add a validation handler, which happens before a real DB operation, after the `auto_field_process`.

Another advantage of this method is that it won't break other uses. We could still override the insert/update/upsert method to do the validation.

### Checklist

- [x] The Pull Request has tests (covered by original test)
- [x] There's an entry in the CHANGELOG
- [ ] N/A<s>There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE</s>

### Full changelog

* Refactoring the DAO: adding a method named "validate", happen before strategy.insert/update/upsert.
* Fix the test. The original test relies on the ordering of checks(protocol check happens before other schema checks).

Behavior:
* For plugins attached to a service:
  * Before the change, it needs to match at least one protocol of a route attached to the service if any;
  * After the change, it needs to match the service's protocol
* For both: the check is done after populating the default values

### Issue reference

Fix FTI-4436
