### PR TITLE
refactor(clustering): clean the code of config thread

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -181,47 +181,50 @@ function _M:communicate(premature)
   local config_thread = ngx.thread.spawn(function()
     while not exiting() and not config_exit do
       local ok, err = config_semaphore:wait(1)
-      if ok then
-        local data = next_data
-        if data then
-          local msg = assert(inflate_gzip(data))
-          yield()
-          msg = assert(cjson_decode(msg))
-          yield()
 
-          if msg.type == "reconfigure" then
-            if msg.timestamp then
-              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane with timestamp: ",
-                                 msg.timestamp, log_suffix)
-
-            else
-              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane", log_suffix)
-            end
-
-            local config_table = assert(msg.config_table)
-            local pok, res
-            pok, res, err = pcall(config_helper.update, self.declarative_config,
-                                  config_table, msg.config_hash, msg.hashes)
-            if pok then
-              if not res then
-                ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
-              end
-
-              ping_immediately = true
-
-            else
-              ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", res)
-            end
-
-            if next_data == data then
-              next_data = nil
-            end
-          end
+      if not ok then
+        if err ~= "timeout" then
+          ngx_log(ngx_ERR, _log_prefix, "semaphore wait error: ", err)
         end
 
-      elseif err ~= "timeout" then
-        ngx_log(ngx_ERR, _log_prefix, "semaphore wait error: ", err)
+        goto continue
       end
+
+      local data = next_data
+      if not data then
+        goto continue
+      end
+
+      local msg = assert(inflate_gzip(data))
+      yield()
+      msg = assert(cjson_decode(msg))
+      yield()
+
+      if msg.type ~= "reconfigure" then
+        goto continue
+      end
+
+      ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane",
+                         msg.timestamp and " with timestamp: " .. msg.timestamp or "",
+                         log_suffix)
+
+      local config_table = assert(msg.config_table)
+
+      local pok, res, err = pcall(config_helper.update, self.declarative_config,
+                                  config_table, msg.config_hash, msg.hashes)
+      if pok then
+        ping_immediately = true
+      end
+
+      if not pok or not res then
+        ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
+      end
+
+      if next_data == data then
+        next_data = nil
+      end
+
+      ::continue::
     end
   end)
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -271,7 +271,7 @@ function _M:communicate(premature)
           next_data = data
           if config_semaphore:count() <= 0 then
             -- the following line always executes immediately after the `if` check
-            -- because `:count` will never yield, and result is that the semaphore
+            -- because `:count` will never yield, end result is that the semaphore
             -- count is guaranteed to not exceed 1
             config_semaphore:post()
           end

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -268,7 +268,7 @@ function _M:communicate(premature)
           next_data = data
           if config_semaphore:count() <= 0 then
             -- the following line always executes immediately after the `if` check
-            -- because `:count` will never yield, end result is that the semaphore
+            -- because `:count` will never yield, and result is that the semaphore
             -- count is guaranteed to not exceed 1
             config_semaphore:post()
           end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Port some core code of #11006, removing the usage of worker events.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


