### PR TITLE
tests(coverage): add coverage for integration tests

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -29,6 +29,10 @@ else
     export TEST_CMD="bin/busted $BUSTED_ARGS,postgres,db"
 fi
 
+if [[ "$KONG_TEST_COVERAGE" = true ]]; then
+    export TEST_CMD="$TEST_CMD --keep-going"
+fi
+
 if [ "$TEST_SUITE" == "integration" ]; then
     if [[ "$TEST_SPLIT" == first* ]]; then
         # GitHub Actions, run first batch of integration tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,8 +15,6 @@ on:
     - master
     - release/*
     - test-please/*
-  schedule:
-    - cron: "15 0 * * 0"
   workflow_dispatch:
     inputs:
       coverage:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -110,7 +110,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-1
+        name: luacov-stats-out-${{ env.time_now }}
         retention-days: 1
         path: |
           luacov.stats.out
@@ -219,6 +219,20 @@ jobs:
           source ${{ env.BUILD_ROOT }}/kong-dev-venv.sh
           .ci/run_tests.sh
 
+    - name: Update current time
+      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
+      run: |
+        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
+
+    - name: Archive coverage stats file
+      uses: actions/upload-artifact@v3
+      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
+      with:
+        name: luacov-stats-out-${{ env.time_now }}
+        retention-days: 1
+        path: |
+          luacov.stats.out
+
   integration-tests-dbless:
     name: DB-less integration tests
     runs-on: ubuntu-22.04
@@ -277,6 +291,20 @@ jobs:
           source ${{ env.BUILD_ROOT }}/kong-dev-venv.sh
           .ci/run_tests.sh
 
+    - name: Update current time
+      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
+      run: |
+        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
+
+    - name: Archive coverage stats file
+      uses: actions/upload-artifact@v3
+      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
+      with:
+        name: luacov-stats-out-${{ env.time_now }}
+        retention-days: 1
+        path: |
+          luacov.stats.out
+
   pdk-tests:
     name: PDK tests
     runs-on: ubuntu-22.04
@@ -316,17 +344,22 @@ jobs:
           eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
           .ci/run_tests.sh
 
+    - name: Update current time
+      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
+      run: |
+        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
+
     - name: Archive coverage stats file
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-2
+        name: luacov-stats-out-${{ env.time_now }}
         retention-days: 1
         path: |
           luacov.stats.out
 
   aggregator:
-    needs: [lint-doc-and-unit-tests,pdk-tests]
+    needs: [lint-doc-and-unit-tests,pdk-tests,integration-tests-postgres,integration-tests-dbless]
     name: Luacov stats aggregator
     if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
     runs-on: ubuntu-22.04
@@ -339,6 +372,7 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install -y luarocks
         sudo luarocks install luacov
+        sudo luarocks install luafilesystem
 
     # Download all archived coverage stats files
     - uses: actions/download-artifact@v3
@@ -347,4 +381,4 @@ jobs:
       shell: bash
       run: |
         lua .ci/luacov-stats-aggregator.lua "luacov-stats-out-" "luacov.stats.out" ${{ github.workspace }}/
-        awk '/Summary/,0' luacov.report.out
+        awk -v RS='Summary\n=+\n' 'NR>1{print $0}' luacov.report.out

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,7 +108,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-${{ env.time_now }}
+        name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
         retention-days: 1
         path: |
           luacov.stats.out
@@ -217,16 +217,11 @@ jobs:
           source ${{ env.BUILD_ROOT }}/kong-dev-venv.sh
           .ci/run_tests.sh
 
-    - name: Update current time
-      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
-      run: |
-        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
-
     - name: Archive coverage stats file
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-${{ env.time_now }}
+        name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}-${{ matrix.suite }}-${{ contains(matrix.split, 'first') && '1' || '2' }}
         retention-days: 1
         path: |
           luacov.stats.out
@@ -289,16 +284,11 @@ jobs:
           source ${{ env.BUILD_ROOT }}/kong-dev-venv.sh
           .ci/run_tests.sh
 
-    - name: Update current time
-      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
-      run: |
-        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
-
     - name: Archive coverage stats file
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-${{ env.time_now }}
+        name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
         retention-days: 1
         path: |
           luacov.stats.out
@@ -342,16 +332,11 @@ jobs:
           eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
           .ci/run_tests.sh
 
-    - name: Update current time
-      if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
-      run: |
-        echo "time_now=$(date +%s%N)" >> $GITHUB_ENV
-
     - name: Archive coverage stats file
       uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
-        name: luacov-stats-out-${{ env.time_now }}
+        name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
         retention-days: 1
         path: |
           luacov.stats.out

--- a/spec/fixtures/default_nginx.template
+++ b/spec/fixtures/default_nginx.template
@@ -46,6 +46,9 @@ http {
     lua_shared_dict kong_core_db_cache_miss     12m;
     lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss          12m;
+> if database == "cassandra" then
+    lua_shared_dict kong_cassandra              5m;
+> end
 > if role == "control_plane" then
     lua_shared_dict kong_clustering             5m;
 > end
@@ -66,6 +69,7 @@ http {
         require 'luacov'
         jit.off()
 > end
+
         Kong = require 'kong'
         Kong.init()
     }
@@ -455,259 +459,6 @@ http {
     }
 > end -- role == "control_plane"
 
-> if role ~= "data_plane" then
-    server {
-        server_name mock_upstream;
-
-        listen 15555;
-        listen 15556 ssl;
-
-> for i = 1, #ssl_cert do
-        ssl_certificate     $(ssl_cert[i]);
-        ssl_certificate_key $(ssl_cert_key[i]);
-> end
-        ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-
-        set_real_ip_from 127.0.0.1;
-
-        location / {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                ngx.status = 404
-                return mu.send_default_json_response()
-            }
-        }
-
-        location = / {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response({
-                    valid_routes = {
-                        ["/ws"]                         = "Websocket echo server",
-                        ["/get"]                        = "Accepts a GET request and returns it in JSON format",
-                        ["/xml"]                        = "Returns a simple XML document",
-                        ["/post"]                       = "Accepts a POST request and returns it in JSON format",
-                        ["/response-headers?:key=:val"] = "Returns given response headers",
-                        ["/cache/:n"]                   = "Sets a Cache-Control header for n seconds",
-                        ["/anything"]                   = "Accepts any request and returns it in JSON format",
-                        ["/request"]                    = "Alias to /anything",
-                        ["/delay/:duration"]            = "Delay the response for <duration> seconds",
-                        ["/basic-auth/:user/:pass"]     = "Performs HTTP basic authentication with the given credentials",
-                        ["/status/:code"]               = "Returns a response with the specified <status code>",
-                        ["/stream/:num"]                = "Stream <num> chunks of JSON data via chunked Transfer Encoding",
-                    },
-                })
-            }
-        }
-
-        location = /ws {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.serve_web_sockets()
-            }
-        }
-
-        location /get {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_method("GET")
-            }
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response()
-            }
-        }
-
-        location /xml {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                local xml = [[
-                  <?xml version="1.0" encoding="UTF-8"?>
-                    <note>
-                      <body>Kong, Monolith destroyer.</body>
-                    </note>
-                ]]
-                return mu.send_text_response(xml, "application/xml")
-            }
-        }
-
-        location /post {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_method("POST")
-            }
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response()
-            }
-        }
-
-        location = /response-headers {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_method("GET")
-            }
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response({}, ngx.req.get_uri_args(0))
-            }
-        }
-
-        location = /hop-by-hop {
-            content_by_lua_block {
-                local header = ngx.header
-                header["Keep-Alive"]          = "timeout=5, max=1000"
-                header["Proxy"]               = "Remove-Me"
-                header["Proxy-Connection"]    = "close"
-                header["Proxy-Authenticate"]  = "Basic"
-                header["Proxy-Authorization"] = "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
-                header["Transfer-Encoding"]   = "chunked"
-                header["Content-Length"]      = nil
-                header["TE"]                  = "trailers, deflate;q=0.5"
-                header["Trailer"]             = "Expires"
-                header["Upgrade"]             = "example/1, foo/2"
-
-                ngx.print("hello\r\n\r\nExpires: Wed, 21 Oct 2015 07:28:00 GMT\r\n\r\n")
-                ngx.exit(200)
-            }
-        }
-
-        location ~ "^/cache/(?<n>\d+)$" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response({}, {
-                    ["Cache-Control"] = "public, max-age=" .. ngx.var.n,
-                })
-            }
-        }
-
-        location ~ "^/basic-auth/(?<username>[a-zA-Z0-9_]+)/(?<password>.+)$" {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_basic_auth(ngx.var.username,
-                                                      ngx.var.password)
-            }
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response({
-                    authenticated = true,
-                    user          = ngx.var.username,
-                })
-            }
-        }
-
-        location ~ "^/(request|anything)" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.send_default_json_response()
-            }
-        }
-
-        location ~ "^/delay/(?<delay_seconds>\d{1,3})$" {
-            content_by_lua_block {
-                local mu            = require "spec.fixtures.mock_upstream"
-                local delay_seconds = tonumber(ngx.var.delay_seconds)
-                if not delay_seconds then
-                    return ngx.exit(ngx.HTTP_NOT_FOUND)
-                end
-
-                ngx.sleep(delay_seconds)
-
-                return mu.send_default_json_response({
-                    delay = delay_seconds,
-                })
-            }
-        }
-
-        location ~ "^/status/(?<code>\d{3})$" {
-            content_by_lua_block {
-                local mu   = require "spec.fixtures.mock_upstream"
-                local code = tonumber(ngx.var.code)
-                if not code then
-                    return ngx.exit(ngx.HTTP_NOT_FOUND)
-                end
-                ngx.status = code
-                return mu.send_default_json_response({
-                  code = code,
-                })
-            }
-        }
-
-        location ~ "^/stream/(?<num>\d+)$" {
-            content_by_lua_block {
-                local mu  = require "spec.fixtures.mock_upstream"
-                local rep = tonumber(ngx.var.num)
-                local res = require("cjson").encode(mu.get_default_json_response())
-
-                ngx.header["X-Powered-By"] = "mock_upstream"
-                ngx.header["Content-Type"] = "application/json"
-
-                for i = 1, rep do
-                  ngx.say(res)
-                end
-            }
-        }
-
-        location ~ "^/post_log/(?<logname>[a-z0-9_]+)$" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.store_log(ngx.var.logname)
-            }
-        }
-
-        location ~ "^/post_auth_log/(?<logname>[a-z0-9_]+)/(?<username>[a-zA-Z0-9_]+)/(?<password>.+)$" {
-            access_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.filter_access_by_basic_auth(ngx.var.username,
-                                                      ngx.var.password)
-            }
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.store_log(ngx.var.logname)
-            }
-        }
-
-        location ~ "^/read_log/(?<logname>[a-z0-9_]+)$" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.retrieve_log(ngx.var.logname)
-            }
-        }
-
-        location ~ "^/count_log/(?<logname>[a-z0-9_]+)$" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.count_log(ngx.var.logname)
-            }
-        }
-
-        location ~ "^/reset_log/(?<logname>[a-z0-9_]+)$" {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.reset_log(ngx.var.logname)
-            }
-        }
-
-        location = /echo_sni {
-            return 200 'SNI=$ssl_server_name\n';
-        }
-
-        location = /ocsp {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.handle_ocsp()
-            }
-        }
-
-        location = /set_ocsp {
-            content_by_lua_block {
-                local mu = require "spec.fixtures.mock_upstream"
-                return mu.set_ocsp(ngx.var.arg_status)
-            }
-        }
-    }
-> end -- role ~= "data_plane"
-
     include '*.http_mock';
 
     server {
@@ -750,6 +501,9 @@ stream {
     lua_shared_dict stream_kong_core_db_cache_miss     12m;
     lua_shared_dict stream_kong_db_cache               ${{MEM_CACHE_SIZE}};
     lua_shared_dict stream_kong_db_cache_miss          12m;
+> if database == "cassandra" then
+    lua_shared_dict stream_kong_cassandra              5m;
+> end
 
 > if ssl_ciphers then
     ssl_ciphers ${{SSL_CIPHERS}};
@@ -765,6 +519,7 @@ stream {
         require 'luacov'
         jit.off()
 > end
+
         -- shared dictionaries conflict between stream/http modules. use a prefix.
         local shared = ngx.shared
         ngx.shared = setmetatable({}, {

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -34,6 +34,8 @@ local REDIS_HOST = os.getenv("KONG_SPEC_TEST_REDIS_HOST") or "localhost"
 local REDIS_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_PORT") or 6379)
 local REDIS_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_SSL_PORT") or 6380)
 local REDIS_SSL_SNI = os.getenv("KONG_SPEC_TEST_REDIS_SSL_SNI") or "test-redis.example.com"
+local TEST_COVERAGE_MODE = os.getenv("KONG_COVERAGE")
+local TEST_COVERAGE_TIMEOUT = 30
 local BLACKHOLE_HOST = "10.255.255.255"
 local KONG_VERSION = require("kong.meta")._VERSION
 local PLUGINS_LIST
@@ -78,7 +80,6 @@ ffi.cdef [[
   int setenv(const char *name, const char *value, int overwrite);
   int unsetenv(const char *name);
 ]]
-
 
 local kong_exec   -- forward declaration
 
@@ -771,6 +772,12 @@ end
 function resty_http_proxy_mt:_connect()
   local opts = self.options
 
+  if TEST_COVERAGE_MODE == "true" then
+    opts.connect_timeout = TEST_COVERAGE_TIMEOUT * 1000
+    opts.send_timeout    = TEST_COVERAGE_TIMEOUT * 1000
+    opts.read_timeout    = TEST_COVERAGE_TIMEOUT * 1000
+  end
+
   local _, err = self:connect(opts)
   if err then
     error("Could not connect to " ..
@@ -856,6 +863,10 @@ end
 local function http_client(host, port, timeout)
   if type(host) == "table" then
     return http_client_opts(host)
+  end
+
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT * 1000
   end
 
   return http_client_opts({
@@ -961,6 +972,10 @@ end
 -- @function admin_ssl_client
 -- @param timeout (optional, number) the timeout to use
 local function admin_ssl_client(timeout)
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT * 1000
+  end
+
   local admin_ip, admin_port
   for _, entry in ipairs(conf.proxy_listeners) do
     if entry.ssl == true then
@@ -1168,6 +1183,9 @@ end
 local function tcp_server(port, opts)
   local threads = require "llthreads2.ex"
   opts = opts or {}
+  if TEST_COVERAGE_MODE == "true" then
+    opts.timeout = TEST_COVERAGE_TIMEOUT
+  end
   local thread = threads.new({
     function(port, opts)
       local socket = require "socket"
@@ -1304,6 +1322,9 @@ local function http_server(port, opts)
                         "or helpers.http_mock instead.", 2))
   local threads = require "llthreads2.ex"
   opts = opts or {}
+  if TEST_COVERAGE_MODE == "true" then
+    opts.timeout = TEST_COVERAGE_TIMEOUT
+  end
   local thread = threads.new({
     function(port, opts)
       local socket = require "socket"
@@ -1503,6 +1524,9 @@ end
 local function http_mock(port, opts)
   local socket = require "socket"
   local server = assert(socket.tcp())
+  if TEST_COVERAGE_MODE == "true" then
+    opts.timeout = TEST_COVERAGE_TIMEOUT
+  end
   server:settimeout(opts and opts.timeout or 60)
   assert(server:setoption('reuseaddr', true))
   assert(server:bind("*", port))
@@ -1555,6 +1579,10 @@ end
 -- @return A thread object (from the `llthreads2` Lua package)
 local function udp_server(port, n, timeout)
   local threads = require "llthreads2.ex"
+
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT
+  end
 
   local thread = threads.new({
     function(port, n, timeout)
@@ -1632,6 +1660,10 @@ require("spec.helpers.wait")
 -- -- wait 10 seconds for a file "myfilename" to appear
 -- helpers.wait_until(function() return file_exist("myfilename") end, 10)
 local function wait_until(f, timeout, step)
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT
+  end
+
   luassert.wait_until({
     condition = "truthy",
     fn = f,
@@ -1654,6 +1686,10 @@ end
 -- @return nothing. It returns when the condition is met, or throws an error
 -- when it times out.
 local function pwait_until(f, timeout, step)
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT
+  end
+
   luassert.wait_until({
     condition = "no_error",
     fn = f,
@@ -1842,6 +1878,9 @@ end
 -- @tparam[opt=false] boolean opts.override_global_key_auth_plugin to override the global key-auth plugin in waiting
 local function wait_for_all_config_update(opts)
   opts = opts or {}
+  if TEST_COVERAGE_MODE == "true" then
+    opts.timeout = TEST_COVERAGE_TIMEOUT
+  end
   local timeout = opts.timeout or 30
   local admin_client_timeout = opts.admin_client_timeout
   local forced_admin_port = opts.forced_admin_port
@@ -3216,6 +3255,10 @@ end
 -- @param timeout (optional) in seconds, defaults to 10.
 local function wait_pid(pid_path, timeout, is_retry)
   local pid = get_pid_from_file(pid_path)
+
+  if TEST_COVERAGE_MODE == "true" then
+    timeout = TEST_COVERAGE_TIMEOUT
+  end
 
   if pid then
     if pid_dead(pid, timeout) then

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3505,10 +3505,8 @@ local function start_kong(env, tables, preserve_prefix, fixtures)
 
   truncate_tables(db, tables)
 
-  local nginx_conf = ""
-  if env.nginx_conf then
-    nginx_conf = " --nginx-conf " .. env.nginx_conf
-  end
+  env.nginx_conf = env.nginx_conf or "spec/fixtures/default_nginx.template"
+  local nginx_conf = " --nginx-conf " .. env.nginx_conf
 
   if dcbp and not env.declarative_config and not env.declarative_config_string then
     if not config_yml then


### PR DESCRIPTION
### Summary

Add test coverage for integration and plugins tests.

Luacov is enabled in these tests via nginx configuration, similarly to the following:
```
init_by_lua_block {
    require 'luacov'
    jit.off()
    -- (rest of the init_by_lua_block)
}    
```
This is done conditionally, in `custom_nginx.template`, when `KONG_TEST_COVERAGE=on`.
In order to make this possible even for tests that currently don't use a custom nginx configuration, a new template `default_nginx.template` was defined, that will be used when when `helpers.start_kong` is called without passing a custom template via `nginx_conf`.

---
Enabling coverage with luacov produces a considerable performance degradation. This has the direct consequence of producing more flakiness and failures. This PR aims to define a workflow that runs integration tests with coverage enabled and produce a report. This report can only be considered valid when all tests will reliably pass. This might take an additional effort that could involve tuning the luacov configuration and/or rewrite/adapt some of the tests. Such effort will be tracked with a separate PR (and KAG-1550).

Note: coverage runs fail (or are cancelled) due to runner limitations, example [here](https://github.com/Kong/kong/actions/runs/5092321414/jobs/9153714167). Because of this, the schedule trigger for running with coverage is currently disabled, more info in the linked issue.

### Checklist

- [x] The Pull Request has tests
- [x] (no need) There's an entry in the CHANGELOG
- [x] (no need) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Conditionally enable coverage in the tests' nginx template when KONG_TEST_COVERAGE=true
* Define a new "default" nginx template to be used in tests when `helpers.start_kong` is called without passing a custom template
* Add coverage stat files and aggregation for integration tests to the `build_and_test` workflow.
* When running with coverage enabled, busted uses the `--keep-going` option, to ensure the output is as complete as possible even in case of failures (we might decide to remove this once flakiness with coverage will be reduced or eliminated).
* When running with coverage enabled, most timeouts are overridden to a higher value in `helpers.lua`, to reduce failures.

### Issue reference

KAG-1325
