### PR TITLE
tracing(instrumentation): add http.route span attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@
 ### Changed
 
 #### Core
+- Tracing: new attribute `http.route` added to http request spans.
+  [#10981](https://github.com/Kong/kong/pull/10981)
 
 #### PDK
 

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -294,6 +294,8 @@ function _M.runloop_before_header_filter()
   local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
   if root_span then
     root_span:set_attribute("http.status_code", ngx.status)
+    local r = ngx.ctx.route
+    root_span:set_attribute("http.route", r and r.paths and r.paths[1] or "")
   end
 end
 

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -1,5 +1,39 @@
 local helpers = require "spec.helpers"
-local cjson = require "cjson"
+local cjson   = require "cjson"
+local pretty  = require "pl.pretty"
+
+local fmt = string.format
+
+local function get_span(name, spans)
+  for _, span in ipairs(spans) do
+    if span.name == name then
+      return span
+    end
+  end
+end
+
+local function assert_has_span(name, spans)
+  local span = get_span(name, spans)
+  assert.is_truthy(span, fmt("\nExpected to find %q span in:\n%s\n",
+                             name, pretty.write(spans)))
+  return span
+end
+
+local function assert_has_no_span(name, spans)
+  local found = get_span(name, spans)
+  assert.is_falsy(found, fmt("\nExpected not to find %q span in:\n%s\n",
+                             name, pretty.write(spans)))
+end
+
+local function assert_has_attributes(span, attributes)
+  for k, v in pairs(attributes) do
+    assert.is_not_nil(span.attributes[k], fmt(
+          "Expected span to have attribute %s, but got %s\n", k, pretty.write(span.attributes)))
+    assert.matches(v, span.attributes[k], fmt(
+          "Expected span to have attribute %s with value matching %s, but got %s\n",
+          k, v, span.attributes[k]))
+  end
+end
 
 local TCP_PORT = 35001
 local tcp_trace_plugin_name = "tcp-trace-exporter"
@@ -24,6 +58,12 @@ for _, strategy in helpers.each_strategy() do
       bp.routes:insert({ service = http_srv,
                          protocols = { "http" },
                          paths = { "/" }})
+
+      bp.routes:insert({ service = http_srv,
+                         protocols = { "http" },
+                         paths = { "/status" },
+                         hosts = { "status" },
+                         strip_path = false })
 
       bp.plugins:insert({
         name = tcp_trace_plugin_name,
@@ -54,7 +94,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains no spans", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -82,7 +122,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected database span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -95,11 +135,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        local expected_span_num = 2
-        assert.is_same(expected_span_num, #spans, res)
-        assert.is_same("kong.database.query", spans[2].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.database.query", spans)
+
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -112,7 +156,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected router span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -125,10 +169,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(2, #spans, res)
-        assert.is_same("kong.router", spans[2].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.router", spans)
+
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -141,7 +190,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected kong.internal.request span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -154,10 +203,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(5, #spans, res)
-        assert.matches("kong.internal.request", spans[3].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.internal.request", spans)
+
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -170,7 +224,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected balancer span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -183,10 +237,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(2, #spans, res)
-        assert.is_same("kong.balancer", spans[2].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.balancer", spans)
+
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -199,7 +258,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected kong.rewrite.plugin span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -212,10 +271,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(2, #spans, res)
-        assert.is_same("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans[2].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -228,7 +292,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected kong.header_filter.plugin span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -243,8 +307,14 @@ for _, strategy in helpers.each_strategy() do
 
         -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(2, #spans, res)
-        assert.is_same("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans[2].name)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
+
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -258,7 +328,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected kong.dns span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -271,19 +341,15 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        -- If the db host if a domain, it creates extra db query
-        assert.is_true(#spans >= 4, res)
+        assert_has_span("kong", spans)
+        assert_has_span("kong.dns", spans)
 
-        local found
-        for _, span in ipairs(spans) do
-          if span.name == "kong.dns" then
-            found = true
-          end
-        end
-
-        assert.is_true(found, res)
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
     end)
 
@@ -296,11 +362,14 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains all spans", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/status/200",
+          headers = {
+            host = "status",
+          }
         })
         assert.res_status(200, r)
 
@@ -309,11 +378,51 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        local expected_span_num = 13
+        local kong_span = assert_has_span("kong", spans)
+        local dns_span = assert_has_span("kong.dns", spans)
+        local balancer_span = assert_has_span("kong.balancer", spans)
+        local db_span = assert_has_span("kong.database.query", spans)
+        local int_req_span = assert_has_span("kong.internal.request", spans)
+        assert_has_span("kong.router", spans)
+        assert_has_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+        assert_has_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
 
-        assert.is_same(expected_span_num, #spans, res)
+        -- span attributes check
+        assert_has_attributes(kong_span, {
+          ["http.method"]    = "GET",
+          ["http.url"]       = "http://status/status/200",
+          ["http.route"]     = "/status",
+          ["http.host"]      = "status",
+          ["http.scheme"]    = "http",
+          ["http.flavor"]    = "1.1",
+          ["http.client_ip"] = "127.0.0.1",
+          ["net.peer.ip"]    = "127.0.0.1",
+        })
+
+        assert_has_attributes(dns_span, {
+          ["dns.record.domain"] = "[%w\\.]+",
+          ["dns.record.ip"] = "[%d\\.]+",
+          ["dns.record.port"] = "%d+"
+        })
+
+        assert_has_attributes(balancer_span, {
+          ["net.peer.ip"] = "127.0.0.1",
+          ["net.peer.port"] = "%d+",
+        })
+
+        assert_has_attributes(db_span, {
+          ["db.statement"] = ".*",
+          ["db.system"] = "%w+",
+        })
+
+        assert_has_attributes(int_req_span, {
+          ["http.method"]    = "GET",
+          ["http.flavor"]    = "1.1",
+          ["http.status_code"] = "200",
+          ["http.url"] = "http[s]?://.*",
+          ["http.user_agent"] = "[%w%s\\.]+"
+        })
       end)
     end)
 
@@ -326,7 +435,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("works", function ()
+      it("contains the expected kong span", function ()
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
@@ -339,9 +448,8 @@ for _, strategy in helpers.each_strategy() do
         assert.True(ok)
         assert.is_string(res)
 
-        -- Making sure it's alright
         local spans = cjson.decode(res)
-        assert.is_same(1, #spans, res)
+        assert_has_span("kong", spans)
       end)
     end)
   end)

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -455,6 +455,7 @@ for _, strategy in helpers.each_strategy() do
           { key = "http.flavor", value = { string_value = "1.1", value = "string_value" } },
           { key = "http.host", value = { string_value = "0.0.0.0", value = "string_value" } },
           { key = "http.method", value = { string_value = "GET", value = "string_value" } },
+          { key = "http.route", value = { string_value = "/", value = "string_value" } },
           { key = "http.scheme", value = { string_value = "http", value = "string_value" } },
           { key = "http.status_code", value = { int_value = 200, value = "int_value" } },
           { key = "http.url", value = { string_value = "http://0.0.0.0/", value = "string_value" } },


### PR DESCRIPTION
### Summary

This PR adds the `http.route` span attribute to the kong request span, adapts existing tests to pass with the new attribute and improves instrumentation tests, by adding checks for all spans and attributes.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] (NA) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-1719](https://konghq.atlassian.net/browse/KAG-1719)

#8125

[KAG-1719]: https://konghq.atlassian.net/browse/KAG-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ