### PR TITLE
fix(cmd): do not error when kong is stopping on secret resolving errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@
   [#10680](https://github.com/Kong/kong/pull/10680)
 - Tracing: fix an approximation issue that resulted in reduced precision of the balancer span start and end times.
   [#10681](https://github.com/Kong/kong/pull/10681)
+- Fix issue when stopping a Kong could error out if using Vault references
+  [#10775](https://github.com/Kong/kong/pull/10775)
 
 #### Admin API
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1702,10 +1702,11 @@ local function load(path, custom_conf, opts)
 
           local deref, deref_err = vault.get(v)
           if deref == nil or deref_err then
-            return nil, fmt("failed to dereference '%s': %s for config option '%s'", v, deref_err, k)
-          end
+            if opts.starting then
+              return nil, fmt("failed to dereference '%s': %s for config option '%s'", v, deref_err, k)
+            end
 
-          if deref ~= nil then
+          else
             conf[k] = deref
           end
         end


### PR DESCRIPTION
### Summary

Fixes Kong error on kong stop when references are not available.