### PR TITLE
perf(dbless): load declarative schema during init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@
 
 #### PDK
 
+#### Performance
+
+- In dbless mode, the declarative schema is now fully initialized at startup
+  instead of on-demand in the request path. This is most evident in decreased
+  response latency when updating configuration via the `/config` API endpoint.
+  [#10932](https://github.com/Kong/kong/pull/10932)
+
 ### Fixes
 
 #### Core

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -118,7 +118,13 @@ return {
       local opts = parse_config_post_opts(self.params)
 
       local old_hash = opts.check_hash and declarative.get_current_hash()
-      local dc = declarative.new_config(kong.configuration)
+
+      local dc = kong.db.declarative_config
+      if not dc then
+        kong.log.crit("received POST request to /config endpoint, but ",
+                      "kong.db.declarative_config was not initialized")
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
+      end
 
       local dc_table, new_hash = hydrate_config_from_request(self.params, dc)
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -59,8 +59,11 @@ function _M.new(clustering)
   assert(type(clustering.cert_key) == "cdata",
          "kong.clustering did not provide the cluster certificate private key")
 
+  assert(kong.db.declarative_config,
+         "kong.db.declarative_config was not initialized")
+
   local self = {
-    declarative_config = assert(declarative.new_config(clustering.conf)),
+    declarative_config = kong.db.declarative_config,
     conf = clustering.conf,
     cert = clustering.cert,
     cert_key = clustering.cert_key,

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -448,9 +448,7 @@ local function has_declarative_config(kong_config)
 end
 
 
-local function parse_declarative_config(kong_config)
-  local dc = declarative.new_config(kong_config)
-
+local function parse_declarative_config(kong_config, dc)
   local declarative_config, is_file, is_string = has_declarative_config(kong_config)
 
   local entities, err, _, meta, hash
@@ -625,13 +623,22 @@ function Kong.init()
   end
 
   if is_dbless(config) then
+    local dc, err = declarative.new_config(config)
+    if not dc then
+      error(err)
+    end
+
+    kong.db.declarative_config = dc
+
+
     if is_http_module or
        (#config.proxy_listeners == 0 and
         #config.admin_listeners == 0 and
         #config.status_listeners == 0)
     then
-      local err
-      declarative_entities, err, declarative_meta, declarative_hash = parse_declarative_config(kong.configuration)
+      declarative_entities, err, declarative_meta, declarative_hash =
+        parse_declarative_config(kong.configuration, dc)
+
       if not declarative_entities then
         error(err)
       end


### PR DESCRIPTION
### Summary

I was curious as to why some admin API tests for `/config` were so slow and went digging. Turns out this endpoint was reloading the declarative schema on every request, adding several hundred milliseconds of latency.

This updates the logic in Kong.init() to load the declarative config schema and store it in the kong global at `kong.db.declarative_config`.

#### before

```
$ busted spec/02-integration/04-admin_api/15-off_spec.lua --filter concurrency
●
1 success / 0 failures / 0 errors / 0 pending : 42.547819 seconds
```

#### after

```
$ busted spec/02-integration/04-admin_api/15-off_spec.lua --filter concurrency
●
1 success / 0 failures / 0 errors / 0 pending : 3.752036 seconds
```

No additional tests are needed because the functionality is already tested:

The following tests exercise the declarative config endpoint (POST /config):

spec/02-integration/02-cmd/03-reload_spec.lua
spec/02-integration/04-admin_api/11-reports_spec.lua
spec/02-integration/04-admin_api/15-off_spec.lua
spec/02-integration/05-proxy/02-router_spec.lua
spec/02-integration/08-status_api/01-core_routes_spec.lua
spec/02-integration/08-status_api/03-readiness_endpoint_spec.lua
spec/02-integration/11-dbless/01-respawn_spec.lua
spec/02-integration/11-dbless/03-config_persistence_spec.lua

And the following tests exercise the data plane configuration reload functionality:

spec/02-integration/09-hybrid_mode/01-sync_spec.lua
spec/02-integration/09-hybrid_mode/03-pki_spec.lua
spec/02-integration/09-hybrid_mode/04-cp_cluster_sync_spec.lua
spec/02-integration/09-hybrid_mode/08-lazy_export_spec.lua
spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua

### Checklist

- [x] ~The Pull Request has tests~ N/A - tested by existing tests
- [x] There's an entry in the CHANGELOG
- [x] ~There is a user-facing docs PR~