### PR TITLE
perf(*): use cycle aware deep clone everywhere 

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -1,5 +1,4 @@
 local cjson = require "cjson"
-local utils = require "kong.tools.utils"
 local reports = require "kong.reports"
 local endpoints = require "kong.api.endpoints"
 local arguments = require "kong.api.arguments"
@@ -12,6 +11,7 @@ local find = string.find
 local pairs = pairs
 local lower = string.lower
 local setmetatable = setmetatable
+local tablex_deepcopy = require("pl.tablex").deepcopy
 
 
 local function reports_timer(premature, data)
@@ -19,7 +19,7 @@ local function reports_timer(premature, data)
     return
   end
 
-  local r_data = utils.deep_copy(data)
+  local r_data = tablex_deepcopy(data)
 
   r_data.config = nil
   r_data.route = nil

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -11,7 +11,6 @@ local find = string.find
 local pairs = pairs
 local lower = string.lower
 local setmetatable = setmetatable
-local tablex_deepcopy = require("pl.tablex").deepcopy
 
 
 local function reports_timer(premature, data)
@@ -19,7 +18,7 @@ local function reports_timer(premature, data)
     return
   end
 
-  local r_data = tablex_deepcopy(data)
+  local r_data = kong.table.deepclone(data)
 
   r_data.config = nil
   r_data.route = nil

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -13,7 +13,6 @@ local gsub = string.gsub
 local split = utils.split
 local deflate_gzip = utils.deflate_gzip
 local cjson_encode = cjson.encode
-local tablex_deepcopy = require("pl.tablex").deepcopy
 
 local ngx = ngx
 local ngx_log = ngx.log
@@ -375,7 +374,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
   end
 
   local has_update
-  payload = tablex_deepcopy(payload)
+  payload = kong.table.deepclone(payload)
   local config_table = payload["config_table"]
 
   for _, checker in ipairs(COMPATIBILITY_CHECKERS) do

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -10,10 +10,10 @@ local table_insert = table.insert
 local table_sort = table.sort
 local table_remove = table.remove
 local gsub = string.gsub
-local deep_copy = utils.deep_copy
 local split = utils.split
 local deflate_gzip = utils.deflate_gzip
 local cjson_encode = cjson.encode
+local tablex_deepcopy = require("pl.tablex").deepcopy
 
 local ngx = ngx
 local ngx_log = ngx.log
@@ -375,7 +375,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
   end
 
   local has_update
-  payload = deep_copy(payload, false)
+  payload = tablex_deepcopy(payload)
   local config_table = payload["config_table"]
 
   for _, checker in ipairs(COMPATIBILITY_CHECKERS) do

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -6,6 +6,8 @@ local hooks = require "kong.hooks"
 local workspaces = require "kong.workspaces"
 local new_tab = require "table.new"
 local DAO_MAX_TTL = require("kong.constants").DATABASE.DAO_MAX_TTL
+local tablex_deepcopy = require("pl.tablex").deepcopy
+
 
 local setmetatable = setmetatable
 local tostring     = tostring
@@ -154,7 +156,7 @@ local function get_pagination_options(self, options)
     error("options must be a table when specified", 3)
   end
 
-  options = utils.deep_copy(options, false)
+  options = tablex_deepcopy(options)
 
   if type(options.pagination) == "table" then
     options.pagination = table_merge(self.pagination, options.pagination)
@@ -1444,12 +1446,12 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   if self.events then
     local entity_without_nulls
     if entity then
-      entity_without_nulls = remove_nulls(utils.deep_copy(entity, false))
+      entity_without_nulls = remove_nulls(tablex_deepcopy(entity))
     end
 
     local old_entity_without_nulls
     if old_entity then
-      old_entity_without_nulls = remove_nulls(utils.deep_copy(old_entity, false))
+      old_entity_without_nulls = remove_nulls(tablex_deepcopy(old_entity))
     end
 
     local ok, err = self.events.post_local("dao:crud", operation, {

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -6,7 +6,6 @@ local hooks = require "kong.hooks"
 local workspaces = require "kong.workspaces"
 local new_tab = require "table.new"
 local DAO_MAX_TTL = require("kong.constants").DATABASE.DAO_MAX_TTL
-local tablex_deepcopy = require("pl.tablex").deepcopy
 
 
 local setmetatable = setmetatable
@@ -156,7 +155,7 @@ local function get_pagination_options(self, options)
     error("options must be a table when specified", 3)
   end
 
-  options = tablex_deepcopy(options)
+  options = kong.table.deepclone(options)
 
   if type(options.pagination) == "table" then
     options.pagination = table_merge(self.pagination, options.pagination)
@@ -1446,12 +1445,12 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   if self.events then
     local entity_without_nulls
     if entity then
-      entity_without_nulls = remove_nulls(tablex_deepcopy(entity))
+      entity_without_nulls = remove_nulls(kong.table.deepclone(entity))
     end
 
     local old_entity_without_nulls
     if old_entity then
-      old_entity_without_nulls = remove_nulls(tablex_deepcopy(old_entity))
+      old_entity_without_nulls = remove_nulls(kong.table.deepclone(old_entity))
     end
 
     local ok, err = self.events.post_local("dao:crud", operation, {

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -7,7 +7,6 @@ local declarative_config = require("kong.db.schema.others.declarative_config")
 
 
 local cjson_encode = require("cjson.safe").encode
-local deepcopy = require("pl.tablex").deepcopy
 local marshall = require("kong.db.declarative.marshaller").marshall
 local schema_topological_sort = require("kong.db.schema.topological_sort")
 local nkeys = require("table.nkeys")
@@ -85,13 +84,15 @@ local function load_into_db(entities, meta)
     transform = meta._transform,
   }
 
+  local cycle_aware_cache = {}
+
   for i = 1, #sorted_schemas do
     local schema = sorted_schemas[i]
     local schema_name = schema.name
 
     local primary_key, ok, err, err_t
     for _, entity in pairs(entities[schema_name]) do
-      entity = deepcopy(entity)
+      entity = kong.table.deepclone(entity, cycle_aware_cache)
       entity._tags = nil
       entity.ws_id = nil
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1081,7 +1081,7 @@ function _M.new(connector, schema, errors)
   do
     local function add(name, opts, add_ws)
       local orig_argn = opts.argn
-      opts = pl_tablex.deepcopy(opts)
+      opts = kong.table.deepclone(opts)
 
       -- ensure LIMIT table is the same
       for i, n in ipairs(orig_argn) do

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -9,7 +9,7 @@ local kong = kong
 local insert = table.insert
 local tablepool_fetch = tablepool.fetch
 local tablepool_release = tablepool.release
-local deep_copy = utils.deep_copy
+local tablex_deepcopy = require("pl.tablex").deepcopy
 local table_merge = utils.table_merge
 local setmetatable = setmetatable
 
@@ -160,7 +160,7 @@ do
   encode_traces = function(spans, resource_attributes)
     local tab = tablepool_fetch(POOL_OTLP, 0, 2)
     if not tab.resource_spans then
-      tab.resource_spans = deep_copy(pb_memo.resource_spans)
+      tab.resource_spans = tablex_deepcopy(pb_memo.resource_spans)
     end
 
     local resource = tab.resource_spans[1].resource

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -9,7 +9,6 @@ local kong = kong
 local insert = table.insert
 local tablepool_fetch = tablepool.fetch
 local tablepool_release = tablepool.release
-local tablex_deepcopy = require("pl.tablex").deepcopy
 local table_merge = utils.table_merge
 local setmetatable = setmetatable
 
@@ -160,7 +159,7 @@ do
   encode_traces = function(spans, resource_attributes)
     local tab = tablepool_fetch(POOL_OTLP, 0, 2)
     if not tab.resource_spans then
-      tab.resource_spans = tablex_deepcopy(pb_memo.resource_spans)
+      tab.resource_spans = kong.table.deepclone(pb_memo.resource_spans)
     end
 
     local resource = tab.resource_spans[1].resource

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -23,7 +23,6 @@ local str_find = string.find
 local pairs = pairs
 local error = error
 local rawset = rawset
-local pl_copy_table = pl_tablex.deepcopy
 local lua_enabled = sandbox.configuration.enabled
 local sandbox_enabled = sandbox.configuration.sandbox_enabled
 
@@ -530,7 +529,7 @@ function _M.execute(conf)
   local template_env = {}
   if lua_enabled and sandbox_enabled then
     -- load the sandbox environment to be used to render the template
-    template_env = pl_copy_table(sandbox.configuration.environment)
+    template_env = kong.table.deepclone(sandbox.configuration.environment)
     -- here we can optionally add functions to expose to the sandbox, eg:
     -- tostring = tostring,
     -- because headers may contain array elements such as duplicated headers

--- a/kong/plugins/request-transformer/migrations/common.lua
+++ b/kong/plugins/request-transformer/migrations/common.lua
@@ -1,6 +1,3 @@
-local utils = require "kong.tools.utils"
-
-
 local _M = {}
 
 
@@ -11,6 +8,8 @@ function _M.rt_rename(_, _, dao)
     return err
   end
 
+  local cycle_aware_cache = {}
+
   for i = 1, #plugins do
     local plugin = plugins[i]
     local _, err = dao.plugins:insert({
@@ -18,7 +17,7 @@ function _M.rt_rename(_, _, dao)
       api_id = plugin.api_id,
       consumer_id = plugin.consumer_id,
       enabled = plugin.enabled,
-      config = utils.deep_copy(plugin.config),
+      config = kong.table.deepclone(plugin.config, cycle_aware_cache),
     })
     if err then
       return err
@@ -34,4 +33,3 @@ end
 
 
 return _M
-

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -25,7 +25,6 @@ local fileexists = require("pl.path").exists
 local semaphore = require("ngx.semaphore").new
 local lrucache = require("resty.lrucache")
 local resolver = require("resty.dns.resolver")
-local deepcopy = require("pl.tablex").deepcopy
 local time = ngx.now
 local log = ngx.log
 local ERR = ngx.ERR
@@ -799,7 +798,7 @@ local function asyncQuery(qname, r_opts, try_list)
     key = key,
     semaphore = semaphore(),
     qname = qname,
-    r_opts = deepcopy(r_opts),
+    r_opts = kong.table.deepclone(r_opts),
     try_list = try_list,
   }
   queue[key] = item

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -1,4 +1,3 @@
-local pl_tablex = require "pl.tablex"
 local get_certificate = require "kong.runloop.certificate".get_certificate
 
 local balancers = require "kong.runloop.balancer.balancers"
@@ -245,7 +244,7 @@ function healthcheckers_M.create_healthchecker(balancer, upstream)
   if (ngx.config.subsystem == "stream" and checks.active.type ~= "tcp")
     or (ngx.config.subsystem == "http" and checks.active.type == "tcp")
   then
-    checks = pl_tablex.deepcopy(checks)
+    checks = kong.table.deepclone(checks)
     checks.active.healthy.interval = 0
     checks.active.unhealthy.interval = 0
   end


### PR DESCRIPTION
### Summary

This is continuation of https://github.com/Kong/kong/pull/10970. It tries to reuse caches on declarative whenever possible. It does not clone the keys anymore by default.

This time we use cycle aware deep cloning more aggressively across the codebase.

In my testing this reduces memory usage of workers considerably, e.g. in dbless/dataplanes
I see following numbers:

Before #10970: 79 MB
After #10970: 70 MB
After (this PR): 60 MB

About 24% decrease (may be even bigger in EE).

When I start Kong with:
```
KONG_DATABASE=off \
KONG_ROLE=data_plane \
KONG_CLUSTER_CONTROL_PLANE=cp.test:8005 \
KONG_CLUSTER_CERT=cluster.crt \
KONG_CLUSTER_CERT_KEY=cluster.key \
kong restart -p dp
```

This means that if we decide to include https://github.com/Kong/kong/pull/10798 the privileged worker's memory usage with all plugins is now 30 MB.