### PR TITLE
fix: remove sensitive kong.conf fields

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -551,6 +551,14 @@ local CONF_SENSITIVE = {
   pg_password = true,
   pg_ro_password = true,
   proxy_server = true, -- hide proxy server URL as it may contain credentials
+  declarative_config_string = true, -- config may contain sensitive info
+  -- may contain absolute or base64 value of the the key
+  cluster_cert_key = true,
+  ssl_cert_key = true,
+  client_ssl_cert_key = true,
+  admin_ssl_cert_key = true,
+  status_ssl_cert_key = true,
+  debug_ssl_cert_key = true,
 }
 
 


### PR DESCRIPTION
### Summary

A subset of kong.conf options were truncated. A new audit was performed and additional fields 
were added in.

### Checklist

- [x] The Pull Request has tests - NO tests are added because [existing tests](https://github.com/Kong/kong/blob/a68dbc93b00d2bc13645f49a953cbcbfed3f32d6/spec/01-unit/03-conf_loader_spec.lua#L1663) are assumed to be sufficient.
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR  - not required

### Full changelog

* remove more sensitive fields from kong.conf
