### PR TITLE
chore(deps): bump resty.openssl from 0.8.22 to 0.8.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,8 +105,9 @@
 
 ### Dependencies
 
-- Bumped lua-resty-openssl from 0.8.20 to 0.8.22
+- Bumped lua-resty-openssl from 0.8.20 to 0.8.23
   [#10837](https://github.com/Kong/kong/pull/10837)
+  [#11099](https://github.com/Kong/kong/pull/11099)
 - Bumped kong-lapis from 1.8.3.1 to 1.14.0.2
   [#10841](https://github.com/Kong/kong/pull/10841)
 - Bumped lua-resty-events from 0.1.4 to 0.1.6

--- a/kong-3.4.0-0.rockspec
+++ b/kong-3.4.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.0",
   "lua-resty-healthcheck == 1.6.2",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.22",
+  "lua-resty-openssl == 0.8.23",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.11.0",


### PR DESCRIPTION
### Summary

#### bug fixes

- **\*:** fix typos and add error check for new_of/dup_of ([#2](https://github.com/fffonion/lua-resty-openssl/issues/2)) [aa6ad47](https://github.com/fffonion/lua-resty-openssl/commit/aa6ad4707845cca9c46282a1550bb9fee7d48698)

#### features

- **tests:** add performance test ([#112](https://github.com/fffonion/lua-resty-openssl/issues/112)) [100b4e4](https://github.com/fffonion/lua-resty-openssl/commit/100b4e43843a597327be6e5356c64b5ce621fa56)
- **x509.store:** add store:check_revocation and add flag to skip check CRL for store:add ([#1](https://github.com/fffonion/lua-resty-openssl/issues/1)) [1a5a4c8](https://github.com/fffonion/lua-resty-openssl/commit/1a5a4c881128ffb65d6eaf47bb3961417ef23f0b)