### PR TITLE
chore(test): default output format for more info

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -212,7 +212,7 @@ jobs:
           # Run each test individually, ngx.pipe doesn't like to be imported twice
           # maybe bin/busted --no-auto-insulate
           for f in $(find "spec/04-perf/$suite/" -type f); do
-            bin/busted -o gtest "$f" \
+            bin/busted "$f" \
               -t "${{ steps.choose_perf.outputs.tags }}"
           done
         done
@@ -234,7 +234,7 @@ jobs:
 
         make dev # required to install other dependencies like bin/grpcurl
         source ${{ env.BUILD_ROOT }}/kong-dev-venv.sh
-        bin/busted -o gtest spec/04-perf/99-teardown/
+        bin/busted spec/04-perf/99-teardown/
 
         rm -f ${PERF_TEST_BYO_SSH_KEY_PATH}
 

--- a/kong/plugins/zipkin/README.md
+++ b/kong/plugins/zipkin/README.md
@@ -7,4 +7,4 @@ Run postgres locally.
 
     KONG_SPEC_TEST_GRPCBIN_PORT=15002 \
     KONG_SPEC_TEST_GRPCBIN_SSL_PORT=15003 \
-    bin/busted -o gtest spec/03-plugins/34-zipkin/
+    bin/busted spec/03-plugins/34-zipkin/

--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -155,7 +155,7 @@ function initialize_test_list() {
 
 function run_tests() {
     # Run the tests
-    BUSTED="env KONG_DATABASE=$1 KONG_DNS_RESOLVER= KONG_TEST_PG_DATABASE=kong /kong/bin/busted -o gtest"
+    BUSTED="env KONG_DATABASE=$1 KONG_DNS_RESOLVER= KONG_TEST_PG_DATABASE=kong /kong/bin/busted"
     shift
 
     set $TESTS


### PR DESCRIPTION
### Summary

`gtest` hides a lot of information. It does not even output the assertion failure message.

The output of tests may help us to fix test failures. So this PR tries to remove all `-o gtest` for busted tests.