### PR TITLE
chore(deps): bump resty.session from 4.0.3 to 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@
   [#10841](https://github.com/Kong/kong/pull/10841)
 - Bumped lua-resty-events from 0.1.4 to 0.1.5
   [#10883](https://github.com/Kong/kong/pull/10883)
+- Bumped lua-resty-session from 4.0.3 to 4.0.4
+  [#11011](https://github.com/Kong/kong/pull/11011)
 
 ## 3.3.0
 

--- a/kong-3.4.0-0.rockspec
+++ b/kong-3.4.0-0.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.11.0",
-  "lua-resty-session == 4.0.3",
+  "lua-resty-session == 4.0.4",
   "lua-resty-timer-ng == 0.2.5",
   "lpeg == 1.0.2",
 }


### PR DESCRIPTION
### Summary

- chore(utils): remove dependency for lua_pack