### PR TITLE
tests(queue): verify that capacity warning is produced

### DIFF
--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -448,4 +448,7 @@ function Queue._exists(name)
 end
 
 
+Queue._CAPACITY_WARNING_THRESHOLD = CAPACITY_WARNING_THRESHOLD
+
+
 return Queue

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -125,7 +125,7 @@ describe("plugin queue", function()
     local log_tag = utils.uuid()
     Queue.enqueue(
       queue_conf({ name = "log-tag", log_tag = log_tag }),
-      function (conf)
+      function ()
         handler_invoked = true
         return true
       end,
@@ -310,23 +310,27 @@ describe("plugin queue", function()
           max_entries = capacity,
           max_coalescing_delay = 0.1,
         }),
-        function(_, batch)
+        function()
           return false
         end,
         nil,
         entry
       )
     end
-    for i = 1, math.floor(capacity * Queue._CAPACITY_WARNING_THRESHOLD) - 1 do
+    for _ = 1, math.floor(capacity * Queue._CAPACITY_WARNING_THRESHOLD) - 1 do
       enqueue("something")
     end
-    assert.has.no.match_re(log_messages, "WARN .*queue queue at \\d*% capacity")
+    assert.has.no.match_re(log_messages, "WARN .*queue at \\d*% capacity")
     enqueue("something")
     enqueue("something")
     assert.match_re(log_messages, "WARN .*queue at \\d*% capacity")
     log_messages = ""
     enqueue("something")
-    assert.has.no.match_re(log_messages, "WARN .*queue queue at \\d*% capacity")
+    assert.has.no.match_re(
+      log_messages,
+      "WARN .*queue at \\d*% capacity",
+      "the capacity warning should not be logged more than once"
+    )
   end)
 
   it("drops entries when queue reaches its capacity", function()


### PR DESCRIPTION
### Summary

Add a test that verifies the presence of a capacity warning if a queue is reaching the queue capacity warning threshold.

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-1579