### PR TITLE
perf(*): optimize declarative configuration deep cloning 

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -1,5 +1,4 @@
 local cjson = require "cjson"
-local utils = require "kong.tools.utils"
 local reports = require "kong.reports"
 local endpoints = require "kong.api.endpoints"
 local arguments = require "kong.api.arguments"
@@ -12,6 +11,7 @@ local find = string.find
 local pairs = pairs
 local lower = string.lower
 local setmetatable = setmetatable
+local tablex_deepcopy = require("pl.tablex").deepcopy
 
 
 local function reports_timer(premature, data)
@@ -19,7 +19,7 @@ local function reports_timer(premature, data)
     return
   end
 
-  local r_data = utils.deep_copy(data)
+  local r_data = tablex_deepcopy(data)
 
   r_data.config = nil
   r_data.route = nil

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -10,10 +10,10 @@ local table_insert = table.insert
 local table_sort = table.sort
 local table_remove = table.remove
 local gsub = string.gsub
-local deep_copy = utils.deep_copy
 local split = utils.split
 local deflate_gzip = utils.deflate_gzip
 local cjson_encode = cjson.encode
+local tablex_deepcopy = require("pl.tablex").deepcopy
 
 local ngx = ngx
 local ngx_log = ngx.log
@@ -375,7 +375,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
   end
 
   local has_update
-  payload = deep_copy(payload, false)
+  payload = tablex_deepcopy(payload)
   local config_table = payload["config_table"]
 
   for _, checker in ipairs(COMPATIBILITY_CHECKERS) do

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -6,6 +6,8 @@ local hooks = require "kong.hooks"
 local workspaces = require "kong.workspaces"
 local new_tab = require "table.new"
 local DAO_MAX_TTL = require("kong.constants").DATABASE.DAO_MAX_TTL
+local tablex_deepcopy = require("pl.tablex").deepcopy
+
 
 local setmetatable = setmetatable
 local tostring     = tostring
@@ -154,7 +156,7 @@ local function get_pagination_options(self, options)
     error("options must be a table when specified", 3)
   end
 
-  options = utils.deep_copy(options, false)
+  options = tablex_deepcopy(options)
 
   if type(options.pagination) == "table" then
     options.pagination = table_merge(self.pagination, options.pagination)
@@ -1444,12 +1446,12 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   if self.events then
     local entity_without_nulls
     if entity then
-      entity_without_nulls = remove_nulls(utils.deep_copy(entity, false))
+      entity_without_nulls = remove_nulls(tablex_deepcopy(entity))
     end
 
     local old_entity_without_nulls
     if old_entity then
-      old_entity_without_nulls = remove_nulls(utils.deep_copy(old_entity, false))
+      old_entity_without_nulls = remove_nulls(tablex_deepcopy(old_entity))
     end
 
     local ok, err = self.events.post_local("dao:crud", operation, {

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -9,7 +9,7 @@ local kong = kong
 local insert = table.insert
 local tablepool_fetch = tablepool.fetch
 local tablepool_release = tablepool.release
-local deep_copy = utils.deep_copy
+local tablex_deepcopy = require("pl.tablex").deepcopy
 local table_merge = utils.table_merge
 local setmetatable = setmetatable
 
@@ -160,7 +160,7 @@ do
   encode_traces = function(spans, resource_attributes)
     local tab = tablepool_fetch(POOL_OTLP, 0, 2)
     if not tab.resource_spans then
-      tab.resource_spans = deep_copy(pb_memo.resource_spans)
+      tab.resource_spans = tablex_deepcopy(pb_memo.resource_spans)
     end
 
     local resource = tab.resource_spans[1].resource


### PR DESCRIPTION
### Summary

Optimizes declarative configuration deep cloning operations and uses a cycle aware cache in places that have most impact on memory usage.

The #10970 already removed around 9 MB of memory usage. This will remove another 7 MB, expect Kong CE dataplane/dbless worker take around 63 MB after this.