### PR TITLE
fix(prometheus): fix upstream_health_metrics config true->false change not working issues

### DIFF
--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -50,6 +50,8 @@ function PrometheusHandler.log(self, conf)
 
   if conf.upstream_health_metrics then
     exporter.set_export_upstream_health_metrics(true)
+  else
+    exporter.set_export_upstream_health_metrics(false)
   end
 
   exporter.log(message, serialized)


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
if `upstream_health_metrics` config true->flase change, in the `handler` code, it is not working.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests (Not need)
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog


### Issue reference


