### PR TITLE
perf(plugin/prometheus): generate metrics output data with string.buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - The Prometheus plugin has been optimized to reduce proxy latency impacts during scraping.
   [#10949](https://github.com/Kong/kong/pull/10949)
   [#11040](https://github.com/Kong/kong/pull/11040)
+  [#11065](https://github.com/Kong/kong/pull/11065)
 
 ### Fixes
 

--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -1,17 +1,16 @@
+local buffer = require("string.buffer")
 local exporter = require "kong.plugins.prometheus.exporter"
-local tbl_insert = table.insert
-local tbl_concat = table.concat
 
 
 local printable_metric_data = function(_)
-  local buffer = {}
+  local buf = buffer.new(4096)
   -- override write_fn, since stream_api expect response to returned
   -- instead of ngx.print'ed
   exporter.metric_data(function(new_metric_data)
-    tbl_insert(buffer, tbl_concat(new_metric_data, ""))
+    buf:put(new_metric_data)
   end)
 
-  return tbl_concat(buffer, "")
+  return buf:get()
 end
 
 

--- a/kong/plugins/prometheus/api.lua
+++ b/kong/plugins/prometheus/api.lua
@@ -10,7 +10,11 @@ local printable_metric_data = function(_)
     buf:put(new_metric_data)
   end)
 
-  return buf:get()
+  local str = buf:get()
+
+  buf:free()
+
+  return str
 end
 
 

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -90,7 +90,7 @@ end
 
 local function init()
   local shm = "prometheus_metrics"
-  if not ngx.shared.prometheus_metrics then
+  if not ngx.shared[shm] then
     kong.log.err("prometheus: ngx shared dict 'prometheus_metrics' not found")
     return
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -70,6 +70,7 @@ local tostring = tostring
 local tonumber = tonumber
 local st_format = string.format
 local table_sort = table.sort
+local tb_new = require("table.new")
 local yield = require("kong.tools.utils").yield
 
 
@@ -914,7 +915,7 @@ function Prometheus:metric_data(write_fn, local_only)
   -- numerical order of their label values.
   table_sort(keys)
 
-  local seen_metrics = {}
+  local seen_metrics = tb_new(0, count)
 
   -- the output is an integral string, not an array any more
   local output = buffer.new(DATA_BUFFER_SIZE_HINT)

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -305,7 +305,7 @@ local function construct_bucket_format(buckets)
   for _, bucket in ipairs(buckets) do
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
     -- floating point number with all trailing zeros removed
-    local as_string = string.format("%f", bucket):gsub("0*$", "")
+    local as_string = st_format("%f", bucket):gsub("0*$", "")
     local dot_idx = as_string:find(".", 1, true)
     max_order = math.max(max_order, dot_idx - 1)
     max_precision = math.max(max_precision, as_string:len() - dot_idx)
@@ -364,7 +364,7 @@ local function lookup_or_create(self, label_values)
   local cnt = label_values and #label_values or 0
   -- specially, if first element is nil, # will treat it as "non-empty"
   if cnt ~= self.label_count or (self.label_count > 0 and label_values[1] == nil) then
-    return nil, string.format("inconsistent labels count, expected %d, got %d",
+    return nil, st_format("inconsistent labels count, expected %d, got %d",
                               self.label_count, cnt)
   end
   local t = self.lookup
@@ -408,13 +408,13 @@ local function lookup_or_create(self, label_values)
     end
 
     for i, buc in ipairs(self.buckets) do
-      full_name[i+2] = string.format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
+      full_name[i+2] = st_format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
     end
     -- Last bucket. Note, that the label value is "Inf" rather than "+Inf"
     -- required by Prometheus. This is necessary for this bucket to be the last
     -- one when all metrics are lexicographically sorted. "Inf" will get replaced
     -- by "+Inf" in Prometheus:metric_data().
-    full_name[self.bucket_count+3] = string.format("%sle=\"Inf\"}", bucket_pref)
+    full_name[self.bucket_count+3] = st_format("%sle=\"Inf\"}", bucket_pref)
   else
     full_name = full_metric_name(self.name, self.label_names, label_values)
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -937,7 +937,7 @@ function Prometheus:metric_data(write_fn, local_only)
   for i = 1, count do
     yield()
 
-    key = keys[i]
+    local key = keys[i]
 
     local value, err
     local is_local_metrics = true

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -68,7 +68,6 @@ local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local tonumber = tonumber
-local st_format = string.format
 local table_sort = table.sort
 local tb_new = require("table.new")
 local yield = require("kong.tools.utils").yield
@@ -305,7 +304,7 @@ local function construct_bucket_format(buckets)
   for _, bucket in ipairs(buckets) do
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
     -- floating point number with all trailing zeros removed
-    local as_string = st_format("%f", bucket):gsub("0*$", "")
+    local as_string = string.format("%f", bucket):gsub("0*$", "")
     local dot_idx = as_string:find(".", 1, true)
     max_order = math.max(max_order, dot_idx - 1)
     max_precision = math.max(max_precision, as_string:len() - dot_idx)
@@ -364,7 +363,7 @@ local function lookup_or_create(self, label_values)
   local cnt = label_values and #label_values or 0
   -- specially, if first element is nil, # will treat it as "non-empty"
   if cnt ~= self.label_count or (self.label_count > 0 and label_values[1] == nil) then
-    return nil, st_format("inconsistent labels count, expected %d, got %d",
+    return nil, string.format("inconsistent labels count, expected %d, got %d",
                               self.label_count, cnt)
   end
   local t = self.lookup
@@ -408,13 +407,13 @@ local function lookup_or_create(self, label_values)
     end
 
     for i, buc in ipairs(self.buckets) do
-      full_name[i+2] = st_format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
+      full_name[i+2] = string.format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
     end
     -- Last bucket. Note, that the label value is "Inf" rather than "+Inf"
     -- required by Prometheus. This is necessary for this bucket to be the last
     -- one when all metrics are lexicographically sorted. "Inf" will get replaced
     -- by "+Inf" in Prometheus:metric_data().
-    full_name[self.bucket_count+3] = st_format("%sle=\"Inf\"}", bucket_pref)
+    full_name[self.bucket_count+3] = string.format("%sle=\"Inf\"}", bucket_pref)
   else
     full_name = full_metric_name(self.name, self.label_names, label_values)
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -704,8 +704,9 @@ end
 -- Returns:
 --   an object that should be used to register metrics.
 function Prometheus.init(dict_name, options_or_prefix)
-  if ngx.get_phase() ~= 'init' and ngx.get_phase() ~= 'init_worker' and
-      ngx.get_phase() ~= 'timer' then
+  local phase = ngx.get_phase()
+  if phase ~= 'init' and phase ~= 'init_worker' and
+     phase ~= 'timer' then
     error('Prometheus.init can only be called from ' ..
       'init_by_lua_block, init_worker_by_lua_block or timer' , 2)
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -921,13 +921,13 @@ function Prometheus:metric_data(write_fn, local_only)
   local output = buffer.new(DATA_BUFFER_SIZE_HINT)
   local output_count = 0
 
-  local function buffered_print(data, ...)
-    if data then
+  local function buffered_print(fmt, ...)
+    if fmt then
       output_count = output_count + 1
-      output:putf(data, ...)
+      output:putf(fmt, ...)
     end
 
-    if output_count >= 100 or not data then
+    if output_count >= 100 or not fmt then
       write_fn(output:get())  -- cosume the whole buffer
       output_count = 0
     end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -976,6 +976,8 @@ function Prometheus:metric_data(write_fn, local_only)
   end
 
   buffered_print(nil)
+
+  output:free()
 end
 
 -- Present all metrics in a text format compatible with Prometheus.

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -933,8 +933,10 @@ function Prometheus:metric_data(write_fn, local_only)
     end
   end
 
-  for _, key in ipairs(keys) do
+  for i = 1, count do
     yield()
+
+    key = keys[i]
 
     local value, err
     local is_local_metrics = true

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -402,7 +402,7 @@ local function lookup_or_create(self, label_values)
     local bucket_pref
     if self.label_count > 0 then
       -- strip last }
-      bucket_pref = self.name .. "_bucket" .. string.sub(labels, 1, #labels-1) .. ","
+      bucket_pref = self.name .. "_bucket" .. string.sub(labels, 1, -2) .. ","
     else
       bucket_pref = self.name .. "_bucket{"
     end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -928,7 +928,7 @@ function Prometheus:metric_data(write_fn, local_only)
     end
 
     if output_count >= 100 or not fmt then
-      write_fn(output:get())  -- cosume the whole buffer
+      write_fn(output:get())  -- consume the whole buffer
       output_count = 0
     end
   end

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -921,10 +921,10 @@ function Prometheus:metric_data(write_fn, local_only)
   local output = buffer.new(DATA_BUFFER_SIZE_HINT)
   local output_count = 0
 
-  local function buffered_print(data)
+  local function buffered_print(data, ...)
     if data then
       output_count = output_count + 1
-      output:put(data)
+      output:putf(data, ...)
     end
 
     if output_count >= 100 or not data then
@@ -954,12 +954,12 @@ function Prometheus:metric_data(write_fn, local_only)
       local m = self.registry[short_name]
       if m then
         if m.help then
-          buffered_print(st_format("# HELP %s%s %s\n",
-            self.prefix, short_name, m.help))
+          buffered_print("# HELP %s%s %s\n",
+            self.prefix, short_name, m.help)
         end
         if m.typ then
-          buffered_print(st_format("# TYPE %s%s %s\n",
-            self.prefix, short_name, TYPE_LITERAL[m.typ]))
+          buffered_print("# TYPE %s%s %s\n",
+            self.prefix, short_name, TYPE_LITERAL[m.typ])
         end
       end
       seen_metrics[short_name] = true
@@ -967,7 +967,7 @@ function Prometheus:metric_data(write_fn, local_only)
     if not is_local_metrics then -- local metrics is always a gauge
       key = fix_histogram_bucket_labels(key)
     end
-    buffered_print(st_format("%s%s %s\n", self.prefix, key, value))
+    buffered_print("%s%s %s\n", self.prefix, key, value)
 
     ::continue::
 

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -70,7 +70,6 @@ local tostring = tostring
 local tonumber = tonumber
 local st_format = string.format
 local table_sort = table.sort
-local tb_clear = require("table.clear")
 local yield = require("kong.tools.utils").yield
 
 
@@ -917,6 +916,7 @@ function Prometheus:metric_data(write_fn, local_only)
 
   local seen_metrics = {}
 
+  -- the output is an integral string, not an array any more
   local output = buffer.new(DATA_BUFFER_SIZE_HINT)
   local output_count = 0
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR follows #11040, continue to optimize the string usage by string.buffer.

KAG-1852

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* use `table.new` for `seen_metrics`
* `buffered_print()` outputs a string, not a table
* change `printable_metric_data` of stream to fit the new `buffered_print()` 
* do not use `ipairs` to iterate array
* other small optimizations


