### PR TITLE
chore(deps): bump luacheck from 1.1.0 to 1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6" "luacov 0.15.0"
+DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.1" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6" "luacov 0.15.0"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Features

- Update Löve standard to 11.4 — @RunningDroid
- Documentation improvements — @rcloran and @hramrach

#### Bug Fixes

- Correct compound operators to not crash on modifying upvalues — @arichard4
- Fix warning 582 (error prone negation) not applying to subexpressions — @appgurueu