### PR TITLE
chore(deps): bump resty.openssl from 0.8.20 to 0.8.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Bumped lua-resty-openssl from 0.8.20 to 0.8.22
+  [#10463](https://github.com/Kong/kong/pull/10463)
 
 ## 3.3.0
 

--- a/kong-3.4.0-0.rockspec
+++ b/kong-3.4.0-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.6.2",
   "lua-resty-mlcache == 2.6.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.20",
+  "lua-resty-openssl == 0.8.22",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.11.0",


### PR DESCRIPTION
### Summary

#### [0.8.22] - 2023-04-26
##### bug fixes
- **crypto:** use OPENSSL_free in BoringSSL ([#107](https://github.com/fffonion/lua-resty-openssl/issues/107)) [7830212](https://github.com/fffonion/lua-resty-openssl/commit/78302123ac744f2d0b6de1156e459e9ea72b7edb)

<a name="0.8.21"></a>
#### [0.8.21] - 2023-03-24
##### features
- **x509.store:** extend verify to support setting flags ([#104](https://github.com/fffonion/lua-resty-openssl/issues/104)) [fa45b6c](https://github.com/fffonion/lua-resty-openssl/commit/fa45b6ce197dee7e2a55601bd4833f415c6cbaa2)