### PR TITLE
style(clustering): rename fields `json_handler` and `child`

### DIFF
--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -41,7 +41,7 @@ function _M.new(conf)
   setmetatable(self, _MT)
 
   if conf.role == "control_plane" then
-    self.cp =
+    self.role =
       require("kong.clustering.control_plane").new(self)
   end
 
@@ -73,7 +73,7 @@ function _M:handle_cp_websocket()
     return ngx_exit(444)
   end
 
-  return self.cp:handle_cp_websocket()
+  return self.role:handle_cp_websocket()
 end
 
 
@@ -81,7 +81,7 @@ function _M:init_cp_worker(plugins_list)
 
   events.init()
 
-  self.cp:init_worker(plugins_list)
+  self.role:init_worker(plugins_list)
 end
 
 
@@ -90,8 +90,8 @@ function _M:init_dp_worker(plugins_list)
     return
   end
 
-  self.dp = require("kong.clustering.data_plane").new(self)
-  self.dp:init_worker(plugins_list)
+  self.role = require("kong.clustering.data_plane").new(self)
+  self.role:init_worker(plugins_list)
 end
 
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -40,11 +40,6 @@ function _M.new(conf)
 
   setmetatable(self, _MT)
 
-  if conf.role == "control_plane" then
-    self.role =
-      require("kong.clustering.control_plane").new(self)
-  end
-
   return self
 end
 
@@ -81,6 +76,7 @@ function _M:init_cp_worker(plugins_list)
 
   events.init()
 
+  self.role = require("kong.clustering.control_plane").new(self)
   self.role:init_worker(plugins_list)
 end
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -41,7 +41,7 @@ function _M.new(conf)
   setmetatable(self, _MT)
 
   if conf.role == "control_plane" then
-    self.json_handler =
+    self.cp =
       require("kong.clustering.control_plane").new(self)
   end
 
@@ -73,7 +73,7 @@ function _M:handle_cp_websocket()
     return ngx_exit(444)
   end
 
-  return self.json_handler:handle_cp_websocket()
+  return self.cp:handle_cp_websocket()
 end
 
 
@@ -81,7 +81,7 @@ function _M:init_cp_worker(plugins_list)
 
   events.init()
 
-  self.json_handler:init_worker(plugins_list)
+  self.cp:init_worker(plugins_list)
 end
 
 
@@ -90,8 +90,8 @@ function _M:init_dp_worker(plugins_list)
     return
   end
 
-  self.child = require("kong.clustering.data_plane").new(self)
-  self.child:init_worker(plugins_list)
+  self.dp = require("kong.clustering.data_plane").new(self)
+  self.dp:init_worker(plugins_list)
 end
 
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -68,7 +68,7 @@ function _M:handle_cp_websocket()
     return ngx_exit(444)
   end
 
-  return self.role:handle_cp_websocket()
+  return self.instance:handle_cp_websocket()
 end
 
 
@@ -76,8 +76,8 @@ function _M:init_cp_worker(plugins_list)
 
   events.init()
 
-  self.role = require("kong.clustering.control_plane").new(self)
-  self.role:init_worker(plugins_list)
+  self.instance = require("kong.clustering.control_plane").new(self)
+  self.instance:init_worker(plugins_list)
 end
 
 
@@ -86,8 +86,8 @@ function _M:init_dp_worker(plugins_list)
     return
   end
 
-  self.role = require("kong.clustering.data_plane").new(self)
-  self.role:init_worker(plugins_list)
+  self.instance = require("kong.clustering.data_plane").new(self)
+  self.instance:init_worker(plugins_list)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`json_handler` and `child` are bad names, people can not understand their real meaning and functionality.
Actually, they are the same things but act as different roles. 

If you have a better idea please leave comments here, thanks.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Changelog

- rename `json_handler` and `child` to `instance`
- move `cp:new` to `init_worker()`, this will cause each worker to create the object but not copy from the master, but I think the cost is very small
