### PR TITLE
refactor(clustering): use local event for reconfigure in dp

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -157,13 +157,10 @@ function _M:communicate(premature)
   end
 
   -- how DP connection management works:
-  -- three threads are spawned, when any of these threads exits,
+  -- two threads are spawned, when any of these threads exits,
   -- it means a fatal error has occurred on the connection,
   -- and the other threads are also killed
   --
-  -- * config_thread: it grabs a received declarative config and apply it
-  --                  locally. In addition, this thread also persists the
-  --                  config onto the local file system
   -- * read_thread: it is the only thread that sends WS frames to the CP
   --                by sending out periodic PING frames to CP that checks
   --                for the healthiness of the WS connection. In addition,

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -206,7 +206,7 @@ function _M:communicate(premature)
     end
   end
 
-  -- register the recv event handle in each communication
+  -- register the recv event handler in each communication
   events.clustering_recv_config(handler, true)
 
   local write_thread = ngx.thread.spawn(function()
@@ -278,7 +278,7 @@ function _M:communicate(premature)
     ngx_log(ngx_ERR, _log_prefix, err_msg, log_suffix)
   end
 
-  -- unregister the recv event handle
+  -- unregister the recv event handler
   events.clustering_recv_config(handler, false)
 
   if not exiting() then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -194,15 +194,11 @@ function _M:communicate(premature)
 
     local pok, res, err = pcall(config_helper.update, self.declarative_config,
                                 config_table, msg.config_hash, msg.hashes)
-    if pok then
-      if not res then
-        ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
-      end
-
-      ping_immediately = true
+    if not pok or not res then
+      ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
 
     else
-      ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", res)
+      ping_immediately = true
     end
 
     if next_data == data then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -2,7 +2,6 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
-local semaphore = require("ngx.semaphore")
 local cjson = require("cjson.safe")
 local config_helper = require("kong.clustering.config_helper")
 local clustering_utils = require("kong.clustering.utils")

--- a/kong/clustering/events.lua
+++ b/kong/clustering/events.lua
@@ -84,8 +84,13 @@ local function init_dp()
 end
 
 
-local function clustering_recv_config(handler)
-  worker_events.register(handler, "clustering", "recv_config")
+local function clustering_recv_config(handler, is_reg)
+  if is_reg then
+    worker_events.register(handler, "clustering", "recv_config")
+
+  else
+    worker_events.unregister(handler)
+  end
 end
 
 

--- a/kong/clustering/events.lua
+++ b/kong/clustering/events.lua
@@ -89,10 +89,19 @@ local function clustering_recv_config(handler)
 end
 
 
+local function clustering_notify_recv_config(data)
+  local res, err = worker_events.post_local("clustering", "recv_config", data)
+  if not res then
+    ngx_log(ngx_ERR, _log_prefix, "unable to post local event: ", err)
+  end
+end
+
+
 return {
   init_cp = init_cp,
   clustering_push_config = clustering_push_config,
 
   init_dp = init_dp,
   clustering_recv_config = clustering_recv_config,
+  clustering_notify_recv_config = clustering_notify_recv_config,
 }

--- a/kong/clustering/events.lua
+++ b/kong/clustering/events.lua
@@ -54,7 +54,7 @@ local function handle_dao_crud_event(data)
 end
 
 
-local function init()
+local function init_cp()
   cluster_events = assert(kong.cluster_events)
   worker_events  = assert(kong.worker_events)
 
@@ -79,8 +79,20 @@ local function clustering_push_config(handler)
 end
 
 
-return {
-  init = init,
+local function init_dp()
+  worker_events  = assert(kong.worker_events)
+end
 
+
+local function clustering_recv_config(handler)
+  worker_events.register(handler, "clustering", "recv_config")
+end
+
+
+return {
+  init_cp = init_cp,
   clustering_push_config = clustering_push_config,
+
+  init_dp = init_dp,
+  clustering_recv_config = clustering_recv_config,
 }

--- a/kong/clustering/events.lua
+++ b/kong/clustering/events.lua
@@ -84,8 +84,8 @@ local function init_dp()
 end
 
 
-local function clustering_recv_config(handler, is_reg)
-  if is_reg then
+local function clustering_recv_config(handler, enable)
+  if enable then
     worker_events.register(handler, "clustering", "recv_config")
 
   else

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -74,7 +74,7 @@ end
 
 function _M:init_cp_worker(plugins_list)
 
-  events.init()
+  events.init_cp()
 
   self.instance = require("kong.clustering.control_plane").new(self)
   self.instance:init_worker(plugins_list)
@@ -85,6 +85,8 @@ function _M:init_dp_worker(plugins_list)
   if not is_dp_worker_process() then
     return
   end
+
+  events.init_dp()
 
   self.instance = require("kong.clustering.data_plane").new(self)
   self.instance:init_worker(plugins_list)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Remove semaphore in DP, replaced by lua-resty-events `post_local()`.
Also, remove `config_exit` and `config_thread`.

These changes make the code more understandable.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

*  remove `config_exit` and `config_thread`
* register/unregister the handler for each communication
* add `init_dp` and other APIs in `events.lua`


