### PR TITLE
chore(vault): use name instead of prefix to cache vault strategies and schemas

### DIFF
--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -296,8 +296,8 @@ local function new(self)
 
       schema = schema.fields.config
 
-      STRATEGIES[prefix] = strategy
-      SCHEMAS[prefix] = schema
+      STRATEGIES[name] = strategy
+      SCHEMAS[name] = schema
     end
 
     local config = opts.config


### PR DESCRIPTION
### Summary

Just a small change/fix to use right key in strategies/schema caching.