### PR TITLE
chore(test): eliminate duplicate mig http_server

### DIFF
--- a/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
+++ b/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
@@ -3,57 +3,10 @@ local cjson = require "cjson"
 local tablex = require "pl.tablex"
 
 local uh = require "spec/upgrade_helpers"
+local helpers = require "spec.helpers"
+local http_server = helpers.http_server
 
-local HTTP_PORT = 29100
-
--- Copied from 3.x helpers.lua
-
-local function http_server(port, opts)
-  local threads = require "llthreads2.ex"
-  opts = opts or {}
-  local thread = threads.new(
-    {
-      function(port, opts)
-        local socket = require "socket"
-        local server = assert(socket.tcp())
-        server:settimeout(opts.timeout or 60)
-        assert(server:setoption('reuseaddr', true))
-        assert(server:bind("*", port))
-        assert(server:listen())
-        local client = assert(server:accept())
-
-        local lines = {}
-        local line, err
-        repeat
-          line, err = client:receive("*l")
-          if err then
-            break
-          else
-            table.insert(lines, line)
-          end
-        until line == ""
-
-        if #lines > 0 and lines[1] == "GET /delay HTTP/1.0" then
-          ngx.sleep(2)
-        end
-
-        if err then
-          server:close()
-          error(err)
-        end
-
-        local body, _ = client:receive("*a")
-
-        client:send("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
-        client:close()
-        server:close()
-
-        return lines, body
-      end
-    },
-    port, opts)
-  return thread:start()
-end
+local HTTP_PORT = helpers.get_available_port()
 
 describe("http-log plugin migration", function()
 
@@ -97,12 +50,12 @@ describe("http-log plugin migration", function()
 
         uh.send_proxy_get_request()
 
-        local ok, headers = thread:join()
+        local ok, lines = thread:join()
         assert.truthy(ok)
 
         -- verify that the log HTTP request had the configured header
-        local idx = tablex.find(headers, custom_header_name .. ": " .. custom_header_content)
-        assert.not_nil(idx, headers)
+        local idx = tablex.find(lines, custom_header_name .. ": " .. custom_header_content)
+        assert.not_nil(idx, lines)
     end)
 
     uh.new_after_finish("has updated http-log configuration", function ()

--- a/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
+++ b/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
@@ -51,7 +51,7 @@ describe("http-log plugin migration", function()
         uh.send_proxy_get_request()
 
         local ok, lines = thread:join()
-        assert.truthy(ok)
+        assert.truthy(ok, lines)
 
         -- verify that the log HTTP request had the configured header
         local idx = tablex.find(lines, custom_header_name .. ": " .. custom_header_content)


### PR DESCRIPTION
### Summary

Some tests are using their own copy of `http_server`, and some are using static ports for testing. Some also do not kill the thread if the test fails.

Solution: see Full changelog.

### Checklist

（Do we need to backport this?)

- [ ] The Pull Request has backports to all the versions it needs to cover

### Full changelog

* Rewrite to use the `http_server` in the helper;
* Rewrite to use dynamic ports for every test;
* Kill threads at `after_each`

### Issue reference

Partial fix of KAG-1148
