### PR TITLE
chore(scripts): remove cassandra service

### DIFF
--- a/scripts/dependency_services/docker-compose-test-services.yml
+++ b/scripts/dependency_services/docker-compose-test-services.yml
@@ -19,20 +19,6 @@ services:
     restart: on-failure
     stdin_open: true
     tty: true
-  cassandra:
-      image: cassandra:3
-      ports:
-        - 127.0.0.1::7199
-        - 127.0.0.1::7000
-        - 127.0.0.1::9160
-        - 127.0.0.1::9042
-      volumes:
-        - cassandra-data:/var/lib/cassandra
-      healthcheck:
-        test: ["CMD", "cqlsh", "-e", "'describe cluster'"]
-        interval: 5s
-        timeout: 5s
-        retries: 8
   redis:
     image: redis
     ports:
@@ -58,5 +44,4 @@ services:
 
 volumes:
   postgres-data:
-  cassandra-data:
   redis-data:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

 Now we have disabled the tests for Cassandra (#10832), we should also remove other related things.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


