### PR TITLE
fix(ci): add new path to schema change bot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -171,7 +171,7 @@ plugins/opentelemetry:
 - kong/plugins/opentelemetry/**/*
 
 schema-change-noteworthy:
-- kong/db/schema/entities/**/*
+- kong/db/schema/**/*.lua
 - kong/**/schema.lua
 - kong/plugins/**/daos.lua
 - plugins-ee/**/daos.lua


### PR DESCRIPTION
Previous glob did not match `kong/db/schema/metaschema.lua`. The new glob matches all of the previous (since `kong/db/schema/entities/**/*` matches a subset of `kong/db/schema/**/*.lua`), plus the missing `kong/db/schema/metaschema.lua` - since `**` also matches ε.