### PR TITLE
chore(db): remove connector:wait_for_schema_consensus

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -582,16 +582,6 @@ do
                               skip_teardown_migrations[t.subsystem][mig.name]
 
         if not skip_teardown and run_teardown and strategy_migration.teardown then
-          if run_up then
-            -- ensure schema consensus is reached before running DML queries
-            -- that could span all peers
-            ok, err = self.connector:wait_for_schema_consensus()
-            if not ok then
-              self.connector:close()
-              return nil, prefix_err(self, err)
-            end
-          end
-
           -- kong migrations teardown
           local f = strategy_migration.teardown
 
@@ -611,19 +601,6 @@ do
           end
 
           n_pending = math.max(n_pending - 1, 0)
-
-          if not run_up then
-            -- ensure schema consensus is reached when the next migration to
-            -- run will execute its teardown step, since it may make further
-            -- DML queries; if the next migration runs its up step, it will
-            -- run DDL queries against the same node, so no need to reach
-            -- schema consensus
-            ok, err = self.connector:wait_for_schema_consensus()
-            if not ok then
-              self.connector:close()
-              return nil, prefix_err(self, err)
-            end
-          end
         end
 
         log("%s migrated up to: %s %s", t.subsystem, mig.name,
@@ -631,17 +608,6 @@ do
                                                               or "(executed)")
 
         n_migrations = n_migrations + 1
-      end
-
-      if run_up and i == #migrations then
-        -- wait for schema consensus after the last migration has run
-        -- (only if `run_up`, since if not, we just called it from the
-        -- teardown step)
-        ok, err = self.connector:wait_for_schema_consensus()
-        if not ok then
-          self.connector:close()
-          return nil, prefix_err(self, err)
-        end
       end
     end
 

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -151,11 +151,6 @@ function Connector:run_up_migration()
 end
 
 
-function Connector:wait_for_schema_consensus()
-  return true
-end
-
-
 function Connector:record_migration()
   error(fmt("record_migration() not implemented for '%s' strategy",
             self.database))


### PR DESCRIPTION
### Summary

As Cassandra is now gone from codebase, we can remove this function too.