### PR TITLE
fix(venv): fix cwd var not persist to child process

### DIFF
--- a/scripts/dependency_services/up.fish
+++ b/scripts/dependency_services/up.fish
@@ -14,6 +14,9 @@ end
 source $KONG_SERVICE_ENV_FILE
 
 function stop_services -d 'Stop dependency services of Kong and clean up environment variables.'
+    # set this again in child process without need to export env var
+    set cwd (dirname (status --current-filename))
+
     if test -n $COMPOSE_FILE && test -n $COMPOSE_PROJECT_NAME
         bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE down
     end


### PR DESCRIPTION

### Summary

Set `$cwd` var correctly when calling `stop_services` or `deactivate`.

### Checklist

- [na] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* fix(venv): fix cwd var not persist to child process

