### PR TITLE
perf(tracing): use string.buffer instead of table.concat

### DIFF
--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -14,7 +14,6 @@ local type = type
 local next = next
 local pack = utils.pack
 local unpack = utils.unpack
-local insert = table.insert
 local assert = assert
 local pairs = pairs
 local ipairs = ipairs


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`string.buffer` is faster and efficient than `table.concat`.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

