### PR TITLE
tests(proxy/ssl): enable ssl tests for flavor traditional_compat

### DIFF
--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -12,8 +12,9 @@ local function get_cert(server_name)
   return stdout
 end
 
+for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
 for _, strategy in helpers.each_strategy() do
-  describe("SSL [#" .. strategy .. "]", function()
+  describe("SSL [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     local proxy_client
     local https_client
 
@@ -205,6 +206,7 @@ for _, strategy in helpers.each_strategy() do
       -- /wildcard tests
 
       assert(helpers.start_kong {
+        router_flavor = flavor,
         database    = strategy,
         nginx_conf  = "spec/fixtures/custom_nginx.template",
         trusted_ips = "127.0.0.1",
@@ -373,6 +375,7 @@ for _, strategy in helpers.each_strategy() do
       describe("from not trusted_ip", function()
         lazy_setup(function()
           assert(helpers.restart_kong {
+            router_flavor = flavor,
             database    = strategy,
             nginx_conf  = "spec/fixtures/custom_nginx.template",
             trusted_ips = nil,
@@ -397,6 +400,7 @@ for _, strategy in helpers.each_strategy() do
       describe("from trusted_ip", function()
         lazy_setup(function()
           assert(helpers.restart_kong {
+            router_flavor = flavor,
             database    = strategy,
             nginx_conf  = "spec/fixtures/custom_nginx.template",
             trusted_ips = "127.0.0.1",
@@ -437,6 +441,7 @@ for _, strategy in helpers.each_strategy() do
         -- untrusted ip
         lazy_setup(function()
           assert(helpers.restart_kong {
+            router_flavor = flavor,
             database = strategy,
             nginx_conf  = "spec/fixtures/custom_nginx.template",
             trusted_ips = "1.2.3.4", -- explicitly trust an IP that is not us
@@ -465,6 +470,7 @@ for _, strategy in helpers.each_strategy() do
 
       before_each(function()
         assert(helpers.restart_kong {
+          router_flavor = flavor,
           database = strategy,
           nginx_conf  = "spec/fixtures/custom_nginx.template",
         })
@@ -519,7 +525,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("TLS proxy [#" .. strategy .. "]", function()
+  describe("TLS proxy [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "routes",
@@ -560,6 +566,7 @@ for _, strategy in helpers.each_strategy() do
       }
 
       assert(helpers.start_kong {
+        router_flavor = flavor,
         database    = strategy,
         stream_listen = "127.0.0.1:9020 ssl"
       })
@@ -613,7 +620,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("SSL [#" .. strategy .. "]", function()
+  describe("SSL [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -646,6 +653,7 @@ for _, strategy in helpers.each_strategy() do
       }
 
       assert(helpers.start_kong {
+        router_flavor = flavor,
         database    = strategy,
         nginx_conf  = "spec/fixtures/custom_nginx.template",
       })
@@ -664,9 +672,10 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("kong.runloop.certificate invalid SNI [#" .. strategy .. "]", function()
+  describe("kong.runloop.certificate invalid SNI [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     lazy_setup(function()
       assert(helpers.start_kong {
+        router_flavor = flavor,
         database    = strategy,
       })
     end)
@@ -728,4 +737,5 @@ for _, strategy in helpers.each_strategy() do
     end)
 
   end)
+end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


