### PR TITLE
tests(rate-limiting): explicitly set timeout to 15

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -749,6 +749,7 @@ if limit_by == "ip" then
     })
 
     assert
+      .with_timeout(15)
       .with_max_tries(10)
       .ignore_exceptions(false)
       .eventually(function()
@@ -770,7 +771,7 @@ if limit_by == "ip" then
         local res3 = GET(test_path, { headers = { ["X-Real-IP"] = "127.0.0.3" }})
         assert.res_status(200, res3)
       end)
-      .has_no_error("counter is cleared after current window")
+      .has_no_error("counter should have been cleared after current window")
   end)
 
   it("blocks with a custom error code and message", function()


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Explicitly set a timeout for rate-limiting test. By default, the timeout value is 5, and does not match the max try 10.

### Checklist

- [x] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* explicitly set timeout to 15

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5126
