### PR TITLE
feat(templates): bump default `lmdb_map_size` to 2GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 - The default value of `lmdb_map_size` config has been bumped to `2048m`
   from `128m` to accommodate most commonly deployed config sizes in DB-less
   and Hybrid mode.
-  [11047](https://github.com/Kong/kong/pull/11047)
+  [#11047](https://github.com/Kong/kong/pull/11047)
 
 #### Status API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@
 
 #### Core
 
+- The default value of `lmdb_map_size` config has been bumped to `2048m`
+  from `128m` to accommodate most commonly deployed config sizes in DB-less
+  and Hybrid mode.
+  [11047](https://github.com/Kong/kong/pull/11047)
+
 #### Status API
 
 - Remove the database information from the status API when operating in dbless

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1332,15 +1332,15 @@
                                       #
                                       # This path is relative under the Kong `prefix`.
 
-#lmdb_map_size = 128m                 # Maximum size of the LMDB memory map, used to store the
-                                      # DB-less and Hybird mode configurations. Default is 128m.
+#lmdb_map_size = 2048m                # Maximum size of the LMDB memory map, used to store the
+                                      # DB-less and Hybird mode configurations. Default is 2048m.
                                       #
                                       # This config defines the limit of LMDB file size, the
                                       # actual file size growth will be on-demand and
-                                      # porpotional to the actual config size.
+                                      # proportional to the actual config size.
                                       #
                                       # Note this value can be set very large, say a couple of GBs
-                                      # to accomadate future database growth and
+                                      # to accommodate future database growth and
                                       # Multi Version Concurrency Control (MVCC) headroom needs.
                                       # The file size of the LMDB database file should stabilize
                                       # after a few config reload/Hybrid mode syncs and the actual

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -40,7 +40,7 @@ cluster_use_proxy = off
 cluster_dp_labels = NONE
 
 lmdb_environment_path = dbless.lmdb
-lmdb_map_size = 128m
+lmdb_map_size = 2048m
 mem_cache_size = 128m
 ssl_cert = NONE
 ssl_cert_key = NONE


### PR DESCRIPTION
The current size of 128MB is too conservative and requires bumping by the user in a lot of cases. Bumping to a more sensible value to avoid this.

KAG-1811