### PR TITLE
fix(clustering): support queueing plugins of pre-3.3 DP with 3.3 CP

### DIFF
--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -354,17 +354,17 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
   payload = deep_copy(payload, false)
   local config_table = payload["config_table"]
 
-  local fields = get_removed_fields(dp_version_num)
-  if fields then
-    if invalidate_keys_from_config(config_table["plugins"], fields, log_suffix, dp_version_num) then
-      has_update = true
-    end
-  end
-
   for _, checker in ipairs(COMPATIBILITY_CHECKERS) do
     local ver = checker[1]
     local fn  = checker[2]
     if dp_version_num < ver and fn(config_table, dp_version, log_suffix) then
+      has_update = true
+    end
+  end
+
+  local fields = get_removed_fields(dp_version_num)
+  if fields then
+    if invalidate_keys_from_config(config_table["plugins"], fields, log_suffix, dp_version_num) then
       has_update = true
     end
   end

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -525,7 +525,7 @@ describe("kong.clustering.compat", function()
       assert.is_nil(assert(plugins[2]).instance_name)
     end)
 
-    it("plugin.queue_parameters #xxx", function()
+    it("plugin.queue_parameters", function()
       local has_update, result = compat.update_compatible_payload(config, "3.2.0", "test_")
       assert.truthy(has_update)
       result = cjson_decode(inflate_gzip(result)).config_table

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -417,8 +417,39 @@ describe("kong.clustering.compat", function()
             name = "correlation-id",
             instance_name = "my-correlation-id"
           },
+          plugin3 = {
+            id = "00000000-0000-0000-0000-000000000003",
+            name = "statsd",
+            config = {
+              queue = {
+                max_batch_size = 9,
+                max_coalescing_delay = 9,
+              },
+            },
+          },
+          plugin4 = {
+            id = "00000000-0000-0000-0000-000000000004",
+            name = "datadog",
+            config = {
+              queue = {
+                max_batch_size = 9,
+                max_coalescing_delay = 9,
+              },
+            },
+          },
+          plugin5 = {
+            id = "00000000-0000-0000-0000-000000000005",
+            name = "opentelemetry",
+            config = {
+              endpoint = "http://example.com",
+              queue = {
+                max_batch_size = 9,
+                max_coalescing_delay = 9,
+              },
+            },
+          },
         },
-        services = { 
+        services = {
           service1 = {
             connect_timeout = 60000,
             created_at = 1234567890,
@@ -436,7 +467,7 @@ describe("kong.clustering.compat", function()
             tls_verify = true,
             ca_certificates = { ca_certificate_def.id },
             enabled = true,
-          }, 
+          },
           service2 = {
             connect_timeout = 60000,
             created_at = 1234567890,
@@ -492,6 +523,27 @@ describe("kong.clustering.compat", function()
       local plugins = assert(assert(assert(result).plugins))
       assert.is_nil(assert(plugins[1]).instance_name)
       assert.is_nil(assert(plugins[2]).instance_name)
+    end)
+
+    it("plugin.queue_parameters #xxx", function()
+      local has_update, result = compat.update_compatible_payload(config, "3.2.0", "test_")
+      assert.truthy(has_update)
+      result = cjson_decode(inflate_gzip(result)).config_table
+      local plugins = assert(assert(assert(result).plugins))
+      for _, plugin in ipairs(plugins) do
+        if plugin.name == "statsd" then
+          assert.equals(10, plugin.config.retry_count)
+          assert.equals(9, plugin.config.queue_size)
+          assert.equals(9, plugin.config.flush_timeout)
+        elseif plugin.name == "datadog" then
+          assert.equals(10, plugin.config.retry_count)
+          assert.equals(9, plugin.config.queue_size)
+          assert.equals(9, plugin.config.flush_timeout)
+        elseif plugin.name == "opentelemetry" then
+          assert.equals(9, plugin.config.batch_span_count)
+          assert.equals(9, plugin.config.batch_flush_delay)
+        end
+      end
     end)
 
     it("upstream.algorithm", function()


### PR DESCRIPTION
### Summary

When running a 3.3 CP, queuing parameters that have been required in prior versions would cause DPs to reject the configuration sent by the CP because those parameters are no longer present.  This compatibility fix makes sure that these parameters are present.  Where possible, the values are determined from the new queue configuration hash, otherwise the previous defaults will be supplied.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG N/A
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com N/A

### Issue reference

KAG-1392
