### PR TITLE
fix(api): schema violation when validating valid plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 
 #### Admin API
 
+- Fix an issue where `/schemas/plugins/validate` endpoint fails to validate valid plugin configuration
+  when the key of `custom_fields_by_lua` contains dot character(s).
+  [#11091](https://github.com/Kong/kong/pull/11091)
+
 #### Plugins
 
 - **Response Transformer**: fix an issue that plugin does not transform the response body while upstream returns a Content-Type with +json suffix at subtype.

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -268,12 +268,15 @@ end
 
 local function parse_params(fn)
   return app_helpers.json_params(function(self, ...)
+    local content_type = self.req.headers["content-type"]
+    local is_json
+
     if NEEDS_BODY[get_method()] then
-      local content_type = self.req.headers["content-type"]
       if content_type then
         content_type = content_type:lower()
+        is_json = find(content_type, "application/json", 1, true)
 
-        if find(content_type, "application/json", 1, true) and not self.json then
+        if is_json and not self.json then
           return kong.response.exit(400, { message = "Cannot parse JSON body" })
 
         elseif find(content_type, "application/x-www-form-urlencode", 1, true) then
@@ -282,7 +285,9 @@ local function parse_params(fn)
       end
     end
 
-    self.params = _M.normalize_nested_params(self.params)
+    if not is_json then
+      self.params = _M.normalize_nested_params(self.params)
+    end
 
     local res, err = fn(self, ...)
 

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -523,6 +523,24 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local json = cjson.decode(body)
       assert.equal("schema violation", json.name)
     end)
+    it("returns 200 on a valid plugin schema which contains dot in the key of custom_fields_by_lua", function()
+      local res = assert(client:post("/schemas/plugins/validate", {
+        body = {
+          name = "file-log",
+          config = {
+            path = "tmp/test",
+            custom_fields_by_lua = {
+              new_field = "return 123",
+              ["request.headers.myheader"] = "return nil",
+            },
+          },
+        },
+        headers = {["Content-Type"] = "application/json"}
+      }))
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("schema validation successful", json.message)
+    end)
   end)
 
   describe("/non-existing", function()


### PR DESCRIPTION
### Summary

`parse_params` should not call `normalize_nested_params` for `application/json`. Otherwise, the key-value pair of `custom_fields_by_lua` will be converted into a nested table if the key contains dot character(s), which will cause schema violation when calling `/schemas/plugins/validate`

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG

### Full changelog

* Fix an issue where `/schemas/plugins/validate` endpoint fails to validate valid plugin configuration when the key of `custom_fields_by_lua` contains dot character(s).

### Issue reference

Fix [FTI-5070](https://konghq.atlassian.net/browse/FTI-5070)


[FTI-5070]: https://konghq.atlassian.net/browse/FTI-5070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ