### PR TITLE
tests(ci): enable all tests in t folder, not only the pdk ones (EE changes)

### DIFF
--- a/t/03-dns-client/02-timer-usage.t
+++ b/t/03-dns-client/02-timer-usage.t
@@ -15,7 +15,7 @@ qq {
     init_worker_by_lua_block {
         local client = require("kong.resty.dns.client")
         assert(client.init({
-            nameservers = { "8.8.8.8" },
+            nameservers = { "127.0.0.53" },
             hosts = {}, -- empty tables to parse to prevent defaulting to /etc/hosts
             resolvConf = {}, -- and resolv.conf files
             order = { "A" },


### PR DESCRIPTION
### Summary

Cherry-picks commit from EE to make tests green on EE side, should be fine here too.