### PR TITLE
fix(build): explictly set -O3 for OpenSSL

### DIFF
--- a/build/openresty/openssl/openssl.bzl
+++ b/build/openresty/openssl/openssl.bzl
@@ -18,6 +18,7 @@ CONFIGURE_OPTIONS = select({
     "//conditions:default": [],
 }) + [
     "-g",
+    "-O3",  # force -O3 even we are using --debug (for example on CI)
     "shared",
     "-DPURIFY",
     "no-threads",
@@ -27,7 +28,7 @@ CONFIGURE_OPTIONS = select({
     "--libdir=lib",  # force lib instead of lib64 (multilib postfix)
     "-Wl,-rpath,%s/kong/lib" % KONG_VAR["INSTALL_DESTDIR"],
 ] + select({
-    "@kong//:debug_flag": ["-d"],
+    "@kong//:debug_flag": ["--debug"],
     "//conditions:default": [],
 })
 

--- a/spec/03-plugins/29-acme/03-access_spec.lua
+++ b/spec/03-plugins/29-acme/03-access_spec.lua
@@ -196,7 +196,7 @@ for _, strategy in helpers.each_strategy() do
           headers =  { host = "a.subdomain." .. do_domain }
         }
         return res and res.status == 200
-      end, 15)
+      end, 5)
 
       -- key-auth should not run
       local body = assert.response(res).has.status(200)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Previously, openssl seems to default to -O2 even if used with -d (debug build), this is changed on openssl 3.x.
And no opt level is set when using -d, which is the mode we use on CI.

This PR forces opt level to be set on both debug build (on CI) and release build (for releasing artifacts). So the performance degression on CI could be solved.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* fix(build): explictly set -O3 for OpenSSL
* [fix(tests): revert previous change that increases some timeout when bump openssl to 3.0.8](https://github.com/Kong/kong/commit/b9b80c210fc3283cf7f8c1515b2fc48e5c1747d8)

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
