### PR TITLE
tests(http-log): address flakiness

### DIFF
--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -223,7 +223,6 @@ for _, strategy in helpers.each_strategy() do
                                     .. ":"
                                     .. helpers.mock_upstream_port
                                     .. "/post_log/grpc",
-          timeout = 1
         },
       }
 
@@ -246,7 +245,6 @@ for _, strategy in helpers.each_strategy() do
                                     .. ":"
                                     .. helpers.mock_upstream_port
                                     .. "/post_log/grpcs",
-          timeout = 1
         },
       }
 


### PR DESCRIPTION
### Summary

Remove erroneously configured timeouts

The test was configuring 1ms timeouts in two instances of the `http-log` plugin. This was probably done by mistakenly using in route7 and route8 the same configuration [as route6](https://github.com/Kong/kong/blob/e62ec50531644f32c18ed1399315ef6048958f6b/spec/03-plugins/03-http-log/01-log_spec.lua#L203), which is meant to timeout.

What happened under the hood was that 1ms timeout was enough for the logs to be stored but not always enough for the response to get back, so after the queue retries, more than one entry existed, and [this assertion](https://github.com/Kong/kong/blob/041a0e9cdc7996e5ef4bb96e6c2b0a57a14d74af/spec/03-plugins/03-http-log/01-log_spec.lua#L526) failed.

### Checklist

- [x] The Pull Request has tests
- [x] (NA) ~There's an entry in the CHANGELOG~
- [x] (NA) ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
