### PR TITLE
chore(tests): reduce flakiness in mock vault on dns errors

### DIFF
--- a/spec/fixtures/custom_vaults/kong/vaults/mock/init.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/mock/init.lua
@@ -20,7 +20,7 @@ local function get(conf, resource, version)
   end
 
   client:set_timeouts(20000, 20000, 20000)
-  assert(client:request_uri("http://mockbin.org/headers", {
+  assert(client:request_uri("http://127.0.0.1:9000", {
     headers = {
       Accept = "application/json",
     },


### PR DESCRIPTION
### Summary

I have recently seen this error on our CI:

```
         ERR spec/02-integration/13-vaults/01-vault_spec.lua:133: /certificates with DB: #postgres create certificates with cert and key as secret using mock vault
./spec/fixtures/custom_vaults/kong/vaults/mock/init.lua:30: [cosocket] DNS resolution failed: dns lookup pool exceeded retries (1): timeout. Tried: ["(short)mockbin.org:(na) - cache-miss","mockbin.org:33 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout","mockbin.org.ci.konghq.com.internal:33 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout","mockbin.org:1 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout","mockbin.org.ci.konghq.com.internal:1 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout","mockbin.org:5 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout","mockbin.org.ci.konghq.com.internal:5 - cache-miss/scheduled/try 1 error: timeout/scheduled/try 2 error: timeout/dns lookup pool exceeded retries (1): timeout"]

stack traceback:
	./spec/fixtures/custom_vaults/kong/vaults/mock/init.lua:30: in function 'get'
	./kong/pdk/vault.lua:168: in function 'config_secret'
	./kong/pdk/vault.lua:424: in function 'get'
	./kong/db/schema/init.lua:1747: in function 'process_auto_fields'
	./kong/db/dao/init.lua:1454: in function 'row_to_entity'
	./kong/db/dao/init.lua:1034: in function 'select'
	spec/02-integration/13-vaults/01-vault_spec.lua:152: in function <spec/02-integration/13-vaults/01-vault_spec.lua:133>
```

This commit is to reduce such flakiness.