### PR TITLE
docs(developer): correct the plugin development guide url

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -10,7 +10,7 @@ If you are planning on developing on Kong, you'll need a development
 installation. The `master` branch holds the latest unreleased source code.
 
 You can read more about writing your own plugins in the [Plugin Development
-Guide](https://docs.konghq.com/latest/plugin-development/), or browse an
+Guide](https://docs.konghq.com/gateway/latest/plugin-development/), or browse an
 online version of Kong's source code documentation in the [Plugin Development
 Kit (PDK) Reference](https://docs.konghq.com/latest/pdk/).
 


### PR DESCRIPTION
### Summary

Correct the Plugin Development Guide url.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

