### PR TITLE
perf(plugin/prometheus): remove the usage of `string.gsub` and `ipairs`

### DIFF
--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -64,7 +64,6 @@ local ngx_re_gsub = ngx.re.gsub
 local ngx_print = ngx.print
 local error = error
 local type = type
-local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local tonumber = tonumber
@@ -189,7 +188,8 @@ local function full_metric_name(name, label_names, label_values)
   -- format "name{k1=v1,k2=v2}"
   buf:put(name):put("{")
 
-  for idx, key in ipairs(label_names) do
+  for idx = 1, #label_names do
+    local key = label_names[idx]
     local label_value = label_values[idx]
 
     -- we only check string value for '\\' and '"'
@@ -273,7 +273,8 @@ local function check_metric_and_label_names(metric_name, label_names)
   if not metric_name:match("^[a-zA-Z_:][a-zA-Z0-9_:]*$") then
     return "Metric name '" .. metric_name .. "' is invalid"
   end
-  for _, label_name in ipairs(label_names or {}) do
+  for i = 1, #label_names do
+    local label_name = label_names[i]
     if label_name == "le" then
       return "Invalid label name 'le' in " .. metric_name
     end
@@ -410,7 +411,8 @@ local function lookup_or_create(self, label_values)
       bucket_pref = self.name .. "_bucket{"
     end
 
-    for i, buc in ipairs(self.buckets) do
+    for i = 1, #self.buckets do
+      local buc = self.buckets[i]
       full_name[i+2] = string.format("%sle=\"%s\"}", bucket_pref, self.bucket_format:format(buc))
     end
     -- Last bucket. Note, that the label value is "Inf" rather than "+Inf"
@@ -642,7 +644,8 @@ local function reset(self)
     name_prefixes[self.name .. "{"] = name_prefix_length_base + 1
   end
 
-  for _, key in ipairs(keys) do
+  for i = 1, #keys do
+    local key = keys[i]
     local value, err = self._dict:get(key)
     if value then
       -- For a metric to be deleted its name should either match exactly, or

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -805,9 +805,10 @@ local function register(self, name, help, label_names, buckets, typ, local_stora
     return
   end
 
-  local name_maybe_historgram = name:gsub("_bucket$", "")
-                                    :gsub("_count$", "")
-                                    :gsub("_sum$", "")
+  local gsub_a = ngx_re_gsub(name, "_bucket$", "", "jo")
+  local gsub_b = ngx_re_gsub(gsub_a, "_count$", "", "jo")
+  local name_maybe_historgram = ngx_re_gsub(gsub_b, "_sum$", "", "jo")
+
   if (typ ~= TYPE_HISTOGRAM and (
       self.registry[name] or self.registry[name_maybe_historgram]
     )) or

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -301,10 +301,14 @@ end
 local function construct_bucket_format(buckets)
   local max_order = 1
   local max_precision = 1
-  for _, bucket in ipairs(buckets) do
+  for i = 1, #buckets do
+    local bucket = buckets[i]
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
+
     -- floating point number with all trailing zeros removed
-    local as_string = string.format("%f", bucket):gsub("0*$", "")
+    local bucket_str = string.format("%f", bucket)
+    local as_string = ngx_re_gsub(bucket_str, "0*$", "", "jo")
+
     local dot_idx = as_string:find(".", 1, true)
     max_order = math.max(max_order, dot_idx - 1)
     max_precision = math.max(max_precision, as_string:len() - dot_idx)

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -812,9 +812,17 @@ local function register(self, name, help, label_names, buckets, typ, local_stora
     return
   end
 
-  local gsub_a = ngx_re_gsub(name, "_bucket$", "", "jo")
-  local gsub_b = ngx_re_gsub(gsub_a, "_count$", "", "jo")
-  local name_maybe_historgram = ngx_re_gsub(gsub_b, "_sum$", "", "jo")
+  local name_maybe_historgram = name
+
+  if string.find(name_maybe_historgram, "_bucket", 1, true) then
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_bucket$", "", "jo")
+  end
+  if string.find(name_maybe_historgram, "_count", 1, true) then
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_count$", "", "jo")
+  end
+  if string.find(name_maybe_historgram, ""_sum, 1, true) then
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_sum$", "", "jo")
+  end
 
   if (typ ~= TYPE_HISTOGRAM and (
       self.registry[name] or self.registry[name_maybe_historgram]

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -273,6 +273,10 @@ local function check_metric_and_label_names(metric_name, label_names)
   if not metric_name:match("^[a-zA-Z_:][a-zA-Z0-9_:]*$") then
     return "Metric name '" .. metric_name .. "' is invalid"
   end
+  if not label_names then
+    return
+  end
+
   for i = 1, #label_names do
     local label_name = label_names[i]
     if label_name == "le" then

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -312,8 +312,7 @@ local function construct_bucket_format(buckets)
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
 
     -- floating point number with all trailing zeros removed
-    local bucket_str = string.format("%f", bucket)
-    local as_string = ngx_re_gsub(bucket_str, "0*$", "", "jo")
+    local as_string = ngx_re_gsub(string.format("%f", bucket), "0*$", "", "jo")
 
     local dot_idx = as_string:find(".", 1, true)
     max_order = math.max(max_order, dot_idx - 1)

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -306,6 +306,7 @@ end
 local function construct_bucket_format(buckets)
   local max_order = 1
   local max_precision = 1
+
   for i = 1, #buckets do
     local bucket = buckets[i]
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
@@ -318,6 +319,7 @@ local function construct_bucket_format(buckets)
     max_order = math.max(max_order, dot_idx - 1)
     max_precision = math.max(max_precision, as_string:len() - dot_idx)
   end
+
   return "%0" .. (max_order + max_precision + 1) .. "." .. max_precision .. "f"
 end
 
@@ -820,7 +822,7 @@ local function register(self, name, help, label_names, buckets, typ, local_stora
   if string.find(name_maybe_historgram, "_count", 1, true) then
     name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_count$", "", "jo")
   end
-  if string.find(name_maybe_historgram, ""_sum, 1, true) then
+  if string.find(name_maybe_historgram, "_sum", 1, true) then
     name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_sum$", "", "jo")
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Import some changes from https://github.com/knyar/nginx-lua-prometheus/pull/131.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
