### PR TITLE
chore: set PostgreSQL application_name=kong

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -941,6 +941,7 @@ local _M = {}
 
 function _M.new(kong_config)
   local config = {
+    application_name = "kong",
     host        = kong_config.pg_host,
     port        = kong_config.pg_port,
     timeout     = kong_config.pg_timeout,
@@ -997,6 +998,7 @@ function _M.new(kong_config)
     ngx.log(ngx.DEBUG, "PostgreSQL connector readonly connection enabled")
 
     local ro_override = {
+      application_name = "kong",
       host        = kong_config.pg_ro_host,
       port        = kong_config.pg_ro_port,
       timeout     = kong_config.pg_ro_timeout,

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -260,7 +260,6 @@ for _, strategy in helpers.each_strategy() do
       local res = assert(db.connector:query("SELECT application_name from pg_stat_activity WHERE application_name = 'kong';"))
 
       assert.is_table(res[1])
-      -- in test suite the CURRENT_SCHEMA is public
       assert.equal("kong", res[1]["application_name"])
 
       assert(db:close())

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -249,6 +249,23 @@ for _, strategy in helpers.each_strategy() do
       assert(db:close())
     end)
 
+    postgres_only("connects with application_name = kong in postgres", function()
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+      assert(db:init_connector())
+      assert(db:connect())
+
+      local res = assert(db.connector:query("SELECT application_name from pg_stat_activity WHERE application_name = 'kong';"))
+
+      assert.is_table(res[1])
+      -- in test suite the CURRENT_SCHEMA is public
+      assert.equal("kong", res[1]["application_name"])
+
+      assert(db:close())
+    end)
+
     cassandra_only("provided Cassandra contact points resolve DNS", function()
       local conf = utils.deep_copy(helpers.test_conf)
 


### PR DESCRIPTION
### Summary

DB performance monitor and analyzers displays stats based on Postgresql "applicaiton_name"
Currently Kong shows up as pgmoon and that may not be intuitive for those kong operators who do not know that Kong is a lua app that depends on the lua pgmoon library.
This PR attempt to give it a better name like applicaiton_name=kong.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* set postgresql applicaiton_name=kong 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
