### PR TITLE
fix(clustering): move `remove_fields` of `sync_rate` to the right version

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -85,6 +85,10 @@ return {
     zipkin = {
       "queue",
     },
+  },
+
+  -- Any dataplane older than 3.4.0
+  [3004000000] = {
     rate_limiting = {
       "sync_rate",
     },

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -135,24 +135,47 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       local id = utils.uuid()
       local plugin = get_plugin(id, "3.0.0", rate_limit.name)
 
+      --[[
+        For 3.0.x
+        should not have: error_code, error_message, sync_rate
+      --]]
       local expected = utils.cycle_aware_deep_copy(rate_limit.config)
       expected.error_code = nil
       expected.error_message = nil
       expected.sync_rate = nil
-
       assert.same(expected, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
 
 
+      --[[
+        For 3.2.x
+        should have: error_code, error_message
+        should not have: sync_rate
+      --]]
+      id = utils.uuid()
+      plugin = get_plugin(id, "3.2.0", rate_limit.name)
+      expected = utils.cycle_aware_deep_copy(rate_limit.config)
+      expected.sync_rate = nil
+      assert.same(expected, plugin.config)
+      assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+
+
+      --[[
+        For 3.3.x,
+        should have: error_code, error_message
+        should not have: sync_rate
+      --]]
       id = utils.uuid()
       plugin = get_plugin(id, "3.3.0", rate_limit.name)
-      assert.same(rate_limit.config, plugin.config)
+      expected = utils.cycle_aware_deep_copy(rate_limit.config)
+      expected.sync_rate = nil
+      assert.same(expected, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
     end)
 
     it("does not remove fields from DP nodes that are already compatible", function()
       local id = utils.uuid()
-      local plugin = get_plugin(id, "3.3.0", rate_limit.name)
+      local plugin = get_plugin(id, "3.4.0", rate_limit.name)
       assert.same(rate_limit.config, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
     end)


### PR DESCRIPTION
https://github.com/Kong/kong/pull/9538 was created before `3.3.0` released, so the remove_fields was added for `3.3.0`.

Now we are developing `3.4`, so we need to move that to the correct place.