### PR TITLE
tests(ci): enable all tests in t folder, not only the pdk ones

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -125,7 +125,7 @@ if [ "$TEST_SUITE" == "plugins" ]; then
     fi
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
-    prove -I. -r t/01-pdk
+    prove -I. -r t
 fi
 if [ "$TEST_SUITE" == "unit" ]; then
     unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD


### PR DESCRIPTION
### Summary

Just checking how far this goes. Perhaps errors horribly, but we are we not running all the tests in `t/`?