### PR TITLE
tests(cmd): stop/start test improvements

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -735,9 +735,10 @@ describe("kong start/stop #" .. strategy, function()
       nginx_main_worker_processes = 2, -- keeping this low for the sake of speed
     }
 
+    local start_cmd = fmt("start -p %q -c %q", PREFIX, TEST_CONF_PATH)
+
     local function start()
-      local cmd = fmt("start -p %q", PREFIX)
-      local ok, code, stdout, stderr = kong_exec(cmd, env, true)
+      local ok, code, stdout, stderr = kong_exec(start_cmd, env, true)
 
       if ok then
         wait_until_healthy()
@@ -866,7 +867,7 @@ describe("kong start/stop #" .. strategy, function()
         pcall(helpers.dir.rmtree, prefix)
       end)
 
-      assert(kong_exec(fmt("prepare -p %q", prefix), {
+      assert(kong_exec(fmt("prepare -p %q -c %q", prefix, TEST_CONF_PATH), {
         database = strategy,
         proxy_listen = "127.0.0.1:8000",
         stream_listen = "127.0.0.1:9000",

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -470,7 +470,21 @@ describe("kong start/stop #" .. strategy, function()
       end)
 
       it("starts with a valid declarative config string", function()
-        local config_string = [[{"_format_version":"1.1","services":[{"name":"my-service","url":"http://127.0.0.1:15555","routes":[{"name":"example-route","hosts":["example.test"]}]}]}]]
+        local config_string = cjson.encode {
+          _format_version = "1.1",
+          services =  {
+            {
+              name = "my-service",
+              url = "http://127.0.0.1:15555",
+              routes = {
+                {
+                  name = "example-route",
+                  hosts = { "example.test" }
+                }
+              }
+            }
+          }
+        }
 
         assert(helpers.start_kong({
           database = "off",

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -234,10 +234,10 @@ describe("kong start/stop #" .. strategy, function()
         prefix = PREFIX
       }))
 
-      assert.logfile().has.no.line("[emerg]", true)
-      assert.logfile().has.no.line("[alert]", true)
-      assert.logfile().has.no.line("[crit]", true)
-      assert.logfile().has.no.line("[error]", true)
+      assert.logfile().has.no.line("[emerg]", true, 0)
+      assert.logfile().has.no.line("[alert]", true, 0)
+      assert.logfile().has.no.line("[crit]",  true, 0)
+      assert.logfile().has.no.line("[error]", true, 0)
     end)
 
   else
@@ -252,11 +252,11 @@ describe("kong start/stop #" .. strategy, function()
 
       assert(kong_exec("stop", { prefix = PREFIX }))
 
-      assert.logfile().has.no.line("[emerg]", true)
-      assert.logfile().has.no.line("[alert]", true)
-      assert.logfile().has.no.line("[crit]", true)
-      assert.logfile().has.no.line("[error]", true)
-      assert.logfile().has.no.line("[warn]", true)
+      assert.logfile().has.no.line("[emerg]", true, 0)
+      assert.logfile().has.no.line("[alert]", true, 0)
+      assert.logfile().has.no.line("[crit]",  true, 0)
+      assert.logfile().has.no.line("[error]", true, 0)
+      assert.logfile().has.no.line("[warn]",  true, 0)
     end)
   end
 
@@ -888,10 +888,11 @@ describe("kong start/stop #" .. strategy, function()
       assert.truthy(helpers.path.exists(prefix .. "/worker_events.sock"))
       assert.truthy(helpers.path.exists(prefix .. "/stream_worker_events.sock"))
 
-      assert.logfile(prefix .. "/logs/error.log").has.no.line("[error]", true)
-      assert.logfile(prefix .. "/logs/error.log").has.no.line("[alert]", true)
-      assert.logfile(prefix .. "/logs/error.log").has.no.line("[crit]", true)
-      assert.logfile(prefix .. "/logs/error.log").has.no.line("[emerg]", true)
+      local log = prefix .. "/logs/error.log"
+      assert.logfile(log).has.no.line("[error]", true, 0)
+      assert.logfile(log).has.no.line("[alert]", true, 0)
+      assert.logfile(log).has.no.line("[crit]",  true, 0)
+      assert.logfile(log).has.no.line("[emerg]", true, 0)
     end)
   end)
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -93,13 +93,11 @@ describe("kong start/stop #" .. strategy, function()
       admin_client:close()
     end
 
-    helpers.kill_all()
-    helpers.clean_logfile()
+    helpers.stop_kong()
   end)
 
   lazy_teardown(function()
     helpers.stop_kong()
-    helpers.clean_prefix()
   end)
 
   it("fails with referenced values that are not initialized", function()

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -285,8 +285,9 @@ describe("kong start/stop #" .. strategy, function()
 
   it("creates prefix directory if it doesn't exist", function()
     finally(function()
-      helpers.kill_all("foobar")
-      pcall(helpers.dir.rmtree, "foobar")
+      -- this test uses a non-default prefix, so it must manage
+      -- its kong instance directly
+      helpers.stop_kong("foobar")
     end)
 
     assert.falsy(helpers.path.exists("foobar"))
@@ -871,8 +872,9 @@ describe("kong start/stop #" .. strategy, function()
       local prefix = "relpath"
 
       finally(function()
-        helpers.kill_all(prefix)
-        pcall(helpers.dir.rmtree, prefix)
+        -- this test uses a non-default prefix, so it must manage
+        -- its kong instance directly
+        helpers.stop_kong(prefix)
       end)
 
       assert(kong_exec(fmt("prepare -p %q -c %q", prefix, TEST_CONF_PATH), {

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -15,7 +15,15 @@ local TEST_CONF_PATH = helpers.test_conf_path
 
 local function wait_until_healthy(prefix)
   prefix = prefix or PREFIX
-  local cmd = fmt("%s health -p %q", helpers.bin_path, prefix)
+
+  local cmd
+
+  -- use `kong-health` if available
+  if helpers.path.exists(helpers.bin_path .. "-health") then
+    cmd = fmt("%s-health -p %q", helpers.bin_path, prefix)
+  else
+    cmd = fmt("%s health -p %q", helpers.bin_path, prefix)
+  end
 
   assert
     .with_timeout(10)

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -362,12 +362,10 @@ describe("kong start/stop #" .. strategy, function()
         path = "/hello",
       })
       assert.res_status(404, res) -- no Route configured
-      assert(helpers.stop_kong(PREFIX))
 
       -- TEST: since nginx started in the foreground, the 'kong start' command
       -- stdout should receive all of nginx's stdout as well.
-      local stdout = read_file(stdout_path)
-      assert.matches([["GET /hello HTTP/1.1" 404]] , stdout, nil, true)
+      assert.logfile(stdout_path).has.line([["GET /hello HTTP/1.1" 404]], true, 5)
     end)
   end)
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -423,9 +423,7 @@ describe("kong start/stop #" .. strategy, function()
                                 TEST_CONF_PATH, stdout_path)
 
       local ok, _, _, stderr = helpers.execute(cmd, true)
-      if not ok then
-        error(stderr)
-      end
+      assert.truthy(ok, stderr)
 
       wait_until_healthy()
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2708,7 +2708,8 @@ do
   local function re_match(subject, pattern)
     local pos, _, err = ngx.re.find(subject, pattern, "oj")
     if err then
-      error(err)
+      error(("invalid regex provided to logfile assertion %q: %s")
+            :format(pattern, err), 5)
     end
 
     if pos then

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2012,7 +2012,7 @@ local function wait_for_all_config_update(opts)
     if stream_enabled then
       pwait_until(function ()
         local proxy = proxy_client(proxy_client_timeout, stream_port, stream_ip)
-  
+
         res = proxy:get("/always_200")
         local ok, err = pcall(assert, res.status == 200)
         proxy:close()
@@ -2699,6 +2699,39 @@ do
   luassert:register("modifier", "errlog", modifier_errlog) -- backward compat
   luassert:register("modifier", "logfile", modifier_errlog)
 
+  local function substr(subject, pattern)
+    if subject:find(pattern, nil, true) ~= nil then
+      return subject
+    end
+  end
+
+  local function re_match(subject, pattern)
+    local pos, _, err = ngx.re.find(subject, pattern, "oj")
+    if err then
+      error(err)
+    end
+
+    if pos then
+      return subject
+    end
+  end
+
+  local function find_in_file(fpath, pattern, matcher)
+    local fh = assert(io.open(fpath, "r"))
+    local found
+
+    for line in fh:lines() do
+      if matcher(line, pattern) then
+        found = line
+        break
+      end
+    end
+
+    fh:close()
+
+    return found
+  end
+
 
   --- Assertion checking if any line from a file matches the given regex or
   -- substring.
@@ -2728,37 +2761,30 @@ do
            "Expected the regex argument to be a string")
     assert(type(fpath) == "string",
            "Expected the file path argument to be a string")
-    assert(type(timeout) == "number" and timeout > 0,
-           "Expected the timeout argument to be a positive number")
+    assert(type(timeout) == "number" and timeout >= 0,
+           "Expected the timeout argument to be a number >= 0")
 
-    local pok = pcall(wait_until, function()
-      local logs = pl_file.read(fpath)
-      local from, _, err
 
-      for line in logs:gmatch("[^\r\n]+") do
-        if plain then
-          from = string.find(line, regex, nil, true)
+    local matcher = plain and substr or re_match
 
-        else
-          from, _, err = ngx.re.find(line, regex)
-          if err then
-            error(err)
-          end
-        end
+    local found = find_in_file(fpath, regex, matcher)
+    local deadline = ngx.now() + timeout
 
-        if from then
-          table.insert(args, 1, line)
-          table.insert(args, 1, regex)
-          args.n = 2
-          return true
-        end
-      end
-    end, timeout)
+    while not found and ngx.now() <= deadline do
+      ngx.sleep(0.05)
+      found = find_in_file(fpath, regex, matcher)
+    end
 
-    table.insert(args, 1, fpath)
-    args.n = args.n + 1
+    args[1] = fpath
+    args[2] = regex
+    args.n = 2
 
-    return pok
+    if found then
+      args[3] = found
+      args.n = 3
+    end
+
+    return found
   end
 
   say:set("assertion.match_line.negative", unindent [[


### PR DESCRIPTION
### Summary

This changeset includes several improvements to our start/stop CLI tests. Some changes are purely stylistic in nature (formatting, variable naming/conventions), but beyond that there are some functional improvements as well:

* Several tests had their own "block until Kong is up and responsive" pattern. This PR adds a single helper function to do just that and refactors all tests to use it.
* The usage of `finally(...)` blocks for cleanup has been reduced. The top-level `after_each()` handler for this test suite closes client connections and stops the default Kong instance, so we don't need `finally(function() helpers.stop_kong() end)` in every single test case.
* Additional assertion error output has been added to the `dangling socket cleanup` tests for debugging
* The `logfile(...).has.no.line(...)` assertion has been updated to accept a `0` timeout. Updating tests in this file to use the `0` timeout has reduced the average run-time of this test suite by ~20s on my machine.

The style changes make this changeset a little noisy for what it is. Read commit-by-commit if needed.

### re: cassandra

I have not removed the cassandra test logic from the file, because leaving it all untouched affords us the opportunity to backport these changes if we'd like to.

### Checklist

- [x] The Pull Request has tests
- [x] ~There's an entry in the CHANGELOG~ **N/A**
- [x] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~ **N/A**