### PR TITLE
feat(hybrid): report configuration of DP to the CP

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -137,6 +137,8 @@ function _M:communicate(premature)
     end
   end
 
+  local configuration = kong.configuration.remove_sensitive()
+
   -- connection established
   -- first, send out the plugin list and DP labels to CP
   -- The CP will make the decision on whether sync will be allowed
@@ -144,6 +146,7 @@ function _M:communicate(premature)
   local _
   _, err = c:send_binary(cjson_encode({ type = "basic_info",
                                         plugins = self.plugins_list,
+                                        process_conf = configuration,
                                         labels = labels, }))
   if err then
     ngx_log(ngx_ERR, _log_prefix, "unable to send basic information to control plane: ", uri,

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -421,6 +421,10 @@ describe("CP/DP #version check #" .. strategy, function()
         dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
         labels = { some_key = "some_value", b = "aA090).zZ", ["a-._123z"] = "Zz1.-_aA" }
       },
+      ["DP sends process conf"] = {
+        dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+        process_conf = { foo = "bar" },
+      },
     }
 
     local pl1 = utils.cycle_aware_deep_copy(helpers.get_plugins_list())

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -490,7 +490,8 @@ describe("CP/DP #version check #" .. strategy, function()
           node_id = uuid,
           node_version = harness.dp_version,
           node_plugins_list = harness.plugins_list,
-          node_labels = harness.labels
+          node_labels = harness.labels,
+          node_process_conf = harness.process_conf,
         }))
 
         assert.equals("reconfigure", res.type)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3767,6 +3767,7 @@ local function clustering_client(opts)
                                         plugins = opts.node_plugins_list or
                                                   PLUGINS_LIST,
                                         labels = opts.node_labels,
+                                        process_conf = opts.node_process_conf,
                                       }))
   assert(c:send_binary(payload))
 


### PR DESCRIPTION
### Summary

With this patch, kong.conf settings of a DP are self-reported to the CP. Sensitive credentials from kong.conf are redacted before they are sent to the CP.
This patch reports the configuration, LuaCP isn't going to do anything with it just yet. This feature is specific to Kong Inc's Konnect offering.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG - None because the patch has no end-user visible changes (yet)
- [x] There is a user-facing docs PR - None because the patch has no end-user visible changes (yet)

