### PR TITLE
chore(*): update copyright year to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2022 Kong Inc.
+   Copyright 2016-2023 Kong Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -1,6 +1,6 @@
 --- Module for timestamp support.
 -- Based on the LuaTZ module.
--- @copyright Copyright 2016-2022 Kong Inc. All rights reserved.
+-- @copyright Copyright 2016-2023 Kong Inc. All rights reserved.
 -- @license [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 -- @module kong.tools.timestamp
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

It seems that we have to maintain the copyright year manually,
Could we do this job with some bots? 

refer: #8240

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


