### PR TITLE
fix(acme): sanity test can work with "kong" storage in Hybrid mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+#### Core
+
+#### Plugins
+
+### Additions
+
+#### Core
+
+#### Admin API
+
+#### Status API
+
+#### Plugins
+
+#### PDK
+
+### Fixes
+
+#### Core
+
+#### Admin API
+
+#### Plugins
+
+- **ACME**: Fixed sanity test can't work with "kong" storage in Hybrid mode
+  [10852](https://github.com/Kong/kong/pull/10852)
+
+#### PDK
+
+### Changed
+
+#### Core
+
+#### PDK
+
+#### Plugins
+
 ### Dependencies
 
 - Bumped lua-resty-openssl from 0.8.20 to 0.8.22

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -221,10 +221,9 @@ function ACMEHandler:access(conf)
     end
 
     if captures then
-      -- creating account through proxy side with "kong" storage in Hybrid mode is not supported
-      -- if this is just a sanity test, we always return 200 status
-      if captures[1] == "x" and kong.configuration.role == "data_plane" and conf.storage == "kong" then
-        return kong.response.exit(200, { message = "ok" })
+      -- if this is just a sanity test, we always return 404 status
+      if captures[1] == "x" then
+        return kong.response.exit(404, "Not found\n")
       end
 
       -- TODO: race condition creating account?

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -221,6 +221,12 @@ function ACMEHandler:access(conf)
     end
 
     if captures then
+      -- creating account through proxy side with "kong" storage in Hybrid mode is not supported
+      -- if this is just a sanity test, we always return 200 status
+      if captures[1] == "x" and kong.configuration.role == "data_plane" and conf.storage == "kong" then
+        return kong.response.exit(200, { message = "ok" })
+      end
+
       -- TODO: race condition creating account?
       local err = client.create_account(conf)
       if err then

--- a/spec/03-plugins/29-acme/06-hybrid_mode_spec.lua
+++ b/spec/03-plugins/29-acme/06-hybrid_mode_spec.lua
@@ -1,0 +1,74 @@
+local cjson = require "cjson"
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
+  describe("Plugin: acme (handler.access) worked with [#" .. strategy .. "]", function()
+    local domain = "mydomain.com"
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "services",
+        "routes",
+        "plugins",
+      }, { "acme", })
+
+      assert(bp.routes:insert {
+        paths = { "/" },
+      })
+
+      plugin = assert(bp.plugins:insert {
+        name = "acme",
+        config = {
+          account_email = "test@test.com",
+          api_uri = "https://api.acme.org",
+          domains = { domain },
+          storage = "kong",
+          storage_config = {
+            kong = {},
+          },
+        },
+      })
+
+      assert(helpers.start_kong({
+        role = "control_plane",
+        database = strategy,
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+        cluster_listen = "127.0.0.1:9005",
+        cluster_telemetry_listen = "127.0.0.1:9006",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "servroot2",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+        cluster_control_plane = "127.0.0.1:9005",
+        cluster_telemetry_endpoint = "127.0.0.1:9006",
+        proxy_listen = "0.0.0.0:9002",
+      }))
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong("servroot2")
+      helpers.stop_kong()
+    end)
+
+    it("sanity test works with \"kong\" storage in Hybrid mode", function()
+      local proxy_client = helpers.http_client("127.0.0.1", 9002)
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/.well-known/acme-challenge/x",
+        headers =  { host = domain }
+      })
+
+      local body = assert.response(res).has.status(200)
+      assert.same({ message = "ok" }, cjson.decode(body))
+      proxy_client:close()
+    end)
+  end)
+end

--- a/spec/03-plugins/29-acme/06-hybrid_mode_spec.lua
+++ b/spec/03-plugins/29-acme/06-hybrid_mode_spec.lua
@@ -16,7 +16,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
         paths = { "/" },
       })
 
-      plugin = assert(bp.plugins:insert {
+      assert(bp.plugins:insert {
         name = "acme",
         config = {
           account_email = "test@test.com",


### PR DESCRIPTION
### Summary

Currently, there is a technical limitation in hybrid mode, that is, the DP side cannot perform any write database operation. However, when the sanity test is executed and the account identifier information is needed to write to storage, we will skip this operation (after a private discussion with @fffonion) and always return 404 directly with all storages. This will not have any substantial impact on the functionality.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Fixed sanity test can't work with "kong" storage in Hybrid mode

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4909
