### PR TITLE
feat(plugins/aws-lambda): support AWS IRSA credentials method

### DIFF
--- a/kong/plugins/aws-lambda/iam-sts-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-sts-credentials.lua
@@ -2,6 +2,7 @@ local http  = require "resty.http"
 local json  = require "cjson"
 local aws_v4 = require "kong.plugins.aws-lambda.v4"
 local utils = require "kong.tools.utils"
+local pl_file = require "pl.file"
 local ngx_now = ngx.now
 local kong = kong
 
@@ -18,6 +19,79 @@ local function get_regional_sts_endpoint(aws_region)
   end
 end
 
+local function fetch_credentials_with_web_identity(config)
+  if not config.aws_web_identity_role_arn then
+    return nil, "Missing required parameter 'config.aws_web_identity_role_arn' for" ..
+    " fetching credentials with web identity"
+  end
+
+  local aws_role_session_name = config.aws_role_session_name or DEFAULT_ROLE_SESSION_NAME
+
+  if not config.aws_web_identity_token_file then
+    return nil, "Missing required parameter 'config.aws_web_identity_token_file' for" ..
+    ' fetching credentials with web identity'
+  end
+
+  local web_identity_token, err = pl_file.read(config.aws_web_identity_token_file)
+  if not web_identity_token then
+    local err_s = 'Unable to assume role [' ..  config.aws_web_identity_role_arn .. '] with web' ..
+    ' identity error reading web identity token file: ' .. tostring(err)
+    return nil, err_s
+  end
+
+  kong.log.debug('Trying to assume role [', config.aws_web_identity_role_arn, '] with web identity token')
+
+  local sts_host = get_regional_sts_endpoint(config.aws_region)
+
+  local assume_role_request_headers = {
+    Accept                    = "application/json",
+    ["Content-Type"]          = "application/x-www-form-urlencoded; charset=utf-8",
+    Host                      = sts_host
+  }
+
+  local assume_role_query_params = {
+    Action          = "AssumeRoleWithWebIdentity",
+    Version         = "2011-06-15",
+    RoleArn         = config.aws_web_identity_role_arn,
+    DurationSeconds = DEFAULT_SESSION_DURATION_SECONDS,
+    RoleSessionName = aws_role_session_name,
+    WebIdentityToken = web_identity_token,
+  }
+
+  local sts_url = 'https://' .. sts_host .. '?' .. utils.encode_args(assume_role_query_params)
+
+  -- Call STS to assume role
+  local client = http.new()
+  client:set_timeout(DEFAULT_HTTP_CLINET_TIMEOUT)
+  local res, err = client:request_uri(sts_url, {
+    method = "GET",
+    headers = assume_role_request_headers,
+    ssl_verify = false,
+  })
+
+  if err then
+    local err_s = 'Unable to assume role [' ..  config.aws_web_identity_role_arn .. '] with web identity' ..
+                  ' due to: ' .. tostring(err)
+    return nil, err_s
+  end
+
+  if res.status ~= 200 then
+    local err_s = 'Unable to assume role [' .. config.aws_web_identity_role_arn .. '] with web identity due' ..
+                  '  to: status [' .. res.status .. '] - ' ..
+                  'reason [' .. res.body .. ']'
+    return nil, err_s
+  end
+
+  local credentials = json.decode(res.body).AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials
+  local result = {
+    access_key    = credentials.AccessKeyId,
+    secret_key    = credentials.SecretAccessKey,
+    session_token = credentials.SessionToken,
+    expiration    = credentials.Expiration
+  }
+
+  return result, nil, result.expiration - ngx_now()
+end
 
 local function fetch_assume_role_credentials(aws_region, assume_role_arn,
                                              role_session_name, access_key,
@@ -104,4 +178,5 @@ end
 
 return {
   fetch_assume_role_credentials = fetch_assume_role_credentials,
+  fetchCredentials = fetch_credentials_with_web_identity,
 }

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -31,6 +31,21 @@ return {
           referenceable = true,
           description = "The AWS secret credential to be used when invoking the function. ",
         } },
+        { aws_web_identity_credential = {
+          description = "Whether to use AWS Web Identity Credential Provider (IRSA) flow to obtain temporary credentials to invoke the Lambda function",
+          type = "boolean",
+          default = false,
+        } },
+        { aws_web_identity_token_file = {
+          description = "The path to the file containing the token (JWT). Falls back to the environment variable AWS_WEB_IDENTITY_TOKEN_FILE if not specified.",
+          type = "string",
+          required = false,
+        } },
+        { aws_web_identity_role_arn = {
+          description = "The target AWS IAM role ARN used to obtain temporary credentials. Falls back to the environment variable AWS_ROLE_ARN if not specified.",
+          type = "string",
+          required = false,
+        } },
         { aws_assume_role_arn = { description = "The target AWS IAM role ARN used to invoke the Lambda function.", type = "string",
           encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
           referenceable = true,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Currently, Kong works great with IAM User credentials or running inside EC2, ECS or a Kubernetes with `KIAM` or `Kube2IAM`, but it doesn't support [AWS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IAM Role for Service Accounts). This PR enables it.

This PR is a "side project", I'll open as Draft; So, fell free to takeover if you'd like to.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* feature: plugin AWS Lambda can source credentials using `Web Identity` method (IRSA). Useful when running Kong in EKS.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
