### PR TITLE
fix(build): use seperate target to install atc-router lualib

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -29,7 +29,7 @@ lualib_deps = [
 install_lualib_deps_cmd = "\n".join([
     """
     DEP=$(pwd)/external/%s
-    if [[ ${DEP} == "atc_router" ]]; then
+    if [[ ${DEP} == */atc_router ]]; then
         INSTALL=/usr/bin/install make --silent -C ${DEP} LUA_LIB_DIR=${BUILD_DESTDIR}/openresty/lualib install-lualib
     else
         INSTALL=/usr/bin/install make --silent -C ${DEP} LUA_LIB_DIR=${BUILD_DESTDIR}/openresty/lualib install


### PR DESCRIPTION
Sister PR https://github.com/Kong/atc-router/pull/61

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Make the step slightly more robust.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
