### PR TITLE
docs(changelog): update changelog for 3.3.0 with the released one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,8 +138,8 @@
   [#10385](https://github.com/Kong/kong/pull/10385)
 - Request and response buffering options are now enabled for incoming HTTP 2.0 requests too.
   Thanks [@PidgeyBE](https://github.com/PidgeyBE) for contributing this change.
-  [#10204](https://github.com/Kong/kong/pull/10204)
   [#10595](https://github.com/Kong/kong/pull/10595)
+  [#10204](https://github.com/Kong/kong/pull/10204)
 - Add `KONG_UPSTREAM_DNS_TIME` to `kong.ctx` so that we can record the time it takes for DNS
   resolution when Kong proxies to upstream.
   [#10355](https://github.com/Kong/kong/pull/10355)
@@ -149,6 +149,7 @@
   [#10288](https://github.com/Kong/kong/pull/10288)
 - Added new span attribute `http.client_ip` to capture the client IP when behind a proxy.
   [#10723](https://github.com/Kong/kong/pull/10723)
+  [#10204](https://github.com/Kong/kong/pull/10204)
 
 #### Admin API
 
@@ -167,7 +168,7 @@
   prepared to process user requests.
   Load balancers frequently utilize this functionality to ascertain
   Kong's availability to distribute incoming requests.
-  [#10610](https://github.com/Kong/kong/pull/10610)
+  [#10610](https://github.com/Kong/kong/pull/10610),
   [#10787](https://github.com/Kong/kong/pull/10787)
 
 #### Plugins
@@ -228,8 +229,6 @@
   [#10514](https://github.com/Kong/kong/pull/10514)
 - Fix the UDP socket leak caused by frequent DNS queries.
   [#10691](https://github.com/Kong/kong/pull/10691)
-- Reports: fix a potential issue that could cause socket leaks.
-  [#10783](https://github.com/Kong/kong/pull/10783)
 - Fix a typo of mlcache option `shm_set_tries`.
   [#10712](https://github.com/Kong/kong/pull/10712)
 - Fix an issue where slow start up of Go plugin server causes dead lock.
@@ -277,10 +276,9 @@
   [#10687](https://github.com/Kong/kong/pull/10687)
 - **Oauth2**: prevent an authorization code created by one plugin instance to be exchanged for an access token by a different plugin instance.
   [#10011](https://github.com/Kong/kong/pull/10011)
-- **gRPC gateway**: fixed an issue that empty arrays in JSON are incorrectly encoded as `"{}"`; they are now encoded as `"[]"` to comply with standard.
+- **gRPC gateway**: fixed an issue that empty arrays in JSON are incorrectly encoded as `"{}"`; they are
+now encoded as `"[]"` to comply with standard.
   [#10790](https://github.com/Kong/kong/pull/10790)
-- **loggly & tcp-log & udp-log**: fix a potential issue that could cause socket leaks.
-  [#10783](https://github.com/Kong/kong/pull/10783)
 
 #### PDK
 


### PR DESCRIPTION
I revised the changes one by one. Besides trivial changes in punctuation/order:

#10783 (Reports: fix a potential issue that could cause socket leaks. and **loggly & tcp-log & udp-log**: fix a potential issue that could cause socket leaks.) was resolved after code freeze and was not backported to 3.3 - its changelog entry was put in the wrong place

#

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
