### PR TITLE
tests(rate-limiting): order two request lines

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -754,8 +754,6 @@ if limit_by == "ip" then
       .ignore_exceptions(false)
       .eventually(function()
         local res1 = GET(test_path, { headers = { ["X-Real-IP"] = "127.0.0.3" }})
-        local res2 = GET(test_path, { headers = { ["X-Real-IP"] = "127.0.0.3" }})
-
         assert.res_status(200, res1)
         assert.are.same(1, tonumber(res1.headers["RateLimit-Limit"]))
         assert.are.same(0, tonumber(res1.headers["RateLimit-Remaining"]))
@@ -763,6 +761,7 @@ if limit_by == "ip" then
         assert.are.same(1, tonumber(res1.headers["X-RateLimit-Limit-Second"]))
         assert.are.same(0, tonumber(res1.headers["X-RateLimit-Remaining-Second"]))
 
+        local res2 = GET(test_path, { headers = { ["X-Real-IP"] = "127.0.0.3" }})
         local body2 = assert.res_status(429, res2)
         local json2 = cjson.decode(body2)
         assert.same({ message = "API rate limit exceeded" }, json2)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The current test make two sequencial requests. The two response bodies may be overlapped.

The fix reorders the request lines.

### Checklist

- [x] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* reorder the request lines.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5126
