### PR TITLE
chore(tests): remove mention of resty.worker.events from helpers/perf/utils.lua

### DIFF
--- a/spec/helpers/perf/utils.lua
+++ b/spec/helpers/perf/utils.lua
@@ -216,7 +216,7 @@ end
 -- and won't affect kong instances performing tests
 local function clear_loaded_package()
   for _, p in ipairs({
-    "spec.helpers", "resty.worker.events", "kong.cluster_events",
+    "spec.helpers", "kong.cluster_events",
     "kong.global", "kong.constants",
     "kong.cache", "kong.db", "kong.plugins", "kong.pdk", "kong.enterprise_edition.pdk",
   }) do


### PR DESCRIPTION
### Summary

This is the last place where we have `resty.worker.events` since we merged: https://github.com/Kong/kong/pull/10142