### PR TITLE
chore(migrations): do not create ttls table anymore and remove it

### DIFF
--- a/kong-3.4.0-0.rockspec
+++ b/kong-3.4.0-0.rockspec
@@ -247,6 +247,7 @@ build = {
     ["kong.db.migrations.core.017_300_to_310"] = "kong/db/migrations/core/017_300_to_310.lua",
     ["kong.db.migrations.core.018_310_to_320"] = "kong/db/migrations/core/018_310_to_320.lua",
     ["kong.db.migrations.core.019_320_to_330"] = "kong/db/migrations/core/019_320_to_330.lua",
+    ["kong.db.migrations.core.020_330_to_340"] = "kong/db/migrations/core/020_330_to_340.lua",
     ["kong.db.migrations.operations.200_to_210"] = "kong/db/migrations/operations/200_to_210.lua",
     ["kong.db.migrations.operations.212_to_213"] = "kong/db/migrations/operations/212_to_213.lua",
     ["kong.db.migrations.operations.280_to_300"] = "kong/db/migrations/operations/280_to_300.lua",

--- a/kong/db/migrations/core/020_330_to_340.lua
+++ b/kong/db/migrations/core/020_330_to_340.lua
@@ -1,0 +1,7 @@
+return {
+  postgres = {
+    up = [[
+      DROP TABLE IF EXISTS "ttls";
+    ]]
+  }
+}

--- a/spec/05-migration/db/migrations/core/020_330_to_340_spec.lua
+++ b/spec/05-migration/db/migrations/core/020_330_to_340_spec.lua
@@ -1,0 +1,10 @@
+local uh = require "spec/upgrade_helpers"
+
+
+describe("database migration", function()
+  if uh.database_type() == "postgres" then
+    uh.all_phases("does not have ttls table", function()
+      assert.not_database_has_relation("ttls")
+    end)
+  end
+end)

--- a/spec/upgrade_helpers.lua
+++ b/spec/upgrade_helpers.lua
@@ -19,6 +19,33 @@ local function get_database()
   return db
 end
 
+
+local function database_has_relation(state, arguments)
+  local table_name = arguments[1]
+  local schema = arguments[2] or "public"
+  local db = get_database()
+  local res, err
+  if database_type() == 'postgres' then
+    res, err = db.connector:query(string.format(
+        "select true"
+        .. " from pg_tables"
+        .. " where tablename = '%s'"
+        .. " and schemaname = '%s'",
+        table_name, schema))
+  else
+    return false
+  end
+  if err then
+    return false
+  end
+  return not(not(res[1]))
+end
+
+say:set("assertion.database_has_relation.positive", "Expected schema to have table %s")
+say:set("assertion.database_has_relation.negative", "Expected schema not to have table %s")
+assert:register("assertion", "database_has_relation", database_has_relation, "assertion.database_has_relation.positive", "assertion.database_has_relation.negative")
+
+
 local function database_has_trigger(state, arguments)
   local trigger_name = arguments[1]
   local db = get_database()
@@ -41,6 +68,7 @@ end
 say:set("assertion.database_has_trigger.positive", "Expected database to have trigger %s")
 say:set("assertion.database_has_trigger.negative", "Expected database not to have trigger %s")
 assert:register("assertion", "database_has_trigger", database_has_trigger, "assertion.database_has_trigger.positive", "assertion.database_has_trigger.negative")
+
 
 local function table_has_column(state, arguments)
   local table = arguments[1]


### PR DESCRIPTION
### Summary

It looks like we forgot to drop this table in a past, so removing it now in 3.4.0.