### PR TITLE
chore(dev): silent error if stop_services does not exist

### DIFF
--- a/build/templates/venv.sh
+++ b/build/templates/venv.sh
@@ -25,7 +25,7 @@ deactivate () {
     unset _OLD_KONG_VENV_PATH _OLD_KONG_VENV_PS1
     unset LUAROCKS_CONFIG LUA_PATH LUA_CPATH KONG_PREFIX LIBRARY_PREFIX OPENSSL_DIR
 
-    type stop_services >/dev/null && stop_services
+    type stop_services &>/dev/null && stop_services
 
     unset -f deactivate
     unset -f start_services


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

chore(dev): silent error if stop_services does not exist

```
~ $ type stop_services >/dev/null
-bash: type: stop_services: not found

~ $ type stop_services &>/dev/null
~ $ echo $?
1
```

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Redirect stderr to `/dev/null` as well.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-5035
