### PR TITLE
perf(router/atc): iterate routes with for loop 

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -181,7 +181,9 @@ local function new_from_scratch(routes, get_exp_and_priority)
 
   local new_updated_at = 0
 
-  for _, r in ipairs(routes) do
+  for i = 1, routes_n do
+    local r = routes[i]
+
     local route = r.route
     local route_id = route.id
 
@@ -240,7 +242,9 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
   local new_updated_at = 0
 
   -- create or update routes
-  for _, r in ipairs(routes) do
+  for i = 1, #routes do
+    local r = routes[i]
+
     local route = r.route
     local route_id = route.id
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`for` loop has better performance than function `ipairs()`, especially for huge table.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
