### PR TITLE
perf(tracing): remove ipairs in spans iteration

### DIFF
--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -16,7 +16,6 @@ local pack = utils.pack
 local unpack = utils.unpack
 local assert = assert
 local pairs = pairs
-local ipairs = ipairs
 local new_tab = base.new_tab
 local time_ns = utils.time_ns
 local tablepool_release = tablepool.release
@@ -317,7 +316,9 @@ do
     __tostring = function(spans)
       local logs_buf = buffer.new(1024)
 
-      for i, span in ipairs(spans) do
+      for i = 1, #spans do
+        local span = spans[i]
+
         logs_buf:putf("\nSpan #%d name=%s", i, span.name)
 
         if span.end_time_ns then
@@ -350,7 +351,8 @@ function _M.runloop_log_after(ctx)
   if type(ctx.KONG_SPANS) == "table" then
     ngx_log(ngx_DEBUG, _log_prefix, "collected " .. #ctx.KONG_SPANS .. " spans: ", lazy_format_spans(ctx.KONG_SPANS))
 
-    for _, span in ipairs(ctx.KONG_SPANS) do
+    for i = 1, #ctx.KONG_SPANS do
+      local span = ctx.KONG_SPANS[i]
       if type(span) == "table" and type(span.release) == "function" then
         span:release()
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`for` loop has better performance than `ipairs()`.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
