### PR TITLE
fix(tracing): address flakiness and resolve approximation bug

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1039,6 +1039,7 @@ end
 function Kong.balancer()
   -- This may be called multiple times, and no yielding here!
   local now_ms = now() * 1000
+  local now_ns = time_ns()
 
   local ctx = ngx.ctx
   if not ctx.KONG_BALANCER_START then
@@ -1079,7 +1080,7 @@ function Kong.balancer()
   tries[try_count] = current_try
 
   current_try.balancer_start = now_ms
-  current_try.balancer_start_ns = time_ns()
+  current_try.balancer_start_ns = now_ns
 
   if try_count > 1 then
     -- only call balancer on retry, first one is done in `runloop.access.after`
@@ -1439,6 +1440,7 @@ function Kong.body_filter()
   end
 
   ctx.KONG_BODY_FILTER_ENDED_AT = get_updated_now_ms()
+  ctx.KONG_BODY_FILTER_ENDED_AT_NS = time_ns()
   ctx.KONG_BODY_FILTER_TIME = ctx.KONG_BODY_FILTER_ENDED_AT - ctx.KONG_BODY_FILTER_START
 
   if ctx.KONG_PROXIED then

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -131,7 +131,7 @@ function _M.balancer(ctx)
         span:set_status(2)
       end
 
-      local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
+      local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT_NS
       span:finish(upstream_finish_time)
     end
   end

--- a/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
@@ -78,7 +78,7 @@ local function push_data(premature, data, config)
   end
 
   local tcpsock = ngx.socket.tcp()
-  tcpsock:settimeout(1000)
+  tcpsock:settimeouts(10000, 10000, 10000)
   local ok, err = tcpsock:connect(config.host, config.port)
   if not ok then
     kong.log.err("connect err: ".. err)


### PR DESCRIPTION
### Summary

Fix a bug (only affecting 3.3+) that will result in resolving flakiness in the following tests:

* opentelemetry exporter #postgres #scoping for service with global works
* tracing propagation spec #postgres spans hierarchy propagates the balancer span
* tracing propagation spec #postgres parsing incoming headers enables sampling when incoming header has sampled enabled

Caused by:

- [This error](https://github.com/Kong/kong/blob/77e4e124532be603075f257ab8173d59d5d336b9/kong/pdk/tracing.lua#L288) that came from [here](https://github.com/Kong/kong/blob/77e4e124532be603075f257ab8173d59d5d336b9/kong/tracing/instrumentation.lua#L135) due to [the approximation](https://github.com/Kong/kong/blob/77e4e124532be603075f257ab8173d59d5d336b9/kong/tracing/instrumentation.lua#LL134C1-L134C1) that resulted from converting ms to ns. This sometimes resulted in the span's **end** timestamp (converted from ms to ns) to be prior to the span **start** timestamp (directly set in ns).

This PR also sets a higher timeout for the tcp connection in a test, to reduce flakiness.

[Successful run (200 times)](https://github.com/Kong/kong/actions/runs/4993163168/jobs/8942602283)

### Checklist

- [x] (NA) The Pull Request has tests
- [x] (NA) There's an entry in the CHANGELOG
- [x] (NA) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-1486
KAG-1358
