### PR TITLE
tests(integration): fix flaky vault sticky configuration test

### DIFF
--- a/spec/02-integration/13-vaults/04-echo_spec.lua
+++ b/spec/02-integration/13-vaults/04-echo_spec.lua
@@ -120,8 +120,10 @@ for _, strategy in helpers.each_strategy() do
       })
       assert.response(res).has.status(200)
 
-      -- Check Output:
-      make_requests(proxy_client, "suffix")
+      assert.eventually(function()
+        -- Check Output:
+        make_requests(proxy_client, "suffix")
+      end).has_no_error("The vault configuration is not sticky")
 
       -- Patch Vault:
       local res = admin_client:patch("/vaults/secrets", {


### PR DESCRIPTION
### Summary

One sticky vault configuration test turned to be flaky, this fixes the test.