### PR TITLE
fix(queues): log deprecation warnings at runtime

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -116,11 +116,11 @@ return {
                     { after = "4.0", })
                 end
                 if (entity.queue_size or ngx.null) ~= ngx.null and entity.queue_size ~= 1 then
-                  deprecation("datadog: config.queue_size no longer works, please use config.queue.max_batch_size instead",
+                  deprecation("datadog: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
                     { after = "4.0", })
                 end
                 if (entity.flush_timeout or ngx.null) ~= ngx.null and entity.flush_timeout ~= 2 then
-                  deprecation("datadog: config.flush_timeout no longer works, please use config.queue.max_coalescing_delay instead",
+                  deprecation("datadog: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
                     { after = "4.0", })
                 end
                 return true

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -54,11 +54,11 @@ return {
                             { after = "4.0", })
               end
               if (entity.queue_size or ngx.null) ~= ngx.null and entity.queue_size ~= 1 then
-                deprecation("http-log: config.queue_size no longer works, please use config.queue.max_batch_size instead",
+                deprecation("http-log: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
                             { after = "4.0", })
               end
               if (entity.flush_timeout or ngx.null) ~= ngx.null and entity.flush_timeout ~= 2 then
-                deprecation("http-log: config.flush_timeout no longer works, please use config.queue.max_coalescing_delay instead",
+                deprecation("http-log: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
                             { after = "4.0", })
               end
               return true

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -60,11 +60,11 @@ return {
           field_sources = { "batch_span_count", "batch_flush_delay" },
           fn = function(entity)
             if (entity.batch_span_count or ngx.null) ~= ngx.null and entity.batch_span_count ~= 200 then
-              deprecation("opentelemetry: batch_span_count no longer works, please use config.queue.max_batch_size instead",
+              deprecation("opentelemetry: config.batch_span_count is deprecated, please use config.queue.max_batch_size instead",
                           { after = "4.0", })
             end
             if (entity.batch_flush_delay or ngx.null) ~= ngx.null and entity.batch_flush_delay ~= 3 then
-              deprecation("opentelemetry: batch_flush_delay no longer works, please use config.queue.max_coalescing_delay instead",
+              deprecation("opentelemetry: config.batch_flush_delay is deprecated, please use config.queue.max_coalescing_delay instead",
                           { after = "4.0", })
             end
             return true

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -205,11 +205,11 @@ return {
                             { after = "4.0", })
               end
               if (entity.queue_size or ngx.null) ~= ngx.null and entity.queue_size ~= 1 then
-                deprecation("statsd: config.queue_size no longer works, please use config.queue.max_batch_size instead",
+                deprecation("statsd: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
                             { after = "4.0", })
               end
               if (entity.flush_timeout or ngx.null) ~= ngx.null and entity.flush_timeout ~= 2 then
-                deprecation("statsd: config.flush_timeout no longer works, please use config.queue.max_coalescing_delay instead",
+                deprecation("statsd: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
                             { after = "4.0", })
               end
               return true

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -60,6 +60,10 @@ local semaphore = require("ngx.semaphore")
 local table_new = require("table.new")
 
 
+-- Minimum interval to warn about usage of legacy queueing related parameters
+local MIN_WARNING_INTERVAL_SECONDS = 60
+
+
 local string_format = string.format
 local assert = assert
 local select = select
@@ -287,30 +291,64 @@ function Queue:process_once()
 end
 
 
+local legacy_params_warned = {}
+
+local function maybe_warn(name, message)
+  local key = name .. "/" .. message
+  if ngx.now() - (legacy_params_warned[key] or 0) >= MIN_WARNING_INTERVAL_SECONDS then
+    kong.log.warn(message)
+    legacy_params_warned[key] = ngx.now()
+  end
+end
+
+
 -- This function retrieves the queue parameters from a plugin configuration, converting legacy parameters
--- to their new locations.  The conversion is silently done here, as we're already warning about the legacy
--- parameters being used when validating each plugin's configuration.
+-- to their new locations
 function Queue.get_params(config)
   local queue_config = config.queue or table_new(0, 5)
+
+  if not queue_config.name then
+    queue_config.name = kong.plugin.get_id()
+  end
+
+  if (config.retry_count or null) ~= null and config.retry_count ~= 10 then
+    maybe_warn(
+      queue_config.name,
+      "the retry_count parameter no longer works, please update "
+        .. "your configuration to use initial_retry_delay and max_retry_time instead")
+  end
+
   if (config.queue_size or null) ~= null and config.queue_size ~= 1 then
     queue_config.max_batch_size = config.queue_size
+    maybe_warn(
+      queue_config.name,
+      "the queue_size parameter is deprecated, please update your "
+        .. "configuration to use queue.max_batch_size instead")
   end
 
   if (config.flush_timeout or null) ~= null and config.flush_timeout ~= 2 then
     queue_config.max_coalescing_delay = config.flush_timeout
+    maybe_warn(
+      queue_config.name,
+      "the flush_timeout parameter is deprecated, please update your "
+        .. "configuration to use queue.max_coalescing_delay instead")
   end
 
   -- Queue related opentelemetry plugin parameters
   if (config.batch_span_count or null) ~= null and config.batch_span_count ~= 200 then
     queue_config.max_batch_size = config.batch_span_count
+    maybe_warn(
+      queue_config.name,
+      "the batch_span_count parameter is deprecated, please update your "
+        .. "configuration to use queue.max_batch_size instead")
   end
 
   if (config.batch_flush_delay or null) ~= null and config.batch_flush_delay ~= 3 then
     queue_config.max_coalescing_delay = config.batch_flush_delay
-  end
-
-  if not queue_config.name then
-    queue_config.name = kong.plugin.get_id()
+    maybe_warn(
+      queue_config.name,
+      "the batch_flush_delay parameter is deprecated, please update your "
+        .. "configuration to use queue.max_coalescing_delay instead")
   end
 
   return queue_config

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -303,7 +303,7 @@ end
 
 
 -- This function retrieves the queue parameters from a plugin configuration, converting legacy parameters
--- to their new locations
+-- to their new locations.
 function Queue.get_params(config)
   local queue_config = config.queue or table_new(0, 5)
 
@@ -311,6 +311,8 @@ function Queue.get_params(config)
     queue_config.name = kong.plugin.get_id()
   end
 
+  -- It is planned to remove the legacy parameters in Kong Gateway 4.0, removing
+  -- the need for the checks below. ({ after = "4.0", })
   if (config.retry_count or null) ~= null and config.retry_count ~= 10 then
     maybe_warn(
       queue_config.name,
@@ -334,7 +336,6 @@ function Queue.get_params(config)
         .. "configuration to use queue.max_coalescing_delay instead")
   end
 
-  -- Queue related opentelemetry plugin parameters
   if (config.batch_span_count or null) ~= null and config.batch_span_count ~= 200 then
     queue_config.max_batch_size = config.batch_span_count
     maybe_warn(

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -47,6 +47,10 @@ describe("plugin queue", function()
   local now_offset
   local log_messages
 
+  local function count_matching_log_messages(s)
+    return select(2, string.gsub(log_messages, s, ""))
+  end
+
   before_each(function()
     local real_now = ngx.now
     now_offset = 0
@@ -591,13 +595,12 @@ describe("plugin queue", function()
     for _ = 1,10 do
       Queue.get_params(legacy_parameters)
     end
-    assert.has.no.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works')
+    assert.equals(1, count_matching_log_messages('the retry_count parameter no longer works'))
     now_offset = 1000
     for _ = 1,10 do
       Queue.get_params(legacy_parameters)
     end
-    assert.has.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works')
-    assert.has.no.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works.*the retry_count parameter no longer works')
+    assert.equals(2, count_matching_log_messages('the retry_count parameter no longer works'))
   end)
 
   it("defaulted legacy parameters are ignored when converting", function()

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -5,6 +5,7 @@ local timerng = require "resty.timerng"
 local queue_schema = require "kong.tools.queue_schema"
 local queue_num = 1
 
+
 local function queue_conf(conf)
   local defaulted_conf = {}
   if conf.name then
@@ -43,12 +44,13 @@ describe("plugin queue", function()
   end)
 
   local unmock
-  local now_offset = 0
+  local now_offset
   local log_messages
 
   before_each(function()
     local real_now = ngx.now
     now_offset = 0
+
     log_messages = ""
     local function log(level, message) -- luacheck: ignore
       log_messages = log_messages .. level .. " " .. message .. "\n"
@@ -84,6 +86,7 @@ describe("plugin queue", function()
       }
     })
   end)
+
   after_each(unmock)
 
   it("passes configuration to handler", function ()
@@ -551,20 +554,50 @@ describe("plugin queue", function()
       retry_count = 123,
       queue_size = 234,
       flush_timeout = 345,
+      queue = {
+        name = "common-legacy-conversion-test",
+      },
     }
     local converted_parameters = Queue.get_params(legacy_parameters)
+    assert.match_re(log_messages, 'the retry_count parameter no longer works, please update your configuration to use initial_retry_delay and max_retry_time instead')
     assert.equals(legacy_parameters.queue_size, converted_parameters.max_batch_size)
+    assert.match_re(log_messages, 'the queue_size parameter is deprecated, please update your configuration to use queue.max_batch_size instead')
     assert.equals(legacy_parameters.flush_timeout, converted_parameters.max_coalescing_delay)
+    assert.match_re(log_messages, 'the flush_timeout parameter is deprecated, please update your configuration to use queue.max_coalescing_delay instead')
   end)
 
   it("converts opentelemetry plugin legacy queue parameters", function()
     local legacy_parameters = {
       batch_span_count = 234,
       batch_flush_delay = 345,
+      queue = {
+        name = "opentelemetry-legacy-conversion-test",
+      },
     }
     local converted_parameters = Queue.get_params(legacy_parameters)
     assert.equals(legacy_parameters.batch_span_count, converted_parameters.max_batch_size)
+    assert.match_re(log_messages, 'the batch_span_count parameter is deprecated, please update your configuration to use queue.max_batch_size instead')
     assert.equals(legacy_parameters.batch_flush_delay, converted_parameters.max_coalescing_delay)
+    assert.match_re(log_messages, 'the batch_flush_delay parameter is deprecated, please update your configuration to use queue.max_coalescing_delay instead')
+  end)
+
+  it("logs deprecation messages only every so often", function()
+    local legacy_parameters = {
+      retry_count = 123,
+      queue = {
+        name = "legacy-warning-suppression",
+      },
+    }
+    for _ = 1,10 do
+      Queue.get_params(legacy_parameters)
+    end
+    assert.has.no.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works')
+    now_offset = 1000
+    for _ = 1,10 do
+      Queue.get_params(legacy_parameters)
+    end
+    assert.has.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works')
+    assert.has.no.match_re(log_messages, '(?s)the retry_count parameter no longer works.*the retry_count parameter no longer works.*the retry_count parameter no longer works')
   end)
 
   it("defaulted legacy parameters are ignored when converting", function()

--- a/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
+++ b/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
@@ -5,6 +5,7 @@ local helpers    = require "spec.helpers"
 for _, strategy in helpers.each_strategy() do
   describe("legacy queue parameters [#" .. strategy .. "]", function()
     local db
+    local admin_client
 
     lazy_setup(function()
       -- Create a service to make sure that our database is initialized properly.
@@ -13,31 +14,37 @@ for _, strategy in helpers.each_strategy() do
         "services",
       })
 
+      db:truncate()
+
       bp.services:insert{
         protocol = "http",
         host     = helpers.mock_upstream_host,
         port     = helpers.mock_upstream_port,
       }
-    end)
-
-    local admin_client
-
-    before_each(function()
-
-      helpers.clean_logfile()
-      db:truncate()
-
       assert(helpers.start_kong({
         database = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
-
       admin_client = helpers.admin_client()
     end)
 
-    after_each(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
+      end
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      helpers.clean_logfile()
+    end)
+
+    local plugin_id
+
+    after_each(function()
+      if plugin_id then
+        local res = admin_client:delete("/plugins/" .. plugin_id)
+        assert.res_status(204, res)
       end
     end)
 
@@ -53,35 +60,38 @@ for _, strategy in helpers.each_strategy() do
     }
 
     for plugin, base_config in pairs(plugins) do
-      describe("[#" .. plugin .. "]", function()
-        local function create_plugin(parameter, value)
-          local config = table.clone(base_config)
-          if parameter then
-            config[parameter] = value
-          end
-          local res = admin_client:post(
-            "/plugins",
-            {
-              headers = {
-                ["Content-Type"] = "application/json"
-              },
-              body = cjson.encode({
-                name = plugin,
-                config = config
-              })
-            }
-          )
-          helpers.stop_kong(nil, true)
-          assert.res_status(201, res)
-        end
 
-        it("no unexpected queue parameter deprecation warnings", function()
+      local function create_plugin(parameter, value)
+        local config = table.clone(base_config)
+        if parameter then
+          config[parameter] = value
+        end
+        local res = admin_client:post(
+          "/plugins",
+          {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = cjson.encode({
+              name = plugin,
+              config = config
+            })
+          }
+        )
+        local body = cjson.decode(assert.res_status(201, res))
+        plugin_id = body.id
+      end
+
+      local log_wait_time = 0.01
+      describe("[#" .. plugin .. "]", function()
+        it("no unexpected queue parameter deprecation warnings by default", function()
           create_plugin()
-          assert.logfile().has.no.line("no longer works, please use config.queue")
+          assert.logfile().has.no.line("no longer works, please use config.queue", true, log_wait_time)
+          assert.logfile().has.no.line("is deprecated, please use config.queue", true, log_wait_time)
         end)
 
         local parameters = {
-          retry_count = 10,
+          retry_count = 10, -- treated specially below
           queue_size = 1,
           flush_timeout = 2
         }
@@ -94,16 +104,20 @@ for _, strategy in helpers.each_strategy() do
         end
 
         for parameter, default_value in pairs(parameters) do
+          local expected_warning
+          if parameter == "retry_count" then
+            expected_warning = "config.retry_count no longer works, please use config.queue."
+          else
+            expected_warning = "config." .. parameter .. " is deprecated, please use config.queue."
+          end
           it ("does not warn when " .. parameter .. " is set to the old default " .. tostring(default_value), function()
             create_plugin(parameter, default_value)
-            assert.logfile().has.no.line(parameter)
-            assert.logfile().has.no.line("no longer works, please use config.queue", true)
+            assert.logfile().has.no.line(expected_warning, true, log_wait_time)
           end)
 
           it ("does warn when " .. parameter .. " is set to a value different from the old default " .. tostring(default_value), function()
             create_plugin(parameter, default_value + 1)
-            assert.logfile().has.line(parameter)
-            assert.logfile().has.line("no longer works, please use config.queue", true)
+            assert.logfile().has.line(expected_warning, true, log_wait_time)
           end)
         end
       end)

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -157,7 +157,11 @@ describe(PLUGIN_NAME .. ": (schema)", function()
       flush_timeout = 92,
     })
     assert.is_truthy(entity)
+    entity.config.queue.name = "legacy-conversion-test"
     local conf = Queue.get_params(entity.config)
+    assert.match_re(log_messages, "the retry_count parameter no longer works")
+    assert.match_re(log_messages, "the queue_size parameter is deprecated")
+    assert.match_re(log_messages, "the flush_timeout parameter is deprecated")
     assert.is_same(46, conf.max_batch_size)
     assert.is_same(92, conf.max_coalescing_delay)
   end)


### PR DESCRIPTION
### Summary

This reverts commit 40008ec9a1ad423acc97912e0290737e1daea867 and improves how deprecation messages are logged.  Instead of creating a log message for every `Queue.enqueue` operation, each message for each queue is now logged only once per minute.  This is supposed to provide good visibility for these messages without flooding the log with duplicates.

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG N/A (unreleased)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com N/A (unreleased)

### Issue reference

KAG-1279
KAG-1340