### PR TITLE
feat(build): build wasmx as static or dynamic module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -160,7 +160,7 @@ bool_flag(
 
 # --//:wasmx_module=dynamic
 string_flag(
-    name = "wasmx_module",
+    name = "wasmx_module_flag",
     build_setting_default = "dynamic",
     values = [
         "dynamic",
@@ -177,19 +177,19 @@ config_setting(
 )
 
 config_setting(
-    name = "wasmx_static_mod_flag",
+    name = "wasmx_static_mod",
     flag_values = {
         ":wasmx": "true",
-        ":wasmx_module": "static",
+        ":wasmx_module_flag": "static",
     },
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "wasmx_dynamic_mod_flag",
+    name = "wasmx_dynamic_mod",
     flag_values = {
         ":wasmx": "true",
-        ":wasmx_module": "dynamic",
+        ":wasmx_module_flag": "dynamic",
     },
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -169,6 +169,14 @@ string_flag(
 )
 
 config_setting(
+    name = "wasmx_flag",
+    flag_values = {
+        ":wasmx": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "wasmx_static_mod_flag",
     flag_values = {
         ":wasmx": "true",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,10 +158,30 @@ bool_flag(
     build_setting_default = True,
 )
 
+# --//:wasmx_module=static
+string_flag(
+    name = "wasmx_module",
+    build_setting_default = "static",
+    values = [
+        "dynamic",
+        "static",
+    ],
+)
+
 config_setting(
-    name = "wasmx_flag",
+    name = "wasmx_static_mod_flag",
     flag_values = {
         ":wasmx": "true",
+        ":wasmx_module": "static",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "wasmx_dynamic_mod_flag",
+    flag_values = {
+        ":wasmx": "true",
+        ":wasmx_module": "dynamic",
     },
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,10 +158,10 @@ bool_flag(
     build_setting_default = True,
 )
 
-# --//:wasmx_module=static
+# --//:wasmx_module=dynamic
 string_flag(
     name = "wasmx_module",
-    build_setting_default = "static",
+    build_setting_default = "dynamic",
     values = [
         "dynamic",
         "static",
@@ -198,52 +198,30 @@ string_flag(
 )
 
 config_setting(
-    name = "wasmx_v8_flag",
+    name = "wasmx_v8",
     flag_values = {
+        ":wasmx": "true",
         ":wasm_runtime": "v8",
     },
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "wasmx_wasmer_flag",
+    name = "wasmx_wasmer",
     flag_values = {
+        ":wasmx": "true",
         ":wasm_runtime": "wasmer",
     },
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "wasmx_wasmtime_flag",
+    name = "wasmx_wasmtime",
     flag_values = {
+        ":wasmx": "true",
         ":wasm_runtime": "wasmtime",
     },
     visibility = ["//visibility:public"],
-)
-
-# wasm runtime settings should only be set when wasm is enabled
-selects.config_setting_group(
-    name = "wasmx_v8",
-    match_all = [
-        ":wasmx_v8_flag",
-        ":wasmx_flag",
-    ],
-)
-
-selects.config_setting_group(
-    name = "wasmx_wasmer",
-    match_all = [
-        ":wasmx_wasmer_flag",
-        ":wasmx_flag",
-    ],
-)
-
-selects.config_setting_group(
-    name = "wasmx_wasmtime",
-    match_all = [
-        ":wasmx_wasmtime_flag",
-        ":wasmx_flag",
-    ],
 )
 
 ##### constraints, platforms and config_settings for cross-compile

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -101,11 +101,14 @@ wasmx_vm_cmd = select({
 wasmx_load_module = select({
     "@kong//:wasmx_dynamic_mod_flag": """
   if ! grep -q "ngx_wasm_module.so" kong/templates/nginx.lua; then
-      WASM_LINE=$((`grep -n -m1 "error_log"  kong/templates/nginx.lua | cut -d: -f1` + 1))
+      WASM_LINE_TPL=$((`grep -n -m1 "error_log"  kong/templates/nginx.lua | cut -d: -f1` + 1))
+      WASM_LINE_FXT=$((`grep -n -m1 "error_log"  spec/fixtures/custom_nginx.template | cut -d: -f1` + 1))
       if [[ "$OSTYPE" == "darwin"* ]]; then
-          gsed -i "$WASM_LINE a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+          gsed -i "$WASM_LINE_TPL a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+          gsed -i "$WASM_LINE_FXT a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" spec/fixtures/custom_nginx.template
       else
-          sed -i "$WASM_LINE a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+          sed -i "$WASM_LINE_TPL a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+          sed -i "$WASM_LINE_FXT a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" spec/fixtures/custom_nginx.template
       fi
   fi
 """,

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -99,7 +99,7 @@ wasmx_vm_cmd = select({
 })
 
 wasmx_load_module = select({
-  "@kong//:wasmx_dynamic_mod_flag": """
+    "@kong//:wasmx_dynamic_mod_flag": """
   if ! grep -q "ngx_wasm_module.so" kong/templates/nginx.lua; then
       WASM_LINE=$((`grep -n -m1 "error_log"  kong/templates/nginx.lua | cut -d: -f1` + 1))
       if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -109,16 +109,16 @@ wasmx_load_module = select({
       fi
   fi
 """,
-  "//conditions:default": "",
+    "//conditions:default": "",
 })
 
 kong_directory_genrule(
     name = "kong",
     srcs = [
-        "@openresty//:openresty",
-        "@openresty//:luajit",
         "@luarocks//:luarocks_make",
         "@luarocks//:luarocks_target",
+        "@openresty",
+        "@openresty//:luajit",
         "@protoc//:all_srcs",
     ] + lib_deps + lualib_deps + wasmx_deps,
     cmd =

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -98,23 +98,6 @@ wasmx_vm_cmd = select({
     "//conditions:default": "",
 })
 
-wasmx_load_module = select({
-    "@kong//:wasmx_dynamic_mod_flag": """
-  if ! grep -q "ngx_wasm_module.so" kong/templates/nginx.lua; then
-      WASM_LINE_TPL=$((`grep -n -m1 "error_log"  kong/templates/nginx.lua | cut -d: -f1` + 1))
-      WASM_LINE_FXT=$((`grep -n -m1 "error_log"  spec/fixtures/custom_nginx.template | cut -d: -f1` + 1))
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-          gsed -i "$WASM_LINE_TPL a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
-          gsed -i "$WASM_LINE_FXT a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" spec/fixtures/custom_nginx.template
-      else
-          sed -i "$WASM_LINE_TPL a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
-          sed -i "$WASM_LINE_FXT a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" spec/fixtures/custom_nginx.template
-      fi
-  fi
-""",
-    "//conditions:default": "",
-})
-
 kong_directory_genrule(
     name = "kong",
     srcs = [
@@ -167,8 +150,6 @@ kong_directory_genrule(
 
         ATC_ROUTER=${WORKSPACE_PATH}/$(location @atc_router)
         cp $ATC_ROUTER ${BUILD_DESTDIR}/openresty/lualib/.
-    """ + wasmx_load_module +
-        """
         cp -r $(locations @protoc//:all_srcs) ${BUILD_DESTDIR}/kong/.
 
     """ + install_lib_deps_cmd + install_lualib_deps_cmd + wasm_libs_cmd + wasmx_vm_cmd +

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -50,27 +50,21 @@ wasmx_vm_deps = select({
 })
 
 wasmx_deps = select({
-    "@kong//:wasmx_static_mod_flag": [
-        "@ngx_wasm_module//:lua_libs",
-    ],
-    "@kong//:wasmx_dynamic_mod_flag": [
+    "@kong//:wasmx_flag": [
         "@ngx_wasm_module//:lua_libs",
     ],
     "//conditions:default": [],
 }) + wasmx_vm_deps
 
-wasm_libs_install = """
+wasm_libs_install = select({
+    "@kong//:wasmx_flag": """
     for fname in $(locations @ngx_wasm_module//:lua_libs); do
         base=${fname##*/ngx_wasm_module/lib/}
         dest="${BUILD_DESTDIR}/openresty/lualib/$base"
         mkdir -p "$(dirname "$dest")"
         cp -v "$fname" "$dest"
     done
-"""
-
-wasm_libs_cmd = select({
-    "@kong//:wasmx_static_mod_flag": wasm_libs_install,
-    "@kong//:wasmx_dynamic_mod_flag": wasm_libs_install,
+""",
     "//conditions:default": "\n",
 })
 
@@ -150,9 +144,10 @@ kong_directory_genrule(
 
         ATC_ROUTER=${WORKSPACE_PATH}/$(location @atc_router)
         cp $ATC_ROUTER ${BUILD_DESTDIR}/openresty/lualib/.
+
         cp -r $(locations @protoc//:all_srcs) ${BUILD_DESTDIR}/kong/.
 
-    """ + install_lib_deps_cmd + install_lualib_deps_cmd + wasm_libs_cmd + wasmx_vm_cmd +
+    """ + install_lib_deps_cmd + install_lualib_deps_cmd + wasm_libs_install + wasmx_vm_cmd +
         """
         mkdir -p ${BUILD_DESTDIR}/etc/kong
         cp kong.conf.default ${BUILD_DESTDIR}/etc/kong/kong.conf.default

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -50,21 +50,27 @@ wasmx_vm_deps = select({
 })
 
 wasmx_deps = select({
-    "@kong//:wasmx_flag": [
+    "@kong//:wasmx_static_mod_flag": [
+        "@ngx_wasm_module//:lua_libs",
+    ],
+    "@kong//:wasmx_dynamic_mod_flag": [
         "@ngx_wasm_module//:lua_libs",
     ],
     "//conditions:default": [],
 }) + wasmx_vm_deps
 
-wasm_libs_cmd = select({
-    "@kong//:wasmx_flag": """
+WASM_LIBS_INSTALL = """
     for fname in $(locations @ngx_wasm_module//:lua_libs); do
         base=${fname##*/ngx_wasm_module/lib/}
         dest="${BUILD_DESTDIR}/openresty/lualib/$base"
         mkdir -p "$(dirname "$dest")"
         cp -v "$fname" "$dest"
     done
-""",
+"""
+
+wasm_libs_cmd = select({
+    "@kong//:wasmx_static_mod_flag": WASM_LIBS_INSTALL,
+    "@kong//:wasmx_dynamic_mod_flag": WASM_LIBS_INSTALL,
     "//conditions:default": "\n",
 })
 

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -59,7 +59,7 @@ wasmx_deps = select({
     "//conditions:default": [],
 }) + wasmx_vm_deps
 
-WASM_LIBS_INSTALL = """
+wasm_libs_install = """
     for fname in $(locations @ngx_wasm_module//:lua_libs); do
         base=${fname##*/ngx_wasm_module/lib/}
         dest="${BUILD_DESTDIR}/openresty/lualib/$base"
@@ -69,8 +69,8 @@ WASM_LIBS_INSTALL = """
 """
 
 wasm_libs_cmd = select({
-    "@kong//:wasmx_static_mod_flag": WASM_LIBS_INSTALL,
-    "@kong//:wasmx_dynamic_mod_flag": WASM_LIBS_INSTALL,
+    "@kong//:wasmx_static_mod_flag": wasm_libs_install,
+    "@kong//:wasmx_dynamic_mod_flag": wasm_libs_install,
     "//conditions:default": "\n",
 })
 
@@ -96,6 +96,20 @@ wasmx_vm_cmd = select({
     fi
 """,
     "//conditions:default": "",
+})
+
+wasmx_load_module = select({
+  "@kong//:wasmx_dynamic_mod_flag": """
+  if ! grep -q "ngx_wasm_module.so" kong/templates/nginx.lua; then
+      WASM_LINE=$((`grep -n -m1 "error_log"  kong/templates/nginx.lua | cut -d: -f1` + 1))
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+          gsed -i "$WASM_LINE a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+      else
+          sed -i "$WASM_LINE a load_module ${BUILD_DESTDIR}/openresty/nginx/modules/ngx_wasm_module.so;" kong/templates/nginx.lua
+      fi
+  fi
+""",
+  "//conditions:default": "",
 })
 
 kong_directory_genrule(
@@ -150,7 +164,8 @@ kong_directory_genrule(
 
         ATC_ROUTER=${WORKSPACE_PATH}/$(location @atc_router)
         cp $ATC_ROUTER ${BUILD_DESTDIR}/openresty/lualib/.
-
+    """ + wasmx_load_module +
+        """
         cp -r $(locations @protoc//:all_srcs) ${BUILD_DESTDIR}/kong/.
 
     """ + install_lib_deps_cmd + install_lualib_deps_cmd + wasm_libs_cmd + wasmx_vm_cmd +

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -232,7 +232,7 @@ CONFIGURE_OPTIONS = [
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_flag": [
+    "@kong//:wasmx_static_mod_flag": [
         "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
         # FIXME: this is a workaround for rhel/centos builds, when enabled breaks
         #        the build for macos
@@ -241,6 +241,10 @@ CONFIGURE_OPTIONS = [
         # * https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
         # * https://github.com/Kong/ngx_wasm_module/blob/e70a19f53e1dda99d016c5cfa393652720959afd/util/Dockerfiles/Dockerfile.amd64.centos7#L9-L11
         #"--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
+    ],
+    "@kong//:wasmx_dynamic_mod_flag": [
+        "--with-compat",
+        "--add-dynamic-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
     ],
     "//conditions:default": [],
 }) + select({

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -232,7 +232,7 @@ CONFIGURE_OPTIONS = [
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_static_mod_flag": [
+    "@kong//:wasmx_static_mod": [
         "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
         # FIXME: this is a workaround for rhel/centos builds, when enabled breaks
         #        the build for macos
@@ -242,7 +242,7 @@ CONFIGURE_OPTIONS = [
         # * https://github.com/Kong/ngx_wasm_module/blob/e70a19f53e1dda99d016c5cfa393652720959afd/util/Dockerfiles/Dockerfile.amd64.centos7#L9-L11
         #"--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
     ],
-    "@kong//:wasmx_dynamic_mod_flag": [
+    "@kong//:wasmx_dynamic_mod": [
         "--with-compat",
         "--add-dynamic-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
     ],

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -187,4 +187,5 @@ tracing_sampling_rate = 0.01
 
 wasm = off
 wasm_filters_path = NONE
+wasm_dynamic_module = NONE
 ]]

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -2,6 +2,10 @@ return [[
 pid pids/nginx.pid;
 error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
+> if wasm and wasm_dynamic_module then
+load_module $(wasm_dynamic_module);
+> end
+
 # injected nginx_main_* directives
 > for _, el in ipairs(nginx_main_directives) do
 $(el.name) $(el.value);
@@ -19,7 +23,7 @@ events {
 > end
 }
 
-> if wasm_modules_parsed and #wasm_modules_parsed > 0 then
+> if wasm and wasm_modules_parsed and #wasm_modules_parsed > 0 then
 wasm {
   shm_kv kong_wasm_rate_limiting_counters 12m;
 

--- a/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
@@ -151,19 +151,24 @@
   Needed    :
   - libc.so.6
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libdl.so.2
   - libpthread.so.0
   - libcrypt.so.1
   - libluajit-5.1.so.2
-  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
-  - libgcc_s.so.1
   - libc.so.6
-  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -150,19 +150,24 @@
   Needed    :
   - libc.so.6
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libdl.so.2
   - libpthread.so.0
   - libcrypt.so.1
   - libluajit-5.1.so.2
-  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
-  - libgcc_s.so.1
   - libc.so.6
-  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -141,17 +141,22 @@
   Needed    :
   - libc.so.6
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libcrypt.so.1
   - libluajit-5.1.so.2
-  - libm.so.6
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
-  - libgcc_s.so.1
   - libc.so.6
-  - ld-linux-x86-64.so.2
   Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -136,6 +136,14 @@
   - libc.so.6
   - ld-linux-aarch64.so.1
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libcrypt.so.1
@@ -151,6 +159,7 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -3,6 +3,10 @@
 pid pids/nginx.pid; # mandatory even for custom config templates
 error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
+> if wasm and wasm_dynamic_module then
+load_module $(wasm_dynamic_module);
+> end
+
 # injected nginx_main_* directives
 > for _, el in ipairs(nginx_main_directives) do
 $(el.name) $(el.value);


### PR DESCRIPTION
### Summary

This change makes it possible to build ngx_wasm_module as a dynamic Nginx module.

It adds the new flag `--//:wasmx_module`, which accepts `dynamic` and `static` options. Currently `dynamic` is the default value.

There is a new feature to include the `load_module` directive in `nginx.conf` when dynamic module is in use and `wasm = on`. It will search for the shared object in the path defined by the environment variable `KONG_DYNAMIC_MODULES_PATH`, the nginx build prefix and then in `/usr/local/openresty/nginx/modules` (the default installation path).

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Build scripts changed.

### Issue reference

KAG-664