### PR TITLE
docs(upgrade.md): fix a typo in UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -133,7 +133,7 @@ Data Planes (DPs) are capable of serving traffic normally during the entire migr
    as your old one. Run `kong migrations up` and `kong migrations finish`.
 3. Start the newly installed 3.0.x CP. Old DPs are expected to complain
 about connection failure to the CP in the log, for example:
-`connection to Control Plane ... broken: failed to connect: connection refused` but this is perfectly okay during the upgrade ad does not affect normal proxy traffic.
+`connection to Control Plane ... broken: failed to connect: connection refused` but this is perfectly okay during the upgrade and does not affect normal proxy traffic.
 4. Start provisioning 3.0.x DPs.
 5. Gradually shift traffic from your old 2.8.x DPs to
    your 3.0.x DPs. Monitor your traffic to make sure everything


### PR DESCRIPTION
I think 'and' was mistakenly written as 'ad'

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
