### PR TITLE
tests(integration): disable vault sticky test on cassandra because of flakiness

### DIFF
--- a/spec/02-integration/13-vaults/04-echo_spec.lua
+++ b/spec/02-integration/13-vaults/04-echo_spec.lua
@@ -62,7 +62,7 @@ local function make_requests(proxy_client, suffix)
 end
 
 
-for _, strategy in helpers.each_strategy() do
+for _, strategy in helpers.each_strategy({ "postgres" }) do
   describe("Vault configuration #" .. strategy, function()
     local admin_client
     local proxy_client


### PR DESCRIPTION
### Summary

Disables one test on Cassandra, because it for some reason is flaky.

KAG-1517