### PR TITLE
perf(router/atc): generate headers_key with `string.buffer`

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -9,7 +9,6 @@ local context = require("resty.router.context")
 local lrucache = require("resty.lrucache")
 local server_name = require("ngx.ssl").server_name
 local tb_new = require("table.new")
-local tb_clear = require("table.clear")
 local utils = require("kong.router.utils")
 local yield = require("kong.tools.utils").yield
 
@@ -487,12 +486,10 @@ end
 
 local get_headers_key
 do
-  local headers_t = tb_new(8, 0)
+  local headers_buf = buffer.new(64)
 
   get_headers_key = function(headers)
-    tb_clear(headers_t)
-
-    local headers_count = 0
+    headers_buf:reset()
 
     for name, value in pairs(headers) do
       local name = name:gsub("-", "_"):lower()
@@ -508,15 +505,10 @@ do
         value = value:lower()
       end
 
-      headers_t[headers_count + 1] = "|"
-      headers_t[headers_count + 2] = name
-      headers_t[headers_count + 3] = "="
-      headers_t[headers_count + 4] = value
-
-      headers_count = headers_count + 4
+      headers_buf:putf("|%s=%s", name, value)
     end
 
-    return tb_concat(headers_t, nil, 1, headers_count)
+    return headers_buf:get()
   end
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -491,6 +491,7 @@ do
   get_headers_key = function(headers)
     headers_buf:reset()
 
+    -- NOTE: DO NOT yield until headers_buf:get()
     for name, value in pairs(headers) do
       local name = name:gsub("-", "_"):lower()
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR follows #11045, continue to optimize the string usage by `string.buffer`.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]


