### PR TITLE
[revert kong/#10646] fix(plugins): change opentelemetry plugin version to match core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
   Serverless Functions plugins: it does not provide access to the global kong cache. Access to
   certain fields in kong.configuration has also been restricted.
   [#10417](https://github.com/Kong/kong/pull/10417)
-- **Opentelemetry**: plugin version has been updated to match Kong's version
-  [#10646](https://github.com/Kong/kong/pull/10646)
 - **Zipkin**: The zipkin plugin now uses queues for internal
   buffering.  The standard queue parameter set is available to
   control queuing behavior.

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -3,7 +3,6 @@ local http = require "resty.http"
 local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
-local kong_meta = require "kong.meta"
 
 
 local ngx = ngx
@@ -28,7 +27,7 @@ local _log_prefix = "[otel] "
 
 
 local OpenTelemetryHandler = {
-  VERSION = kong_meta.version,
+  VERSION = "0.1.0",
   PRIORITY = 14,
 }
 

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -9,7 +9,6 @@ local plugins_definition = require "kong.db.schema.entities.plugins"
 local dao_plugins = require "kong.db.dao.plugins"
 local certificates_definition = require "kong.db.schema.entities.certificates"
 local constants = require "kong.constants"
-local kong_meta = require "kong.meta"
 
 describe("plugins", function()
   local Plugins
@@ -313,13 +312,6 @@ describe("plugins", function()
           end
         end
         assert.is_true(has_protocols_field, "bundled plugin " .. plugin_name .. " missing required field: protocols")
-      end
-    end)
-    it("ensure every bundled plugin version is same as core version", function()
-      for plugin_name, _ in pairs(constants.BUNDLED_PLUGINS) do
-        local handler = require("kong.plugins." .. plugin_name .. ".handler")
-        local plugin_version = handler.VERSION
-        assert.equal(kong_meta.version, plugin_version)
       end
     end)
 


### PR DESCRIPTION
### Summary

This reverts commit fabbcdd72867065f450341d742151e20bf80e630.

### Checklist

- [x] (no need) The Pull Request has tests
- [x] (no need) There's an entry in the CHANGELOG
- [X] (no need) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
KAG-1410
