### PR TITLE
tests(*): fix ssl upstream cert verify depth for mockbin.com

### DIFF
--- a/spec/02-integration/04-admin_api/22-debug_spec.lua
+++ b/spec/02-integration/04-admin_api/22-debug_spec.lua
@@ -28,6 +28,7 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       trusted_ips = "127.0.0.1",
       nginx_http_proxy_ssl_verify = "on",
       nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+      nginx_http_proxy_ssl_verify_depth = "5",
     })
     assert(helpers.start_kong{
       database = strategy,

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -210,6 +210,7 @@ for _, strategy in helpers.each_strategy() do
         trusted_ips = "127.0.0.1",
         nginx_http_proxy_ssl_verify = "on",
         nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+        nginx_http_proxy_ssl_verify_depth = "5",
       })
 
       ngx.sleep(0.01)
@@ -540,7 +541,7 @@ for _, strategy in helpers.each_strategy() do
         snis     = { "example.com" },
         service   = service,
       }
-      
+
       bp.routes:insert {
         protocols = { "tls" },
         snis      = { "foobar.example.com." },
@@ -564,7 +565,7 @@ for _, strategy in helpers.each_strategy() do
         stream_listen = "127.0.0.1:9020 ssl"
       })
 
-    
+
     end)
 
     lazy_teardown(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Rerunning the master test results in red today: https://github.com/Kong/kong/actions/runs/4830133642/jobs/8643121705

After digging, the errorlog shows
```
2023/05/01 17:50:00 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://172.67.204.7:443/requ
est", host: "mockbin.com"
2023/05/01 17:50:01 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://104.21.60.253:443/req
uest", host: "mockbin.com"
2023/05/01 17:50:01 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://172.67.204.7:443/requ
est", host: "mockbin.com"
2023/05/01 17:50:02 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://104.21.60.253:443/req
uest", host: "mockbin.com"
2023/05/01 17:50:02 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://172.67.204.7:443/requ
est", host: "mockbin.com"
2023/05/01 17:50:03 [error] 71095#0: *2 upstream SSL certificate verify error: (22:certificate chain too long) while SSL handshaking to upstream, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", upstream: "https://104.21.60.253:443/req
uest", host: "mockbin.com"
```

It seems that the `mockbin.com` has changed its cert the day before yesterday(04-29). I'm not sure how does the old server cert looks like, but having additional configuration on the SSL verify depth can solve this problem.



### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
