### PR TITLE
chore(clustering/db): reduce log flooding on clustering and schema validation

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -61,6 +61,9 @@ local RECONFIGURE_TYPE = "RECONFIGURE"
 local _log_prefix = "[clustering] "
 
 
+local no_connected_clients_logged
+
+
 local function handle_export_deflated_reconfigure_payload(self)
   ngx_log(ngx_DEBUG, _log_prefix, "exporting config")
 
@@ -485,7 +488,10 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
     end
 
     if isempty(self.clients) then
-      ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
+      if not no_connected_clients_logged then
+        ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
+        no_connected_clients_logged = true
+      end
       sleep(1)
       -- re-queue the task. wait until we have clients connected
       if push_config_semaphore:count() <= 0 then
@@ -493,6 +499,9 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
       end
 
       goto continue
+
+    else
+      no_connected_clients_logged = nil
     end
 
     ok, err = pcall(self.push_config, self)

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1117,9 +1117,8 @@ validate_fields = function(self, input)
         errors[k] = validation_errors.SCHEMA_CANNOT_VALIDATE
         kong.log.debug(errors[k], ": ", err)
       end
-    elseif self.unvalidated_fields[k]() then
-      kong.log.debug("ignoring validation on ", k, " field")
-    else
+
+    elseif not self.unvalidated_fields[k]() then
       field, err = resolve_field(self, k, field, subschema)
       if field then
         _, errors[k] = self:validate_field(field, v)


### PR DESCRIPTION
### Summary

On control plane there was a debug log written on every second on every worker that had no connected clients. This will now only log it once per worker, until number of connected clients changes.

The schema validation also had a thing called unvalidated fields that caused huge amounts of logs to be written with large config import / validation. (I didn't count but with my example config I got thousands, perhaps tens of thousands of log lines on same second with exactly same uninformal message `2023/06/26 20:08:36 [debug] 72011#0: *10 [kong] init.lua:1121 ignoring validation on updated_at field`).