### PR TITLE
tests(dbless): harden test against eventual consistency

### DIFF
--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -3,6 +3,24 @@ local cjson = require "cjson"
 
 local WORKER_PROCS = 4
 
+-- transient errors can leave holes in worker PID tables/arrays,
+-- which may be encoded as NULL by cjson, so we need to filter those
+-- out before attempting any maths
+local function remove_nulls(t)
+  local n = 0
+
+  for i = 1, #t do
+    local item = t[i]
+    t[i] = nil
+
+    if item ~= cjson.null then
+      n = n + 1
+      t[n] = item
+    end
+  end
+end
+
+
 local function count_common_values(t1, t2)
   local counts = {}
 
@@ -58,76 +76,87 @@ describe("worker respawn", function()
   end)
 
   it("rotates pids and deletes the old ones", function()
-    local res = admin_client:get("/")
-    local body = assert.res_status(200, res)
-    local json = cjson.decode(body)
-    local pids = json.pids.workers
+    local pids
 
-    assert.same(WORKER_PROCS, #pids, "unexpected number of worker pids")
+    assert.eventually(function()
+      local res = admin_client:get("/")
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      pids = json.pids.workers
+      remove_nulls(pids)
+
+      if #pids == WORKER_PROCS then
+        return true
+      end
+
+      return nil, {
+                    err = "invalid worker pid count",
+                    exp = WORKER_PROCS,
+                    got = #pids,
+                  }
+    end)
+    .is_truthy("expected / API endpoint to return the current number of workers")
 
     helpers.signal_workers(nil, "-TERM")
 
+    -- `helpers.wait_until_no_common_workers()` is not used here because it
+    -- works by using the very same API that this case is supposed to test
     assert.eventually(function()
-      local pok, admin_client2 = pcall(helpers.admin_client)
-      if not pok then
-        return nil, "failed creating admin client: " .. tostring(admin_client2)
-      end
-
-      local res2 = admin_client2:get("/")
+      local res2 = admin_client:get("/")
       local body2 = assert.res_status(200, res2)
       local json2 = cjson.decode(body2)
       local pids2 = json2.pids.workers
-
-      admin_client2:close()
-
-      if #pids2 ~= WORKER_PROCS then
-        return nil, "unexpected number of new worker pids: " .. tostring(#pids2)
-      end
+      remove_nulls(pids2)
 
       if count_common_values(pids, pids2) > 0 then
         return nil, "old and new worker pids both present"
+
+      elseif #pids2 ~= WORKER_PROCS then
+        return nil, {
+                      err = "unexpected number of worker pids",
+                      exp = WORKER_PROCS,
+                      got = #pids2,
+                    }
       end
 
       return true
     end)
+    .ignore_exceptions(true)
     .is_truthy("expected the admin API to report only new (respawned) worker pids")
   end)
 
   it("rotates kong:mem stats and deletes the old ones", function()
-    local proxy_res = proxy_client:get("/")
-    assert.res_status(404, proxy_res)
+    local mem
 
-    local res = admin_client:get("/status")
-    local body = assert.res_status(200, res)
-    local json = cjson.decode(body)
-    local mem = json.memory.workers_lua_vms
+    assert.eventually(function()
+      local res = admin_client:get("/status")
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      mem = json.memory.workers_lua_vms
+      remove_nulls(mem)
+
+      if #mem == WORKER_PROCS then
+        return true
+      end
+
+      return nil, {
+                    err = "unexpected worker count",
+                    exp = WORKER_PROCS,
+                    got = #mem,
+                  }
+    end)
+    .is_truthy("expected /status API endpoint to return the current number of workers")
 
     helpers.signal_workers(nil, "-TERM")
 
-    helpers.wait_until(function()
-      local pok, proxy_client2 = pcall(helpers.proxy_client)
-      if not pok then
-        return false
-      end
-
-      local proxy_res2 = proxy_client2:get("/")
-      assert.res_status(404, proxy_res2)
-      proxy_client2:close()
-
-      local admin_client2
-      pok, admin_client2 = pcall(helpers.admin_client)
-      if not pok then
-        return false
-      end
-
-      local res2 = admin_client2:get("/status")
+    -- `helpers.wait_until_no_common_workers()` is not used here because it
+    -- more-or-less relies on the same mechanism that is being tested here.
+    assert.eventually(function()
+      local res2 = admin_client:get("/status")
       local body2 = assert.res_status(200, res2)
       local json2 = cjson.decode(body2)
       local mem2 = json2.memory.workers_lua_vms
-
-      admin_client2:close()
-
-      assert.equal(#mem, #mem2)
+      remove_nulls(mem2)
 
       local matching = 0
       for _, value in ipairs(mem) do
@@ -137,14 +166,26 @@ describe("worker respawn", function()
 
           if value.pid == value2.pid then
             matching = matching + 1
+            break
           end
         end
       end
 
-      assert.equal(0, matching)
+      if matching > 0 then
+        return nil, "old and new worker mem stats still present"
+
+      elseif #mem2 ~= WORKER_PROCS then
+        return nil, {
+                      err = "unexpected number of workers",
+                      exp = WORKER_PROCS,
+                      got = #mem2,
+                    }
+      end
 
       return true
     end)
+    .ignore_exceptions(true)
+    .is_truthy("expected defunct worker memory stats to be cleared")
   end)
 
   it("lands on the correct cache page #5799", function()
@@ -195,7 +236,7 @@ describe("worker respawn", function()
     }))
     assert.res_status(200, res)
 
-    local workers = helpers.get_kong_workers()
+    local workers = helpers.get_kong_workers(WORKER_PROCS)
     proxy_client:close()
 
     -- kill all the workers forcing all of them to respawn


### PR DESCRIPTION
### Summary

This is a follow-up to work that was done in 9cbbee3c8a / #10982 to correct a couple more lingering issues.

In order to reproduce some of the weirdness that seems to only happen in CI, I set WORKER_PROCS to 64 and re-ran the test suite a whole bunch of time. I found the following:

* not all worker data (pids, memory stats, etc) is guaranteed to be available via the admin API immediately after Kong has started, so test cases that fetch this data at the beginning of the test need to be wrapped with `assert.eventually(...)`.
* the way that the worker pid table is computed in the `/` API endpoint [can result in a sparse array with NULL values](https://github.com/Kong/kong/blob/adf6c4d8b5b62c4084ec219e066e50a788d7beee/kong/api/routes/kong.lua#L73-L86), so we need to filter those items out before using the table.
* relying on the default behavior of `reopen = true` for `helpers.admin_client()` helps to simplify try/retry logic, but `admin_client:get("/")` can still throw an error if the connection is dropped/closed/reset between `connect()` and `send()`, so eventual assertions need `ignore_exceptions(true)`.

### Checklist

- [x] The Pull Request has tests
- [x] ~There's an entry in the CHANGELOG~ N/A
- [x] ~There is a user-facing docs PR~ N/A

### Epilogue

It's a bummer that a simple test requires such a high amount of super-duper defensive code which must be heavily paranoid and intimately aware about the underlying APIs it is using. I think this highlights the need for both:

A) more glue in `spec.helpers` for eventual consistency

and

B) more health-check-y API endpoints like `/status/ready`, but with additional support for conditionally blocking (i.e. `GET /status/nginx-workers?timeout=5` would block for as much as 5 seconds while awaiting all worker PIDs to be reported after startup)