### PR TITLE
chore(deps): bump bazelisk from 1.16.0 to 1.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
 GRPCURL_VERSION ?= 1.8.5
-BAZLISK_VERSION ?= 1.16.0
+BAZLISK_VERSION ?= 1.17.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
 


### PR DESCRIPTION
### Summary

Bazelisk v1.17.0 comes with updated dependencies, minor bug fixes and new features:

The Go version...

... supports custom download URLs via the BAZELISK_FORMAT_URL env variable ... now only downloads Bazel when necessary
... can check the hash of downloaded binaries via the BAZELISK_VERIFY_SHA256 env variable ... makes it easier to find out which Bazel change broke your build with the --bisect option ... is more robust in the face of transient GCS download issues

The Python version now properly recognises WORKSPACE.bazel files.

We’d like to thank our amazing contributors @jmmv and @jwnimmer-tri!