### PR TITLE
tests(opentelemetry): improve performance

### DIFF
--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -1,13 +1,14 @@
 require "kong.plugins.opentelemetry.proto"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
-local tablex = require "pl.tablex"
 local pb = require "pb"
 local pl_file = require "pl.file"
 local ngx_re = require "ngx.re"
 local to_hex = require "resty.string".to_hex
 
 local fmt = string.format
+
+local HTTP_MOCK_TIMEOUT = 1
 
 local function gen_trace_id()
   return to_hex(utils.get_rand_bytes(16))
@@ -97,6 +98,7 @@ for _, strategy in helpers.each_strategy() do
     end
 
     describe("valid #http request", function ()
+      local mock
       lazy_setup(function()
         bp, _ = assert(helpers.get_db_utils(strategy, {
           "services",
@@ -109,17 +111,19 @@ for _, strategy in helpers.each_strategy() do
             ["X-Access-Token"] = "token",
           },
         })
+        mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
       end)
 
       lazy_teardown(function()
         helpers.stop_kong()
-        helpers.kill_http_server(HTTP_SERVER_PORT)
+        if mock then
+          mock("close", true)
+        end
       end)
 
       it("works", function ()
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
           local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
@@ -130,20 +134,18 @@ for _, strategy in helpers.each_strategy() do
           -- close client connection
           cli:close()
 
-          local ok
-          ok, headers, body = thread:join()
+          local lines
+          lines, body, headers = mock()
 
-          return ok
+          return lines
         end, 10)
 
         assert.is_string(body)
 
-        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["Content-Type"], "application/x-protobuf")
 
         -- custom http headers
-        idx = tablex.find(headers, "X-Access-Token: token")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["X-Access-Token"], "token")
 
         local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
         assert.not_nil(decoded)
@@ -175,6 +177,7 @@ for _, strategy in helpers.each_strategy() do
                               .. (case[2] and " service" or "")
                               .. (case[3] and " with global" or "")
       , function ()
+        local mock
         lazy_setup(function()
           bp, _ = assert(helpers.get_db_utils(strategy, {
             "services",
@@ -187,15 +190,17 @@ for _, strategy in helpers.each_strategy() do
               ["X-Access-Token"] = "token",
             },
           }, nil, case[1], case[2], case[3])
+          mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
         end)
 
         lazy_teardown(function()
           helpers.stop_kong()
-          helpers.kill_http_server(HTTP_SERVER_PORT)
+          if mock then
+            mock("close", true)
+          end
         end)
 
         it("works", function ()
-          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
           local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
@@ -206,20 +211,21 @@ for _, strategy in helpers.each_strategy() do
           -- close client connection
           cli:close()
 
-          local ok, err = thread:join()
+          local lines, err = mock()
 
-          -- we should have no telemetry reported
+          -- we should only have telemetry reported from the global plugin
           if case[3] then
-            assert(ok, err)
+            assert(lines, err)
 
           else
-            assert.is_falsy(ok)
+            assert.is_falsy(lines)
             assert.matches("timeout", err)
           end
         end)
       end)
     end
     describe("overwrite resource attributes #http", function ()
+      local mock
       lazy_setup(function()
         bp, _ = assert(helpers.get_db_utils(strategy, {
           "services",
@@ -233,17 +239,19 @@ for _, strategy in helpers.each_strategy() do
             ["os.version"] = "debian",
           }
         })
+        mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
       end)
 
       lazy_teardown(function()
         helpers.stop_kong()
-        helpers.kill_http_server(HTTP_SERVER_PORT)
+        if mock then
+          mock("close", true)
+        end
       end)
 
       it("works", function ()
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
           local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
@@ -254,16 +262,15 @@ for _, strategy in helpers.each_strategy() do
           -- close client connection
           cli:close()
 
-          local ok
-          ok, headers, body = thread:join()
+          local lines
+          lines, body, headers = mock()
 
-          return ok
+          return lines
         end, 10)
 
         assert.is_string(body)
 
-        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["Content-Type"], "application/x-protobuf")
 
         local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
         assert.not_nil(decoded)
@@ -386,6 +393,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("#propagation", function ()
+      local mock
       lazy_setup(function()
         bp, _ = assert(helpers.get_db_utils(strategy, {
           "services",
@@ -394,11 +402,14 @@ for _, strategy in helpers.each_strategy() do
         }, { "opentelemetry" }))
 
         setup_instrumentations("request")
+        mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
       end)
 
       lazy_teardown(function()
         helpers.stop_kong()
-        helpers.kill_http_server(HTTP_SERVER_PORT)
+        if mock then
+          mock("close", true)
+        end
       end)
 
       it("#propagate w3c traceparent", function ()
@@ -407,7 +418,6 @@ for _, strategy in helpers.each_strategy() do
 
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
           local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
@@ -421,16 +431,15 @@ for _, strategy in helpers.each_strategy() do
           -- close client connection
           cli:close()
 
-          local ok
-          ok, headers, body = thread:join()
+          local lines
+          lines, body, headers = mock()
 
-          return ok
+          return lines
         end, 10)
 
         assert.is_string(body)
 
-        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["Content-Type"], "application/x-protobuf")
 
         local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
         assert.not_nil(decoded)
@@ -455,6 +464,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("#referenceable fields", function ()
+      local mock
       lazy_setup(function()
         helpers.setenv("TEST_OTEL_ACCESS_KEY", "secret-1")
         helpers.setenv("TEST_OTEL_ACCESS_SECRET", "secret-2")
@@ -471,20 +481,22 @@ for _, strategy in helpers.each_strategy() do
             ["X-Access-Secret"] = "{vault://env/test_otel_access_secret}",
           },
         })
+        mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
       end)
 
       lazy_teardown(function()
         helpers.unsetenv("TEST_OTEL_ACCESS_KEY")
         helpers.unsetenv("TEST_OTEL_ACCESS_SECRET")
-        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
+        if mock then
+          mock("close", true)
+        end
       end)
 
       it("works", function ()
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
-          local cli = helpers.proxy_client(7000)
+          local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
             path    = "/",
@@ -494,23 +506,19 @@ for _, strategy in helpers.each_strategy() do
           -- close client connection
           cli:close()
 
-          local ok
-          ok, headers, body = thread:join()
+          local lines
+          lines, body, headers = mock()
 
-          return ok
+          return lines
         end, 60)
 
         assert.is_string(body)
 
-        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["Content-Type"], "application/x-protobuf")
 
         -- dereferenced headers
-        idx = tablex.find(headers, "X-Access-Key: secret-1")
-        assert.not_nil(idx, headers)
-
-        idx = tablex.find(headers, "X-Access-Secret: secret-2")
-        assert.not_nil(idx, headers)
+        assert.equals(headers["X-Access-Key"], "secret-1")
+        assert.equals(headers["X-Access-Secret"], "secret-2")
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

**Note**: flakiness of this test is addressed by https://github.com/Kong/kong/pull/10877

This PR uses the new helpers.http_mock to replace helpers.http_server and adjusts some timeouts to reduce unnecessary waiting time

**Performance improvement** 
before: [about 58 seconds](https://github.com/Kong/kong/actions/runs/5004201982/jobs/8966490811#step:9:1348)
after: [about 36 seconds](https://github.com/Kong/kong/actions/runs/5006865312/jobs/8972713815?pr=10888#step:9:1336)

### Checklist

- [x] The Pull Request has tests
- [x] (NA) There's an entry in the CHANGELOG
- [x] (NA) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-1590](https://konghq.atlassian.net/browse/KAG-1590)


[KAG-1590]: https://konghq.atlassian.net/browse/KAG-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ