### PR TITLE
chore(ci): add wasm to release builds

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -27,7 +27,7 @@ build-packages:
 - label: ubuntu-22.04-arm64
   os: ubuntu-22.04
   package: deb
-  bazel_args: --platforms=//:generic-crossbuild-aarch64
+  bazel_args: --platforms=//:generic-crossbuild-aarch64 --//:wasmx=false
   check-manifest-suite: ubuntu-22.04-arm64
 
 # Debian

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -155,7 +155,7 @@ config_setting(
 # --//:wasmx=false
 bool_flag(
     name = "wasmx",
-    build_setting_default = False,
+    build_setting_default = True,
 )
 
 config_setting(
@@ -169,7 +169,7 @@ config_setting(
 # --//:wasm_runtime=wasmer
 string_flag(
     name = "wasm_runtime",
-    build_setting_default = "wasmer",
+    build_setting_default = "wasmtime",
     values = [
         "v8",
         "wasmer",
@@ -178,7 +178,7 @@ string_flag(
 )
 
 config_setting(
-    name = "wasmx_v8",
+    name = "wasmx_v8_flag",
     flag_values = {
         ":wasm_runtime": "v8",
     },
@@ -186,7 +186,7 @@ config_setting(
 )
 
 config_setting(
-    name = "wasmx_wasmer",
+    name = "wasmx_wasmer_flag",
     flag_values = {
         ":wasm_runtime": "wasmer",
     },
@@ -194,11 +194,36 @@ config_setting(
 )
 
 config_setting(
-    name = "wasmx_wasmtime",
+    name = "wasmx_wasmtime_flag",
     flag_values = {
         ":wasm_runtime": "wasmtime",
     },
     visibility = ["//visibility:public"],
+)
+
+# wasm runtime settings should only be set when wasm is enabled
+selects.config_setting_group(
+    name = "wasmx_v8",
+    match_all = [
+        ":wasmx_v8_flag",
+        ":wasmx_flag",
+    ],
+)
+
+selects.config_setting_group(
+    name = "wasmx_wasmer",
+    match_all = [
+        ":wasmx_wasmer_flag",
+        ":wasmx_flag",
+    ],
+)
+
+selects.config_setting_group(
+    name = "wasmx_wasmtime",
+    match_all = [
+        ":wasmx_wasmtime_flag",
+        ":wasmx_flag",
+    ],
 )
 
 ##### constraints, platforms and config_settings for cross-compile

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,7 +166,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# --//:wasm_runtime=wasmer
+# --//:wasm_runtime=wasmtime
 string_flag(
     name = "wasm_runtime",
     build_setting_default = "wasmtime",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -152,7 +152,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# --//:wasmx=false
+# --//:wasmx=true
 bool_flag(
     name = "wasmx",
     build_setting_default = True,

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -64,28 +64,30 @@ wasm_libs_cmd = select({
         mkdir -p "$(dirname "$dest")"
         cp -v "$fname" "$dest"
     done
-
-    copy_with_filter ${BUILD_DESTDIR}/openresty/nginx/lib ${BUILD_DESTDIR}/kong/lib
 """,
     "//conditions:default": "\n",
 })
 
 wasmx_vm_cmd = select({
     "@kong//:wasmx_v8": """
-    for fname in $(locations @v8//:lib); do
-        cp -v "$fname" "${BUILD_DESTDIR}/kong/lib"
-    done
-
+    if [[ -d ${BUILD_DESTDIR}/openresty/nginx/lib ]]; then
+        copy_with_filter ${BUILD_DESTDIR}/openresty/nginx/lib ${BUILD_DESTDIR}/kong/lib
+        rm -rf ${BUILD_DESTDIR}/openresty/nginx/lib
+    fi
 """,
     "@kong//:wasmx_wasmer": """
-    for fname in $(locations @wasmer//:lib); do
-        cp -v "$fname" "${BUILD_DESTDIR}/kong/lib"
-    done
+    if [[ -d ${BUILD_DESTDIR}/openresty/nginx/lib ]]; then
+        copy_with_filter ${BUILD_DESTDIR}/openresty/nginx/lib ${BUILD_DESTDIR}/kong/lib
+        rm -rf ${BUILD_DESTDIR}/openresty/nginx/lib
+    fi
 """,
+    # both v8 and wasmer currently depend on openresty/nginx/lib/libngx_wasm_rs.so,
+    # but in the case of wasmtime it is statically linked and thus not needed in
+    # the final package
     "@kong//:wasmx_wasmtime": """
-    for fname in $(locations @wasmtime//:lib); do
-        cp -v "$fname" "${BUILD_DESTDIR}/kong/lib"
-    done
+    if [[ -d ${BUILD_DESTDIR}/openresty/nginx/lib ]]; then
+        rm -rf ${BUILD_DESTDIR}/openresty/nginx/lib
+    fi
 """,
     "//conditions:default": "",
 })

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -234,12 +234,13 @@ CONFIGURE_OPTIONS = [
 }) + select({
     "@kong//:wasmx_flag": [
         "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
-        # this is a workaround for rhel/centos builds
+        # FIXME: this is a workaround for rhel/centos builds, when enabled breaks
+        #        the build for macos
         #
         # see:
         # * https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
         # * https://github.com/Kong/ngx_wasm_module/blob/e70a19f53e1dda99d016c5cfa393652720959afd/util/Dockerfiles/Dockerfile.amd64.centos7#L9-L11
-        "--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
+        #"--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
     ],
     "//conditions:default": [],
 }) + select({

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -1,6 +1,43 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make", "make")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 load("@openresty_binding//:variables.bzl", "LUAJIT_VERSION")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+# this works around an issue that occurs when installing/compiling the v8 wasm
+# runtime engine, specifically: cargo/bazel/rules_foreign_cc decide ARFLAGS
+# should be "rcsD cq ...", which is incorrect and results in ar thinking
+# "cq" is a positional filename parameter-- casuing the install of the wabt-sys
+# rust crate to fail when compiling wabt
+#
+# this works by impersonating ar, and only passing along 'rcsD' when it detects
+# 'rcsd cq' as the first 2 positional parameters passed to "ar"
+#
+# this workaround is specifically only enabeld when targetting the v8 wasm
+# runtime to minimize impact to the rest fo the build
+#
+# note that this dummy ar is technically in use for the entire openresty build,
+# since we build wasm as part of that
+write_file(
+    name = "wasmx_v8_ar",
+    out = "ar",
+    content = ["""#!/usr/bin/env bash
+
+if [[ "${1} ${2}" == 'rcsD cq' ]]; then
+
+    touch /tmp/log
+    echo "before: $@" >> /tmp/log
+
+    shift 2
+    extra='rcsD'
+
+    echo "after: $@" >> /tmp/log
+fi
+
+/usr/bin/ar ${extra:-} $@
+"""],
+    is_executable = True,
+    visibility = ["//visibility:public"],
+)
 
 filegroup(
     name = "luajit_srcs",
@@ -197,6 +234,12 @@ CONFIGURE_OPTIONS = [
 }) + select({
     "@kong//:wasmx_flag": [
         "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
+        # this is a workaround for rhel/centos builds
+        #
+        # see:
+        # * https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
+        # * https://github.com/Kong/ngx_wasm_module/blob/e70a19f53e1dda99d016c5cfa393652720959afd/util/Dockerfiles/Dockerfile.amd64.centos7#L9-L11
+        "--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
     ],
     "//conditions:default": [],
 }) + select({
@@ -245,6 +288,7 @@ configure_make(
         "@v8//:all_srcs",
         "@wasmer//:all_srcs",
         "@wasmtime//:all_srcs",
+        "@openresty//:wasmx_v8_ar",
     ],
     configure_command = "configure",
     configure_in_place = True,
@@ -254,16 +298,24 @@ configure_make(
             "NGX_WASM_RUNTIME": "v8",
             "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/v8/lib",
             "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/v8/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L43
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/v8/lib/libwee8.a -lv8bridge -lstdc++ -lm -ldl -lpthread",
+            # see the above comments and source for this dummy ar script
+            "AR": "$(execpath @openresty//:wasmx_v8_ar)",
         },
         "@kong//:wasmx_wasmer": {
             "NGX_WASM_RUNTIME": "wasmer",
             "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmer/lib",
             "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmer/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmer/lib/libwasmer.a -lm -ldl -lpthread",
         },
         "@kong//:wasmx_wasmtime": {
             "NGX_WASM_RUNTIME": "wasmtime",
             "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmtime/lib",
             "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmtime/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmtime/lib/libwasmtime.a -lm -ldl -lpthread",
         },
         "//conditions:default": {},
     }),

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -60,7 +60,7 @@ filegroup(
 
 filegroup(
     name = "lib",
-    srcs = glob(["**/*.so", "**/*.dylib"]),
+    srcs = glob(["**/*.a", "**/*.dylib"]),
     visibility = ["//visibility:public"]
 )
 """,

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -60,7 +60,7 @@ filegroup(
 
 filegroup(
     name = "lib",
-    srcs = glob(["**/*.a", "**/*.dylib"]),
+    srcs = glob(["**/*.a"]),
     visibility = ["//visibility:public"]
 )
 """,

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -47,8 +47,9 @@ filegroup(
         http_archive,
         name = "v8",
         urls = [
-            "https://github.com/Kong/ngx_wasm_runtimes/releases/download/latest/ngx_wasm_runtime-v8-" +
-            v8_version + "-" + v8_os + "-" + v8_arch + ".tar.gz",
+            "https://github.com/Kong/ngx_wasm_runtimes/releases/download/v8-" +
+            v8_version + "/ngx_wasm_runtime-v8-" + v8_version + "-" + v8_os + "-" +
+            v8_arch + ".tar.gz",
         ],
         strip_prefix = "v8-" + v8_version + "-" + v8_os + "-" + v8_arch,
         build_file_content = """

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -165,13 +165,16 @@
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
+  - libgcc_s.so.1
   - libc.so.6
+  - ld-linux-x86-64.so.2
   Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -165,13 +165,16 @@
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
+  - libgcc_s.so.1
   - libc.so.6
+  - ld-linux-x86-64.so.2
   Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True

--- a/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
@@ -157,16 +157,20 @@
   - libpthread.so.0
   - libcrypt.so.1
   - libluajit-5.1.so.2
+  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
+  - libgcc_s.so.1
   - libc.so.6
+  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -156,16 +156,20 @@
   - libpthread.so.0
   - libcrypt.so.1
   - libluajit-5.1.so.2
+  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
+  - libgcc_s.so.1
   - libc.so.6
+  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -51,16 +51,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libwasmer.so
-  Needed    :
-  - libgcc_s.so.1
-  - librt.so.1
-  - libpthread.so.0
-  - libm.so.6
-  - libdl.so.2
-  - libc.so.6
-  - ld-linux-x86-64.so.2
-
 - Path      : /usr/local/kong/lib/ossl-modules/legacy.so
   Needed    :
   - libstdc++.so.6
@@ -155,16 +145,20 @@
   Needed    :
   - libcrypt.so.1
   - libluajit-5.1.so.2
+  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
+  - libgcc_s.so.1
   - libc.so.6
+  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True


### PR DESCRIPTION
This turns on `ngx_wasm_module` by default, adding it to all of our amd64 builds in the release workflow.

Right now we only build and package with `wasmtime`, because that is what is planned to ship, but there is partial support for wasmer and v8 in here as well, should we decide to make them available in the future.

Additionally, with this change the wasm runtime is now statically linked to `ngx_wasm_module`, so there are fewer shared object files that need to be copied around into our common lib directory at build time.