### PR TITLE
chore(db): tablex.deepcopy is cycle aware, no need to re-implement copy

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -2187,27 +2187,6 @@ local function get_foreign_schema_for_field(field)
 end
 
 
---- Cycle-aware table copy.
--- To be replaced by tablex.deepcopy() when it supports cycles.
-local function copy(t, cache)
-  if type(t) ~= "table" then
-    return t
-  end
-  cache = cache or {}
-  if cache[t] then
-    return cache[t]
-  end
-  local c = {}
-  cache[t] = c
-  for k, v in pairs(t) do
-    local kk = copy(k, cache)
-    local vv = copy(v, cache)
-    c[kk] = vv
-  end
-  return c
-end
-
-
 function Schema:get_constraints()
   if self.name == "workspaces" then
     -- merge explicit and implicit constraints for workspaces
@@ -2366,7 +2345,7 @@ function Schema.new(definition, is_subschema)
     return nil, validation_errors.SCHEMA_NO_FIELDS
   end
 
-  local self = copy(definition)
+  local self = tablex.deepcopy(definition)
   setmetatable(self, Schema)
 
   local cache_key = self.cache_key


### PR DESCRIPTION
### Summary

This was fixed a long time ago:
https://github.com/lunarmodules/Penlight/commit/967ed9b99f9a99910ac0ade8ab0383834666f2dc

Now removing code that is not needed anymore.