### PR TITLE
fix(service): explicitly set user in systemd definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
   [#10896](https://github.com/Kong/kong/pull/10896)
 - Fix a bug when worker consuming dynamic log level setting event and using a wrong reference for notice logging
   [#10897](https://github.com/Kong/kong/pull/10897)
+- Added a `User=` specification to the systemd unit definition so that
+  Kong can be controlled by systemd again.
+  [#11066](https://github.com/Kong/kong/pull/11066)
 
 #### Admin API
 

--- a/build/package/kong.service
+++ b/build/package/kong.service
@@ -4,6 +4,7 @@ Documentation=https://docs.konghq.com/
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
+User=root
 ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong
 ExecStart=/usr/local/openresty/nginx/sbin/nginx -p /usr/local/kong -c nginx.conf
 ExecReload=/usr/local/bin/kong prepare -p /usr/local/kong


### PR DESCRIPTION
### Summary

Previously, no User clause was present in the systemd unit definition for Kong.  While this still made systemd run kong under the 'root' user id, the HOME environment variable would not be set in the Kong process.  This caused the datafile library to fail with various error conditions.  This really is an EE-only issue at this point, but providing Kong a complete run environment with all standard environment variables is prudent for CE as well.

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-1832