### PR TITLE
perf(clustering): optionally use privileged agent for control plane connection

### DIFF
--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -2,6 +2,7 @@ local constants = require("kong.constants")
 local ws_client = require("resty.websocket.client")
 local ws_server = require("resty.websocket.server")
 local parse_url = require("socket.url").parse
+local process_type = require("ngx.process").type
 
 local type = type
 local table_insert = table.insert
@@ -156,6 +157,10 @@ end
 
 
 function _M.is_dp_worker_process()
+  if kong.configuration.privileged_agent then
+    return process_type() == "privileged agent"
+  end
+
   return worker_id() == 0
 end
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -382,6 +382,7 @@ local CONF_PARSERS = {
   dns_not_found_ttl = { typ = "number" },
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
+  privileged_agent = { typ = "boolean" },
   worker_consistency = { enum = { "strict", "eventual" },
     -- deprecating values for enums
     deprecated = {

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -1,6 +1,7 @@
 -- TODO: get rid of 'kong.meta'; this module is king
 local meta = require "kong.meta"
 local PDK = require "kong.pdk"
+local process = require "ngx.process"
 local phase_checker = require "kong.pdk.private.phases"
 local kong_cache = require "kong.cache"
 local kong_cluster_events = require "kong.cluster_events"
@@ -216,7 +217,8 @@ end
 
 
 local function get_lru_size(kong_config)
-  if (kong_config.role == "control_plane")
+  if (process.type() == "privileged agent")
+  or (kong_config.role == "control_plane")
   or (kong_config.role == "traditional" and #kong_config.proxy_listeners  == 0
                                         and #kong_config.stream_listeners == 0)
   then

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -635,7 +635,6 @@ function Kong.init()
 
     kong.db.declarative_config = dc
 
-
     if is_http_module or
        (#config.proxy_listeners == 0 and
         #config.admin_listeners == 0 and
@@ -721,6 +720,8 @@ function Kong.init_worker()
     end
   end
 
+  schema_state = nil
+
   local worker_events, err = kong_global.init_worker_events()
   if not worker_events then
     stash_init_worker_error("failed to instantiate 'kong.worker_events' " ..
@@ -792,6 +793,11 @@ function Kong.init_worker()
                                         declarative_entities,
                                         declarative_meta,
                                         declarative_hash)
+
+      declarative_entities = nil
+      declarative_meta = nil
+      declarative_hash = nil
+
       if not ok then
         stash_init_worker_error("failed to load declarative config file: " .. err)
         return

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -153,6 +153,7 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
+privileged_agent = off
 worker_consistency = eventual
 worker_state_update_frequency = 5
 


### PR DESCRIPTION
### Summary

Data plane's connection to control plane is moved to a privileged agent worker process, including:

- maintaining websocket (wrpc) connection and data transfer
- decompression of received data
- json decoding of the received data
- validation and flattening of received data
- inserting data to lmdb

(so that these won't affect latencies / rps on proxy workers)

This time behind configuration flag, and disabled by default.

See previous attempts:
#9432
#8971

KAG-114