### PR TITLE
fix(loggly&tcp-log&udp-log&reports): close sockets explicitly when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,7 @@
   [#10514](https://github.com/Kong/kong/pull/10514)
 - Fix the UDP socket leak caused by frequent DNS queries.
   [#10691](https://github.com/Kong/kong/pull/10691)
-- Reports: fix a potential issue that would socket leak.
+- Reports: fix a potential issue that could cause socket leaks.
   [#10783](https://github.com/Kong/kong/pull/10783)
 - Fix a typo of mlcache option `shm_set_tries`.
   [#10712](https://github.com/Kong/kong/pull/10712)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,10 +272,9 @@
   [#10687](https://github.com/Kong/kong/pull/10687)
 - **Oauth2**: prevent an authorization code created by one plugin instance to be exchanged for an access token by a different plugin instance.
   [#10011](https://github.com/Kong/kong/pull/10011)
-- **gRPC gateway**: fixed an issue that empty arrays in JSON are incorrectly encoded as `"{}"`; they are
-now encoded as `"[]"` to comply with standard.
+- **gRPC gateway**: fixed an issue that empty arrays in JSON are incorrectly encoded as `"{}"`; they are now encoded as `"[]"` to comply with standard.
   [#10790](https://github.com/Kong/kong/pull/10790)
-- **loggly & tcp-log & udp-log**: fix a potential issue that would socket leak.
+- **loggly & tcp-log & udp-log**: fix a potential issue that could cause socket leaks.
   [#10783](https://github.com/Kong/kong/pull/10783)
 
 #### PDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,8 @@
   [#10514](https://github.com/Kong/kong/pull/10514)
 - Fix the UDP socket leak caused by frequent DNS queries.
   [#10691](https://github.com/Kong/kong/pull/10691)
+- Reports: fix a potential issue that would socket leak.
+  [#10783](https://github.com/Kong/kong/pull/10783)
 - Fix a typo of mlcache option `shm_set_tries`.
   [#10712](https://github.com/Kong/kong/pull/10712)
 - Fix an issue where slow start up of Go plugin server causes dead lock.
@@ -273,6 +275,8 @@
 - **gRPC gateway**: fixed an issue that empty arrays in JSON are incorrectly encoded as `"{}"`; they are
 now encoded as `"[]"` to comply with standard.
   [#10790](https://github.com/Kong/kong/pull/10790)
+- **loggly & tcp-log & udp-log**: fix a potential issue that would socket leak.
+  [#10783](https://github.com/Kong/kong/pull/10783)
 
 #### PDK
 

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -75,7 +75,8 @@ local function send_to_loggly(conf, message, pri)
   local ok, err = sock:setpeername(host, port)
   if not ok then
     kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
-    goto socket_close
+    sock:close()
+    return
   end
 
   local ok, err = sock:send(udp_message)
@@ -83,7 +84,6 @@ local function send_to_loggly(conf, message, pri)
     kong.log.err("failed to send data to ", host, ":", tostring(port), ": ", err)
   end
 
-  ::socket_close::
   local ok, err = sock:close()
   if not ok then
     kong.log.err("failed to close connection from ", host, ":", tostring(port), ": ", err)

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -75,7 +75,7 @@ local function send_to_loggly(conf, message, pri)
   local ok, err = sock:setpeername(host, port)
   if not ok then
     kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
-    return
+    goto socket_close
   end
 
   local ok, err = sock:send(udp_message)
@@ -83,6 +83,7 @@ local function send_to_loggly(conf, message, pri)
     kong.log.err("failed to send data to ", host, ":", tostring(port), ": ", err)
   end
 
+  ::socket_close::
   local ok, err = sock:close()
   if not ok then
     kong.log.err("failed to close connection from ", host, ":", tostring(port), ": ", err)

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -27,6 +27,7 @@ local function log(premature, conf, message)
   local ok, err = sock:connect(host, port)
   if not ok then
     kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
+    sock:close()
     return
   end
 
@@ -34,6 +35,7 @@ local function log(premature, conf, message)
     ok, err = sock:sslhandshake(true, conf.tls_sni, false)
     if not ok then
       kong.log.err("failed to perform TLS handshake to ", host, ":", port, ": ", err)
+      sock:close()
       return
     end
   end
@@ -46,6 +48,7 @@ local function log(premature, conf, message)
   ok, err = sock:setkeepalive(keepalive)
   if not ok then
     kong.log.err("failed to keepalive to ", host, ":", tostring(port), ": ", err)
+    sock:close()
     return
   end
 end

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -23,7 +23,7 @@ local function log(premature, conf, str)
   local ok, err = sock:setpeername(conf.host, conf.port)
   if not ok then
     kong.log.err("could not connect to ", conf.host, ":", conf.port, ": ", err)
-    return
+    goto socket_close
   end
 
   ok, err = sock:send(str)
@@ -34,6 +34,7 @@ local function log(premature, conf, str)
     kong.log.debug("sent: ", str)
   end
 
+  ::socket_close::
   ok, err = sock:close()
   if not ok then
     kong.log.err("could not close ", conf.host, ":", conf.port, ": ", err)

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -23,7 +23,8 @@ local function log(premature, conf, str)
   local ok, err = sock:setpeername(conf.host, conf.port)
   if not ok then
     kong.log.err("could not connect to ", conf.host, ":", conf.port, ": ", err)
-    goto socket_close
+    sock:close()
+    return
   end
 
   ok, err = sock:send(str)
@@ -34,7 +35,6 @@ local function log(premature, conf, str)
     kong.log.debug("sent: ", str)
   end
 
-  ::socket_close::
   ok, err = sock:close()
   if not ok then
     kong.log.err("could not close ", conf.host, ":", conf.port, ": ", err)

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -151,12 +151,14 @@ local function send_report(signal_type, t, host, port)
   local ok, err
   ok, err = sock:connect(host, port)
   if not ok then
+    sock:close()
     return nil, err
   end
 
   ok, err = sock:sslhandshake(_ssl_session, nil, _ssl_verify)
   if not ok then
     log(DEBUG, "failed to complete SSL handshake for reports: ", err)
+    sock:close()
     return nil, "failed to complete SSL handshake for reports: " .. err
   end
 
@@ -165,7 +167,12 @@ local function send_report(signal_type, t, host, port)
   -- send return nil plus err msg on failure
   local bytes, err = sock:send(concat(_buffer, ";", 1, mutable_idx) .. "\n")
   if bytes then
-    sock:setkeepalive()
+    local ok, err = sock:setkeepalive()
+    if not ok then
+      log(DEBUG, "failed to keepalive to ", host, ":", tostring(port), ": ", err)
+      _ssl_session = nil  -- force new SSL session on next request
+      sock:close()
+    end
   end
   return bytes, err
 end

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -170,7 +170,6 @@ local function send_report(signal_type, t, host, port)
     local ok, err = sock:setkeepalive()
     if not ok then
       log(DEBUG, "failed to keepalive to ", host, ":", tostring(port), ": ", err)
-      _ssl_session = nil  -- force new SSL session on next request
       sock:close()
     end
   end


### PR DESCRIPTION
### Summary

For those sockets created inside the schedule of timer-ng, the sockets must be closed explicitly. 
More details, please refer to: #10691 

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

#10691 
