### PR TITLE
fix(plugin/prometheus): fix an error of ngx.re.gsub

### DIFF
--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -190,6 +190,9 @@ local function full_metric_name(name, label_names, label_values)
   buf:put(name):put("{")
 
   for idx, key in ipairs(label_names) do
+    local slash, double_slash, reg_slash = [[\]], [[\\]], [[\\]]
+    local quote, slash_quote,  reg_quote = [["]], [[\"]], [["]]
+
     local label_value = label_values[idx]
 
     -- we only check string value for '\\' and '"'
@@ -200,12 +203,12 @@ local function full_metric_name(name, label_names, label_values)
         label_value = string.sub(label_value, 1, pos - 1)
       end
 
-      if string.find(label_value, "\\", 1, true) then
-        label_value = ngx_re_gsub(label_value, "\\", "\\\\", "jo")
+      if string.find(label_value, slash, 1, true) then
+        label_value = ngx_re_gsub(label_value, reg_slash, double_slash, "jo")
       end
 
-      if string.find(label_value, '"', 1, true) then
-        label_value = ngx_re_gsub(label_value, '"', '\\"', "jo")
+      if string.find(label_value, quote, 1, true) then
+        label_value = ngx_re_gsub(label_value, reg_quote, slash_quote, "jo")
       end
     end
 

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -184,15 +184,15 @@ local function full_metric_name(name, label_names, label_values)
     return name
   end
 
+  local slash, double_slash, reg_slash = [[\]], [[\\]], [[\\]]
+  local quote, slash_quote,  reg_quote = [["]], [[\"]], [["]]
+
   local buf = buffer.new(NAME_BUFFER_SIZE_HINT)
 
   -- format "name{k1=v1,k2=v2}"
   buf:put(name):put("{")
 
   for idx, key in ipairs(label_names) do
-    local slash, double_slash, reg_slash = [[\]], [[\\]], [[\\]]
-    local quote, slash_quote,  reg_quote = [["]], [[\"]], [["]]
-
     local label_value = label_values[idx]
 
     -- we only check string value for '\\' and '"'


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The second param of `ngx.re.gsub()` is a regex pattern, 
so `\\` is actually `\`, which is an invalid regex.

Note: `ngx.re.gsub()` is different from `string.gsub()`!

This PR gives the correct regex to `ngx.re.gsub()`.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
