### PR TITLE
docs(changelog): fix name of renamed queue module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 - **http-log, statsd, opentelemetry, datadog**: The queueing system
   has been reworked, causing some plugin parameters to not function as expected
   anymore. If you use queues on these plugin, new parameters must be configured.
-  The module `kong.tools.batch_queue` has been renamed to `kong.tools.batch` in
+  The module `kong.tools.batch_queue` has been renamed to `kong.tools.queue` in
   the process and the API was changed.  If your custom plugin uses queues, it must
   be updated to use the new API.
   [#10172](https://github.com/Kong/kong/pull/10172)


### PR DESCRIPTION
### Summary

The `kong.tools.batch_queue` module was renamed to `kong.tools.queue` as part of a reimplementation of  plugin queues: https://github.com/Kong/kong/pull/10172

The`CHANGELOG.md` incorrectly states that the module has been renamed to `kong.tools.batch`

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
