### PR TITLE
[Backport release/3.2.x] chore(labeler): add new schema noteworthy path 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -171,7 +171,12 @@ plugins/opentelemetry:
 - kong/plugins/opentelemetry/**/*
 
 schema-change-noteworthy:
-- kong/db/schema/entities/**/*
+- kong/db/schema/**/*.lua
+- kong/**/schema.lua
+- kong/plugins/**/daos.lua
+- plugins-ee/**/daos.lua
+- plugins-ee/**/schema.lua
+- kong/db/dao/*.lua
 
 build/bazel:
 - '**/*.bazel'


### PR DESCRIPTION
Backport https://github.com/Kong/kong/commit/9a95a3282e03116ed54d47cf18aeb9504b312eb2 from https://github.com/Kong/kong/pull/10996.