### PR TITLE
chore(dev): use 'exit' instead of 'return' upon shell error

### DIFF
--- a/scripts/dependency_services/common.sh
+++ b/scripts/dependency_services/common.sh
@@ -34,7 +34,7 @@ $DOCKER_COMPOSE up -d
 
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check $DOCKER_COMPOSE output"
-    exit
+    exit 1
 fi
 
 # [service_name_in_docker_compose]="env_var_name_1:port_1_in_docker_compose env_var_name_2:port_2_in_docker_compose"

--- a/scripts/dependency_services/common.sh
+++ b/scripts/dependency_services/common.sh
@@ -34,7 +34,7 @@ $DOCKER_COMPOSE up -d
 
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check $DOCKER_COMPOSE output"
-    return
+    exit
 fi
 
 # [service_name_in_docker_compose]="env_var_name_1:port_1_in_docker_compose env_var_name_2:port_2_in_docker_compose"

--- a/scripts/dependency_services/up.fish
+++ b/scripts/dependency_services/up.fish
@@ -8,7 +8,7 @@ bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
 
 if test $status -ne 0
     echo "Something goes wrong, please check common.sh output"
-    return
+    exit
 end
 
 source $KONG_SERVICE_ENV_FILE

--- a/scripts/dependency_services/up.fish
+++ b/scripts/dependency_services/up.fish
@@ -8,7 +8,7 @@ bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
 
 if test $status -ne 0
     echo "Something goes wrong, please check common.sh output"
-    exit
+    exit 1
 end
 
 source $KONG_SERVICE_ENV_FILE

--- a/scripts/dependency_services/up.sh
+++ b/scripts/dependency_services/up.sh
@@ -16,7 +16,7 @@ fi
 bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check common.sh output"
-    exit
+    exit 1
 fi
 
 . $KONG_SERVICE_ENV_FILE

--- a/scripts/dependency_services/up.sh
+++ b/scripts/dependency_services/up.sh
@@ -16,7 +16,7 @@ fi
 bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check common.sh output"
-    return
+    exit
 fi
 
 . $KONG_SERVICE_ENV_FILE


### PR DESCRIPTION



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Shell utility 'return' can only be used to return from Shell functions.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Use `exit` instead of `return` upon error.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-5071
