### PR TITLE
chore(build): write copyright header in correct encoding

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -51,12 +51,16 @@ def _copyright_header(ctx):
         if path.endswith(".js") or path.endswith(".map") or path.endswith(".css"):
             content = ctx.read(path)
             if not content.startswith(copyright_content_js):
-                ctx.file(path, copyright_content_js + content)
+                # the default enabled |legacy_utf8| leads to a double-encoded utf-8
+                # while writing utf-8 content read by |ctx.read|, let's disable it
+                ctx.file(path, copyright_content_js + content, legacy_utf8 = False)
 
         elif path.endswith(".html"):
             content = ctx.read(path)
             if not content.startswith(copyright_content_html):
-                ctx.file(path, copyright_content_html + content)
+                # the default enabled |legacy_utf8| leads to a double-encoded utf-8
+                # while writing utf-8 content read by |ctx.read|, let's disable it
+                ctx.file(path, copyright_content_html + content, legacy_utf8 = False)
 
 def _github_release_impl(ctx):
     ctx.file("WORKSPACE", "workspace(name = \"%s\")\n" % ctx.name)


### PR DESCRIPTION
In bazel, files are always read in ISO-8859-1 encoding by using `ctx.read` (https://github.com/bazelbuild/bazel/blob/67446d/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java#LL906C39-L906C39), but the `ctx.file` choose write content to disk in UTF-8 by default
(https://github.com/bazelbuild/bazel/blob/67446d/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java#L813-L817)

This behavior will cause the multi-byte character in UTF-8 files been encoded byte-by-byte in UTF-8 again, corrupting the file content.

Luckily, Bazel provides a `legacy_utf8` (https://bazel.build/rules/lib/builtins/repository_ctx#parameters_5) in `ctx.file` to force the file to be written in ISO-8859-1 encoding, make the write result as same as the read result at the byte level.

Although the character-level content read by Bazel is still corrupted, since we don't need to parse the content at the Bazel level, it's safe to leave this issue to Bazel team.

Since some files in KM contain multi-byte utf-8 characters, we deactive the `legacy_utf8` switch in this patch to fix the corrupted bundled content.