### PR TITLE
tests(*): modify tests that need to access mockbin.com from integration test

### DIFF
--- a/spec/02-integration/04-admin_api/22-debug_spec.lua
+++ b/spec/02-integration/04-admin_api/22-debug_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require("spec.helpers")
 local cjson = require("cjson")
+local fmt = string.format
 
 local strategies = {}
 for _, strategy in helpers.each_strategy() do
@@ -8,13 +9,17 @@ end
 table.insert(strategies, "off")
 for _, strategy in pairs(strategies) do
 describe("Admin API - Kong debug route with strategy #" .. strategy, function()
+  local https_server
   lazy_setup(function()
     local bp = helpers.get_db_utils(nil, {}) -- runs migrations
 
+    local mock_https_server_port = helpers.get_available_port()
+
     local service_mockbin = assert(bp.services:insert {
       name     = "service-mockbin",
-      url      = "https://mockbin.com/request",
+      url      = fmt("https://127.0.0.1:%s/request", mock_https_server_port)
     })
+
     assert(bp.routes:insert {
       protocols     = { "http" },
       hosts         = { "mockbin.com" },
@@ -26,11 +31,16 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       service = service_mockbin,
     })
 
+    https_server = helpers.https_server.new(mock_https_server_port, nil, "https")
+    https_server:start()
+
     assert(helpers.start_kong {
       database = strategy,
       db_update_propagation = strategy == "cassandra" and 1 or 0,
       trusted_ips = "127.0.0.1",
       nginx_http_proxy_ssl_verify = "on",
+      -- Mocking https_server is using kong_spec key/cert pairs but the pairs does not
+      -- have domain defined, so ssl verify will still fail with domain mismatch
       nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
       nginx_http_proxy_ssl_verify_depth = "5",
     })
@@ -74,6 +84,7 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
   end)
 
   lazy_teardown(function()
+    https_server:shutdown()
     helpers.stop_kong()
     helpers.stop_kong("node2")
 
@@ -144,9 +155,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.no.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 2)
+      assert.logfile().has.no.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
 
       -- e2e test: we are not printing lower than alert
       helpers.clean_logfile()
@@ -194,9 +204,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 30)
+      assert.logfile().has.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
 
       -- e2e test: we are printing higher than debug
       helpers.clean_logfile()
@@ -574,9 +583,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.no.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 2)
+      assert.logfile().has.no.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
 
       -- e2e test: we are not printing lower than alert
       helpers.clean_logfile()
@@ -614,9 +622,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 30)
+      assert.logfile().has.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
 
       -- e2e test: we are printing higher than debug
       helpers.clean_logfile()

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -1,6 +1,7 @@
 local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers      = require "spec.helpers"
 local cjson        = require "cjson"
+local fmt          = string.format
 
 
 local function get_cert(server_name)
@@ -11,6 +12,32 @@ local function get_cert(server_name)
 
   return stdout
 end
+
+local mock_tls_server_port = helpers.get_available_port()
+
+local fixtures = {
+  dns_mock = helpers.dns_mock.new(),
+  http_mock = {
+    test_upstream_tls_server = fmt([[
+      server {
+          server_name example2.com;
+          listen %s ssl;
+
+          ssl_certificate        ../spec/fixtures/mtls_certs/example2.com.crt;
+          ssl_certificate_key    ../spec/fixtures/mtls_certs/example2.com.key;
+
+          location = / {
+              echo 'it works';
+          }
+      }
+    ]], mock_tls_server_port)
+  },
+}
+
+fixtures.dns_mock:A {
+  name = "example2.com",
+  address = "127.0.0.1",
+}
 
 for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
 for _, strategy in helpers.each_strategy() do
@@ -127,16 +154,18 @@ for _, strategy in helpers.each_strategy() do
         preserve_host = false,
       }
 
-      local service_mockbin = assert(bp.services:insert {
-        name     = "service-mockbin",
-        url      = "https://mockbin.com/request",
+      local service_example2 = assert(bp.services:insert {
+        name     = "service-example2",
+        protocol = "https",
+        host     = "example2.com",
+        port     = mock_tls_server_port,
       })
 
       assert(bp.routes:insert {
         protocols     = { "http" },
-        hosts         = { "mockbin.com" },
+        hosts         = { "example2.com" },
         paths         = { "/" },
-        service       = service_mockbin,
+        service       = service_example2,
       })
 
       assert(bp.routes:insert {
@@ -205,7 +234,7 @@ for _, strategy in helpers.each_strategy() do
 
       -- /wildcard tests
 
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
         router_flavor = flavor,
         database    = strategy,
         nginx_conf  = "spec/fixtures/custom_nginx.template",
@@ -213,7 +242,7 @@ for _, strategy in helpers.each_strategy() do
         nginx_http_proxy_ssl_verify = "on",
         nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
         nginx_http_proxy_ssl_verify_depth = "5",
-      })
+      }, nil, nil, fixtures))
 
       ngx.sleep(0.01)
 
@@ -233,13 +262,13 @@ for _, strategy in helpers.each_strategy() do
           method  = "GET",
           path    = "/",
           headers = {
-            Host  = "mockbin.com",
+            Host  = "example2.com",
           },
         })
         local body = assert.res_status(502, res)
         assert.equal("An invalid response was received from the upstream server", body)
         assert.logfile().has.line("upstream SSL certificate verify error: " ..
-                                  "(20:unable to get local issuer certificate) " ..
+                                  "(21:unable to verify the first certificate) " ..
                                   "while SSL handshaking to upstream", true, 2)
       end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR modifies the integration tests that need real access to mockbin.com, to let them access mocking HTTP server so that we can reduce possible flakiness caused by outer dependencies. 

(Note: if you search for `mockbin.com` or `mockbin.org` in the spec directory there are still some services filling in these domains, but they are not really accessing or depending on the response of the mockbin server, so it's okay)

I'm still using https_server here because http_mock does not support https and we still need https in these cases.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* tests(*): modify tests that need to access mockbin.com from integration test
