### PR TITLE
fix(venv): use shell agnostic script to generate env files and support

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -151,6 +151,9 @@ kong_template_file(
     name = "venv-commons",
     is_executable = True,
     output = "%s-venv/lib/venv-commons" % KONG_VAR["BUILD_NAME"],
+    substitutions = {
+        "{{workspace_path}}": KONG_VAR["WORKSPACE_PATH"],
+    },
     template = "//build:templates/venv-commons",
 )
 

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -13,7 +13,7 @@ KONG_VENV=$1
 KONG_VENV_ENV_FILE=$2
 
 # clear the file
-> $KONG_VENV_ENV_FILE
+>| $KONG_VENV_ENV_FILE
 
 # use env vars to let Fish shell happy, we will unset them later
 LUAROCKS_CONFIG="$KONG_VENV/rocks_config"

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -1,9 +1,23 @@
+#!/bin/bash
 
-test -z "$KONG_VENV" && exit 1
+# template variables starts
+workspace_path="{{workspace_path}}"
+# template variables ends
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 KONG_VENV KONG_VENV_ENV_FILE"
+    exit 1
+fi
+
+KONG_VENV=$1
+KONG_VENV_ENV_FILE=$2
+
+# clear the file
+> $KONG_VENV_ENV_FILE
 
 # use env vars to let Fish shell happy, we will unset them later
-export ROCKS_CONFIG="$KONG_VENV/rocks_config"
-export ROCKS_ROOT="$KONG_VENV"
+LUAROCKS_CONFIG="$KONG_VENV/rocks_config"
+ROCKS_ROOT="$KONG_VENV"
 
 chmod -R a+rw "$KONG_VENV"
 
@@ -14,18 +28,14 @@ $KONG_VENV/openresty/bin/resty -I $KONG_VENV/openresty/site/lualib -I $KONG_VENV
 " >| "$KONG_VENV/venv/bin/resty"
 chmod +x "$KONG_VENV/venv/bin/resty"
 
-export PATH="$KONG_VENV/venv/bin:$KONG_VENV/openresty/bin:$KONG_VENV/openresty/nginx/sbin:$KONG_VENV/openresty/luajit/bin:$KONG_VENV/luarocks/bin:$KONG_VENV/bin:$workspace_path/bin:$PATH"
-
 echo "
 rocks_trees = {
     { name = [[system]], root = [[$ROCKS_ROOT]] }
 }
-" >| "$ROCKS_CONFIG"
-
-export LUAROCKS_CONFIG="$ROCKS_CONFIG"
+" >| "$LUAROCKS_CONFIG"
 
 # duplicate package.[c]path even though we have set in resty-cli, so luajit and kong can consume
-export LUA_PATH="\
+LUA_PATH="\
 $ROCKS_ROOT/share/lua/5.1/?.lua;$ROCKS_ROOT/share/lua/5.1/?.ljbc;\
 $ROCKS_ROOT/share/lua/5.1/?/init.lua;$ROCKS_ROOT/share/lua/5.1/?/init.ljbc;\
 $KONG_VENV/openresty/site/lualib/?.lua;$KONG_VENV/openresty/site/lualib/?.ljbc;\
@@ -33,6 +43,7 @@ $KONG_VENV/openresty/site/lualib/?/init.lua;$KONG_VENV/openresty/site/lualib/?/i
 $KONG_VENV/openresty/lualib/?.lua;$KONG_VENV/openresty/lualib/?.ljbc;\
 $KONG_VENV/openresty/lualib/?/init.lua;$KONG_VENV/openresty/lualib/?/init.ljbc;\
 $KONG_VENV/openresty/luajit/share/luajit-2.1.0-beta3/?.lua"
+
 # XXX EE
 if [ -d "./plugins-ee" ] ; then
     links_dir="${workspace_path}/bazel-bin/build/ee/plugins-ee"
@@ -50,7 +61,15 @@ fi
 # default; duplicate of 'lua_package_path' in kong.conf and nginx_kong.lua
 LUA_PATH="./?.lua;./?/init.lua;$LUA_PATH;;"
 
+# write envs to env file
+cat >> $KONG_VENV_ENV_FILE <<EOF
+export PATH="$KONG_VENV/venv/bin:$KONG_VENV/openresty/bin:$KONG_VENV/openresty/nginx/sbin:$KONG_VENV/openresty/luajit/bin:$KONG_VENV/luarocks/bin:$KONG_VENV/bin:$workspace_path/bin:$PATH"
+export LUAROCKS_CONFIG="$LUAROCKS_CONFIG"
+
+export LUA_PATH="$LUA_PATH"
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
 export KONG_PREFIX="$KONG_VENV/kong/servroot"
 export LIBRARY_PREFIX="$KONG_VENV/kong" # let "make dev" happy
 export OPENSSL_DIR="$KONG_VENV/kong" # let "make dev" happy
+
+EOF

--- a/build/templates/venv.fish
+++ b/build/templates/venv.fish
@@ -41,8 +41,9 @@ function deactivate -d 'Exit Kong\'s venv and return to the normal environment.'
         set -e _OLD_FISH_PROMPT_OVERRIDE
     end
 
-    set -e KONG_VENV
-    set -e ROCKS_CONFIG ROCKS_ROOT LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
+    rm -f KONG_VENV_ENV_FILE
+    set -e KONG_VENV KONG_VENV_ENV_FILE
+    set -e LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
 
     type -q stop_services && stop_services
 
@@ -55,8 +56,11 @@ function start_services -d 'Start dependency services of Kong'
     # stop_services is defined by the script above
 end
 
+
 # actually set env vars
-source $KONG_VENV-venv/lib/venv-commons
+set -xg KONG_VENV_ENV_FILE $(mktemp)
+bash $KONG_VENV-venv/lib/venv-commons $KONG_VENV $KONG_VENV_ENV_FILE
+source $KONG_VENV_ENV_FILE
 set -xg PATH "$PATH"
 
 # set shell prompt

--- a/build/templates/venv.sh
+++ b/build/templates/venv.sh
@@ -20,9 +20,10 @@ export PATH
 deactivate () {
     export PATH="${_OLD_KONG_VENV_PATH}"
     export PS1="${_OLD_KONG_VENV_PS1}"
-    unset KONG_VENV
+    rm -f $KONG_VENV_ENV_FILE
+    unset KONG_VENV KONG_VENV_ENV_FILE
     unset _OLD_KONG_VENV_PATH _OLD_KONG_VENV_PS1
-    unset ROCKS_CONFIG ROCKS_ROOT LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
+    unset LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
 
     type stop_services >/dev/null && stop_services
 
@@ -31,12 +32,15 @@ deactivate () {
 }
 
 start_services () {
-    source $workspace_path/scripts/dependency_services/up.sh
+    . $workspace_path/scripts/dependency_services/up.sh
     # stop_services is defined by the script above
 }
 
 # actually set env vars
-. ${KONG_VENV}-venv/lib/venv-commons
+KONG_VENV_ENV_FILE=$(mktemp)
+export KONG_VENV_ENV_FILE
+bash ${KONG_VENV}-venv/lib/venv-commons $KONG_VENV $KONG_VENV_ENV_FILE
+. $KONG_VENV_ENV_FILE
 
 # set shell prompt
 if [ -z "${KONG_VENV_DISABLE_PROMPT-}" ] ; then

--- a/scripts/dependency_services/up.fish
+++ b/scripts/dependency_services/up.fish
@@ -2,31 +2,29 @@
 
 set cwd (dirname (status --current-filename))
 
-set -xg docker_compose_file $cwd/docker-compose-test-services.yml
-set -xg docker_compose_project kong
+set -xg KONG_SERVICE_ENV_FILE $(mktemp)
 
-set -xg KONG_ENV_FILE $(mktemp) || exit 1
-set -xg KONG_ENV_DOWN_FILE $(mktemp) || exit 1
-
-bash "$cwd/common.sh" $KONG_ENV_FILE $KONG_ENV_DOWN_FILE
+bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE
 
 if test $status -ne 0
     echo "Something goes wrong, please check common.sh output"
     return
 end
 
-source $KONG_ENV_FILE
+source $KONG_SERVICE_ENV_FILE
 
 function stop_services -d 'Stop dependency services of Kong and clean up environment variables.'
-    for i in (cat $KONG_ENV_DOWN_FILE)
+    if test -n $COMPOSE_FILE && test -n $COMPOSE_PROJECT_NAME
+        docker compose down
+    end
+
+    for i in (cat $KONG_SERVICE_ENV_FILE | cut -d ' ' -f2 | cut -d '=' -f1)
       set -e $i
     end
-    rm -rf $KONG_ENV_FILE $KONG_ENV_DOWN_FILE
-    set -e KONG_ENV_FILE KONG_ENV_DOWN_FILE
-    if test -n $docker_compose_file && test -n $docker_compose_project
-        docker-compose -f "$docker_compose_file" -p "$docker_compose_project" down
-        set -e docker_compose_file docker_compose_project
-    end
+
+    rm -f $KONG_SERVICE_ENV_FILE
+    set -e KONG_SERVICE_ENV_FILE
+
     functions -e stop_services
 end
 

--- a/scripts/dependency_services/up.sh
+++ b/scripts/dependency_services/up.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-export KONG_ENV_FILE=$(mktemp) || exit 1
-export KONG_ENV_DOWN_FILE=$(mktemp) || exit 1
-
 if [ "${BASH_SOURCE-}" = "$0" ]; then
     echo "You must source this script: \$ source $0" >&2
     exit 33
 fi
+
+export KONG_SERVICE_ENV_FILE=$(mktemp)
 
 if [ -n "$ZSH_VERSION" ]; then
     cwd=$(realpath $(dirname $(readlink -f ${(%):-%N})))
@@ -14,30 +13,26 @@ else
     cwd=$(realpath $(dirname $(readlink -f ${BASH_SOURCE[0]})))
 fi
 
-docker_compose_file=${cwd}/docker-compose-test-services.yml
-docker_compose_project=kong
-
-
-bash "$cwd/common.sh" $KONG_ENV_FILE $KONG_ENV_DOWN_FILE
+bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check common.sh output"
     return
 fi
 
-source $KONG_ENV_FILE
+. $KONG_SERVICE_ENV_FILE
 
 stop_services () {
-    for i in $(cat $KONG_ENV_DOWN_FILE); do
+    if test -n "$COMPOSE_FILE" && test -n "$COMPOSE_PROJECT_NAME"; then
+        docker compose down
+    fi
+
+    for i in $(cat $KONG_SERVICE_ENV_FILE | cut -f2 | cut -d '=' -f1); do
       unset $i
     done
 
-    rm -rf $KONG_ENV_FILE $KONG_ENV_DOWN_FILE
-    unset KONG_ENV_FILE KONG_ENV_DOWN_FILE
+    rm -rf $KONG_SERVICE_ENV_FILE
+    unset KONG_SERVICE_ENV_FILE
 
-    if test -n "$docker_compose_file" && test -n "$docker_compose_project"; then
-        docker-compose -f "$docker_compose_file" -p "$docker_compose_project" down
-        unset docker_compose_file docker_compose_project cwd
-    fi
     unset -f stop_services
 }
 

--- a/scripts/dependency_services/up.sh
+++ b/scripts/dependency_services/up.sh
@@ -8,9 +8,9 @@ fi
 export KONG_SERVICE_ENV_FILE=$(mktemp)
 
 if [ -n "$ZSH_VERSION" ]; then
-    cwd=$(realpath $(dirname $(readlink -f ${(%):-%N})))
+    cwd=$(dirname $(readlink -f ${(%):-%N}))
 else
-    cwd=$(realpath $(dirname $(readlink -f ${BASH_SOURCE[0]})))
+    cwd=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 fi
 
 bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE


### PR DESCRIPTION
docker compose plugin

### Summary

This reduces the burden of developer needs to learn fish/zsh/bash syntax to add features to the venv. Now only the skleton is depending on each shell's flavor, the actual logic to set env vars and start docker-compose is always in bash.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-441, KAG-1350
