### PR TITLE
feat(ci): print sha256 of packages before upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -592,6 +592,8 @@ jobs:
         PACKAGE_TYPE: ${{ matrix.package }}
         KONG_RELEASE_LABEL: ${{ needs.metadata.outputs.release-label }}
       run: |
+        sha256sum bazel-bin/pkg/*
+
         scripts/release-kong.sh
 
   release-images:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This short PR adds the printing of sha256 checksums right before the packages are uploaded to Pulp.
Which can be a valuable tool when comparing against the packages that ultimately became available in Pulp.

Mirrors https://github.com/Kong/kong-ee/pull/5386
