### PR TITLE
chore(venv): set BUILD_NAME in venv so that `make dev` can pick up

### DIFF
--- a/build/templates/venv.fish
+++ b/build/templates/venv.fish
@@ -9,6 +9,8 @@ if test (echo $FISH_VERSION | head -c 1) -lt 3
     echo "Fish version 3.0.0 or higher is required."
 end
 
+set -xg BUILD_NAME "$build_name"
+
 # Modified from virtualenv: https://github.com/pypa/virtualenv/blob/main/src/virtualenv/activation/fish/activate.fish
 
 set -xg KONG_VENV "$workspace_path/bazel-bin/build/$build_name"

--- a/build/templates/venv.sh
+++ b/build/templates/venv.sh
@@ -8,6 +8,9 @@ workspace_path="{{workspace_path}}"
 KONG_VENV="$workspace_path/bazel-bin/build/$build_name"
 export KONG_VENV
 
+BUILD_NAME=$build_name
+export BUILD_NAME
+
 # set PATH
 if [ -n "${_OLD_KONG_VENV_PATH}" ]; then
     # restore old PATH first, if this script is called multiple times


### PR DESCRIPTION
correct venv automatically

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When having multiple venvs, currently user has to do `make dev BUILD_NAME=another-venv` even if they are 
inside the venv.
This PR expoeses the BUILD_NAME env var in venv so that after user acitvate the env, they don't need to explictly
set BUILD_NAME to `make dev` anymore.

### Checklist

- [na] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

- set BUILD_NAME in venv so that `make dev` can pick up correct venv automatically


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
