### PR TITLE
docs(changelog): fix resty.openssl 0.8.22 bump link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Dependencies
 
 - Bumped lua-resty-openssl from 0.8.20 to 0.8.22
-  [#10463](https://github.com/Kong/kong/pull/10463)
+  [#10837](https://github.com/Kong/kong/pull/10837)
 
 ## 3.3.0
 


### PR DESCRIPTION
### Summary

Fixes changelog to link the right pr.