### PR TITLE
chore(deps): bump ldoc from 1.4.6 to 1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6" "luacov 0.15.0"
+DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.5.0" "luacov 0.15.0"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Features

  * Migrated to lunarmodules org, lowercased repository name, started using 'v' prefix for tags
  * Add Dockerfile and publish build to ghcr.io
  * Configure repository for use *as* a GitHub Action
  * Support CommonMark via cmark-lua processor
  * Add `--version` and improve CLI `--help` output
  * Add 'new' theme
  * Add filetype for xLua's .cs files
  * Add options for project icons & favicons
  * Distinguish between static/class members in moonscript
  * Add support for Lua 5.4
  * Add feature to skip adding timestamps to output
  * Prettify Lua function names
  * Make `@param` tag multiline
  * Allow using `@module`, `@script`, `@file`, etc. multiple times in a single source file
  * Expand builtin tparam aliases to full type names
  * Add `--unsafe_no_sandbox` argument and allow importing Lua modules from config
  * Support LLS-style tags for `@param` and `@return`

#### Fixes

  * Correct documentation typos and errors in example code
  * Honor TMPDIR environment variable
  * Look for absolute references for `@see` references using module names first
  * Use default MD template if none specified
  * Recognize backslash separators in moonscript
  * Do not remove `@see` references from internal data structure
  * Fix Lua 5.1 support
  * Cleanup CLI input to remove trailing slashes