### PR TITLE
fix(venv): pickup bash from env (#5595)

### DIFF
--- a/scripts/dependency_services/common.sh
+++ b/scripts/dependency_services/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 KONG_SERVICE_ENV_FILE [up|down]"

--- a/scripts/dependency_services/up.sh
+++ b/scripts/dependency_services/up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "${BASH_SOURCE-}" = "$0" ]; then
     echo "You must source this script: \$ source $0" >&2
@@ -13,7 +13,7 @@ else
     cwd=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 fi
 
-bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
+/usr/bin/env bash "$cwd/common.sh" $KONG_SERVICE_ENV_FILE up
 if [ $? -ne 0 ]; then
     echo "Something goes wrong, please check common.sh output"
     exit 1


### PR DESCRIPTION
on OSX the default bash is v3.2 and does not have associative array support that is needed by dependency_services/common.sh. A more recent bash (for eg via Homebrew) can be picked up correctly if supplied in the PATH.

Cherry-pick from EE#5595

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
