### PR TITLE
perf(core): reduce memory usage of control plane worker processes

### DIFF
--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -98,7 +98,7 @@ function _M.new(opts)
     shm_miss         = shm_miss_name,
     shm_locks        = "kong_locks",
     shm_set_tries    = 3,
-    lru_size         = LRU_SIZE,
+    lru_size         = opts.lru_size or LRU_SIZE,
     ttl              = ttl,
     neg_ttl          = neg_ttl,
     resurrect_ttl    = opts.resurrect_ttl or 30,

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -226,7 +226,12 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     db_cache_neg_ttl = 0
    end
 
-  return kong_cache.new {
+  local lru_size
+  if kong_config.role == "control_plane" then
+    lru_size = 1000
+  end
+
+  return kong_cache.new({
     shm_name        = "kong_db_cache",
     cluster_events  = cluster_events,
     worker_events   = worker_events,
@@ -236,7 +241,8 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     page            = page,
     cache_pages     = cache_pages,
     resty_lock_opts = LOCK_OPTS,
-  }
+    lru_size        = lru_size,
+  })
 end
 
 
@@ -251,7 +257,12 @@ function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
     db_cache_neg_ttl = 0
   end
 
-  return kong_cache.new {
+  local lru_size
+  if kong_config.role == "control_plane" then
+    lru_size = 1000
+  end
+
+  return kong_cache.new({
     shm_name        = "kong_core_db_cache",
     cluster_events  = cluster_events,
     worker_events   = worker_events,
@@ -261,7 +272,8 @@ function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
     page            = page,
     cache_pages     = cache_pages,
     resty_lock_opts = LOCK_OPTS,
-  }
+    lru_size        = lru_size,
+  })
 end
 
 


### PR DESCRIPTION
### Summary

Kong cache has huge LRU cache of 500.000 items by default, and we create caches two times, one for core and one for rest. The LRU takes around 15 MB of memory (so 30 MB in total), per worker.

Without this change the:

```
KONG_ROLE=control_plane KONG_CLUSTER_CERT=cluster.crt KONG_CLUSTER_CERT_KEY=cluster.key kong start
```

takes around 65 MB of memory (per worker), after this change, it only takes around 35 MB (per worker). On 8 core machine it would mean about 240 MB reduction in memory usage.

The control plane rarely if ever uses `kong.cache`, and it does not require such big LRU. This commit reduces size of LRU cache on control planes to 1.000 items.