### PR TITLE
fix(migrations): wait schema consensus before running up_function when migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   and return a 500 error under certain circumstances.
   [#10896](https://github.com/Kong/kong/pull/10896)
 
+#### Core
+
+- Fix a bug that might lead to an error when running migrations due to a slow consensus across the database cluster.
+  [#10946](https://github.com/Kong/kong/pull/10946)
+
 ## 3.3.0
 
 ### Breaking Changes

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -554,6 +554,14 @@ do
             end
           end
 
+          -- ensure schema consensus is reached before running DML queries
+          -- in up_f that could span all peers
+          ok, err = self.connector:wait_for_schema_consensus()
+          if not ok then
+            self.connector:close()
+            return nil, prefix_err(self, err)
+          end
+
           if strategy_migration.up_f then
             local pok, perr, err = xpcall(strategy_migration.up_f, debug.traceback, self.connector)
             if not pok or err then


### PR DESCRIPTION
### Summary

In the progress of migrations, we need to ensure schema consensus is reached before running DML queries in up_function that could span all peers when the database is a cluster.

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

- FTI-4743
