### PR TITLE
fix(test): fix failing http-log test

### DIFF
--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -23,11 +23,13 @@ for _, strategy in helpers.each_strategy() do
     local vault_env_value = "the secret"
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, {
+      local bp, db = helpers.get_db_utils(strategy, {
         "routes",
         "services",
         "plugins",
       })
+
+      db:truncate()
 
       local service1 = bp.services:insert{
         protocol = "http",


### PR DESCRIPTION
### Summary

The http-log test now defines an instance name for one of the plugins.  This fails if the database already has a plugin with that instance name, which is the case in CI.

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
