### PR TITLE
tests(coverage): luacov include untested files

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -364,4 +364,8 @@ jobs:
       shell: bash
       run: |
         lua .ci/luacov-stats-aggregator.lua "luacov-stats-out-" "luacov.stats.out" ${{ github.workspace }}/
-        awk -v RS='Summary\n=+\n' 'NR>1{print $0}' luacov.report.out
+        # The following prints a report with each file sorted by coverage percentage, and the total coverage
+        printf "\n\nCoverage   File\n\n"
+        awk -v RS='Coverage\n-+\n' 'NR>1{print $0}' luacov.report.out | grep -vE "^-|^$" > summary.out
+        cat summary.out | grep -v "^Total" | awk '{printf "%7d%%   %s\n", $4, $1}' | sort -n
+        cat summary.out | grep "^Total" | awk '{printf "%7d%%   %s\n", $4, $1}'

--- a/.luacov
+++ b/.luacov
@@ -1,5 +1,8 @@
 return {
 
+  includeuntestedfiles = {
+    "kong/",
+  },
   runreport = true,
 
   include = {
@@ -9,7 +12,7 @@ return {
 
   exclude = {
     "bazel%-bin/build",
-    "^spec/"
+    "^spec/",
   }
 
 }

--- a/t/pdk.luacov
+++ b/t/pdk.luacov
@@ -1,4 +1,5 @@
 runreport = true
+includeuntestedfiles = true
 
 modules = {
    ["kong.pdk.*"] = ".",


### PR DESCRIPTION
### Summary

Icludes untested files (coverage = 0%) in luacov reports
Modifies the coverage report to print files sorted by coverage in the CI workflow

### Checklist

- [x] (NA) The Pull Request has tests
- [x] (NA) There's an entry in the CHANGELOG
- [x] (NA) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-1914
