### PR TITLE
doc(developer): install  depended by OpenSSL 3.0 On Fedora/CentOS/RHEL

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -119,6 +119,7 @@ dnf install \
     make \
     patch \
     perl \
+    perl-IPC-Cmd \
     protobuf-devel \
     unzip \
     valgrind \


### PR DESCRIPTION
\### Summary

OpenSSL 3.0 will depend on `IPC/Cmd.pm`, which is not ship in Fedora/CentOS/RHEL distributions by default. Otherwise you will see the following error:

```
Action build/kong-dev.nop failed: (Exit 2): bash failed: error executing command (from target @openssl//:openssl) 
```
### Checklist

- [ ] NA The Pull Request has tests
- [ ] NA There's an entry in the CHANGELOG
- [ ] NA There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
