### PR TITLE
feat(conf): use openssl to detect system ca-certs path

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1670,6 +1670,7 @@
                                         # The following pathnames will be tested in order,
                                         # and the first one found will be used:
                                         #
+                                        # - OPENSSL_DIR/cert.pem (Generic)
                                         # - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)
                                         # - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)
                                         # - /etc/ssl/ca-bundle.pem (OpenSUSE)


### PR DESCRIPTION
### Summary

Previously the code ran through these paths:
- "/etc/ssl/certs/ca-certificates.crt",                -- Debian/Ubuntu/Gentoo
- "/etc/pki/tls/certs/ca-bundle.crt",                  -- Fedora/RHEL 6
- "/etc/ssl/ca-bundle.pem",                            -- OpenSUSE
- "/etc/pki/tls/cacert.pem",                           -- OpenELEC
- "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", -- CentOS/RHEL 7
- "/etc/ssl/cert.pem",                                 -- OpenBSD, Alpine

when trying to find system ca-file.

The commit here asks `openssl` about it and tries from there first.