### PR TITLE
refactor(router): remove unnecessary sort of paths and code clean

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -21,8 +21,6 @@ local ipairs = ipairs
 
 
 local max = math.max
-local tb_concat = table.concat
-local tb_sort = table.sort
 
 
 local ngx           = ngx
@@ -486,6 +484,9 @@ end
 
 local get_headers_key
 do
+  local tb_sort = table.sort
+  local tb_concat = table.concat
+
   local headers_buf = buffer.new(64)
 
   get_headers_key = function(headers)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -21,7 +21,6 @@ local pairs = pairs
 local ipairs = ipairs
 local assert = assert
 local tb_insert = table.insert
-local tb_sort = table.sort
 local byte = string.byte
 local bor, band, lshift = bit.bor, bit.band, bit.lshift
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -136,13 +136,6 @@ local function get_expression(route)
                   hosts_buf:put(")"):get())
   end
 
-  -- resort `paths` to move regex routes to the front of the array
-  if not is_empty_field(paths) then
-    tb_sort(paths, function(a, b)
-      return is_regex_magic(a) and not is_regex_magic(b)
-    end)
-  end
-
   gen = gen_for_field("http.path", function(path)
     return is_regex_magic(path) and OP_REGEX or OP_PREFIX
   end, paths, function(op, p)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

In PR #10615, we have grouped regex and plain paths,
so the sort action is unnecessary.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* remove sort action in `compat.lua`
* move table.* in `get_headers_key` block


