### PR TITLE
perf(dbless): load declarative schema during init() (#10932) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,13 @@ now encoded as `"[]"` to comply with standard.
 - Support for `upstream_status` field in log serializer.
   [#10296](https://github.com/Kong/kong/pull/10296)
 
+#### Performance
+
+- In dbless mode, the declarative schema is now fully initialized at startup
+  instead of on-demand in the request path. This is most evident in decreased
+  response latency when updating configuration via the `/config` API endpoint.
+  [#10932](https://github.com/Kong/kong/pull/10932)
+
 ### Fixes
 
 #### Core

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -118,7 +118,13 @@ return {
       local opts = parse_config_post_opts(self.params)
 
       local old_hash = opts.check_hash and declarative.get_current_hash()
-      local dc = declarative.new_config(kong.configuration)
+
+      local dc = kong.db.declarative_config
+      if not dc then
+        kong.log.crit("received POST request to /config endpoint, but ",
+                      "kong.db.declarative_config was not initialized")
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
+      end
 
       local dc_table, new_hash = hydrate_config_from_request(self.params, dc)
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -59,8 +59,11 @@ function _M.new(clustering)
   assert(type(clustering.cert_key) == "cdata",
          "kong.clustering did not provide the cluster certificate private key")
 
+  assert(kong.db.declarative_config,
+         "kong.db.declarative_config was not initialized")
+
   local self = {
-    declarative_config = assert(declarative.new_config(clustering.conf)),
+    declarative_config = kong.db.declarative_config,
     conf = clustering.conf,
     cert = clustering.cert,
     cert_key = clustering.cert_key,

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -448,9 +448,7 @@ local function has_declarative_config(kong_config)
 end
 
 
-local function parse_declarative_config(kong_config)
-  local dc = declarative.new_config(kong_config)
-
+local function parse_declarative_config(kong_config, dc)
   local declarative_config, is_file, is_string = has_declarative_config(kong_config)
 
   local entities, err, _, meta, hash
@@ -625,13 +623,22 @@ function Kong.init()
   end
 
   if is_dbless(config) then
+    local dc, err = declarative.new_config(config)
+    if not dc then
+      error(err)
+    end
+
+    kong.db.declarative_config = dc
+
+
     if is_http_module or
        (#config.proxy_listeners == 0 and
         #config.admin_listeners == 0 and
         #config.status_listeners == 0)
     then
-      local err
-      declarative_entities, err, declarative_meta, declarative_hash = parse_declarative_config(kong.configuration)
+      declarative_entities, err, declarative_meta, declarative_hash =
+        parse_declarative_config(kong.configuration, dc)
+
       if not declarative_entities then
         error(err)
       end


### PR DESCRIPTION
This is a backport of #10932.

## summary

With this change we are no longer reloading the declarative schema for every `POST /config` request (something that has been the case since 3.0, I think).

The schema load operation adds 150-200ms of latency to each request in my local testing:

```
# serialize requests (otherwise we're just fighting lock contention)
$ wrk -c 1 -t 1 -s wrk.lua --latency -d 60 http://localhost:8001/config
```

<details>
<summary>wrk.lua</summary>

```lua
local cjson = require "cjson"

local conf = {
  _transform = false,
  _format_version = "3.0",
  services = {},
}

for i = 1, 500 do
  conf.services[i] = {
    name     = "my-service-" .. tostring(i),
    protocol = "http",
    host     = "127.0.0.1",
    port     = 80,
    routes   = {
      {
        name = "my-service-route-" .. tostring(i),
        hosts = { "my-service-route-" .. tostring(i) .. ".test" },
        paths = { "/" },
      }
    }
  }
end

local body = cjson.encode(conf)

local headers = {
  ["content-type"] = "application/json",
}

local wrk = assert(_G.wrk)

wrk.scheme = "http"
wrk.host = "127.0.0.1"
wrk.port = 8001
wrk.method = "POST"
wrk.path = "/config"
wrk.body = body
wrk.headers = headers
```
</details>


Results for cc3b056e97:
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   361.96ms   53.54ms 439.67ms   55.15%
    Req/Sec     2.41      0.57     5.00     60.00%
  Latency Distribution
     50%  391.33ms
     75%  406.90ms
     90%  416.41ms
     99%  433.45ms
  165 requests in 1.00m, 59.94MB read
Requests/sec:      2.75
Transfer/sec:      1.00MB
```

Results for c339a8cb7a:
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   160.62ms   27.79ms 229.26ms   78.06%
    Req/Sec     6.60      2.50    10.00     59.26%
  Latency Distribution
     50%  146.25ms
     75%  171.50ms
     90%  210.79ms
     99%  221.30ms
  351 requests in 1.00m, 127.51MB read
Requests/sec:      5.84
Transfer/sec:      2.12MB
```

## why backport?

For an API-centric product, something that decreases the latency on a heavily-used API endpoint by triple digit milliseconds is worth a backport, especially given 3.3 is destined to be the next LTS.