### PR TITLE
perf(router/atc): generate expressions with string.buffer

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -128,10 +128,8 @@ local function gen_for_field(name, op, vals, val_transform)
                     escape_str(val_transform and val_transform(op, p) or p))
   end
 
-  values_buf:put(")")
-
   -- consume the whole buffer
-  return values_buf:get()
+  return values_buf:put(")"):get()
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -95,11 +95,11 @@ end
 
 local function escape_str(str)
   if str:find([[\]], 1, true) then
-    str:gsub([[\]], [[\\]])
+    str = str:gsub([[\]], [[\\]])
   end
 
   if str:find([["]], 1, true) then
-    str:gsub([["]], [[\"]])
+    str = str:gsub([["]], [[\"]])
   end
 
   return "\"" .. str .. "\""

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -95,7 +95,15 @@ end
 
 
 local function escape_str(str)
-  return "\"" .. str:gsub([[\]], [[\\]]):gsub([["]], [[\"]]) .. "\""
+  if str:find([[\]], 1, true) then
+    str:gsub([[\]], [[\\]])
+  end
+
+  if str:find([["]], 1, true) then
+    str:gsub([["]], [[\"]])
+  end
+
+  return "\"" .. str .. "\""
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -52,9 +52,8 @@ local LOGICAL_OR  = " || "
 local LOGICAL_AND = " && "
 
 
--- reuse table objects
+-- reuse buffer object
 local values_buf = buffer.new(64)
-local gen_values_t = tb_new(10, 0)
 
 
 local CACHED_SCHEMA
@@ -115,7 +114,7 @@ local function gen_for_field(name, op, vals, val_transform)
   local vals_n = #vals
   assert(vals_n > 0)
 
-  values_buf:put("(")
+  values_buf:reset():put("(")
 
   for i = 1, vals_n do
     local p = vals[i]
@@ -125,12 +124,13 @@ local function gen_for_field(name, op, vals, val_transform)
       values_buf:put(LOGICAL_OR)
     end
 
-    values_buf:put(name):put(" "):put(op):put(" ")
-    values_buf:put(escape_str(val_transform and val_transform(op, p) or p))
+    values_buf:putf("%s %s %s", name, op,
+                    escape_str(val_transform and val_transform(op, p) or p))
   end
 
   values_buf:put(")")
 
+  -- consume the whole buffer
   return values_buf:get()
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Use `string.buffer` in function `gen_for_field()` to improve the performance.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Use `string.buffer` in function `gen_for_field()`
* `string.find` then `string.gsub`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
