### PR TITLE
perf(router/compat): using string buffer to generate expressions

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -123,14 +123,11 @@ local function get_expression(route)
       end
 
       local exp = "http.host ".. op .. " \"" .. host .. "\""
-      if not port then
-        buffer_append(hosts_buf, LOGICAL_OR, exp)
-
-      else
-        buffer_append(hosts_buf, LOGICAL_OR,
-                      "(" .. exp .. LOGICAL_AND ..
-                      "net.port ".. OP_EQUAL .. " " .. port .. ")")
+      if port then
+        exp = "(" .. exp .. LOGICAL_AND ..
+              "net.port ".. OP_EQUAL .. " " .. port .. ")"
       end
+      buffer_append(hosts_buf, LOGICAL_OR, exp)
     end -- for route.hosts
 
     buffer_append(expr_buf, LOGICAL_AND,

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -188,9 +188,6 @@ local function get_expression(route)
       tb_insert(headers_t, "(" .. tb_concat(single_header_t, LOGICAL_OR) .. ")")
     end
 
-    if #expr_buf > 0 then
-      expr_buf:put(LOGICAL_AND)
-    end
     buffer_append(expr_buf, LOGICAL_AND, tb_concat(headers_t, LOGICAL_AND))
   end
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -49,7 +49,7 @@ local function buffer_append(buf, sep, str, idx)
   if #buf > 0 and
      (idx == nil or idx > 1)
   then
-    buf:put(assert(sep))
+    buf:put(sep)
   end
   buf:put(str)
 end

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -5,10 +5,10 @@ local bit = require("bit")
 local buffer = require("string.buffer")
 local atc = require("kong.router.atc")
 local tb_new = require("table.new")
-local tb_clear = require("table.clear")
 local tb_nkeys = require("table.nkeys")
 local uuid = require("resty.jit-uuid")
 local utils = require("kong.tools.utils")
+
 
 local escape_str      = atc.escape_str
 local is_empty_field  = atc.is_empty_field
@@ -20,7 +20,6 @@ local type = type
 local pairs = pairs
 local ipairs = ipairs
 local assert = assert
-local tb_concat = table.concat
 local tb_insert = table.insert
 local tb_sort = table.sort
 local byte = string.byte


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Introduce `string.buffer` to replace `table.concat`

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]


