### PR TITLE
fix(api/status): remove the database status in dbless mode and data-plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 
 #### Status API
 
+- Remove the database information from the status API when operating in dbless
+  mode or data plane.
+
 #### Plugins
 
 #### PDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,6 @@
 
 #### Status API
 
-- Remove the database information from the status API when operating in dbless
-  mode or data plane.
-  [#10995](https://github.com/Kong/kong/pull/10995)
-
 #### Plugins
 
 #### PDK
@@ -85,6 +81,12 @@
 ### Changed
 
 #### Core
+
+#### Status API
+
+- Remove the database information from the status API when operating in dbless
+  mode or data plane.
+  [#10995](https://github.com/Kong/kong/pull/10995)
 
 #### PDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 - Remove the database information from the status API when operating in dbless
   mode or data plane.
+  [#10995](https://github.com/Kong/kong/pull/10995)
 
 #### Plugins
 

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -51,6 +51,8 @@ return {
       -- has been reset to empty).
       if dbless or data_plane_role then
         status_response.configuration_hash = declarative.get_current_hash()
+        -- remove the meanless database entry when in dbless mode or data plane
+        status_response.database = nil
       end
 
       -- TODO: no way to bypass connection pool

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -198,10 +198,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.is_table(json.database)
       assert.is_table(json.server)
-
-      assert.is_boolean(json.database.reachable)
 
       assert.is_number(json.server.connections_accepted)
       assert.is_number(json.server.connections_active)
@@ -212,8 +209,12 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.total_requests)
       if strategy == "off" then
         assert.is_equal(empty_config_hash, json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+        assert.is_nil(json.database)
+
       else
         assert.is_nil(json.configuration_hash) -- not present in DB mode
+        assert.is_table(json.database)
+        assert.is_boolean(json.database.reachable)
       end
     end)
 
@@ -242,9 +243,13 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.is_table(json.database)
+      if strategy == "off" then
+        assert.is_nil(json.database)
+      else
+        assert.is_table(json.database)
+        assert.is_boolean(json.database.reachable)
+      end
       assert.is_table(json.server)
-      assert.is_boolean(json.database.reachable)
       assert.is_number(json.server.connections_accepted)
       assert.is_number(json.server.connections_active)
       assert.is_number(json.server.connections_handled)
@@ -272,7 +277,11 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
 
-      assert.is_true(json.database.reachable)
+      if strategy == "off" then
+        assert.is_nil(json.database)
+      else
+        assert.is_true(json.database.reachable)
+      end
     end)
 
     describe("memory stats", function()

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -243,12 +243,15 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
+
       if strategy == "off" then
         assert.is_nil(json.database)
+
       else
         assert.is_table(json.database)
         assert.is_boolean(json.database.reachable)
       end
+
       assert.is_table(json.server)
       assert.is_number(json.server.connections_accepted)
       assert.is_number(json.server.connections_active)

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -139,6 +139,7 @@ services:
 
         if strategy == "off" then
           assert.is_nil(json.database)
+
         else
           assert.is_table(json.database)
           assert.is_boolean(json.database.reachable)
@@ -314,6 +315,7 @@ for _, strategy in helpers.all_strategies() do
 
       if strategy == "off" then
         assert.is_nil(json.database)
+
       else
         assert.is_table(json.database)
         assert.is_boolean(json.database.reachable)

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -28,10 +28,7 @@ for _, strategy in helpers.all_strategies() do
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.is_table(json.database)
         assert.is_table(json.server)
-
-        assert.is_boolean(json.database.reachable)
 
         assert.is_number(json.server.connections_accepted)
         assert.is_number(json.server.connections_active)
@@ -42,8 +39,12 @@ for _, strategy in helpers.all_strategies() do
         assert.is_number(json.server.total_requests)
         if strategy == "off" then
           assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+          assert.is_nil(json.database)
+
         else
           assert.is_nil(json.configuration_hash) -- not present in DB mode
+          assert.is_table(json.database)
+          assert.is_boolean(json.database.reachable)
         end
         client:close()
       end)
@@ -77,9 +78,8 @@ services:
           })
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
-          assert.is_table(json.database)
+          assert.is_nil(json.database)
           assert.is_table(json.server)
-          assert.is_boolean(json.database.reachable)
           assert.is_number(json.server.connections_accepted)
           assert.is_number(json.server.connections_active)
           assert.is_number(json.server.connections_handled)
@@ -135,10 +135,14 @@ services:
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.is_table(json.database)
         assert.is_table(json.server)
 
-        assert.is_boolean(json.database.reachable)
+        if strategy == "off" then
+          assert.is_nil(json.database)
+        else
+          assert.is_table(json.database)
+          assert.is_boolean(json.database.reachable)
+        end
 
         assert.is_number(json.server.connections_accepted)
         assert.is_number(json.server.connections_active)
@@ -248,7 +252,11 @@ for _, strategy in helpers.each_strategy() do
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.is_true(json.database.reachable)
+      if strategy == "off" then
+        assert.is_nil(json.database)
+      else
+        assert.is_true(json.database.reachable)
+      end
 
       assert(helpers.stop_kong())
 
@@ -265,7 +273,11 @@ for _, strategy in helpers.each_strategy() do
       })
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
-      assert.is_falsy(json.database.reachable)
+      if strategy == "off" then
+        assert.is_nil(json.database)
+      else
+        assert.is_falsy(json.database.reachable)
+      end
     end)
   end)
 end
@@ -300,8 +312,12 @@ for _, strategy in helpers.all_strategies() do
 
       assert.equal('200', headers:get ":status")
 
-      assert.is_table(json.database)
-      assert.is_boolean(json.database.reachable)
+      if strategy == "off" then
+        assert.is_nil(json.database)
+      else
+        assert.is_table(json.database)
+        assert.is_boolean(json.database.reachable)
+      end
 
       assert.is_number(json.server.connections_accepted)
       assert.is_number(json.server.connections_active)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Remove the meaningless database status information from the status API when operating in dbless mode or data plane.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference



<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-5034](https://konghq.atlassian.net/browse/FTI-5034)


[FTI-5034]: https://konghq.atlassian.net/browse/FTI-5034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ