### PR TITLE
perf: load migration state only when connected to a database

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -82,7 +82,6 @@ local concurrency = require "kong.concurrency"
 local cache_warmup = require "kong.cache.warmup"
 local balancer = require "kong.runloop.balancer"
 local kong_error_handlers = require "kong.error_handlers"
-local migrations_utils = require "kong.cmd.utils.migrations"
 local plugin_servers = require "kong.runloop.plugin_servers"
 local lmdb_txn = require "resty.lmdb.transaction"
 local instrumentation = require "kong.tracing.instrumentation"
@@ -584,18 +583,23 @@ function Kong.init()
   instrumentation.db_query(db.connector)
   assert(db:init_connector())
 
-  schema_state = assert(db:schema_state())
-  migrations_utils.check_state(schema_state)
+  -- check state of migration only if there is an external database
+  if not is_dbless(config) then
+    ngx_log(ngx_DEBUG, "checking database schema state")
+    local migrations_utils = require "kong.cmd.utils.migrations"
+    schema_state = assert(db:schema_state())
+    migrations_utils.check_state(schema_state)
 
-  if schema_state.missing_migrations or schema_state.pending_migrations then
-    if schema_state.missing_migrations then
-      ngx_log(ngx_WARN, "database is missing some migrations:\n",
-                        schema_state.missing_migrations)
-    end
+    if schema_state.missing_migrations or schema_state.pending_migrations then
+      if schema_state.missing_migrations then
+        ngx_log(ngx_WARN, "database is missing some migrations:\n",
+                          schema_state.missing_migrations)
+      end
 
-    if schema_state.pending_migrations then
-      ngx_log(ngx_WARN, "database has pending migrations:\n",
-                        schema_state.pending_migrations)
+      if schema_state.pending_migrations then
+        ngx_log(ngx_WARN, "database has pending migrations:\n",
+                          schema_state.pending_migrations)
+      end
     end
   end
 
@@ -696,7 +700,7 @@ function Kong.init_worker()
     return
   end
 
-  if worker_id() == 0 then
+  if worker_id() == 0 and not is_dbless(kong.configuration) then
     if schema_state.missing_migrations then
       ngx_log(ngx_WARN, "missing migrations: ",
               list_migrations(schema_state.missing_migrations))


### PR DESCRIPTION
### Summary

Loading and checking of migration state is necessary only when the node is connected to a database. This is true only for traditional mode nodes and 'control_plane' nodes in hybrid mode. Checking the migration state when there is no database is a wasteful operation.

This patch checks (and loads migration state) only when necessary. Early test report a reduction of 5 MB of RSS per worker on start-up.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->


<!--- Why is this change required? What problem does it solve? -->

### Checklist
N/A
- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE