### PR TITLE
feat(build): cross build alpine arm64

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -59,8 +59,13 @@ build-packages:
 - label: alpine
   os: ubuntu-22.04
   package: apk
-  bazel_args: --platforms=//:alpine-x86_64
+  bazel_args: --platforms=//:alpine-crossbuild-x86_64
   check-manifest-suite: alpine-amd64
+- label: alpine-arm64
+  os: ubuntu-22.04
+  package: apk
+  bazel_args: --platforms=//:alpine-crossbuild-aarch64
+  check-manifest-suite: alpine-arm64
 
 # Amazon Linux
 - label: amazonlinux-2
@@ -104,6 +109,8 @@ build-images:
   base-image: alpine:3.16
   package: apk
   artifact-from: alpine
+  artifact-from-alt: alpine-arm64
+  docker_platforms: linux/amd64, linux/arm64
 
 smoke-tests:
 - label: ubuntu

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -27,7 +27,7 @@ build-packages:
 - label: ubuntu-22.04-arm64
   os: ubuntu-22.04
   package: deb
-  bazel_args: --platforms=//:ubuntu-22.04-arm64
+  bazel_args: --platforms=//:generic-crossbuild-aarch64
   check-manifest-suite: ubuntu-22.04-arm64
 
 # Debian

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -204,7 +204,7 @@ alias(
 )
 
 platform(
-    name = "alpine-x86_64",
+    name = "alpine-crossbuild-x86_64",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
@@ -213,13 +213,29 @@ platform(
     ],
 )
 
+# backward compatibility
+alias(
+    name = "alpine-x86_64",
+    actual = ":alpine-crossbuild-x86_64",
+)
+
+platform(
+    name = "alpine-crossbuild-aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        ":musl",
+        ":cross_build",
+    ],
+)
+
 # config_settings define a select() condition based on user-set constraint_values
 # see https://bazel.build/docs/configurable-attributes
 config_setting(
-    name = "arm64-linux-gnu-cross",
+    name = "aarch64-linux-anylibc-cross",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
         ":cross_build",
     ],
     visibility = ["//visibility:public"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,8 +157,10 @@ config_setting(
 constraint_setting(name = "libc_version")
 
 constraint_value(
-    name = "glibc_2_35",
+    # use whatever glibc version provided by the system installed cross toolchain
+    name = "glibc_system",
     constraint_setting = ":libc_version",
+    visibility = ["//visibility:public"],
 )
 
 constraint_value(
@@ -176,23 +178,29 @@ constraint_value(
 
 # platform sets the constraint values based on user input (--platform=//:PLATFOTM)
 platform(
-    name = "ubuntu-22.04-x86_64",
+    name = "generic-crossbuild-x86_64",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
-        ":glibc_2_35",
+        ":glibc_system",
         ":cross_build",
     ],
 )
 
 platform(
-    name = "ubuntu-22.04-arm64",
+    name = "generic-crossbuild-aarch64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
-        ":glibc_2_35",
+        "@platforms//cpu:aarch64",
+        ":glibc_system",
         ":cross_build",
     ],
+)
+
+# backward compatibility
+alias(
+    name = "ubuntu-22.04-arm64",
+    actual = ":generic-crossbuild-aarch64",
 )
 
 platform(
@@ -232,7 +240,7 @@ selects.config_setting_group(
     # matches all cross build platforms
     name = "any-cross",
     match_any = [
-        ":arm64-linux-gnu-cross",
+        ":aarch64-linux-anylibc-cross",
         ":x86_64-linux-musl-cross",
     ],
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,6 +60,20 @@ load("//build/toolchain:repositories.bzl", "toolchain_repositories")
 
 toolchain_repositories()
 
-register_toolchains("//build/toolchain:gcc_cross_arm64_toolchain")
+register_toolchains("//build/toolchain:local_aarch64-linux-gnu_toolchain")
 
-register_toolchains("//build/toolchain:gcc_cross_musl_x86_64_toolchain")
+load("//build/toolchain:managed_toolchain.bzl", "register_managed_toolchain")
+
+register_managed_toolchain(
+    arch = "x86_64",
+    gcc_version = "11",
+    libc = "musl",
+    vendor = "alpine",
+)
+
+register_managed_toolchain(
+    arch = "aarch64",
+    gcc_version = "11",
+    libc = "musl",
+    vendor = "alpine",
+)

--- a/build/README.md
+++ b/build/README.md
@@ -174,15 +174,16 @@ bazel build //:kong_el8 --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_
 
 Cross compiling is currently only tested on Ubuntu 22.04 x86_64 with following targeting platforms:
 
-- **//:ubuntu-22.04-arm64** Ubuntu 22.04 ARM64
-  - Requires user to manually install `crossbuild-essential-arm64`.
-- **//:alpine-x86_64** Alpine Linux x86_64; bazel manages the build toolchain.
+- **//:generic-crossbuild-aarch64** Use the system installed aarch64 toolchain.
+  - Requires user to manually install `crossbuild-essential-arm64` on Debian/Ubuntu.
+- **//:alpine-crossbuild-x86_64** Alpine Linux x86_64; bazel manages the build toolchain.
+- **//:alpine-crossbuild-aarch64** Alpine Linux aarch64; bazel manages the build toolchain.
 
 Make sure platforms are selected both in building Kong and packaging kong:
 
 ```bash
-bazel build --config release //build:kong --platforms=//:ubuntu-2204-arm64
-bazel build --config release :kong_deb --platforms=//:ubuntu-2204-arm64
+bazel build --config release //build:kong --platforms=//:generic-crossbuild-aarch64
+bazel build --config release :kong_deb --platforms=//:generic-crossbuild-aarch64
 ```
 
 ## Troubleshooting

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,7 @@ This directory contains the build system for the project.
 The build system is designed to be used with the [Bazel](https://bazel.build/).
 It is designed to be running on Linux without root privileges, and no virtualization technology is required.
 
-The build system is tested on Linux (x86_64 and arm64) and macOS (Intel chip and AppleSilicon Chip).
+The build system is tested on Linux (x86_64 and aarch64) and macOS (Intel chip and AppleSilicon Chip).
 
 ## Prerequisites
 

--- a/build/cross_deps/libxcrypt/BUILD.libxcrypt.bazel
+++ b/build/cross_deps/libxcrypt/BUILD.libxcrypt.bazel
@@ -14,7 +14,7 @@ configure_make(
     configure_command = "configure",
     configure_in_place = True,
     configure_options = select({
-        "@kong//:arm64-linux-gnu-cross": [
+        "@kong//:aarch64-linux-anylibc-cross": [
             "--host=aarch64-linux",
         ],
         "@kong//:x86_64-linux-musl-cross": [

--- a/build/cross_deps/libyaml/BUILD.libyaml.bazel
+++ b/build/cross_deps/libyaml/BUILD.libyaml.bazel
@@ -14,7 +14,7 @@ configure_make(
     configure_command = "configure",
     configure_in_place = True,
     configure_options = select({
-        "@kong//:arm64-linux-gnu-cross": [
+        "@kong//:aarch64-linux-anylibc-cross": [
             "--host=aarch64-linux",
         ],
         "@kong//:x86_64-linux-musl-cross": [

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -17,7 +17,7 @@ genrule(
               "//conditions:default": "0",
           }) + "\n" +
           "aarch64=" + select({
-              "@platforms//cpu:arm64": "1",
+              "@platforms//cpu:aarch64": "1",
               "//conditions:default": "0",
           }) + "\n" +
           "debug=" + select({
@@ -140,7 +140,7 @@ CONFIGURE_OPTIONS = [
     "--add-module=$$EXT_BUILD_ROOT$$/external/lua-resty-lmdb",
     "--add-module=$$EXT_BUILD_ROOT$$/external/lua-resty-events",
 ] + select({
-    "@kong//:arm64-linux-gnu-cross": [
+    "@kong//:aarch64-linux-anylibc-cross": [
         "--crossbuild=Linux:aarch64",
         "--with-endian=little",
         "--with-int=4",
@@ -176,7 +176,7 @@ CONFIGURE_OPTIONS = [
 }) + select({
     # any cross build that migrated to use libxcrypt needs those flags
     # alpine uses different libc so doesn't need it
-    "@kong//:arm64-linux-gnu-cross": [
+    "@kong//:aarch64-linux-anylibc-cross": [
         "--with-cc-opt=\"-I$$EXT_BUILD_DEPS$$/libxcrypt/include\"",
         "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/libxcrypt/lib\"",
     ],
@@ -244,7 +244,7 @@ configure_make(
     }) + select({
         # any cross build that migrated to use libxcrypt needs those flags
         # alpine uses different libc so doesn't need it
-        "@kong//:arm64-linux-gnu-cross": [
+        "@kong//:aarch64-linux-anylibc-cross": [
             "@cross_deps_libxcrypt//:libxcrypt",
         ],
         "//conditions:default": [],

--- a/build/openresty/openssl/BUILD.openssl.bazel
+++ b/build/openresty/openssl/BUILD.openssl.bazel
@@ -40,7 +40,7 @@ configure_make(
         "@platforms//os:macos": {
             "AR": "/usr/bin/ar",
         },
-        "@kong//:arm64-linux-gnu-cross": {
+        "@kong//:aarch64-linux-anylibc-cross": {
             "MACHINE": "aarch64",
             "SYSTEM": "linux2",
         },

--- a/build/toolchain/.gitignore
+++ b/build/toolchain/.gitignore
@@ -1,0 +1,1 @@
+wrappers-*

--- a/build/toolchain/BUILD
+++ b/build/toolchain/BUILD
@@ -8,21 +8,22 @@ filegroup(name = "empty")
 # aarch64-linux-gnu (installed with system)
 
 toolchain(
-    name = "gcc_cross_arm64_toolchain",
+    name = "local_aarch64-linux-gnu_toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
     target_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
+        "//:glibc_system",
     ],
-    toolchain = ":gcc_cross_arm64_cc_toolchain",
+    toolchain = ":local_aarch64-linux-gnu_cc_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 cc_toolchain_config(
-    name = "gcc_cross_arm64_cc_toolchain_config",
+    name = "local_aarch64-linux-gnu_cc_toolchain_config",
     compiler_configuration = {},
     target_cpu = "aarch64",
     toolchain_path_prefix = "/usr/aarch64-linux-gnu/",  # is this required?
@@ -30,7 +31,7 @@ cc_toolchain_config(
 )
 
 cc_toolchain(
-    name = "gcc_cross_arm64_cc_toolchain",
+    name = "local_aarch64-linux-gnu_cc_toolchain",
     all_files = ":empty",
     compiler_files = ":empty",
     dwp_files = ":empty",

--- a/build/toolchain/BUILD
+++ b/build/toolchain/BUILD
@@ -1,4 +1,5 @@
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load(":managed_toolchain.bzl", "define_managed_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,61 +40,25 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 0,
-    toolchain_config = ":gcc_cross_arm64_cc_toolchain_config",
-    toolchain_identifier = "gcc_cross_arm64-toolchain",
+    toolchain_config = ":local_aarch64-linux-gnu_cc_toolchain_config",
+    toolchain_identifier = "local_aarch64-linux-gnu_cc_toolchain",
 )
 
 ###################
-# x86_64-linux-musl (downloaded by bazel)
+# managed toolchains (downloaded by Bazel)
 
-toolchain(
-    name = "gcc_cross_musl_x86_64_toolchain",
-    exec_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-        "//:musl",
-    ],
-    toolchain = ":gcc_cross_musl_x86_64_cc_toolchain",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+define_managed_toolchain(
+    arch = "x86_64",
+    gcc_version = "11",
+    libc = "musl",
+    target_compatible_with = ["//:musl"],
+    vendor = "alpine",
 )
 
-cc_toolchain_config(
-    name = "gcc_cross_musl_x86_64_cc_toolchain_config",
-    ld = "gcc",
-    target_cpu = "x86_64",
-    target_libc = "musl",
-    toolchain_path_prefix = "gcc-11-x86_64-linux-musl-wrappers/",  # is this required?
-    tools_path_prefix = "gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-",
-)
-
-filegroup(
-    name = "wrappers",
-    srcs = glob([
-        "gcc-11-x86_64-linux-musl-wrappers/**",
-    ]),
-)
-
-filegroup(
-    name = "musl_toolchain_files",
-    srcs = [
-        ":wrappers",
-        "@gcc-11-x86_64-linux-musl-cross//:toolchain",
-    ],
-)
-
-cc_toolchain(
-    name = "gcc_cross_musl_x86_64_cc_toolchain",
-    all_files = ":musl_toolchain_files",
-    compiler_files = ":musl_toolchain_files",
-    dwp_files = ":empty",
-    linker_files = ":musl_toolchain_files",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 0,
-    toolchain_config = ":gcc_cross_musl_x86_64_cc_toolchain_config",
-    toolchain_identifier = "gcc_cross_musl_x86_64-toolchain",
+define_managed_toolchain(
+    arch = "aarch64",
+    gcc_version = "11",
+    libc = "musl",
+    target_compatible_with = ["//:musl"],
+    vendor = "alpine",
 )

--- a/build/toolchain/cc_toolchain_config.bzl
+++ b/build/toolchain/cc_toolchain_config.bzl
@@ -22,7 +22,7 @@ def _fmt_flags(flags, toolchain_path_prefix):
 
 # Macro for calling cc_toolchain_config from @bazel_tools with setting the
 # right paths and flags for the tools.
-def _impl(ctx):
+def _cc_toolchain_config_impl(ctx):
     target_cpu = ctx.attr.target_cpu
     toolchain_path_prefix = ctx.attr.toolchain_path_prefix
     tools_path_prefix = ctx.attr.tools_path_prefix
@@ -200,7 +200,7 @@ def _impl(ctx):
     )
 
 cc_toolchain_config = rule(
-    implementation = _impl,
+    implementation = _cc_toolchain_config_impl,
     attrs = {
         "target_cpu": attr.string(),
         "toolchain_path_prefix": attr.string(),

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-addr2line
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-addr2line
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ar
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ar
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-as
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-as
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-c++
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-c++
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-c++filt
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-c++filt
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-cc@
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-cc@
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-cpp
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-cpp
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-dwp
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-dwp
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-elfedit
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-elfedit
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-g++
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-g++
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-11.2.1
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-11.2.1
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-ar
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-ar
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-nm
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-nm
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-ranlib
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcc-ranlib
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov-dump
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov-dump
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov-tool
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gcov-tool
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gfortran
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gfortran
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gprof
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-gprof
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld.bfd
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld.bfd
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld.gold
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ld.gold
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-lto-dump
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-lto-dump
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-nm
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-nm
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-objcopy
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-objcopy
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-objdump
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-objdump
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ranlib
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-ranlib
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-readelf
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-readelf
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-size
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-size
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-strings
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-strings
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-strip
+++ b/build/toolchain/gcc-11-x86_64-linux-musl-wrappers/x86_64-linux-musl-strip
@@ -1,1 +1,0 @@
-wrapper

--- a/build/toolchain/generate_wrappers.sh
+++ b/build/toolchain/generate_wrappers.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+name=$1
+wrapper=$2
+prefix=$3
+dummy_file=$4
+
+if [[ -z $name || -z $wrapper || -z $prefix ]]; then
+    echo "Usage: $0 <name> <wrapper> <prefix>"
+    exit 1
+fi
+
+cwd=$(realpath $(dirname $(readlink -f ${BASH_SOURCE[0]})))
+dir=wrappers-$name
+mkdir -p $cwd/$dir
+cp $wrapper $cwd/$dir/
+chmod 755 $cwd/$dir/wrapper
+
+pushd $cwd/$dir >/dev/null
+
+tools="addr2line ar as c++ cc@ c++filt cpp dwp elfedit g++ gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool gfortran gprof ld ld.bfd ld.gold lto-dump nm objcopy objdump ranlib readelf size strings strip"
+for tool in $tools; do
+    ln -sf wrapper $prefix$tool
+done
+
+popd >/dev/null
+
+if [[ -n $dummy_file ]]; then
+    touch $dummy_file
+fi
+

--- a/build/toolchain/managed_toolchain.bzl
+++ b/build/toolchain/managed_toolchain.bzl
@@ -1,0 +1,120 @@
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+def _generate_wrappers_impl(ctx):
+    wrapper_file = ctx.actions.declare_file("wrapper")
+    ctx.actions.expand_template(
+        template = ctx.file._wrapper_template,
+        output = wrapper_file,
+        substitutions = {
+            "{{TOOLCHAIN_NAME}}": ctx.attr.toolchain_name,
+        },
+        is_executable = True,
+    )
+
+    dummy_output = ctx.actions.declare_file(ctx.attr.name + ".wrapper-marker")
+
+    ctx.actions.run_shell(
+        command = "build/toolchain/generate_wrappers.sh %s %s %s %s" % (
+            ctx.attr.toolchain_name,
+            wrapper_file.path,
+            ctx.attr.tools_prefix,
+            dummy_output.path,
+        ),
+        progress_message = "Create wrappers for " + ctx.attr.toolchain_name,
+        inputs = [wrapper_file],
+        outputs = [dummy_output],
+    )
+
+    return [DefaultInfo(files = depset([dummy_output, wrapper_file]))]
+
+generate_wrappers = rule(
+    implementation = _generate_wrappers_impl,
+    attrs = {
+        "toolchain_name": attr.string(mandatory = True),
+        "tools_prefix": attr.string(mandatory = True),
+        "_wrapper_template": attr.label(
+            default = "//build/toolchain:templates/wrapper",
+            allow_single_file = True,
+        ),
+    },
+)
+
+def define_managed_toolchain(
+        name = None,
+        arch = "x86_64",
+        vendor = "unknown",
+        libc = "gnu",
+        gcc_version = "11",
+        ld = "gcc",
+        target_compatible_with = []):
+    identifier = "{arch}-{vendor}-linux-{libc}-gcc-{gcc_version}".format(
+        arch = arch,
+        vendor = vendor,
+        libc = libc,
+        gcc_version = gcc_version,
+    )
+
+    tools_prefix = "{arch}-{vendor}-linux-{libc}-".format(
+        arch = arch,
+        vendor = vendor,
+        libc = libc,
+    )
+
+    native.toolchain(
+        name = "%s_toolchain" % identifier,
+        exec_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
+        ],
+        target_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:%s" % arch,
+        ] + target_compatible_with,
+        toolchain = ":%s_cc_toolchain" % identifier,
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
+
+    cc_toolchain_config(
+        name = "%s_cc_toolchain_config" % identifier,
+        ld = ld,
+        target_cpu = arch,
+        target_libc = libc,
+        toolchain_path_prefix = "wrappers-%s/" % identifier,  # is this required?
+        tools_path_prefix = "wrappers-%s/%s" % (identifier, tools_prefix),
+    )
+
+    generate_wrappers(
+        name = "%s_wrappers" % identifier,
+        toolchain_name = identifier,
+        tools_prefix = tools_prefix,
+    )
+
+    native.filegroup(
+        name = "%s_files" % identifier,
+        srcs = [
+            ":%s_wrappers" % identifier,
+            "@%s//:toolchain" % identifier,
+        ],
+    )
+
+    native.cc_toolchain(
+        name = "%s_cc_toolchain" % identifier,
+        all_files = ":%s_files" % identifier,
+        compiler_files = ":%s_files" % identifier,
+        dwp_files = ":empty",
+        linker_files = "%s_files" % identifier,
+        objcopy_files = ":empty",
+        strip_files = ":empty",
+        supports_param_files = 0,
+        toolchain_config = ":%s_cc_toolchain_config" % identifier,
+        toolchain_identifier = "%s_cc_toolchain" % identifier,
+    )
+
+def register_managed_toolchain(name = None, arch = "x86_64", vendor = "unknown", libc = "gnu", gcc_version = "11"):
+    identifier = "{arch}-{vendor}-linux-{libc}-gcc-{gcc_version}".format(
+        arch = arch,
+        vendor = vendor,
+        libc = libc,
+        gcc_version = gcc_version,
+    )
+    native.register_toolchains("//build/toolchain:%s_toolchain" % identifier)

--- a/build/toolchain/repositories.bzl
+++ b/build/toolchain/repositories.bzl
@@ -2,13 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def toolchain_repositories():
-    http_archive(
-        name = "gcc-11-x86_64-linux-musl-cross",
-        url = "https://more.musl.cc/11/x86_64-linux-musl/x86_64-linux-musl-cross.tgz",
-        sha256 = "c6226824d6b7214ce974344b186179c9fa89be3c33dd7431c4b6585649ce840b",
-        strip_prefix = "x86_64-linux-musl-cross",
-        build_file_content = """
+musl_build_file_content = """
 filegroup(
     name = "toolchain",
     srcs = glob(
@@ -18,11 +12,27 @@ filegroup(
             "lib/**",
             "libexec/**",
             "share/**",
-            "x86_64-linux-musl/**",
+            "*-linux-musl/**",
         ],
         exclude = ["usr"],
     ),
     visibility = ["//visibility:public"],
 )
-        """,
+"""
+
+def toolchain_repositories():
+    http_archive(
+        name = "x86_64-alpine-linux-musl-gcc-11",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.4.0/x86_64-alpine-linux-musl-gcc-11.tar.gz",
+        sha256 = "4fbc9a48f1f7ace6d2a19a1feeac1f69cf86ce8ece40b101e351d1f703b3560c",
+        strip_prefix = "x86_64-alpine-linux-musl",
+        build_file_content = musl_build_file_content,
+    )
+
+    http_archive(
+        name = "aarch64-alpine-linux-musl-gcc-11",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.4.0/aarch64-alpine-linux-musl-gcc-11.tar.gz",
+        sha256 = "abd7003fc4aa6d533c5aad97a5726040137f580026b1db78d3a8059a69c3d45b",
+        strip_prefix = "aarch64-alpine-linux-musl",
+        build_file_content = musl_build_file_content,
     )

--- a/build/toolchain/templates/wrapper
+++ b/build/toolchain/templates/wrapper
@@ -3,12 +3,12 @@
 PREFIX=
 if [[ ! -z ${EXT_BUILD_ROOT} ]]; then
     PREFIX=${EXT_BUILD_ROOT}/
-elif [[ ! -e external/gcc-11-x86_64-linux-musl-cross/bin ]]; then
+elif [[ ! -e external/{{TOOLCHAIN_NAME}}/bin ]]; then
     echo "EXT_BUILD_ROOT is not set and wrapper can't find the toolchain, is this script running with the correct environment (foreign_cc rules, cc_* rules)?"
     exit 1
 fi
 
 NAME=$(/usr/bin/basename "$0")
-TOOLCHAIN_BINDIR=${PREFIX}external/gcc-11-x86_64-linux-musl-cross/bin
+TOOLCHAIN_BINDIR=${PREFIX}external/{{TOOLCHAIN_NAME}}/bin
  
 exec "${TOOLCHAIN_BINDIR}"/"${NAME}" "$@"

--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -29,6 +29,12 @@ targets = {
         manifest="fixtures/alpine-amd64.txt",
         use_rpath=True,
     ),
+    "alpine-arm64": ExpectSuite(
+        name="Alpine Linux (arm64)",
+        manifest="fixtures/alpine-arm64.txt",
+        use_rpath=True,
+        extra_tests=[arm64_suites],
+    ),
     "amazonlinux-2-amd64": ExpectSuite(
         name="Amazon Linux 2 (amd64)",
         manifest="fixtures/amazonlinux-2-amd64.txt",

--- a/scripts/explain_manifest/fixtures/alpine-arm64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-arm64.txt
@@ -1,0 +1,135 @@
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-1.1/afalg.so
+  Needed    :
+  - libcrypto.so.1.1
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-1.1/capi.so
+  Needed    :
+  - libcrypto.so.1.1
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-1.1/padlock.so
+  Needed    :
+  - libcrypto.so.1.1
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libcrypto.so.1.1
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libssl.so.1.1
+  Needed    :
+  - libcrypto.so.1.1
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.1.1
+  - libcrypto.so.1.1
+  - libc.so
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so
+
+- Path      : /usr/local/openresty/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libc.so
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+  Needed    :
+  - libc.so
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libluajit-5.1.so.2
+  - libssl.so.1.1
+  - libcrypto.so.1.1
+  - libz.so.1
+  - libc.so
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  OpenSSL   : OpenSSL 1.1.1t  7 Feb 2023
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR cleans up the toolchain definition, and introduce the alpine aarch64 target.

Although alpine is going away in coming release, this PR prepares the fundamental for adding other aarch64
toolchains and even other architectures.

We will create another PR to actually remove alpine from the matrix-full.yml, so that this PR can be backported to branches that alpine is still supported.

### Checklist

- [x] The Pull Request has tests
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
- [na] The Pull Request has backports to all the versions it needs to cover

### Full changelog

* Unify the name `arm64` to be `aarch64` in Bazel files; old arm64 names are kept as aliases for backward compatibility.
* Move to use our automatically built toolchain at https://github.com/Kong/crosstool-ng-actions
* Add the `//:generic-crossbuild-aarch64` platform for targets uses system-installed aarch64 toolchain.
* Add the `//:alpine-crossbuild-aarch64` platform and alpine-arm64 matrix.
* Toolchains are named with GCC's naming convension like `aarch64-unknown-linux-gnu`.
* Remove the wrapper symlinks farm for each toolchain from git, they are now created automatically.

### Issue reference

KAG-856