### PR TITLE
refactor(core): plugins iterator state-building & lookup algorithm 

### DIFF
--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -1,43 +1,21 @@
 local workspaces   = require "kong.workspaces"
 local constants    = require "kong.constants"
-local warmup       = require "kong.cache.warmup"
 local utils        = require "kong.tools.utils"
 local tablepool    = require "tablepool"
 
 
-local log          = ngx.log
-local kong         = kong
-local exit         = ngx.exit
 local null         = ngx.null
-local error        = error
-local pairs        = pairs
-local ipairs       = ipairs
-local assert       = assert
-local tostring     = tostring
+local format       = string.format
 local fetch_table  = tablepool.fetch
 local release_table = tablepool.release
 
-
-local TTL_ZERO     = { ttl = 0 }
+local TTL_ZERO          = { ttl = 0 }
 local GLOBAL_QUERY_OPTS = { workspace = null, show_ws_id = true }
-
-local COMBO_R      = 1
-local COMBO_S      = 2
-local COMBO_RS     = 3
-local COMBO_C      = 4
-local COMBO_RC     = 5
-local COMBO_SC     = 6
-local COMBO_RSC    = 7
-local COMBO_GLOBAL = 0
-
-local ERR = ngx.ERR
-local ERROR = ngx.ERROR
-
 
 local subsystem = ngx.config.subsystem
 
-
-local NON_COLLECTING_PHASES, DOWNSTREAM_PHASES, DOWNSTREAM_PHASES_COUNT, COLLECTING_PHASE do
+local NON_COLLECTING_PHASES, DOWNSTREAM_PHASES, DOWNSTREAM_PHASES_COUNT, COLLECTING_PHASE
+do
   if subsystem == "stream" then
     NON_COLLECTING_PHASES = {
       "certificate",
@@ -75,6 +53,19 @@ end
 
 local PLUGINS_NS = "plugins." .. subsystem
 
+local PluginsIterator = {}
+
+-- Build a compound key by string formatting route_id, service_id, and consumer_id with colons as separators.
+--
+-- @function build_compound_key
+-- @tparam string|nil route_id The route identifier. If `nil`, an empty string is used.
+-- @tparam string|nil service_id The service identifier. If `nil`, an empty string is used.
+-- @tparam string|nil consumer_id The consumer identifier. If `nil`, an empty string is used.
+-- @treturn string The compound key, in the format `route_id:service_id:consumer_id`.
+---
+function PluginsIterator.build_compound_key(route_id, service_id, consumer_id)
+  return format("%s:%s:%s", route_id or "", service_id or "", consumer_id or "")
+end
 
 local function get_table_for_ctx(ws)
   local tbl = fetch_table(PLUGINS_NS, 0, DOWNSTREAM_PHASES_COUNT + 2)
@@ -93,7 +84,6 @@ local function get_table_for_ctx(ws)
 
   return tbl
 end
-
 
 local function release(ctx)
   local plugins = ctx.plugins
@@ -127,18 +117,6 @@ end
 
 local next_seq = 0
 
--- Loads a plugin config from the datastore.
--- @return plugin config table or an empty sentinel table in case of a db-miss
-local function load_plugin_from_db(key)
-  local row, err = kong.db.plugins:select_by_cache_key(key)
-  if err then
-    return nil, tostring(err)
-  end
-
-  return row
-end
-
-
 local function get_plugin_config(plugin, name, ws_id)
   if not plugin or not plugin.enabled then
     return
@@ -153,11 +131,11 @@ local function get_plugin_config(plugin, name, ws_id)
   cfg.__plugin_id = plugin.id
 
   local key = kong.db.plugins:cache_key(name,
-    cfg.route_id,
-    cfg.service_id,
-    cfg.consumer_id,
-    nil,
-    ws_id)
+                                        cfg.route_id,
+                                        cfg.service_id,
+                                        cfg.consumer_id,
+                                        nil,
+                                        ws_id)
 
   -- TODO: deprecate usage of __key__ as id of plugin
   if not cfg.__key__ then
@@ -169,173 +147,104 @@ local function get_plugin_config(plugin, name, ws_id)
   return cfg
 end
 
+---
+-- Lookup a configuration for a given combination of route_id, service_id, consumer_id
+--
+-- The function checks various combinations of route_id, service_id and consumer_id to find
+-- the best matching configuration in the given 'combos' table. The priority order is as follows:
+--
+-- Route, Service, Consumer
+-- Route, Consumer
+-- Service, Consumer
+-- Route, Service
+-- Consumer
+-- Route
+-- Service
+-- Global
+--
+-- @function lookup_cfg
+-- @tparam table combos A table containing configuration data indexed by compound keys.
+-- @tparam string|nil route_id The route identifier.
+-- @tparam string|nil service_id The service identifier.
+-- @tparam string|nil consumer_id The consumer identifier.
+-- @return any|nil The configuration corresponding to the best matching combination, or 'nil' if no configuration is found.
+---
+function PluginsIterator.lookup_cfg(combos, route_id, service_id, consumer_id)
+  -- Use the build_compound_key function to create an index for the 'combos' table
+  local build_compound_key = PluginsIterator.build_compound_key
 
---- Load the configuration for a plugin entry.
--- Given a Route, Service, Consumer and a plugin name, retrieve the plugin's
--- configuration if it exists. Results are cached in ngx.dict
--- @param[type=string] name Name of the plugin being tested for configuration.
--- @param[type=string] route_id Id of the route being proxied.
--- @param[type=string] service_id Id of the service being proxied.
--- @param[type=string] consumer_id Id of the consumer making the request (if any).
--- @treturn table Plugin configuration, if retrieved.
-local function load_configuration(ctx,
-                                  name,
-                                  route_id,
-                                  service_id,
-                                  consumer_id)
-  local ws_id = workspaces.get_workspace_id(ctx) or kong.default_workspace
-  local key = kong.db.plugins:cache_key(name,
-                                        route_id,
-                                        service_id,
-                                        consumer_id,
-                                        nil,
-                                        ws_id)
-  local plugin, err = kong.core_cache:get(key,
-                                          nil,
-                                          load_plugin_from_db,
-                                          key)
-  if err then
-    ctx.delay_response = nil
-    ctx.buffered_proxying = nil
-    log(ERR, tostring(err))
-    return exit(ERROR)
-  end
+    local key
+    if route_id and service_id and consumer_id then
+        key = build_compound_key(route_id, service_id, consumer_id)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if route_id and consumer_id then
+        key = build_compound_key(route_id, nil, consumer_id)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if service_id and consumer_id then
+        key = build_compound_key(nil, service_id, consumer_id)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if route_id and service_id then
+        key = build_compound_key(route_id, service_id, nil)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if consumer_id then
+        key = build_compound_key(nil, nil, consumer_id)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if route_id then
+        key = build_compound_key(route_id, nil, nil)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    if service_id then
+        key = build_compound_key(nil, service_id, nil)
+        if combos[key] then
+            return combos[key]
+        end
+    end
+    return combos[build_compound_key(nil, nil, nil)]
 
-  return get_plugin_config(plugin, name, ws_id)
 end
 
 
+---
+-- Load the plugin configuration based on the context (route, service, and consumer) and plugin handler rules.
+--
+-- This function filters out route, service, and consumer information from the context based on the plugin handler rules,
+-- and then calls the 'lookup_cfg' function to get the best matching plugin configuration for the given combination of
+-- route_id, service_id, and consumer_id.
+--
+-- @function load_configuration_through_combos
+-- @tparam table ctx A table containing the context information, including route, service, and authenticated_consumer.
+-- @tparam table combos A table containing configuration data indexed by compound keys.
+-- @tparam table plugin A table containing plugin information, including the handler with no_route, no_service, and no_consumer rules.
+-- @treturn any|nil The configuration corresponding to the best matching combination, or 'nil' if no configuration is found.
+---
 local function load_configuration_through_combos(ctx, combos, plugin)
-  local plugin_configuration
-  local name = plugin.name
 
-  local route    = ctx.route
-  local service  = ctx.service
-  local consumer = ctx.authenticated_consumer
+    -- Filter out route, service, and consumer based on the plugin handler rules and get their ids
+  local route_id = (ctx.route and not plugin.handler.no_route) and ctx.route.id or nil
+  local service_id = (ctx.service and not plugin.handler.no_service) and ctx.service.id or nil
+  -- TODO: kong.client.get_consumer() for more consistency. This might be an exception though as we're aiming for raw speed instead of compliance.
+  local consumer_id = (ctx.authenticated_consumer and not plugin.handler.no_consumer) and ctx.authenticated_consumer.id or nil
 
-  if route and plugin.handler.no_route then
-    route = nil
-  end
-  if service and plugin.handler.no_service then
-    service = nil
-  end
-  if consumer and plugin.handler.no_consumer then
-    consumer = nil
-  end
-
-  local    route_id = route    and    route.id or nil
-  local  service_id = service  and  service.id or nil
-  local consumer_id = consumer and consumer.id or nil
-
-  if kong.db.strategy == "off" then
-    if route_id and service_id and consumer_id and combos[COMBO_RSC]
-      and combos.rsc[route_id] and combos.rsc[route_id][service_id]
-      and combos.rsc[route_id][service_id][consumer_id]
-    then
-      return combos.rsc[route_id][service_id][consumer_id]
-    end
-
-    if route_id and consumer_id and combos[COMBO_RC]
-      and combos.rc[route_id] and combos.rc[route_id][consumer_id]
-    then
-      return combos.rc[route_id][consumer_id]
-    end
-
-    if service_id and consumer_id and combos[COMBO_SC]
-      and combos.sc[service_id] and combos.sc[service_id][consumer_id]
-    then
-      return combos.sc[service_id][consumer_id]
-    end
-
-    if route_id and service_id and combos[COMBO_RS]
-      and combos.rs[route_id] and combos.rs[route_id][service_id]
-    then
-      return combos.rs[route_id][service_id]
-    end
-
-    if consumer_id and combos[COMBO_C] and combos.c[consumer_id] then
-      return combos.c[consumer_id]
-    end
-
-    if route_id and combos[COMBO_R] and combos.r[route_id] then
-      return combos.r[route_id]
-    end
-
-    if service_id and combos[COMBO_S] and combos.s[service_id] then
-      return combos.s[service_id]
-    end
-
-    if combos[COMBO_GLOBAL] then
-      return combos[COMBO_GLOBAL]
-    end
-
-  else
-    if route_id and service_id and consumer_id and combos[COMBO_RSC]
-      and combos.both[route_id] == service_id
-    then
-      plugin_configuration = load_configuration(ctx, name, route_id, service_id,
-                                                consumer_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if route_id and consumer_id and combos[COMBO_RC]
-      and combos.routes[route_id]
-    then
-      plugin_configuration = load_configuration(ctx, name, route_id, nil,
-                                                consumer_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if service_id and consumer_id and combos[COMBO_SC]
-      and combos.services[service_id]
-    then
-      plugin_configuration = load_configuration(ctx, name, nil, service_id,
-                                                consumer_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if route_id and service_id and combos[COMBO_RS]
-      and combos.both[route_id] == service_id
-    then
-      plugin_configuration = load_configuration(ctx, name, route_id, service_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if consumer_id and combos[COMBO_C] then
-      plugin_configuration = load_configuration(ctx, name, nil, nil, consumer_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if route_id and combos[COMBO_R] and combos.routes[route_id] then
-      plugin_configuration = load_configuration(ctx, name, route_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if service_id and combos[COMBO_S] and combos.services[service_id] then
-      plugin_configuration = load_configuration(ctx, name, nil, service_id)
-      if plugin_configuration then
-        return plugin_configuration
-      end
-    end
-
-    if combos[COMBO_GLOBAL] then
-      return load_configuration(ctx, name)
-    end
-  end
+  -- Call the lookup_cfg function to get the best matching plugin configuration
+  return PluginsIterator.lookup_cfg(combos, route_id, service_id, consumer_id)
 end
-
 
 local function get_workspace(self, ctx)
   if not ctx then
@@ -344,7 +253,6 @@ local function get_workspace(self, ctx)
 
   return self.ws[workspaces.get_workspace_id(ctx) or kong.default_workspace]
 end
-
 
 local function get_next_init_worker(plugins, i)
   local i = i + 1
@@ -376,7 +284,7 @@ local function get_next_global_or_collected_plugin(plugins, i)
     return nil
   end
 
-  return i, plugins[i-1], plugins[i]
+  return i, plugins[i - 1], plugins[i]
 end
 
 
@@ -445,7 +353,6 @@ local function get_next_and_collect(ctx, i)
   return get_next_and_collect(ctx, i)
 end
 
-
 local function get_collecting_iterator(self, ctx)
   local ws = get_workspace(self, ctx)
   if not ws then
@@ -461,10 +368,6 @@ local function get_collecting_iterator(self, ctx)
 
   return get_next_and_collect, ctx
 end
-
-
-local PluginsIterator = {}
-
 
 local function new_ws_data()
   return {
@@ -489,10 +392,10 @@ function PluginsIterator.new(version)
     [ws_id] = new_ws_data()
   }
 
-  local cache_full
   local counter = 0
   local page_size = kong.db.plugins.pagination.max_page_size
-  local globals do
+  local globals
+  do
     globals = {}
     for _, phase in ipairs(NON_COLLECTING_PHASES) do
       globals[phase] = { [0] = 0 }
@@ -519,7 +422,11 @@ function PluginsIterator.new(version)
     local plugins = data.plugins
     local combos = data.combos
 
-    if kong.core_cache and counter > 0 and counter % page_size == 0 and kong.db.strategy ~= "off" then
+    if kong.core_cache
+       and counter > 0
+       and counter % page_size == 0
+       and kong.db.strategy ~= "off" then
+
       local new_version, err = kong.core_cache:get("plugins_iterator:version", TTL_ZERO, utils.uuid)
       if err then
         return nil, "failed to retrieve plugins iterator version: " .. err
@@ -540,102 +447,31 @@ function PluginsIterator.new(version)
 
       plugins[name] = true
 
-      local combo_key = (plugin.route    and 1 or 0)
-                      + (plugin.service  and 2 or 0)
-                      + (plugin.consumer and 4 or 0)
+      -- Retrieve route_id, service_id, and consumer_id from the plugin object, if they exist
+      local route_id = plugin.route and plugin.route.id
+      local service_id = plugin.service and plugin.service.id
+      local consumer_id = plugin.consumer and plugin.consumer.id
 
-      local cfg
-      if combo_key == COMBO_GLOBAL then
-        cfg = get_plugin_config(plugin, name, ws_id)
-        if cfg then
-          globals[name] = cfg
-        end
+      -- Get the plugin configuration for the specified workspace (ws_id)
+      local cfg = get_plugin_config(plugin, name, plugin.ws_id)
+      -- Determine if the plugin configuration is global (i.e., not tied to any route, service, consumer or group)
+      local is_global = not route_id and not service_id and not consumer_id and plugin.ws_id == kong.default_workspace
+      if is_global then
+        -- Store the global configuration for the plugin in the 'globals' table
+        globals[name] = cfg
       end
 
-      if kong.db.strategy == "off" then
-        cfg = cfg or get_plugin_config(plugin, name, ws_id)
-        if cfg then
-          combos[name]     = combos[name]     or {}
-          combos[name].rsc = combos[name].rsc or {}
-          combos[name].rc  = combos[name].rc  or {}
-          combos[name].sc  = combos[name].sc  or {}
-          combos[name].rs  = combos[name].rs  or {}
-          combos[name].c   = combos[name].c   or {}
-          combos[name].r   = combos[name].r   or {}
-          combos[name].s   = combos[name].s   or {}
+      if cfg then
+        -- Initialize an empty table for the plugin in the 'combos' table if it doesn't already exist
+        combos[name] = combos[name] or {}
 
-          combos[name][combo_key] = cfg
+        -- Build a compound key using the route_id, service_id, and consumer_id
+        local compound_key = PluginsIterator.build_compound_key(route_id, service_id, consumer_id)
 
-          if cfg.route_id and cfg.service_id and cfg.consumer_id then
-            combos[name].rsc[cfg.route_id] =
-            combos[name].rsc[cfg.route_id] or {}
-            combos[name].rsc[cfg.route_id][cfg.service_id] =
-            combos[name].rsc[cfg.route_id][cfg.service_id] or {}
-            combos[name].rsc[cfg.route_id][cfg.service_id][cfg.consumer_id] = cfg
-
-          elseif cfg.route_id and cfg.consumer_id then
-            combos[name].rc[cfg.route_id] =
-            combos[name].rc[cfg.route_id] or {}
-            combos[name].rc[cfg.route_id][cfg.consumer_id] = cfg
-
-          elseif cfg.service_id and cfg.consumer_id then
-            combos[name].sc[cfg.service_id] =
-            combos[name].sc[cfg.service_id] or {}
-            combos[name].sc[cfg.service_id][cfg.consumer_id] = cfg
-
-          elseif cfg.route_id and cfg.service_id then
-            combos[name].rs[cfg.route_id] =
-            combos[name].rs[cfg.route_id] or {}
-            combos[name].rs[cfg.route_id][cfg.service_id] = cfg
-
-          elseif cfg.consumer_id then
-            combos[name].c[cfg.consumer_id] = cfg
-
-          elseif cfg.route_id then
-            combos[name].r[cfg.route_id] = cfg
-
-          elseif cfg.service_id then
-            combos[name].s[cfg.service_id] = cfg
-          end
-        end
-
-      else
-        if version == "init" and not cache_full then
-          local ok
-          ok, err = warmup.single_entity(kong.db.plugins, plugin)
-          if not ok then
-            if err ~= "no memory" then
-              return nil, err
-            end
-
-            kong.log.warn("cache warmup of plugins has been stopped because ",
-                          "cache memory is exhausted, please consider increasing ",
-                          "the value of 'mem_cache_size' (currently at ",
-                           kong.configuration.mem_cache_size, ")")
-
-            cache_full = true
-          end
-        end
-
-        combos[name]          = combos[name]          or {}
-        combos[name].both     = combos[name].both     or {}
-        combos[name].routes   = combos[name].routes   or {}
-        combos[name].services = combos[name].services or {}
-
-        combos[name][combo_key] = true
-
-        if plugin.route and plugin.service then
-          combos[name].both[plugin.route.id] = plugin.service.id
-
-        elseif plugin.route then
-          combos[name].routes[plugin.route.id] = true
-
-        elseif plugin.service then
-          combos[name].services[plugin.service.id] = true
-        end
+        -- Store the plugin configuration in the 'combos' table using the compound key
+        combos[name][compound_key] = cfg
       end
     end
-
     counter = counter + 1
   end
 
@@ -659,7 +495,7 @@ function PluginsIterator.new(version)
           local n = plugins[0] + 2
           plugins[0] = n
           plugins[n] = cfg
-          plugins[n-1] = plugin
+          plugins[n - 1] = plugin
         end
       end
     end
@@ -678,6 +514,5 @@ function PluginsIterator.new(version)
     release = release,
   }
 end
-
 
 return PluginsIterator

--- a/spec/01-unit/28-plugins-iterator/01-compound_key_spec.lua
+++ b/spec/01-unit/28-plugins-iterator/01-compound_key_spec.lua
@@ -1,0 +1,50 @@
+-- This software is copyright Kong Inc. and its licensors.
+-- Use of the software is subject to the agreement between your organization
+-- and Kong Inc. If there is no such agreement, use is governed by and
+-- subject to the terms of the Kong Master Software License Agreement found
+-- at https://konghq.com/enterprisesoftwarelicense/.
+-- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
+
+local build_compound_key = require("kong.runloop.plugins_iterator").build_compound_key
+
+describe("Testing build_compound_key function", function()
+  it("Should create a compound key with all three IDs", function()
+    local result = build_compound_key("route1", "service1", "consumer1")
+    assert.are.equal("route1:service1:consumer1", result)
+  end)
+
+  it("Should create a compound key with only route_id and service_id", function()
+    local result = build_compound_key("route1", "service1", nil)
+    assert.are.equal("route1:service1:", result)
+  end)
+
+  it("Should create a compound key with only route_id and consumer_id", function()
+    local result = build_compound_key("route1", nil, "consumer1")
+    assert.are.equal("route1::consumer1", result)
+  end)
+
+  it("Should create a compound key with only service_id and consumer_id", function()
+    local result = build_compound_key(nil, "service1", "consumer1")
+    assert.are.equal(":service1:consumer1", result)
+  end)
+
+  it("Should create a compound key with only route_id", function()
+    local result = build_compound_key("route1", nil, nil)
+    assert.are.equal("route1::", result)
+  end)
+
+  it("Should create a compound key with only service_id", function()
+    local result = build_compound_key(nil, "service1", nil)
+    assert.are.equal(":service1:", result)
+  end)
+
+  it("Should create a compound key with only consumer_id", function()
+    local result = build_compound_key(nil, nil, "consumer1")
+    assert.are.equal("::consumer1", result)
+  end)
+
+  it("Should create an empty compound key when all parameters are nil", function()
+    local result = build_compound_key(nil, nil, nil)
+    assert.are.equal("::", result)
+  end)
+end)

--- a/spec/01-unit/28-plugins-iterator/02-lookup_cfg_spec.lua
+++ b/spec/01-unit/28-plugins-iterator/02-lookup_cfg_spec.lua
@@ -1,0 +1,61 @@
+-- This software is copyright Kong Inc. and its licensors.
+-- Use of the software is subject to the agreement between your organization
+-- and Kong Inc. If there is no such agreement, use is governed by and
+-- subject to the terms of the Kong Master Software License Agreement found
+-- at https://konghq.com/enterprisesoftwarelicense/.
+-- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
+
+local PluginsIterator = require("kong.runloop.plugins_iterator")
+
+describe("PluginsIterator.lookup_cfg", function()
+	local combos = {
+		["r:s:c"] = "config1",
+		["r::c"] = "config2",
+		[":s:c"] = "config3",
+		["r:s:"] = "config4",
+		["::c"] = "config5",
+		["r::"] = "config6",
+		[":s:"] = "config7",
+		["::"] = "config8"
+	}
+
+	it("returns the correct configuration for a given route, service, consumer combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, "r", "s", "c")
+		assert.equals(result, "config1")
+	end)
+
+	it("returns the correct configuration for a given route, consumer combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, "r", nil, "c")
+		assert.equals(result, "config2")
+	end)
+
+	it("returns the correct configuration for a given service, consumer combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, nil, "s", "c")
+		assert.equals(result, "config3")
+	end)
+
+	it("returns the correct configuration for a given route, service combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, "r", "s", nil)
+		assert.equals(result, "config4")
+	end)
+
+	it("returns the correct configuration for a given consumer combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, nil, nil, "c")
+		assert.equals(result, "config5")
+	end)
+
+	it("returns the correct configuration for a given route combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, "r", nil, nil)
+		assert.equals(result, "config6")
+	end)
+
+	it("returns the correct configuration for a given service combination", function()
+		local result = PluginsIterator.lookup_cfg(combos, nil, "s", nil)
+		assert.equals(result, "config7")
+	end)
+
+	it("returns the correct configuration for the global configuration", function()
+		local result = PluginsIterator.lookup_cfg(combos, nil, nil, nil)
+		assert.equals(result, "config8")
+	end)
+end)


### PR DESCRIPTION
### Data structure to store plugin scope configurations

This patch set changes how the Plugins Iterator finds suitable plugin configurations for defined precedence rules.

To achieve that, we move from a nested table structure that stores various combinations of `route, service and consumer` to a _flat_ hashmap.

**Before.**

```lua
combos[name].rsc[cfg.route_id] =
combos[name].rsc[cfg.route_id] or {}
combos[name].rsc[cfg.route_id][cfg.service_id] =
combos[name].rsc[cfg.route_id][cfg.service_id] or {}
combos[name].rsc[cfg.route_id][cfg.service_id][cfg.consumer_id] = cfg

combos[name].rc[cfg.route_id] =
combos[name].rc[cfg.route_id] or {}
combos[name].rc[cfg.route_id][cfg.consumer_id] = cfg
-- and so on for all possible combinations
```

**After:**

```lua
-- Build a compound key using the route_id, service_id, and consumer_id
local compound_key = PluginsIterator.build_compound_key(route_id, service_id, consumer_id)

-- Store the plugin configuration in the 'combos' table using the compound key as index
combos[name][compound_key] = cfg
```

The `build_compound_key` function concatenates the `ids` of scoped entity to generate a unique index.


### Lookup algorithm

The change to the data structure allows us to move away from the concept of [combo_keys](https://github.com/Kong/kong/blob/fb6aeff909a508cca6746acd5711cea5d927b6d5/kong/runloop/plugins_iterator.lua#L24-L31) to an index based lookup.

**Before:**

```lua
if route_id and service_id and consumer_id and combos[COMBO_RSC]
  and combos.rsc[route_id] and combos.rsc[route_id][service_id]
  and combos.rsc[route_id][service_id][consumer_id]
then
  return combos.rsc[route_id][service_id][consumer_id]
end
```

**After:**

```lua
if route_id and service_id and consumer_id then
  key = build_compound_key(route_id, service_id, consumer_id)
  if combos[key] then
    return combos[key]
  end
end
```


### Aligning db-less and db modes


This patch also streamlines the way these different modes handle configuration retrieval.

In traditional mode, we stored a placeholder value of `true` in the lookup tables to indicate that a configuration is in fact present. This would trigger a cache retrieval with transparent database lookup in case of a cache-miss.

In db-less mode, we saved the entire configuration alongside the lookup table. This reduces the lookup-time by avoiding potentially costly detours to the database, as well as the extra function call to `cache`

The obvious drawbacks are an increased memory footprint _for traditional_ _mode_ as we're saving configuration data alongside the lookup table. 
In _db-less_ mode, the memory footprint should be slightly reduced due to a more efficient/predictable table structure.

This change also allows to drop cache-warmups during Plugins Iterator rebuilds, which speeds rebuild times in _traditional mode_.


#### Past caching behavior in Traditional mode

In the past, we utilized `kong.cache` in traditional mode. When there was a change in the configuration of a plugin, route, service, or consumer Kong would invalidate the core, plugins, and the plugin iterator's cache. Consequently, this would initiate a rebuild process for the plugin iterator.

Whenever a new request was initiated, and the iterator had not completed its rebuild process, the request would bypass the cache and would pull the updated plugin directly from the database.
This approach must not necessarily pose problems, but the information obtained by a plugin is not bound to the state of the plugin iterator. As a result, the system ends up retrieving a prematurely updated plugin.

To resolve this, our latest implementation bypasses cache usage, opting instead to store all data directly in memory. This change guarantees a sealed system operation and facilitates atomic rebuilds, accurately reflecting the behavior we experience in hybrid mode. This is a more efficient and reliable approach, ensuring that plugins have access to the appropriate, timely data, thereby avoiding the earlier stated issue.

### Tests

Tests to support the validity of this change are here:

`kong/spec/02-integration/15-plugins-iterator`


https://konghq.atlassian.net/browse/KAG-1882
