### PR TITLE
fix(status): CP /status/ready return 503 when DB is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,8 @@
   prepared to process user requests.
   Load balancers frequently utilize this functionality to ascertain
   Kong's availability to distribute incoming requests.
-  [#10610](https://github.com/Kong/kong/pull/10610)
+  [#10610](https://github.com/Kong/kong/pull/10610),
+  [#10787](https://github.com/Kong/kong/pull/10787)
 
 #### Plugins
 

--- a/kong/status/ready.lua
+++ b/kong/status/ready.lua
@@ -70,11 +70,6 @@ Checks if Kong is ready to serve.
 @return string|nil an error message if Kong is not ready, or nil otherwise.
 --]]
 local function is_ready()
-  -- control plane has no need to serve traffic
-  if is_control_plane then
-    return true
-  end
-
   local ok = kong.db:connect() -- for dbless, always ok
 
   if not ok then
@@ -82,6 +77,10 @@ local function is_ready()
   end
   
   kong.db:close()
+
+  if is_control_plane then
+    return true
+  end
 
   local router_rebuilds = 
       tonumber(kong_shm:get(ROUTERS_REBUILD_COUNTER_KEY)) or 0

--- a/spec/02-integration/09-hybrid_mode/11-status_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/11-status_spec.lua
@@ -33,8 +33,7 @@ for _, strategy in helpers.each_strategy() do
         prefix = "serve_cp",
         cluster_listen = "127.0.0.1:9005",
         nginx_conf = "spec/fixtures/custom_nginx.template",
-
-        status_listen = "127.0.0.1:" .. cp_status_port
+        status_listen = "127.0.0.1:" .. cp_status_port,
       })
     end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR changes the behavior of the new readiness endpoint for control plane nodes. 

The new endpoint `/status/ready` added in #10610 checks if Kong Gateway is ready for proxying. This check only makes sense in data plane nodes, as control plane nodes don't proxy traffic. But the response could be misleading, control plane nodes failing to connect to the database would return `200 OK`, even if they are not functional.

Note: this PR has no automated tests, [our test suite does not support stopping the database while the tests are running](https://github.com/Kong/kong/blob/3.2.2/spec/02-integration/04-admin_api/02-kong_routes_spec.lua#L261-L264).

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Check for database connection in control plane nodes.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-1437
