### PR TITLE
perf(*): use cycle aware deep copy instead

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -19,7 +19,7 @@ local function reports_timer(premature, data)
     return
   end
 
-  local r_data = utils.deep_copy(data)
+  local r_data = utils.cycle_aware_deep_copy(data)
 
   r_data.config = nil
   r_data.route = nil

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -10,7 +10,6 @@ local table_insert = table.insert
 local table_sort = table.sort
 local table_remove = table.remove
 local gsub = string.gsub
-local deep_copy = utils.deep_copy
 local split = utils.split
 local deflate_gzip = utils.deflate_gzip
 local cjson_encode = cjson.encode
@@ -375,7 +374,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
   end
 
   local has_update
-  payload = deep_copy(payload, false)
+  payload = utils.cycle_aware_deep_copy(payload, true)
   local config_table = payload["config_table"]
 
   for _, checker in ipairs(COMPATIBILITY_CHECKERS) do

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1148,7 +1148,7 @@ local function check_and_parse(conf, opts)
 
   if conf.tracing_instrumentations and #conf.tracing_instrumentations > 0 then
     local instrumentation = require "kong.tracing.instrumentation"
-    local available_types_map = tablex.deepcopy(instrumentation.available_types)
+    local available_types_map = utils.cycle_aware_deep_copy(instrumentation.available_types)
     available_types_map["all"] = true
     available_types_map["off"] = true
     available_types_map["request"] = true
@@ -1957,7 +1957,7 @@ return setmetatable({
   end,
 
   remove_sensitive = function(conf)
-    local purged_conf = tablex.deepcopy(conf)
+    local purged_conf = utils.cycle_aware_deep_copy(conf)
 
     local refs = purged_conf["$refs"]
     if type(refs) == "table" then

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -154,7 +154,7 @@ local function get_pagination_options(self, options)
     error("options must be a table when specified", 3)
   end
 
-  options = utils.deep_copy(options, false)
+  options = utils.cycle_aware_deep_copy(options, true)
 
   if type(options.pagination) == "table" then
     options.pagination = table_merge(self.pagination, options.pagination)
@@ -1444,12 +1444,12 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   if self.events then
     local entity_without_nulls
     if entity then
-      entity_without_nulls = remove_nulls(utils.deep_copy(entity, false))
+      entity_without_nulls = remove_nulls(utils.cycle_aware_deep_copy(entity, true))
     end
 
     local old_entity_without_nulls
     if old_entity then
-      old_entity_without_nulls = remove_nulls(utils.deep_copy(old_entity, false))
+      old_entity_without_nulls = remove_nulls(utils.cycle_aware_deep_copy(old_entity, true))
     end
 
     local ok, err = self.events.post_local("dao:crud", operation, {

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -7,7 +7,6 @@ local declarative_config = require("kong.db.schema.others.declarative_config")
 
 
 local cjson_encode = require("cjson.safe").encode
-local deepcopy = require("pl.tablex").deepcopy
 local marshall = require("kong.db.declarative.marshaller").marshall
 local schema_topological_sort = require("kong.db.schema.topological_sort")
 local nkeys = require("table.nkeys")
@@ -91,7 +90,7 @@ local function load_into_db(entities, meta)
 
     local primary_key, ok, err, err_t
     for _, entity in pairs(entities[schema_name]) do
-      entity = deepcopy(entity)
+      entity = utils.cycle_aware_deep_copy(entity)
       entity._tags = nil
       entity.ws_id = nil
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1001,7 +1001,7 @@ end
 local function handle_missing_field(field, value, opts)
   local no_defaults = opts and opts.no_defaults
   if field.default ~= nil and not no_defaults then
-    local copy = tablex.deepcopy(field.default)
+    local copy = utils.cycle_aware_deep_copy(field.default)
     if (field.type == "array" or field.type == "set")
       and type(copy) == "table"
       and not getmetatable(copy)
@@ -1615,7 +1615,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
   local is_select = context == "select"
   if not is_select then
-    data = tablex.deepcopy(data)
+    data = utils.cycle_aware_deep_copy(data)
   end
 
   local shorthand_fields = self.shorthand_fields
@@ -2345,7 +2345,7 @@ function Schema.new(definition, is_subschema)
     return nil, validation_errors.SCHEMA_NO_FIELDS
   end
 
-  local self = tablex.deepcopy(definition)
+  local self = utils.cycle_aware_deep_copy(definition)
   setmetatable(self, Schema)
 
   local cache_key = self.cache_key

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -6,7 +6,7 @@ local Schema = require("kong.db.schema")
 local constants = require("kong.constants")
 local plugin_loader = require("kong.db.schema.plugin_loader")
 local vault_loader = require("kong.db.schema.vault_loader")
-local schema_topological_sort = require "kong.db.schema.topological_sort"
+local schema_topological_sort = require("kong.db.schema.topological_sort")
 
 
 local null = ngx.null
@@ -98,7 +98,7 @@ local function add_top_level_entities(fields, known_entities)
   local records = {}
 
   for _, entity in ipairs(known_entities) do
-    local definition = utils.deep_copy(all_schemas[entity], false)
+    local definition = utils.cycle_aware_deep_copy(all_schemas[entity], true)
 
     for k, _ in pairs(definition.fields) do
       if type(k) ~= "number" then
@@ -130,8 +130,8 @@ local function add_top_level_entities(fields, known_entities)
 end
 
 
-local function copy_record(record, include_foreign, duplicates, name)
-  local copy = utils.deep_copy(record, false)
+local function copy_record(record, include_foreign, duplicates, name, cycle_aware_cache)
+  local copy = utils.cycle_aware_deep_copy(record, true, nil, cycle_aware_cache)
   if include_foreign then
     return copy
   end
@@ -165,6 +165,7 @@ end
 -- indexable by entity name. These records are modified in-place.
 local function nest_foreign_relationships(known_entities, records, include_foreign)
   local duplicates = {}
+  local cycle_aware_cache = {}
   for i = #known_entities, 1, -1 do
     local entity = known_entities[i]
     local record = records[entity]
@@ -177,7 +178,7 @@ local function nest_foreign_relationships(known_entities, records, include_forei
         insert(records[ref].fields, {
           [entity] = {
             type = "array",
-            elements = copy_record(record, include_foreign, duplicates, entity),
+            elements = copy_record(record, include_foreign, duplicates, entity, cycle_aware_cache),
           },
         })
 
@@ -185,7 +186,7 @@ local function nest_foreign_relationships(known_entities, records, include_forei
           insert(dest.fields, {
             [entity] = {
               type = "array",
-              elements = copy_record(record, include_foreign, duplicates, entity)
+              elements = copy_record(record, include_foreign, duplicates, entity, cycle_aware_cache)
             }
           })
         end
@@ -357,7 +358,7 @@ local function populate_references(input, known_entities, by_id, by_key, expecte
       end
 
       if parent_fk then
-        item[child_key] = utils.deep_copy(parent_fk, false)
+        item[child_key] = utils.cycle_aware_deep_copy(parent_fk, true)
       end
     end
 
@@ -540,7 +541,7 @@ local function generate_ids(input, known_entities, parent_entity)
       local pk_name, key = get_key_for_uuid_gen(entity, item, schema,
                                                 parent_fk, child_key)
       if key then
-        item = utils.deep_copy(item, false)
+        item = utils.cycle_aware_deep_copy(item, true)
         item[pk_name] = generate_uuid(schema.name, key)
         input[entity][i] = item
       end
@@ -600,7 +601,7 @@ local function populate_ids_for_validation(input, known_entities, parent_entity,
       end
 
       if parent_fk and not item[child_key] then
-        item[child_key] = utils.deep_copy(parent_fk, false)
+        item[child_key] = utils.cycle_aware_deep_copy(parent_fk, true)
       end
     end
 
@@ -692,11 +693,11 @@ local function flatten(self, input)
       self.full_schema = DeclarativeConfig.load(self.plugin_set, self.vault_set, true)
     end
 
-    local input_copy = utils.deep_copy(input, false)
+    local input_copy = utils.cycle_aware_deep_copy(input, true)
     populate_ids_for_validation(input_copy, self.known_entities)
     local ok2, err2 = self.full_schema:validate(input_copy)
     if not ok2 then
-      local err3 = utils.deep_merge(err2, extract_null_errors(err))
+      local err3 = utils.cycle_aware_deep_merge(err2, extract_null_errors(err))
       return nil, err3
     end
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -2,7 +2,7 @@ local arrays        = require "pgmoon.arrays"
 local json          = require "pgmoon.json"
 local cjson         = require "cjson"
 local cjson_safe    = require "cjson.safe"
-local pl_tablex     = require "pl.tablex"
+local utils         = require "kong.tools.utils"
 local new_tab       = require "table.new"
 local clear_tab     = require "table.clear"
 
@@ -1081,7 +1081,7 @@ function _M.new(connector, schema, errors)
   do
     local function add(name, opts, add_ws)
       local orig_argn = opts.argn
-      opts = pl_tablex.deepcopy(opts)
+      opts = utils.cycle_aware_deep_copy(opts)
 
       -- ensure LIMIT table is the same
       for i, n in ipairs(orig_argn) do

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -9,7 +9,6 @@ local kong = kong
 local insert = table.insert
 local tablepool_fetch = tablepool.fetch
 local tablepool_release = tablepool.release
-local deep_copy = utils.deep_copy
 local table_merge = utils.table_merge
 local setmetatable = setmetatable
 
@@ -160,7 +159,7 @@ do
   encode_traces = function(spans, resource_attributes)
     local tab = tablepool_fetch(POOL_OTLP, 0, 2)
     if not tab.resource_spans then
-      tab.resource_spans = deep_copy(pb_memo.resource_spans)
+      tab.resource_spans = utils.cycle_aware_deep_copy(pb_memo.resource_spans)
     end
 
     local resource = tab.resource_spans[1].resource

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -3,6 +3,7 @@ local cjson = require("cjson.safe").new()
 local pl_template = require "pl.template"
 local pl_tablex = require "pl.tablex"
 local sandbox = require "kong.tools.sandbox"
+local utils = require "kong.tools.utils"
 
 local table_insert = table.insert
 local get_uri_args = kong.request.get_query
@@ -23,7 +24,6 @@ local str_find = string.find
 local pairs = pairs
 local error = error
 local rawset = rawset
-local pl_copy_table = pl_tablex.deepcopy
 local lua_enabled = sandbox.configuration.enabled
 local sandbox_enabled = sandbox.configuration.sandbox_enabled
 
@@ -221,7 +221,7 @@ local function transform_querystrings(conf, template_env)
     return
   end
 
-  local querystring = pl_copy_table(template_env.query_params)
+  local querystring = utils.cycle_aware_deep_copy(template_env.query_params)
 
   -- Remove querystring(s)
   for _, name, value in iter(conf.remove.querystring, template_env) do
@@ -530,7 +530,7 @@ function _M.execute(conf)
   local template_env = {}
   if lua_enabled and sandbox_enabled then
     -- load the sandbox environment to be used to render the template
-    template_env = pl_copy_table(sandbox.configuration.environment)
+    template_env = utils.cycle_aware_deep_copy(sandbox.configuration.environment)
     -- here we can optionally add functions to expose to the sandbox, eg:
     -- tostring = tostring,
     -- because headers may contain array elements such as duplicated headers

--- a/kong/plugins/request-transformer/migrations/common.lua
+++ b/kong/plugins/request-transformer/migrations/common.lua
@@ -18,7 +18,7 @@ function _M.rt_rename(_, _, dao)
       api_id = plugin.api_id,
       consumer_id = plugin.consumer_id,
       enabled = plugin.enabled,
-      config = utils.deep_copy(plugin.config),
+      config = utils.cycle_aware_deep_copy(plugin.config),
     })
     if err then
       return err
@@ -34,4 +34,3 @@ end
 
 
 return _M
-

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -1,5 +1,5 @@
 local pl_template = require "pl.template"
-local tx = require "pl.tablex"
+local utils = require "kong.tools.utils"
 local typedefs = require "kong.db.schema.typedefs"
 local validate_header_name = require("kong.tools.utils").validate_header_name
 
@@ -116,7 +116,7 @@ local colon_rename_strings_array_record = {
 }
 
 
-local colon_strings_array_record_plus_uri = tx.deepcopy(colon_strings_array_record)
+local colon_strings_array_record_plus_uri = utils.cycle_aware_deep_copy(colon_strings_array_record)
 local uri = { uri = { type = "string" } }
 table.insert(colon_strings_array_record_plus_uri.fields, uri)
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -25,7 +25,7 @@ local fileexists = require("pl.path").exists
 local semaphore = require("ngx.semaphore").new
 local lrucache = require("resty.lrucache")
 local resolver = require("resty.dns.resolver")
-local deepcopy = require("pl.tablex").deepcopy
+local cycle_aware_deep_copy = require("kong.tools.utils").cycle_aware_deep_copy
 local time = ngx.now
 local log = ngx.log
 local ERR = ngx.ERR
@@ -799,7 +799,7 @@ local function asyncQuery(qname, r_opts, try_list)
     key = key,
     semaphore = semaphore(),
     qname = qname,
-    r_opts = deepcopy(r_opts),
+    r_opts = cycle_aware_deep_copy(r_opts),
     try_list = try_list,
   }
   queue[key] = item

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -1,4 +1,4 @@
-local pl_tablex = require "pl.tablex"
+local utils = require "kong.tools.utils"
 local get_certificate = require "kong.runloop.certificate".get_certificate
 
 local balancers = require "kong.runloop.balancer.balancers"
@@ -245,7 +245,7 @@ function healthcheckers_M.create_healthchecker(balancer, upstream)
   if (ngx.config.subsystem == "stream" and checks.active.type ~= "tcp")
     or (ngx.config.subsystem == "http" and checks.active.type == "tcp")
   then
-    checks = pl_tablex.deepcopy(checks)
+    checks = utils.cycle_aware_deep_copy(checks)
     checks.active.healthy.interval = 0
     checks.active.unhealthy.interval = 0
   end

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -38,6 +38,8 @@ local re_find       = ngx.re.find
 local re_match      = ngx.re.match
 local inflate_gzip  = zlib.inflateGzip
 local deflate_gzip  = zlib.deflateGzip
+local setmetatable  = setmetatable
+local getmetatable  = getmetatable
 
 ffi.cdef[[
 typedef unsigned char u_char;
@@ -623,10 +625,11 @@ do
   end
 end
 
+
 --- Merges two tables recursively
--- For each subtable in t1 and t2, an equivalent (but different) table will
--- be created in the resulting merge. If t1 and t2 have a subtable with in the
--- same key k, res[k] will be a deep merge of both subtables.
+-- For each sub-table in t1 and t2, an equivalent (but different) table will
+-- be created in the resulting merge. If t1 and t2 have a sub-table with the
+-- same key k, res[k] will be a deep merge of both sub-tables.
 -- Metatables are not taken into account.
 -- Keys are copied by reference (if tables are used as keys they will not be
 -- duplicated)
@@ -646,6 +649,87 @@ function _M.deep_merge(t1, t2)
 
   return res
 end
+
+
+--- Cycle aware deep copies a table into a new table.
+-- Cycle aware means that a table value is only copied once even
+-- if it is referenced multiple times in input table or its sub-tables.
+-- Tables used as keys are not deep copied. Metatables are set to same
+-- on copies as they were in the original.
+-- @param orig The table to copy
+-- @param remove_metatables Removes the metatables when set to `true`.
+-- @param deep_copy_keys Deep copies the keys (and not only the values) when set to `true`.
+-- @param cycle_aware_cache Cached tables that are not copied (again).
+--                          (the function creates this table when not given)
+-- @return Returns a copy of the input table
+function _M.cycle_aware_deep_copy(orig, remove_metatables, deep_copy_keys, cycle_aware_cache)
+  if type(orig) ~= "table" then
+    return orig
+  end
+
+  cycle_aware_cache = cycle_aware_cache or {}
+  if cycle_aware_cache[orig] then
+    return cycle_aware_cache[orig]
+  end
+
+  local copy = _M.shallow_copy(orig)
+
+  cycle_aware_cache[orig] = copy
+
+  local mt
+  if not remove_metatables then
+    mt = getmetatable(orig)
+  end
+
+  for k, v in pairs(orig) do
+    if type(v) == "table" then
+      copy[k] = _M.cycle_aware_deep_copy(v, remove_metatables, deep_copy_keys, cycle_aware_cache)
+    end
+
+    if deep_copy_keys and type(k) == "table" then
+      local new_k = _M.cycle_aware_deep_copy(k, remove_metatables, deep_copy_keys, cycle_aware_cache)
+      copy[new_k] = copy[k]
+      copy[k] = nil
+    end
+  end
+
+  if mt then
+    setmetatable(copy, mt)
+  end
+
+  return copy
+end
+
+
+--- Cycle aware merges two tables recursively
+-- The table t1 is deep copied using cycle_aware_deep_copy function.
+-- The table t2 is deep merged into t1. The t2 values takes precedence
+-- over t1 ones. Tables used as keys are not deep copied. Metatables
+-- are set to same on copies as they were in the original.
+-- @param t1 one of the tables to merge
+-- @param t2 one of the tables to merge
+-- @param remove_metatables Removes the metatables when set to `true`.
+-- @param deep_copy_keys Deep copies the keys (and not only the values) when set to `true`.
+-- @param cycle_aware_cache Cached tables that are not copied (again)
+--                          (the function creates this table when not given)
+-- @return Returns a table representing a deep merge of the new table
+function _M.cycle_aware_deep_merge(t1, t2, remove_metatables, deep_copy_keys, cycle_aware_cache)
+  cycle_aware_cache = cycle_aware_cache or {}
+  local merged = _M.cycle_aware_deep_copy(t1, remove_metatables, deep_copy_keys, cycle_aware_cache)
+  for k, v in pairs(t2) do
+    if type(v) == "table" then
+      if type(merged[k]) == "table" then
+        merged[k] = _M.cycle_aware_deep_merge(merged[k], v, remove_metatables, deep_copy_keys, cycle_aware_cache)
+      else
+        merged[k] = _M.cycle_aware_deep_copy(v, remove_metatables, deep_copy_keys, cycle_aware_cache)
+      end
+    else
+      merged[k] = v
+    end
+  end
+  return merged
+end
+
 
 local err_list_mt = {}
 

--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -194,7 +194,7 @@ describe("DAO", function()
         update = function(_, _, value)
           -- defaults pre-applied before partial update
           assert(value.b == "hello")
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -219,7 +219,7 @@ describe("DAO", function()
         update = function(_, _, value)
           -- no defaults pre-applied before partial update
           assert(value.r.f2 == nil)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -248,7 +248,7 @@ describe("DAO", function()
             f1 = null,
             f2 = "world",
           }, value.r)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -274,7 +274,7 @@ describe("DAO", function()
           -- defaults pre-applied before partial update
           assert.equal("hello", value.b)
           assert.same(null, value.r)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -298,7 +298,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -350,7 +350,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -373,7 +373,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -396,7 +396,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -419,7 +419,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -442,7 +442,7 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }

--- a/spec/01-unit/01-db/09-no_broadcast_crud_event_spec.lua
+++ b/spec/01-unit/01-db/09-no_broadcast_crud_event_spec.lua
@@ -28,7 +28,7 @@ describe("option no_broadcast_crud_event", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }
@@ -60,7 +60,7 @@ describe("option no_broadcast_crud_event", function()
           return data
         end,
         update = function(_, _, value)
-          data = utils.deep_merge(data, value)
+          data = utils.cycle_aware_deep_merge(data, value)
           return data
         end,
       }

--- a/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
+++ b/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
@@ -187,7 +187,7 @@ for _, consistency in ipairs({"strict", "eventual"}) do
         },
       }
 
-      local passive_hc = utils.deep_copy(hc_defaults)
+      local passive_hc = utils.cycle_aware_deep_copy(hc_defaults)
       passive_hc.passive.healthy.successes = 1
       passive_hc.passive.unhealthy.http_failures = 1
 

--- a/spec/01-unit/20-sandbox_spec.lua
+++ b/spec/01-unit/20-sandbox_spec.lua
@@ -1,7 +1,4 @@
 local utils = require "kong.tools.utils"
-
-
-local deep_copy = utils.deep_copy
 local fmt = string.format
 
 describe("sandbox functions wrapper", function()
@@ -18,7 +15,7 @@ describe("sandbox functions wrapper", function()
   }
 
   lazy_setup(function()
-    _G.kong.configuration = deep_copy(base_conf)
+    _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
 
     -- load and reference module we can spy on
     load_s = spy.new(load)
@@ -46,7 +43,7 @@ describe("sandbox functions wrapper", function()
       end)
 
       lazy_teardown(function()
-        _G.kong.configuration = deep_copy(base_conf)
+        _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
       end)
 
       -- https://github.com/Kong/kong/issues/5110
@@ -70,7 +67,7 @@ describe("sandbox functions wrapper", function()
       end)
 
       lazy_teardown(function()
-        _G.kong.configuration = deep_copy(base_conf)
+        _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
       end)
 
       it("validates input is lua that returns a function", function()
@@ -102,7 +99,7 @@ describe("sandbox functions wrapper", function()
       end)
 
       lazy_teardown(function()
-        _G.kong.configuration = deep_copy(base_conf)
+        _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
       end)
 
       it("errors", function()
@@ -121,7 +118,7 @@ describe("sandbox functions wrapper", function()
     end)
 
     lazy_teardown(function()
-      _G.kong.configuration = deep_copy(base_conf)
+      _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
     end)
 
     describe("untrusted_lua = 'off'", function()
@@ -237,7 +234,7 @@ describe("sandbox functions wrapper", function()
           _G.baz = nil
           _G.fizz = nil
 
-          _G.kong.configuration = deep_copy(base_conf)
+          _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
         end)
 
         it("has access to string.rep", function()
@@ -320,7 +317,7 @@ describe("sandbox functions wrapper", function()
       end)
 
       lazy_teardown(function()
-        _G.kong.configuration = deep_copy(base_conf)
+        _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
       end)
 
       it("returns a function when it gets code returning a function", function()
@@ -350,7 +347,7 @@ describe("sandbox functions wrapper", function()
       end)
 
       lazy_teardown(function()
-        _G.kong.configuration = deep_copy(base_conf)
+        _G.kong.configuration = utils.cycle_aware_deep_copy(base_conf)
       end)
 
       it("errors", function()

--- a/spec/01-unit/21-dns-client/03-client_cache_spec.lua
+++ b/spec/01-unit/21-dns-client/03-client_cache_spec.lua
@@ -1,4 +1,4 @@
-local deepcopy = require("pl.tablex").deepcopy
+local utils = require("kong.tools.utils")
 
 local gettime, sleep
 if ngx then
@@ -189,7 +189,7 @@ describe("[DNS client cache]", function()
           ttl = 0.1,
         }}
       }
-      local mock_copy = require("pl.tablex").deepcopy(mock_records)
+      local mock_copy = utils.cycle_aware_deep_copy(mock_records)
 
       -- resolve and check whether we got the mocked record
       local result = client.resolve("myhost6")
@@ -417,7 +417,7 @@ describe("[DNS client cache]", function()
         ttl = 60,
       }
       mock_records = setmetatable({
-        ["myhost9.domain.com:"..client.TYPE_CNAME] = { deepcopy(CNAME1) },  -- copy to make it different
+        ["myhost9.domain.com:"..client.TYPE_CNAME] = { utils.cycle_aware_deep_copy(CNAME1) },  -- copy to make it different
         ["myhost9.domain.com:"..client.TYPE_A] = { CNAME1, A2 },  -- not there, just a reference and target
         ["myotherhost.domain.com:"..client.TYPE_A] = { A2 },
       }, {

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -8,7 +8,7 @@ local queue_num = 1
 
 
 local function queue_conf(conf)
-  local defaulted_conf = utils.deep_copy(conf)
+  local defaulted_conf = utils.cycle_aware_deep_copy(conf)
   if not conf.name then
     defaulted_conf.name = "test-" .. tostring(queue_num)
     queue_num = queue_num + 1

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -49,7 +49,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       postgres_only("initializes infos with custom schema", function()
-        local conf = utils.deep_copy(helpers.test_conf)
+        local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
         conf.pg_schema = "demo"
 
@@ -72,7 +72,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       postgres_only("initializes infos with readonly support", function()
-        local conf = utils.deep_copy(helpers.test_conf)
+        local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
         conf.pg_ro_host = "127.0.0.1"
 
@@ -135,7 +135,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     postgres_only("initializes infos with custom schema", function()
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_schema = "demo"
 
@@ -200,7 +200,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     postgres_only("connects to custom schema when configured", function()
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_schema = "demo"
 
@@ -289,7 +289,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns opened connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -315,7 +315,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns opened connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -341,7 +341,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("connects to postgres with readonly account (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)
@@ -369,7 +369,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("connects to postgres with readonly account (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)
@@ -460,7 +460,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -488,7 +488,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -543,7 +543,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("keepalives both read only and write connection (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)
@@ -580,7 +580,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("connects and keepalives only write connection (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)
@@ -669,7 +669,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -695,7 +695,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
 
       conf.pg_ssl = true
 
@@ -747,7 +747,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when both read-only and write connection exists (cosockets)", function()
       ngx.IS_CLI = false
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)
@@ -784,7 +784,7 @@ for _, strategy in helpers.each_strategy() do
     postgres_only("returns true when both read-only and write connection exists (luasocket)", function()
       ngx.IS_CLI = true
 
-      local conf = utils.deep_copy(helpers.test_conf)
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
       conf.pg_ro_host = conf.pg_host
 
       local db, err = DB.new(conf, strategy)

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -1,7 +1,6 @@
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local cjson = require "cjson.safe"
-local pl_tablex = require "pl.tablex"
 local _VERSION_TABLE = require "kong.meta" ._VERSION_TABLE
 local MAJOR = _VERSION_TABLE.major
 local MINOR = _VERSION_TABLE.minor
@@ -374,7 +373,7 @@ describe("CP/DP #version check #" .. strategy, function()
 
     local plugins_map = {}
     -- generate a map of current plugins
-    local plugin_list = pl_tablex.deepcopy(helpers.get_plugins_list())
+    local plugin_list = utils.cycle_aware_deep_copy(helpers.get_plugins_list())
     for _, plugin in pairs(plugin_list) do
       plugins_map[plugin.name] = plugin.version
     end
@@ -424,7 +423,7 @@ describe("CP/DP #version check #" .. strategy, function()
       },
     }
 
-    local pl1 = pl_tablex.deepcopy(helpers.get_plugins_list())
+    local pl1 = utils.cycle_aware_deep_copy(helpers.get_plugins_list())
     table.insert(pl1, 2, { name = "banana", version = "1.1.1" })
     table.insert(pl1, { name = "pineapple", version = "1.1.2" })
     allowed_cases["DP plugin set is a superset of CP"] = {
@@ -436,7 +435,7 @@ describe("CP/DP #version check #" .. strategy, function()
       plugins_list = { KEY_AUTH_PLUGIN }
     }
 
-    local pl2 = pl_tablex.deepcopy(helpers.get_plugins_list())
+    local pl2 = utils.cycle_aware_deep_copy(helpers.get_plugins_list())
     for i, _ in ipairs(pl2) do
       local v = pl2[i].version
       local minor = v and v:match("%d+%.(%d+)%.%d+")
@@ -456,7 +455,7 @@ describe("CP/DP #version check #" .. strategy, function()
       plugins_list = pl2
     }
 
-    local pl3 = pl_tablex.deepcopy(helpers.get_plugins_list())
+    local pl3 = utils.cycle_aware_deep_copy(helpers.get_plugins_list())
     for i, _ in ipairs(pl3) do
       local v = pl3[i].version
       local patch = v and v:match("%d+%.%d+%.(%d+)")

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -134,7 +134,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       local id = utils.uuid()
       local plugin = get_plugin(id, "3.0.0", rate_limit.name)
 
-      local expected = utils.deep_copy(rate_limit.config)
+      local expected = utils.cycle_aware_deep_copy(rate_limit.config)
       expected.error_code = nil
       expected.error_message = nil
 

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -1,4 +1,4 @@
-local deepcopy = require "pl.tablex".deepcopy
+local utils = require "kong.tools.utils"
 local date = require "date"
 
 describe("[AWS Lambda] aws-gateway input", function()
@@ -12,8 +12,8 @@ describe("[AWS Lambda] aws-gateway input", function()
     local body_data
     _G.ngx = setmetatable({
       req = {
-        get_headers = function() return deepcopy(mock_request.headers) end,
-        get_uri_args = function() return deepcopy(mock_request.query) end,
+        get_headers = function() return utils.cycle_aware_deep_copy(mock_request.headers) end,
+        get_uri_args = function() return utils.cycle_aware_deep_copy(mock_request.query) end,
         read_body = function() body_data = mock_request.body end,
         get_body_data = function() return body_data end,
         http_version = function() return mock_request.http_version end,

--- a/spec/03-plugins/29-acme/01-client_spec.lua
+++ b/spec/03-plugins/29-acme/01-client_spec.lua
@@ -6,7 +6,7 @@ local cjson = require "cjson"
 local pkey = require("resty.openssl.pkey")
 local x509 = require("resty.openssl.x509")
 
-local tablex = require "pl.tablex"
+local utils = require "kong.tools.utils"
 
 local client
 
@@ -110,7 +110,7 @@ for _, strategy in ipairs(strategies) do
     describe("create with preconfigured account_key with key_set", function()
       lazy_setup(function()
         account_key = {key_id = KEY_ID, key_set = KEY_SET_NAME}
-        config = tablex.deepcopy(proper_config)
+        config = utils.cycle_aware_deep_copy(proper_config)
         config.account_key = account_key
         c = client.new(config)
 
@@ -167,7 +167,7 @@ for _, strategy in ipairs(strategies) do
     describe("create with preconfigured account_key without key_set", function()
       lazy_setup(function()
         account_key = {key_id = KEY_ID}
-        config = tablex.deepcopy(proper_config)
+        config = utils.cycle_aware_deep_copy(proper_config)
         config.account_key = account_key
         c = client.new(config)
 
@@ -208,7 +208,7 @@ for _, strategy in ipairs(strategies) do
       local account_keys = {}
 
       lazy_setup(function()
-        config = tablex.deepcopy(proper_config)
+        config = utils.cycle_aware_deep_copy(proper_config)
         c = client.new(config)
 
         account_keys[1] = util.create_pkey()

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -1,7 +1,5 @@
 local ssl_fixtures = require "spec.fixtures.ssl"
 local utils = require "kong.tools.utils"
-
-local deep_merge = utils.deep_merge
 local fmt = string.format
 
 
@@ -11,7 +9,7 @@ Blueprint.__index = Blueprint
 
 function Blueprint:build(overrides)
   overrides = overrides or {}
-  return deep_merge(self.build_function(overrides), overrides)
+  return utils.cycle_aware_deep_merge(self.build_function(overrides), overrides)
 end
 
 

--- a/spec/fixtures/dc_blueprints.lua
+++ b/spec/fixtures/dc_blueprints.lua
@@ -1,5 +1,5 @@
 local blueprints = require "spec.fixtures.blueprints"
-local tablex = require "pl.tablex"
+local utils = require "kong.tools.utils"
 
 
 local dc_blueprints = {}
@@ -36,7 +36,7 @@ function dc_blueprints.new(db)
   for name, _ in pairs(db.daos) do
     dc_as_db[name] = {
       insert = function(_, tbl)
-        tbl = tablex.deepcopy(tbl)
+        tbl = utils.cycle_aware_deep_copy(tbl)
         if not dc[name] then
           dc[name] = {}
         end
@@ -50,13 +50,13 @@ function dc_blueprints.new(db)
           end
         end
         table.insert(dc[name], remove_nulls(tbl))
-        return tablex.deepcopy(tbl)
+        return utils.cycle_aware_deep_copy(tbl)
       end,
       update = function(_, id, tbl)
         if not dc[name] then
           return nil, "not found"
         end
-        tbl = tablex.deepcopy(tbl)
+        tbl = utils.cycle_aware_deep_copy(tbl)
         local element
         for _, e in ipairs(dc[name]) do
           if e.id == id then

--- a/spec/fixtures/router_path_handling_tests.lua
+++ b/spec/fixtures/router_path_handling_tests.lua
@@ -166,7 +166,7 @@ local function expand(root_test)
     for _, test in ipairs(expanded_tests) do
       if type(test[field_name]) == "table" then
         for _, field_value in ipairs(test[field_name]) do
-          local et = utils.deep_copy(test)
+          local et = utils.cycle_aware_deep_copy(test)
           et[field_name] = field_value
           new_tests[#new_tests + 1] = et
         end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -815,7 +815,7 @@ end
 -- @see admin_ssl_client
 local function http_client_opts(options)
   if not options.scheme then
-    options = utils.deep_copy(options)
+    options = utils.cycle_aware_deep_copy(options)
     options.scheme = "http"
     if options.port == 443 then
       options.scheme = "https"
@@ -3520,7 +3520,7 @@ local function start_kong(env, tables, preserve_prefix, fixtures)
         return nil, err
       end
     end
-    env = utils.deep_copy(env)
+    env = utils.cycle_aware_deep_copy(env)
     env.declarative_config = config_yml
   end
 

--- a/spec/helpers/perf/charts.lua
+++ b/spec/helpers/perf/charts.lua
@@ -2,7 +2,7 @@ local math = require "math"
 local utils = require("spec.helpers.perf.utils")
 local logger = require("spec.helpers.perf.logger")
 local cjson = require "cjson"
-local tablex = require "pl.tablex"
+local cycle_aware_deep_copy = require("kong.tools.utils").cycle_aware_deep_copy
 
 local fmt = string.format
 local my_logger = logger.new_logger("[charts]")
@@ -83,7 +83,7 @@ local function ingest_combined_results(ver, results, suite_name)
     return false
   end
 
-  local row = tablex.deepcopy(results)
+  local row = cycle_aware_deep_copy(results)
   row.version = ver
   row.suite = suite_name
 


### PR DESCRIPTION
### Summary

`kong.tools.utils.deep_copy` is not cycle aware which means it will clone tables again even when same table was already cloned (it also has a bit bad defaults -> deep copies keys but does not set metatables, and when asked to set metatables, it will deep copy them too):

```lua
local a = {}
local b = {
  [a] = a,
  a = a,
  b = a,
  c = a,
}
```

Cycle-aware clone will clone `a` just once, while non-cycle aware deep clone will make 4-5 clones of `a` (depending whether it clones keys too).

It is almost never requirement to clone metatables that kong.tools.utils.deep_copy when given false as second parameter. And it does not set metatables by default, which usually is nice thing to do by default.

Changing to cycle-aware deep copy, the memory usage of workers especially on data planes and dbless nodes where declarative config requires a lot of deep copying of records.

In my testing with:
```
KONG_DATABASE=off \
KONG_ROLE=data_plane \
KONG_CLUSTER_CONTROL_PLANE=cp.test:8005 \
KONG_CLUSTER_CERT=cluster.crt \
KONG_CLUSTER_CERT_KEY=cluster.key \
kong start -p dp
```

Before this commit:
79 MB

After this commit:
64 MB

So about 15 MB reduction in memory usage per worker.