### PR TITLE
perf(plugin/prometheus): generate metrics string with string.buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
   [#10932](https://github.com/Kong/kong/pull/10932)
 - The Prometheus plugin has been optimized to reduce proxy latency impacts during scraping.
   [#10949](https://github.com/Kong/kong/pull/10949)
+  [#11040](https://github.com/Kong/kong/pull/11040)
 
 ### Fixes
 

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -216,8 +216,7 @@ local function full_metric_name(name, label_names, label_values)
 
   local metric = buf:get()
 
-  -- free buffer space ASAP
-  buf:free()
+  buf:free()    -- free buffer space ASAP
 
   return metric
 end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -207,7 +207,12 @@ local function full_metric_name(name, label_names, label_values)
       end
     end
 
-    buf:putf('%s%s="%s"', idx == 1 and "" or ",", key, tostring(label_value))
+    -- add a comma to seperate k=v
+    if idx > 1 then
+      buf:put(",")
+    end
+
+    buf:putf('%s="%s"', key, tostring(label_value))
   end
 
   buf:put("}")  -- close the bracket

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -87,6 +87,9 @@ local TYPE_LITERAL = {
 }
 
 
+-- Default size for string.buffer.new()
+local STRING_BUFFER_SIZE_HINT = 1024
+
 -- Default name for error metric incremented by this library.
 local DEFAULT_ERROR_METRIC_NAME = "nginx_metric_errors_total"
 
@@ -179,8 +182,9 @@ local function full_metric_name(name, label_names, label_values)
     return name
   end
 
+  local buf = buffer.new(STRING_BUFFER_SIZE_HINT)
+
   -- format "name{k1=v1,k2=v2}"
-  local buf = buffer.new()
   buf:put(name):put("{")
 
   for idx, key in ipairs(label_names) do
@@ -206,7 +210,11 @@ local function full_metric_name(name, label_names, label_values)
     buf:putf('%s%s="%s"', idx == 1 and "" or ",", key, tostring(label_value))
   end
 
-  local metric = buf:put("}"):get()
+  buf:put("}")  -- close the bracket
+
+  STRING_BUFFER_SIZE_HINT = #buf
+
+  local metric = buf:get()
 
   -- free buffer space ASAP
   buf:free()

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -207,7 +207,12 @@ local function full_metric_name(name, label_names, label_values)
   end
 
   -- remove the ',' at the end of string
-  return buf:get(#buf - 1) .. "}"
+  local metric = buf:get(#buf - 1) .. "}"
+
+  -- free buffer space ASAP
+  buf:free()
+
+  return metric
 end
 
 -- Extract short metric name from the full one.

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -240,15 +240,15 @@ end
 --   (string) short metric name with no labels. For a `*_bucket` metric of
 --     histogram the _bucket suffix will be removed.
 local function short_metric_name(full_name)
-  local labels_start, _ = full_name:find("{")
+  local labels_start, _ = full_name:find("{", 1, true)
   if not labels_start then
     return full_name
   end
   -- Try to detect if this is a histogram metric. We only check for the
   -- `_bucket` suffix here, since it alphabetically goes before other
   -- histogram suffixes (`_count` and `_sum`).
-  local suffix_idx, _ = full_name:find("_bucket{")
-  if suffix_idx and full_name:find("le=") then
+  local suffix_idx, _ = full_name:find("_bucket{", 1, true)
+  if suffix_idx and full_name:find("le=", 1, true) then
     -- this is a histogram metric
     return full_name:sub(1, suffix_idx - 1)
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -87,8 +87,8 @@ local TYPE_LITERAL = {
 }
 
 
--- Default size for string.buffer.new()
-local STRING_BUFFER_SIZE_HINT = 128
+-- Default metric name size for string.buffer.new()
+local NAME_BUFFER_SIZE_HINT = 256
 
 -- Default name for error metric incremented by this library.
 local DEFAULT_ERROR_METRIC_NAME = "nginx_metric_errors_total"
@@ -182,7 +182,7 @@ local function full_metric_name(name, label_names, label_values)
     return name
   end
 
-  local buf = buffer.new(STRING_BUFFER_SIZE_HINT)
+  local buf = buffer.new(NAME_BUFFER_SIZE_HINT)
 
   -- format "name{k1=v1,k2=v2}"
   buf:put(name):put("{")
@@ -218,8 +218,8 @@ local function full_metric_name(name, label_names, label_values)
   buf:put("}")  -- close the bracket
 
   -- update the size hint
-  if STRING_BUFFER_SIZE_HINT < #buf then
-    STRING_BUFFER_SIZE_HINT = #buf
+  if NAME_BUFFER_SIZE_HINT < #buf then
+    NAME_BUFFER_SIZE_HINT = #buf
   end
 
   local metric = buf:get()

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -217,7 +217,10 @@ local function full_metric_name(name, label_names, label_values)
 
   buf:put("}")  -- close the bracket
 
-  STRING_BUFFER_SIZE_HINT = #buf
+  -- update the size hint
+  if STRING_BUFFER_SIZE_HINT < #buf then
+    STRING_BUFFER_SIZE_HINT = #buf
+  end
 
   local metric = buf:get()
 

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -88,7 +88,7 @@ local TYPE_LITERAL = {
 
 
 -- Default size for string.buffer.new()
-local STRING_BUFFER_SIZE_HINT = 1024
+local STRING_BUFFER_SIZE_HINT = 128
 
 -- Default name for error metric incremented by this library.
 local DEFAULT_ERROR_METRIC_NAME = "nginx_metric_errors_total"

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -181,7 +181,7 @@ local function full_metric_name(name, label_names, label_values)
 
   -- format "name{k1=v1,k2=v2}"
   local buf = buffer.new()
-  buf:put(name .. "{")
+  buf:put(name):put("{")
 
   for idx, key in ipairs(label_names) do
     local label_value = label_values[idx]
@@ -203,11 +203,10 @@ local function full_metric_name(name, label_names, label_values)
       end
     end
 
-    buf:putf('%s="%s",', key, tostring(label_value))
+    buf:putf('%s%s="%s"', idx == 1 and "" or ",", key, tostring(label_value))
   end
 
-  -- remove the ',' at the end of string
-  local metric = buf:get(#buf - 1) .. "}"
+  local metric = buf:put("}"):get()
 
   -- free buffer space ASAP
   buf:free()

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -215,7 +215,7 @@ local function full_metric_name(name, label_names, label_values)
     buf:putf('%s="%s"', key, tostring(label_value))
   end
 
-  buf:put("}")  -- close the bracket
+  buf:put("}") -- close the bracket
 
   -- update the size hint
   if NAME_BUFFER_SIZE_HINT < #buf then
@@ -224,7 +224,7 @@ local function full_metric_name(name, label_names, label_values)
 
   local metric = buf:get()
 
-  buf:free()    -- free buffer space ASAP
+  buf:free() -- free buffer space ASAP
 
   return metric
 end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -186,6 +186,7 @@ local function full_metric_name(name, label_names, label_values)
   for idx, key in ipairs(label_names) do
     local label_value = label_values[idx]
 
+    -- we only check string value for '\\' and '"'
     if type(label_value) == "string" then
       local valid, pos = validate_utf8_string(label_value)
 
@@ -193,19 +194,16 @@ local function full_metric_name(name, label_names, label_values)
         label_value = string.sub(label_value, 1, pos - 1)
       end
 
-    else
-      label_value = tostring(label_value)
+      if string.find(label_value, "\\", 1, true) then
+        label_value = ngx_re_gsub(label_value, "\\", "\\\\", "jo")
+      end
+
+      if string.find(label_value, '"', 1, true) then
+        label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
+      end
     end
 
-    if string.find(label_value, "\\", 1, true) then
-      label_value = ngx_re_gsub(label_value, "\\", "\\\\", "jo")
-    end
-
-    if string.find(label_value, '"', 1, true) then
-      label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
-    end
-
-    buf:putf('%s="%s",', key, label_value)
+    buf:putf('%s="%s",', key, tostring(label_value))
   end
 
   -- remove the ',' at the end of string


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This a performance improvement of #10949, using `string.buffer` to generate metrics string,
eliminate the cost of huge table.

KAG-1783

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* remove `table.new`
* introduce `string.buffer`
* only do `gsub` for string value


