### PR TITLE
chore(runloop): remove unused handler functions

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -823,8 +823,6 @@ function Kong.init_worker()
     end
   end
 
-  runloop.init_worker.after()
-
   if is_not_control_plane then
     plugin_servers.start()
   end
@@ -853,10 +851,9 @@ function Kong.ssl_certificate()
   -- this is the first phase to run on an HTTPS request
   ctx.workspace = kong.default_workspace
 
-  runloop.certificate.before(ctx)
+  certificate.execute()
   local plugins_iterator = runloop.get_updated_plugins_iterator()
   execute_global_plugins_iterator(plugins_iterator, "certificate", ctx)
-  runloop.certificate.after(ctx)
 
   -- TODO: do we want to keep connection context?
   kong.table.clear(ngx.ctx)
@@ -969,8 +966,6 @@ function Kong.rewrite()
   end
 
   execute_global_plugins_iterator(plugins_iterator, "rewrite", ctx)
-
-  runloop.rewrite.after(ctx)
 
   ctx.KONG_REWRITE_ENDED_AT = get_updated_now_ms()
   ctx.KONG_REWRITE_TIME = ctx.KONG_REWRITE_ENDED_AT - ctx.KONG_REWRITE_START
@@ -1299,9 +1294,7 @@ do
     kong.response.set_status(status)
     kong.response.set_headers(headers)
 
-    runloop.response.before(ctx)
     execute_collected_plugins_iterator(plugins_iterator, "response", ctx)
-    runloop.response.after(ctx)
 
     ctx.KONG_RESPONSE_ENDED_AT = get_updated_now_ms()
     ctx.KONG_RESPONSE_TIME = ctx.KONG_RESPONSE_ENDED_AT - ctx.KONG_RESPONSE_START

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1048,13 +1048,6 @@ return {
 
       end
     end,
-    after = NOOP,
-  },
-  certificate = {
-    before = function(ctx) -- Note: ctx here is for a connection (not for a single request)
-      certificate.execute()
-    end,
-    after = NOOP,
   },
   preread = {
     before = function(ctx)
@@ -1116,7 +1109,6 @@ return {
       ctx.host_port = HOST_PORTS[server_port] or server_port
       instrumentation.request(ctx)
     end,
-    after = NOOP,
   },
   access = {
     before = function(ctx)
@@ -1417,10 +1409,6 @@ return {
         clear_header("Proxy-Connection")
       end
     end
-  },
-  response = {
-    before = NOOP,
-    after = NOOP,
   },
   header_filter = {
     before = function(ctx)


### PR DESCRIPTION
### Summary

There are several functions in handler.lua that does (almost) nothing.

This commit removes that unneccessary indirection. Hopefully less need to jump between files to see what is going on.