### PR TITLE
perf(prometheus): fix upstream health expensive iterate latency spike issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,7 @@
   instead of on-demand in the request path. This is most evident in decreased
   response latency when updating configuration via the `/config` API endpoint.
   [#10932](https://github.com/Kong/kong/pull/10932)
-- The Prometheus plugin has been optimized to address latency issues in scraping metrics
-  spikes for the proxy. This has been achieved through the use of `yield` in the long loop
-  iteration of upstream health.
+- The Prometheus plugin has been optimized to reduce proxy latency impacts during scraping.
   [#10949](https://github.com/Kong/kong/pull/10949)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
   instead of on-demand in the request path. This is most evident in decreased
   response latency when updating configuration via the `/config` API endpoint.
   [#10932](https://github.com/Kong/kong/pull/10932)
+- The Prometheus plugin has been optimized to address latency issues in scraping metrics
+  spikes for the proxy. This has been achieved through the use of `yield` in the long loop
+  iteration of upstream health.
+  [#10949](https://github.com/Kong/kong/pull/10949)
 
 ### Fixes
 

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -421,6 +421,9 @@ local function metric_data(write_fn)
     -- upstream targets accessible?
     local upstreams_dict = get_all_upstreams()
     for key, upstream_id in pairs(upstreams_dict) do
+      -- long loop maybe spike proxy request latency, so we 
+      -- need yield to avoid blocking other requests
+      -- kong.tools.utils.yield(true)
       yield(true)
       local _, upstream_name = key:match("^([^:]*):(.-)$")
       upstream_name = upstream_name and upstream_name or key

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -5,6 +5,7 @@ local concat = table.concat
 local ngx_timer_pending_count = ngx.timer.pending_count
 local ngx_timer_running_count = ngx.timer.running_count
 local balancer = require("kong.runloop.balancer")
+local yield = require("kong.tools.utils").yield
 local get_all_upstreams = balancer.get_all_upstreams
 if not balancer.get_all_upstreams then -- API changed since after Kong 2.5
   get_all_upstreams = require("kong.runloop.balancer.upstreams").get_all_upstreams
@@ -420,6 +421,7 @@ local function metric_data(write_fn)
     -- upstream targets accessible?
     local upstreams_dict = get_all_upstreams()
     for key, upstream_id in pairs(upstreams_dict) do
+      yield(true)
       local _, upstream_name = key:match("^([^:]*):(.-)$")
       upstream_name = upstream_name and upstream_name or key
       -- based on logic from kong.db.dao.targets

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -1,5 +1,6 @@
 local kong = kong
 local ngx = ngx
+local get_phase = ngx.get_phase
 local lower = string.lower
 local concat = table.concat
 local ngx_timer_pending_count = ngx.timer.pending_count
@@ -413,6 +414,8 @@ local function metric_data(write_fn)
     end
   end
 
+  local phase = get_phase()
+
   -- only export upstream health metrics in traditional mode and data plane
   if role ~= "control_plane" and should_export_upstream_health_metrics then
     -- erase all target/upstream metrics, prevent exposing old metrics
@@ -424,7 +427,7 @@ local function metric_data(write_fn)
       -- long loop maybe spike proxy request latency, so we 
       -- need yield to avoid blocking other requests
       -- kong.tools.utils.yield(true)
-      yield(true)
+      yield(true, phase)
       local _, upstream_name = key:match("^([^:]*):(.-)$")
       upstream_name = upstream_name and upstream_name or key
       -- based on logic from kong.db.dao.targets

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -200,9 +200,9 @@ local function full_metric_name(name, label_names, label_values)
       label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
     end
 
-    label_parts[idx] = table.concat({key, '="', label_value, '"'})
+    label_parts[idx] = string.format('%s="%s"', key, label_value)
   end
-  return name .. "{" .. table.concat(label_parts, ",") .. "}"
+  return string.format('%s{%s}', name, table.concat(label_parts, ","))
 end
 
 -- Extract short metric name from the full one.

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -59,6 +59,7 @@ local ngx = ngx
 local ngx_log = ngx.log
 local ngx_sleep = ngx.sleep
 local ngx_re_match = ngx.re.match
+local ngx_re_gsub = ngx.re.gsub
 local ngx_print = ngx.print
 local error = error
 local type = type
@@ -69,6 +70,7 @@ local tonumber = tonumber
 local st_format = string.format
 local table_sort = table.sort
 local tb_clear = require("table.clear")
+local tb_new = require("table.new")
 local yield = require("kong.tools.utils").yield
 
 
@@ -191,11 +193,11 @@ local function full_metric_name(name, label_names, label_values)
       label_value = tostring(label_values[idx])
     end
     if string.find(label_value, "\\") then
-      label_value = ngx.re.gsub(label_value, "\\", "\\\\", "jo")
+      label_value = ngx_re_gsub(label_value, "\\", "\\\\", "jo")
     end
 
     if string.find(label_value, '"') then
-      label_value = ngx.re.gsub(label_value, '"', '\\"', "jo")
+      label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
     end
 
     label_parts[idx] = table.concat({key, '="', label_value, '"'})

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -192,11 +192,11 @@ local function full_metric_name(name, label_names, label_values)
     else
       label_value = tostring(label_values[idx])
     end
-    if string.find(label_value, "\\") then
+    if string.find(label_value, "\\", 1, true) then
       label_value = ngx_re_gsub(label_value, "\\", "\\\\", "jo")
     end
 
-    if string.find(label_value, '"') then
+    if string.find(label_value, '"', 1, true) then
       label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
     end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
base on https://github.com/Kong/kong/pull/10749#issuecomment-1523111032
In my testing, the most CPU-intensive task for the Prometheus plugin is the part of iterating through all upstream health statuses. This part blocks for around 400ms on every metrics request (with 10k upstreams and 20k targets), which is unacceptable for us.
And I found the most time-consuming points in this function, which are caused by excessive creation of temporary tables leading to excessive GC pressure, as well as some performance losses caused by `table.insert` `string.gsub` due to Luajit NYI. Therefore, the solution to this problem is that
1. try to `yield` in long loop in upstream iteration.
2. fix NYI in `full_metrics_name` function, and reduce `gsub` function call.

In my opinion, this iteration doesn't really need to be done in this way. It's clear that traversing all upstream health statuses every time is not a good solution. However, the use of yield here is merely a workaround, as the required CPU time doesn't disappear, but is simply preempted to prevent it from affecting the delay of the proxy too much.




<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests (No need)
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-632
