### PR TITLE
fix(*): fix worker notice logging when setting dynamic log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 
 #### Core
 
+- Fix a bug when worker consuming dynamic log level setting event and using a wrong reference for notice logging
+  [#10897](https://github.com/Kong/kong/pull/10897)
+
 #### Admin API
 
 #### Plugins

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -54,9 +54,9 @@ local DEFAULT_MATCH_LRUCACHE_SIZE = Router.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
 local kong_shm          = ngx.shared.kong
-local PLUGINS_REBUILD_COUNTER_KEY = 
+local PLUGINS_REBUILD_COUNTER_KEY =
                                 constants.PLUGINS_REBUILD_COUNTER_KEY
-local ROUTERS_REBUILD_COUNTER_KEY = 
+local ROUTERS_REBUILD_COUNTER_KEY =
                                 constants.ROUTERS_REBUILD_COUNTER_KEY
 
 
@@ -495,7 +495,7 @@ end
 local new_plugins_iterator
 do
   local PluginsIterator_new = PluginsIterator.new
-  new_plugins_iterator = function(version) 
+  new_plugins_iterator = function(version)
     local plugin_iterator, err = PluginsIterator_new(version)
     if not plugin_iterator then
       return nil, err
@@ -934,7 +934,7 @@ return {
             return
           end
 
-          log(NOTICE, "log level changed to ", data, " for worker ", worker)
+          log(NOTICE, "log level changed to ", data.log_level, " for worker ", worker)
         end, "debug", "log_level")
       end
 

--- a/spec/02-integration/04-admin_api/22-debug_spec.lua
+++ b/spec/02-integration/04-admin_api/22-debug_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require("spec.helpers")
 local cjson = require("cjson")
+local fmt = string.format
 
 local strategies = {}
 for _, strategy in helpers.each_strategy() do
@@ -182,6 +183,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
         message = "log level: debug"
         return json.message == message
       end, 30)
+
+      assert.logfile().has.line(fmt("log level changed to %s", ngx.DEBUG), true, 2)
 
       -- e2e test: we are printing higher than debug
       helpers.clean_logfile()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR fixes a bug when worker consuming dynamic log level setting event and using a wrong reference for notice logging

```
2023/05/18 14:29:06 [error] 23010#0: *3 [lua] callback.lua:98: do_handlerlist(): worker-events: event callback failed; source=debug, event=log_level, wid=0 error='./kong/runloop/handler.lua:937: bad argument #2 to 'log' (expected table to have __tostring metamethod)
stack traceback:
        [C]: in function 'log'
        ./kong/runloop/handler.lua:937: in function <./kong/runloop/handler.lua:925>
        [C]: in function 'xpcall'
        ...uild/kong-dev/openresty/lualib/resty/events/callback.lua:83: in function 'do_handlerlist'
        ...uild/kong-dev/openresty/lualib/resty/events/callback.lua:130: in function 'do_event'
        .../build/kong-dev/openresty/lualib/resty/events/worker.lua:68: in function 'do_event'
        .../build/kong-dev/openresty/lualib/resty/events/worker.lua:239: in function <.../build/kong-dev/openresty/lualib/resty/events/worker.lua:221>', data={"timeout":60,"log_level":8}, context: ngx.timer
```


### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog


### Issue reference

