### PR TITLE
tests(rate-limiting): improve flaky test

### DIFF
--- a/spec/fixtures/redis/docker-entrypoint.sh
+++ b/spec/fixtures/redis/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 if [ -d /workspace ] ;  then
     redis-server                                                    \
+        --port 6379                                                 \
         --tls-port 6380                                             \
         --tls-cert-file /workspace/spec/fixtures/redis/server.crt   \
         --tls-key-file /workspace/spec/fixtures/redis/server.key    \


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The CE plugin `rate-limiting` test units take over 60s for each. This PR tries to improve the performance.

### Checklist

- [x] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Test refactor
* Change limit window from `minute` to `second`.
* Reduce limit number from `6` to `1`.
* Safeguard by 10 rounds.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4988
