### PR TITLE
fix(dao): `created_at` should not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
   [#10896](https://github.com/Kong/kong/pull/10896)
 - Fix a bug when worker consuming dynamic log level setting event and using a wrong reference for notice logging
   [#10897](https://github.com/Kong/kong/pull/10897)
+- Fix a bug that the field `created_at` of entity changes every time entity is 
+  modified by a `PUT` method via admin API.
+  [#10987](https://github.com/Kong/kong/pull/10987)
 
 #### Admin API
 

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -566,13 +566,6 @@ local function check_upsert(self, key, entity, options, name)
     transform = true
   end
 
-  local entity_to_upsert, err =
-    self.schema:process_auto_fields(entity, "upsert")
-  if not entity_to_upsert then
-    local err_t = self.errors:schema_violation(err)
-    return nil, nil, tostring(err_t), err_t
-  end
-
   local rbw_entity
   local err, err_t
   if name then
@@ -582,6 +575,17 @@ local function check_upsert(self, key, entity, options, name)
   end
   if err then
     return nil, nil, err, err_t
+  end
+
+  if rbw_entity and rbw_entity.created_at then
+    entity.created_at = rbw_entity.created_at
+  end
+
+  local entity_to_upsert, err =
+    self.schema:process_auto_fields(entity, "upsert")
+  if not entity_to_upsert then
+    local err_t = self.errors:schema_violation(err)
+    return nil, nil, tostring(err_t), err_t
   end
 
   if name then

--- a/spec/01-unit/01-db/07-dao/03_upsert_spec.lua
+++ b/spec/01-unit/01-db/07-dao/03_upsert_spec.lua
@@ -3,6 +3,7 @@ local helpers = require ("spec.helpers")
 describe("dao upsert: ", function()
   local db
   lazy_setup(function()
+    local _
     _, db = helpers.get_db_utils("postgres", {
       "services"
     })

--- a/spec/01-unit/01-db/07-dao/03_upsert_spec.lua
+++ b/spec/01-unit/01-db/07-dao/03_upsert_spec.lua
@@ -1,0 +1,34 @@
+local helpers = require ("spec.helpers")
+
+describe("dao upsert: ", function()
+  local db
+  lazy_setup(function()
+    _, db = helpers.get_db_utils("postgres", {
+      "services"
+    })
+  end)
+
+  it("behavior of generation of `created_at` and `updated_at`", function()
+
+    local entity1 = db.daos["services"]:insert({
+      name = "foo",
+      host = "foo1.com"
+    })
+    assert(entity1)
+
+    -- `created_at` is generated when entities are created
+    assert(entity1.created_at)
+    -- `updated_at` is generated with the creation of entities
+    assert(entity1.updated_at == entity1.created_at)
+    ngx.sleep(1)
+    local entity2 = db.daos["services"]:upsert(
+      { id = entity1.id },
+      { host = "foo2.com"}
+    )
+    assert(entity2)
+    -- `created_at` never changes with the update of entities
+    assert(entity2.created_at == entity1.created_at)
+    -- `updated_at` will be updated when entities are updated
+    assert(entity2.updated_at ~= nil and entity2.updated_at > entity1.updated_at)
+  end)
+end)


### PR DESCRIPTION
### Summary

fix a bug that the field `created_at` of entity changesevery time entity are modified with `PUT` method via admin API, which is not expected.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-1690
FTI-5108