### PR TITLE
chore(dev): remove downloaded binaries after bazel clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,18 @@ endif
 PACKAGE_TYPE ?= deb
 
 bin/bazel:
+ifeq (,$(wildcard bin/bazel))
 	curl -s -S -L \
 		https://github.com/bazelbuild/bazelisk/releases/download/v$(BAZLISK_VERSION)/bazelisk-$(OS)-$(BAZELISK_MACHINE) -o bin/bazel
 	chmod +x bin/bazel
+endif
 
 bin/grpcurl:
+ifeq (,$(wildcard bin/grpcurl))
 	@curl -s -S -L \
 		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(GRPCURL_MACHINE).tar.gz | tar xz -C bin;
-	@rm bin/LICENSE
+	$(RM) bin/LICENSE
+endif
 
 check-bazel: bin/bazel
 ifndef BAZEL
@@ -113,9 +117,11 @@ install: dev
 
 clean: check-bazel
 	$(BAZEL) clean
+	$(RM) bin/bazel bin/grpcurl
 
 expunge: check-bazel
 	$(BAZEL) clean --expunge
+	$(RM) bin/bazel bin/grpcurl
 
 lint: dev
 	@$(VENV) luacheck -q .

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,14 @@ endif
 PACKAGE_TYPE ?= deb
 
 bin/bazel:
-	curl -s -S -L \
+	@curl -s -S -L \
 		https://github.com/bazelbuild/bazelisk/releases/download/v$(BAZLISK_VERSION)/bazelisk-$(OS)-$(BAZELISK_MACHINE) -o bin/bazel
-	chmod +x bin/bazel
+	@chmod +x bin/bazel
 
 bin/grpcurl:
 	@curl -s -S -L \
 		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(GRPCURL_MACHINE).tar.gz | tar xz -C bin;
-	$(RM) bin/LICENSE
+	@$(RM) bin/LICENSE
 
 check-bazel: bin/bazel
 ifndef BAZEL

--- a/Makefile
+++ b/Makefile
@@ -52,18 +52,14 @@ endif
 PACKAGE_TYPE ?= deb
 
 bin/bazel:
-ifeq (,$(wildcard bin/bazel))
 	curl -s -S -L \
 		https://github.com/bazelbuild/bazelisk/releases/download/v$(BAZLISK_VERSION)/bazelisk-$(OS)-$(BAZELISK_MACHINE) -o bin/bazel
 	chmod +x bin/bazel
-endif
 
 bin/grpcurl:
-ifeq (,$(wildcard bin/grpcurl))
 	@curl -s -S -L \
 		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(GRPCURL_MACHINE).tar.gz | tar xz -C bin;
 	$(RM) bin/LICENSE
-endif
 
 check-bazel: bin/bazel
 ifndef BAZEL


### PR DESCRIPTION



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Improve `Makefile`.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* When we tear down bazel venv, we should remove downloaded binaries.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5139
