### PR TITLE
tests(coverage): simplify aggregation

### DIFF
--- a/.github/workflows/build_and_coverage.yml
+++ b/.github/workflows/build_and_coverage.yml
@@ -126,5 +126,5 @@ jobs:
     - name: Stats aggregation
       shell: bash
       run: |
-        lua .ci/luacov-stats-aggregator.lua "luacov-stats-out-" "luacov.stats.out"
+        lua .ci/luacov-stats-aggregator.lua "luacov-stats-out-" "luacov.stats.out" ${{ github.workspace }}/
         awk '/Summary/,0' luacov.report.out


### PR DESCRIPTION
### Summary

porting of a fix already included in EE [here](https://github.com/Kong/kong-ee/pull/5290)
use luacov.runner to simplify luacov stat file aggregation

### Checklist

- [x] The Pull Request has tests
- [x] (no need) There's an entry in the CHANGELOG
- [x] (no need) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-1324
