### PR TITLE
fix(queues): display plugin name in queue log entries

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -111,7 +111,7 @@ function DatadogHandler:log(conf)
   end
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf, "log_tag", "datadog plugin" .. kong.plugin.get_id()),
+    Queue.get_params(conf, "log_tag", "datadog plugin " .. kong.plugin.get_id()),
     send_entries_to_datadog,
     conf,
     kong.log.serialize()

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -111,7 +111,7 @@ function DatadogHandler:log(conf)
   end
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf),
+    Queue.get_params(conf, "log_tag", "datadog plugin" .. kong.plugin.get_id()),
     send_entries_to_datadog,
     conf,
     kong.log.serialize()

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -111,7 +111,7 @@ function DatadogHandler:log(conf)
   end
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf, "log_tag", "datadog plugin " .. kong.plugin.get_id()),
+    Queue.get_plugin_params("datadog", conf),
     send_entries_to_datadog,
     conf,
     kong.log.serialize()

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -188,8 +188,11 @@ function HttpLogHandler:log(conf)
     end
   end
 
-  local queue_conf = Queue.get_params(conf)
-  queue_conf.name = make_queue_name(conf)
+  local queue_conf = Queue.get_params(
+    conf,
+    "name", make_queue_name(conf),
+    "log_tag", "http-log plugin" .. kong.plugin.get_id()
+  )
   kong.log.debug("Queue name automatically configured based on configuration parameters to: ", queue_conf.name)
 
   local ok, err = Queue.enqueue(

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -191,7 +191,7 @@ function HttpLogHandler:log(conf)
   local queue_conf = Queue.get_params(
     conf,
     "name", make_queue_name(conf),
-    "log_tag", "http-log plugin" .. kong.plugin.get_id()
+    "log_tag", "http-log plugin " .. kong.plugin.get_id()
   )
   kong.log.debug("Queue name automatically configured based on configuration parameters to: ", queue_conf.name)
 

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -188,11 +188,7 @@ function HttpLogHandler:log(conf)
     end
   end
 
-  local queue_conf = Queue.get_params(
-    conf,
-    "name", make_queue_name(conf),
-    "log_tag", "http-log plugin " .. kong.plugin.get_id()
-  )
+  local queue_conf = Queue.get_plugin_params("http-log", conf, make_queue_name(conf))
   kong.log.debug("Queue name automatically configured based on configuration parameters to: ", queue_conf.name)
 
   local ok, err = Queue.enqueue(

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -163,7 +163,7 @@ function OpenTelemetryHandler:log(conf)
     end
 
     local ok, err = Queue.enqueue(
-      Queue.get_params(conf),
+      Queue.get_params(conf, "log_tag", "opentelemetry plugin" .. kong.plugin.get_id()),
       http_export,
       conf,
       encode_span(span)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -163,7 +163,7 @@ function OpenTelemetryHandler:log(conf)
     end
 
     local ok, err = Queue.enqueue(
-      Queue.get_params(conf, "log_tag", "opentelemetry plugin" .. kong.plugin.get_id()),
+      Queue.get_params(conf, "log_tag", "opentelemetry plugin " .. kong.plugin.get_id()),
       http_export,
       conf,
       encode_span(span)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -163,7 +163,7 @@ function OpenTelemetryHandler:log(conf)
     end
 
     local ok, err = Queue.enqueue(
-      Queue.get_params(conf, "log_tag", "opentelemetry plugin " .. kong.plugin.get_id()),
+      Queue.get_plugin_params("opentelemetry", conf),
       http_export,
       conf,
       encode_span(span)

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -455,7 +455,7 @@ function _M.execute(conf)
   message.cache_metrics = ngx.ctx.cache_metrics
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf),
+    Queue.get_params(conf, "log_tag", "statsd plugin" .. kong.plugin.get_id()),
     send_entries_to_upstream_server,
     conf,
     message

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -455,7 +455,7 @@ function _M.execute(conf)
   message.cache_metrics = ngx.ctx.cache_metrics
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf, "log_tag", "statsd plugin" .. kong.plugin.get_id()),
+    Queue.get_params(conf, "log_tag", "statsd plugin " .. kong.plugin.get_id()),
     send_entries_to_upstream_server,
     conf,
     message

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -455,7 +455,7 @@ function _M.execute(conf)
   message.cache_metrics = ngx.ctx.cache_metrics
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(conf, "log_tag", "statsd plugin " .. kong.plugin.get_id()),
+    Queue.get_plugin_params("statsd", conf),
     send_entries_to_upstream_server,
     conf,
     message

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -109,7 +109,7 @@ function zipkin_reporter_methods:report(span)
   }
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(self.conf, "log_tag", "zipkin plugin" .. kong.plugin.get_id()),
+    Queue.get_params(self.conf, "log_tag", "zipkin plugin " .. kong.plugin.get_id()),
     send_entries_to_zipkin,
     self.conf,
     zipkin_span

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -108,7 +108,12 @@ function zipkin_reporter_methods:report(span)
     annotations = span.annotations,
   }
 
-  local ok, err = Queue.enqueue(Queue.get_params(self.conf), send_entries_to_zipkin, self.conf, zipkin_span)
+  local ok, err = Queue.enqueue(
+    Queue.get_params(self.conf, "log_tag", "zipkin plugin" .. kong.plugin.get_id()),
+    send_entries_to_zipkin,
+    self.conf,
+    zipkin_span
+  )
   if not ok then
     kong.log.err("failed to enqueue span: ", err)
   end

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -109,7 +109,7 @@ function zipkin_reporter_methods:report(span)
   }
 
   local ok, err = Queue.enqueue(
-    Queue.get_params(self.conf, "log_tag", "zipkin plugin " .. kong.plugin.get_id()),
+    Queue.get_plugin_params("zipkin", self.conf),
     send_entries_to_zipkin,
     self.conf,
     zipkin_span

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -310,8 +310,8 @@ function Queue.get_plugin_params(plugin_name, config, queue_name)
 
   -- create a tag to put into log files that identifies the plugin instance
   local log_tag = plugin_name .. " plugin " .. kong.plugin.get_id()
-  if config.instance_name then
-    log_tag = log_tag .. " (" .. config.instance_name .. ")"
+  if config.plugin_instance_name then
+    log_tag = log_tag .. " (" .. config.plugin_instance_name .. ")"
   end
   queue_config.log_tag = log_tag
 

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -68,7 +68,10 @@ describe("plugin queue", function()
           info = function(message) return log('INFO', message) end,
           warn = function(message) return log('WARN', message) end,
           err = function(message) return log('ERR', message) end,
-        }
+        },
+        plugin = {
+          get_id = function () return utils.uuid() end,
+        },
       },
       ngx = {
         ctx = {
@@ -584,7 +587,7 @@ describe("plugin queue", function()
         name = "common-legacy-conversion-test",
       },
     }
-    local converted_parameters = Queue.get_params(legacy_parameters)
+    local converted_parameters = Queue.get_plugin_params("someplugin", legacy_parameters)
     assert.match_re(log_messages, 'the retry_count parameter no longer works, please update your configuration to use initial_retry_delay and max_retry_time instead')
     assert.equals(legacy_parameters.queue_size, converted_parameters.max_batch_size)
     assert.match_re(log_messages, 'the queue_size parameter is deprecated, please update your configuration to use queue.max_batch_size instead')
@@ -600,7 +603,7 @@ describe("plugin queue", function()
         name = "opentelemetry-legacy-conversion-test",
       },
     }
-    local converted_parameters = Queue.get_params(legacy_parameters)
+    local converted_parameters = Queue.get_plugin_params("someplugin", legacy_parameters)
     assert.equals(legacy_parameters.batch_span_count, converted_parameters.max_batch_size)
     assert.match_re(log_messages, 'the batch_span_count parameter is deprecated, please update your configuration to use queue.max_batch_size instead')
     assert.equals(legacy_parameters.batch_flush_delay, converted_parameters.max_coalescing_delay)
@@ -615,12 +618,12 @@ describe("plugin queue", function()
       },
     }
     for _ = 1,10 do
-      Queue.get_params(legacy_parameters)
+      Queue.get_plugin_params("someplugin", legacy_parameters)
     end
     assert.equals(1, count_matching_log_messages('the retry_count parameter no longer works'))
     now_offset = 1000
     for _ = 1,10 do
-      Queue.get_params(legacy_parameters)
+      Queue.get_plugin_params("someplugin", legacy_parameters)
     end
     assert.equals(2, count_matching_log_messages('the retry_count parameter no longer works'))
   end)
@@ -636,7 +639,7 @@ describe("plugin queue", function()
         max_coalescing_delay = 234,
       }
     }
-    local converted_parameters = Queue.get_params(legacy_parameters)
+    local converted_parameters = Queue.get_plugin_params("someplugin", legacy_parameters)
     assert.equals(123, converted_parameters.max_batch_size)
     assert.equals(234, converted_parameters.max_coalescing_delay)
   end)

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -355,7 +355,7 @@ for _, strategy in helpers.each_strategy() do
       end, 10)
     end)
 
-    it("identifies plugin in queue handler logs #xxx", function()
+    it("identifies plugin in queue handler logs", function()
       local res = proxy_client:get("/status/200", {
         headers = {
           ["Host"] = "http_logging_tag.test"

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -338,7 +338,7 @@ for _, strategy in helpers.each_strategy() do
 
       helpers.wait_until(function()
         local client = assert(helpers.http_client(helpers.mock_upstream_host,
-          helpers.mock_upstream_port))
+                                                  helpers.mock_upstream_port))
         local res = client:get("/read_log/http", {
           headers = {
             Accept = "application/json"

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -64,7 +64,8 @@ for _, strategy in helpers.each_strategy() do
 
       bp.plugins:insert {
         route = { id = route1_1.id },
-        name     = "http-log",
+        name = "http-log",
+        instance_name = "my-plugin-instance-name",
         config   = {
           http_endpoint = "http://" .. helpers.mock_upstream_host
             .. ":"
@@ -354,7 +355,7 @@ for _, strategy in helpers.each_strategy() do
       end, 10)
     end)
 
-    it("identifies plugin in queue handler logs", function()
+    it("identifies plugin in queue handler logs #xxx", function()
       local res = proxy_client:get("/status/200", {
         headers = {
           ["Host"] = "http_logging_tag.test"
@@ -379,7 +380,7 @@ for _, strategy in helpers.each_strategy() do
         end
       end, 10)
 
-      assert.logfile().has.line("http\\-log.*done processing queue")
+      assert.logfile().has.line("http\\-log.*my-plugin-instance-name.*done processing queue")
     end)
 
     it("logs to HTTP with content-type 'application/json'", function()

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -17,7 +17,7 @@ end
 
 
 describe(PLUGIN_NAME .. ": (schema)", function()
-  local old_log
+  local unmock
   local log_messages
 
   before_each(function()

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -158,7 +158,7 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     })
     assert.is_truthy(entity)
     entity.config.queue.name = "legacy-conversion-test"
-    local conf = Queue.get_params(entity.config)
+    local conf = Queue.get_plugin_params("http-log", entity.config)
     assert.match_re(log_messages, "the retry_count parameter no longer works")
     assert.match_re(log_messages, "the queue_size parameter is deprecated")
     assert.match_re(log_messages, "the flush_timeout parameter is deprecated")


### PR DESCRIPTION
### Summary

Log entries written by queue functions included the name of the queue, but not the name and ID of the plugin using the queue.  This would make it difficult to correlate queue log entries written by the queue consumption side to the configuration.  With this change, an explcit log_tag key can be passed to the queue when enqueuing which is shown in all log entries written by the queue.  An explicit log_tag key was chosen over a more specific 'plugin' or 'plugin_id' key as queues are also used by non-plugin functionality in EE.

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG N/A (unreleased)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - N/A (unreleased)

### Issue reference

Fixes KAG-1394
