### PR TITLE
tests(proxy/ssl): add mocks_only to avoid dns querying

### DIFF
--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -16,7 +16,7 @@ end
 local mock_tls_server_port = helpers.get_available_port()
 
 local fixtures = {
-  dns_mock = helpers.dns_mock.new(),
+  dns_mock = helpers.dns_mock.new({ mocks_only = true }),
   http_mock = {
     test_upstream_tls_server = fmt([[
       server {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

DNS querying costs a lot of time, here I add an option `mocks_only = true`, 
this will avoid actual dns querying, and reduce the time cost from 1-10s to 10ms.

KAG-1644

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


