### PR TITLE
fix(balancer): fix balancer error thread abort code

### DIFF
--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -101,7 +101,6 @@ end
 local function create_balancer_exclusive(upstream)
   local health_threshold = upstream.healthchecks and
     upstream.healthchecks.threshold or nil
-  local err
 
   targets.clean_targets_cache(upstream)
   local targets_list = targets.fetch_targets(upstream)
@@ -140,6 +139,7 @@ local function create_balancer_exclusive(upstream)
     target.balancer = balancer
   end
 
+  local err
   targets_list, err = targets.resolve_targets(targets_list)
   if not targets_list then
     return nil, "failed resolving targets:" .. err

--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -103,7 +103,7 @@ local function create_balancer_exclusive(upstream)
     upstream.healthchecks.threshold or nil
 
   targets.clean_targets_cache(upstream)
-  local targets_list, err = targets.fetch_targets(upstream)
+  local targets_list = targets.fetch_targets(upstream)
   if not targets_list then
     return nil, "failed fetching targets for upstream " .. upstream.name or upstream.id
   end

--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -101,6 +101,7 @@ end
 local function create_balancer_exclusive(upstream)
   local health_threshold = upstream.healthchecks and
     upstream.healthchecks.threshold or nil
+  local err
 
   targets.clean_targets_cache(upstream)
   local targets_list = targets.fetch_targets(upstream)

--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -105,7 +105,7 @@ local function create_balancer_exclusive(upstream)
   targets.clean_targets_cache(upstream)
   local targets_list, err = targets.fetch_targets(upstream)
   if not targets_list then
-    return nil, "failed fetching targets:" .. err
+    return nil, "failed fetching targets for upstream " .. upstream.name or upstream.id
   end
 
   if algorithm_types == nil then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
`targets.fetch_targets(upstream)` can not return error, so `    return nil, "failed fetching targets:" .. err` will abort in coroutine.

<!--- Why is this change required? What problem does it solve? -->
<img width="1306" alt="image" src="https://github.com/Kong/kong/assets/39181969/b0afbd14-3e38-407e-9f88-44beaeb65737">


### Checklist

- [ ] The Pull Request has tests (No Need)
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

