### PR TITLE
feat(templates): bump `cluster_max_payload` default to 16MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@
   from `128m` to accommodate most commonly deployed config sizes in DB-less
   and Hybrid mode.
   [#11047](https://github.com/Kong/kong/pull/11047)
+- The default value of `cluster_max_payload` config has been bumped to `16m`
+  from `4m` to accommodate most commonly deployed config sizes in Hybrid mode.
+  [#11090](https://github.com/Kong/kong/pull/11090)
 
 #### Status API
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -379,10 +379,10 @@
                                  # which configuration updates will be fetched,
                                  # in `host:port` format.
 
-#cluster_max_payload = 4194304
-                                 # This sets the maximum payload size allowed
+#cluster_max_payload = 16777216
+                                 # This sets the maximum compressed payload size allowed
                                  # to be sent across from CP to DP in Hybrid mode
-                                 # Default is 4Mb - 4 * 1024 * 1024 due to historical reasons
+                                 # Default is 16MB - 16 * 1024 * 1024.
 
 #cluster_dp_labels =             # Comma separated list of Labels for the data plane.
                                  # Labels are key-value pairs that provide additional

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -35,7 +35,7 @@ cluster_ca_cert = NONE
 cluster_server_name = NONE
 cluster_data_plane_purge_delay = 1209600
 cluster_ocsp = off
-cluster_max_payload = 16m
+cluster_max_payload = 16777216
 cluster_use_proxy = off
 cluster_dp_labels = NONE
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -35,7 +35,7 @@ cluster_ca_cert = NONE
 cluster_server_name = NONE
 cluster_data_plane_purge_delay = 1209600
 cluster_ocsp = off
-cluster_max_payload = 4194304
+cluster_max_payload = 16m
 cluster_use_proxy = off
 cluster_dp_labels = NONE
 


### PR DESCRIPTION
KAG-1827