### PR TITLE
test(migration): support access to latest code

### DIFF
--- a/scripts/upgrade-tests/docker-compose.yml
+++ b/scripts/upgrade-tests/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       KONG_TEST_PG_HOST: db_postgres
     volumes:
       - ../../worktree/${OLD_KONG_VERSION}:/kong
+      - ../..:/upgrade-test/lastest
     restart: on-failure
     networks:
       upgrade_tests:

--- a/scripts/upgrade-tests/docker-compose.yml
+++ b/scripts/upgrade-tests/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       KONG_TEST_PG_HOST: db_postgres
     volumes:
       - ../../worktree/${OLD_KONG_VERSION}:/kong
-      - ../..:/upgrade-test/lastest
+      - ../..:/upgrade-test/latest
     restart: on-failure
     networks:
       upgrade_tests:

--- a/spec/string_buffer.lua
+++ b/spec/string_buffer.lua
@@ -1,0 +1,106 @@
+-- this is a backport of `string.buffer` module of LuaJIT
+-- for older version of Kong code to run tests with new helper functions
+-- this implementation only promise the same behavior as the original but not the same performance
+-- and the methods decode()/encode() are not implemented
+
+local ffi = require "ffi"
+local tbl_new = require "table.new"
+local tbl_clr = require "table.clear"
+
+local _M = {}
+_M.__index = _M
+
+function _M.new(size)
+  local buf = tbl_new(size or 0, 0)
+  buf.n = 0
+  return setmetatable(buf, _M)
+end
+
+function _M:put(...)
+  local n = select("#", ...)
+  if n == 0 then
+    return
+  end
+
+  local buf = self
+  local offset = self.n
+  self.n = offset + n
+
+  for i = 1, n do
+    local item = select(i, ...)
+    buf[offset + i] = tostring(item)
+  end
+
+  return buf
+end
+
+function _M:putf(fmt, ...)
+  return self:put(string.format(fmt, ...))
+end
+
+function _M:putcdata(cdata, len)
+  return self:put(ffi.string(cdata, len))
+end
+
+function _M:set(str, len)
+  self:reset()
+  if len then
+    return self:putcdata(str, len)
+  else
+    return self:put(str)
+  end
+end
+
+function _M:reserve()
+end
+
+function _M:commit()
+end
+
+function _M:reset()
+  tbl_clr(self)
+  self.n = 0
+  return self
+end
+
+function _M:tostring()
+  local result = table.concat(self)
+  self:reset()
+  self[1] = result
+  self.n = 1
+  return result
+end
+
+_M.__tostring = _M.tostring
+
+function _M:ref()
+  return ffi.cast("const char *", self:tostring())
+end
+
+function _M:__len()
+  return #self:tostring()
+end
+
+function _M:skip(len)
+  self[1] = self:tostring():sub(len + 1)
+end
+
+function _M:get(...)
+  local str = self:tostring()
+  local n = select("#", ...)
+
+  local offset = 0
+  local results = {}
+  for i = 1, n do
+    local len = select(i, ...)
+    local result = str:sub(offset + 1, offset + len)
+    offset = offset + len
+    results[i] = result
+  end
+
+  self[1] = str:sub(offset + 1)
+
+  return unpack(results)
+end
+
+_M.free = _M.reset

--- a/spec/string_buffer.lua
+++ b/spec/string_buffer.lua
@@ -104,3 +104,5 @@ function _M:get(...)
 end
 
 _M.free = _M.reset
+
+return _M

--- a/spec/upgrade_helpers.lua
+++ b/spec/upgrade_helpers.lua
@@ -164,13 +164,11 @@ local function latest_kong_require(module)
     module = "latest." .. module
   end
 
-  print("loading module: " .. module)
-
   if package.loaded[module] then
     return package.loaded[module]
   end
 
-  local path = package.searchpath(module, package.path)
+  local path = package.searchpath(module, package.path .. ";./?/init.lua")
 
   -- some buildin modules like ffi don't have a path
   if not path then
@@ -181,7 +179,7 @@ local function latest_kong_require(module)
   -- recursively load with lastest code
   setfenv(module_code, latest_kong_require_meta)
 
-  package.loaded[module] = module_code()
+  package.loaded[module] = assert(module_code())
   
   return package.loaded[module]
 end

--- a/spec/upgrade_helpers.lua
+++ b/spec/upgrade_helpers.lua
@@ -168,6 +168,14 @@ local function latest_kong_require(module)
     return package.loaded[module]
   end
 
+  -- kong module is too heavy to load, and we need to even go through the whole
+  -- build process to get it, so we just return an empty table and leave the functions
+  -- that uses them not implemented
+  if "latest.kong" == module:sub(1, 11) then
+    package.loaded[module] = {}
+    return package.loaded[module]
+  end
+
   local path = package.searchpath(module, package.path .. ";./?/init.lua")
 
   -- some buildin modules like ffi don't have a path


### PR DESCRIPTION
I'm closing this PR because this is way too complicated than I thought when I came up with the solution. It does not worth the cost.

At some point, we need to refactor the `spec.helpers`. It's too heavy, has too many dependencies and we even need the DB available to load the module. But for now, let's focus on the migration test.

### Summary

Migration tests are run with the old code, which cannot access the latest `spec.helpers` and `spec.helpers.*`. 
We could mount the latest code into the test-running container and map the path with a hack.

### Checklist

- [x] The Pull Request has tests

### Full changelog

* The `require` hack
* Updating the test copy-pasting the `http_server`

### Issue reference

Fix KAG-1770
Unblock #11009
