### PR TITLE
[cherry-pick release/3.2.x] tests(*): modify tests that need to access mockbin.com from integration test (#10893)

### DIFF
--- a/spec/02-integration/04-admin_api/22-debug_spec.lua
+++ b/spec/02-integration/04-admin_api/22-debug_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require("spec.helpers")
 local cjson = require("cjson")
+local fmt = string.format
 
 local strategies = {}
 for _, strategy in helpers.each_strategy() do
@@ -8,13 +9,17 @@ end
 table.insert(strategies, "off")
 for _, strategy in pairs(strategies) do
 describe("Admin API - Kong debug route with strategy #" .. strategy, function()
+  local https_server
   lazy_setup(function()
     local bp = helpers.get_db_utils(nil, {}) -- runs migrations
 
+    local mock_https_server_port = helpers.get_available_port()
+
     local service_mockbin = assert(bp.services:insert {
       name     = "service-mockbin",
-      url      = "https://mockbin.com/request",
+      url      = fmt("https://127.0.0.1:%s/request", mock_https_server_port)
     })
+
     assert(bp.routes:insert {
       protocols     = { "http" },
       hosts         = { "mockbin.com" },
@@ -22,11 +27,16 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       service       = service_mockbin,
     })
 
+    https_server = helpers.https_server.new(mock_https_server_port, nil, "https")
+    https_server:start()
+
     assert(helpers.start_kong {
       database = strategy,
       db_update_propagation = strategy == "cassandra" and 1 or 0,
       trusted_ips = "127.0.0.1",
       nginx_http_proxy_ssl_verify = "on",
+      -- Mocking https_server is using kong_spec key/cert pairs but the pairs does not
+      -- have domain defined, so ssl verify will still fail with domain mismatch
       nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
       nginx_http_proxy_ssl_verify_depth = "5",
     })
@@ -70,6 +80,7 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
   end)
 
   lazy_teardown(function()
+    https_server:shutdown()
     helpers.stop_kong()
     helpers.stop_kong("node2")
 
@@ -140,9 +151,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.no.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 2)
+      assert.logfile().has.no.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
 
       -- go back to default (debug)
       res = assert(helpers.admin_client():send {
@@ -177,9 +187,8 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       })
       body = assert.res_status(502, res)
       assert.equal("An invalid response was received from the upstream server", body)
-      assert.logfile().has.line("upstream SSL certificate verify error: " ..
-      "(20:unable to get local issuer certificate) " ..
-      "while SSL handshaking to upstream", true, 30)
+      assert.logfile().has.line([[upstream SSL certificate does not match]] ..
+        [[ "127.0.0.1" while SSL handshaking to upstream]], true, 2)
     end)
 
     it("changes log level for traditional mode", function()

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -1,6 +1,7 @@
 local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers      = require "spec.helpers"
 local cjson        = require "cjson"
+local fmt          = string.format
 
 
 local function get_cert(server_name)
@@ -11,6 +12,32 @@ local function get_cert(server_name)
 
   return stdout
 end
+
+local mock_tls_server_port = helpers.get_available_port()
+
+local fixtures = {
+  dns_mock = helpers.dns_mock.new(),
+  http_mock = {
+    test_upstream_tls_server = fmt([[
+      server {
+          server_name example2.com;
+          listen %s ssl;
+
+          ssl_certificate        ../spec/fixtures/mtls_certs/example2.com.crt;
+          ssl_certificate_key    ../spec/fixtures/mtls_certs/example2.com.key;
+
+          location = / {
+              echo 'it works';
+          }
+      }
+    ]], mock_tls_server_port)
+  },
+}
+
+fixtures.dns_mock:A {
+  name = "example2.com",
+  address = "127.0.0.1",
+}
 
 for _, strategy in helpers.each_strategy() do
   describe("SSL [#" .. strategy .. "]", function()
@@ -126,16 +153,18 @@ for _, strategy in helpers.each_strategy() do
         preserve_host = false,
       }
 
-      local service_mockbin = assert(bp.services:insert {
-        name     = "service-mockbin",
-        url      = "https://mockbin.com/request",
+      local service_example2 = assert(bp.services:insert {
+        name     = "service-example2",
+        protocol = "https",
+        host     = "example2.com",
+        port     = mock_tls_server_port,
       })
 
       assert(bp.routes:insert {
         protocols     = { "http" },
-        hosts         = { "mockbin.com" },
+        hosts         = { "example2.com" },
         paths         = { "/" },
-        service       = service_mockbin,
+        service       = service_example2,
       })
 
       assert(bp.routes:insert {
@@ -204,14 +233,14 @@ for _, strategy in helpers.each_strategy() do
 
       -- /wildcard tests
 
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
         database    = strategy,
         nginx_conf  = "spec/fixtures/custom_nginx.template",
         trusted_ips = "127.0.0.1",
         nginx_http_proxy_ssl_verify = "on",
         nginx_http_proxy_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
         nginx_http_proxy_ssl_verify_depth = "5",
-      })
+      }, nil, nil, fixtures))
 
       ngx.sleep(0.01)
 
@@ -231,13 +260,13 @@ for _, strategy in helpers.each_strategy() do
           method  = "GET",
           path    = "/",
           headers = {
-            Host  = "mockbin.com",
+            Host  = "example2.com",
           },
         })
         local body = assert.res_status(502, res)
         assert.equal("An invalid response was received from the upstream server", body)
         assert.logfile().has.line("upstream SSL certificate verify error: " ..
-                                  "(20:unable to get local issuer certificate) " ..
+                                  "(21:unable to verify the first certificate) " ..
                                   "while SSL handshaking to upstream", true, 2)
       end)
 


### PR DESCRIPTION
Cherry-picks https://github.com/Kong/kong/pull/10893

Stop using mockbin.com for a couple of tests to reduce external dependencies.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
