### PR TITLE
feat(hmac-auth): add support for RSA signatures

### DIFF
--- a/CHANGELOG/unreleased/kong/11133.yaml
+++ b/CHANGELOG/unreleased/kong/11133.yaml
@@ -1,0 +1,5 @@
+message: "hmac-auth: Added support for RSA signatures"
+type: feature
+scope: Plugin
+prs:
+    - 11133

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -404,6 +404,7 @@ build = {
     ["kong.plugins.hmac-auth.migrations.000_base_hmac_auth"] = "kong/plugins/hmac-auth/migrations/000_base_hmac_auth.lua",
     ["kong.plugins.hmac-auth.migrations.002_130_to_140"] = "kong/plugins/hmac-auth/migrations/002_130_to_140.lua",
     ["kong.plugins.hmac-auth.migrations.003_200_to_210"] = "kong/plugins/hmac-auth/migrations/003_200_to_210.lua",
+    ["kong.plugins.hmac-auth.migrations.004_330_to_340"] = "kong/plugins/hmac-auth/migrations/004_330_to_340.lua",
     ["kong.plugins.hmac-auth.handler"] = "kong/plugins/hmac-auth/handler.lua",
     ["kong.plugins.hmac-auth.access"] = "kong/plugins/hmac-auth/access.lua",
     ["kong.plugins.hmac-auth.schema"] = "kong/plugins/hmac-auth/schema.lua",

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -264,6 +264,32 @@ local compatible_checkers = {
       return has_update
     end
   },
+
+  { 3004000000, --[[ 3.4.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local config_hmacauth_credentials = config_table["hmacauth_credentials"]
+      if not config_hmacauth_credentials then
+        return nil
+      end
+
+      local has_update
+      for _, t in ipairs(config_hmacauth_credentials) do
+        if t["public_key"] ~= nil then
+          t["public_key"] = nil
+          has_update = true
+        end
+      end
+
+      if has_update then
+        log_warn_message("contains configuration 'hmacauth_credentials.public_key'",
+                         "be removed",
+                         dp_version,
+                         log_suffix)
+      end
+
+      return has_update
+    end
+  },
 }
 
 

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -100,12 +100,9 @@ return {
   [3005000000] = {
     cors = {
       "private_network",
-    }
-  },
-
-  [3005000000] = {
+    },
     hmac_auth = {
       "public_key",
     }
-  }
+  },
 }

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -101,5 +101,11 @@ return {
     cors = {
       "private_network",
     }
+  },
+
+  [3005000000] = {
+    hmac_auth = {
+      "public_key",
+    }
   }
 }

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -17,6 +17,7 @@ return {
       { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { username = { type = "string", required = true, unique = true }, },
       { secret = { type = "string", auto = true }, },
+      { public_key = { type = "string" }, },
       { tags   = typedefs.tags },
     },
   },

--- a/kong/plugins/hmac-auth/migrations/004_330_to_340.lua
+++ b/kong/plugins/hmac-auth/migrations/004_330_to_340.lua
@@ -10,9 +10,4 @@ return {
 
     ]],
   },
-  cassandra = {
-    up = [[
-      ALTER TABLE hmacauth_credentials ADD public_key text;
-    ]],
-  }
 }

--- a/kong/plugins/hmac-auth/migrations/004_add_public_key.lua
+++ b/kong/plugins/hmac-auth/migrations/004_add_public_key.lua
@@ -1,0 +1,18 @@
+return {
+  postgres = {
+    up = [[
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY hmacauth_credentials ADD public_key TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+    ]],
+  },
+  cassandra = {
+    up = [[
+      ALTER TABLE hmacauth_credentials ADD public_key text;
+    ]],
+  }
+}

--- a/kong/plugins/hmac-auth/migrations/init.lua
+++ b/kong/plugins/hmac-auth/migrations/init.lua
@@ -2,5 +2,5 @@ return {
   "000_base_hmac_auth",
   "002_130_to_140",
   "003_200_to_210",
-  "004_add_public_key",
+  "004_330_to_340",
 }

--- a/kong/plugins/hmac-auth/migrations/init.lua
+++ b/kong/plugins/hmac-auth/migrations/init.lua
@@ -2,4 +2,5 @@ return {
   "000_base_hmac_auth",
   "002_130_to_140",
   "003_200_to_210",
+  "004_add_public_key",
 }

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -6,6 +6,8 @@ local ALGORITHMS = {
   "hmac-sha256",
   "hmac-sha384",
   "hmac-sha512",
+  "rsa-sha256",
+  "rsa-sha512",
 }
 
 

--- a/spec/03-plugins/19-hmac-auth/01-schema_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/01-schema_spec.lua
@@ -20,7 +20,7 @@ describe("Plugin: hmac-auth (schema)", function()
   it("errors with wrong algorithm", function()
     local ok, err = v({ algorithms = { "sha1024" } }, schema_def)
     assert.is_falsy(ok)
-    assert.equal("expected one of: hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512",
+    assert.equal("expected one of: hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, rsa-sha256, rsa-sha512",
                  err.config.algorithms[1])
   end)
 end)

--- a/spec/05-migration/plugins/hmac-auth/migrations/004_330_to_340_spec.lua
+++ b/spec/05-migration/plugins/hmac-auth/migrations/004_330_to_340_spec.lua
@@ -1,0 +1,7 @@
+local uh = require "spec/upgrade_helpers"
+
+describe("database migration", function ()
+  uh.all_phases("has added the public_key column", function ()
+    assert.table_has_column("hmacauth_credentials", "public_key", "text")
+  end)
+end)


### PR DESCRIPTION
### Summary

The hmac-auth plugin allow authentication with HMAC signatures based on the [draft-cavage-http-signatures](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) draft.
This commit aims to add support for RSA signatures as described in the draft, providing a stronger layer
of security via asymmetric encryption.

Co-authored-by: Jérémy Quilleré <jeremy.quillere@memo.bank>

Note: the feature was coded by @mideuger in #8530, this PR adds cluster compatibility support.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add possible values to `algorithms` (`rsa-sha256` and `rsa-sha512`)
* Add a new field to this plugin's credential (`public_key`)
* Add tests showing failed and succeeded authentications using `rsa` algorithms

### How to test

First, create a RSA key pair : 
```
openssl genrsa -out private_key.pem
openssl rsa -in private_key.pem -pubout -out public_key.pem
```

Then, enable the plugin, create a consumer and a corresponding credential with the public key :
```
curl -X POST http://localhost:8001/plugins \
    --form "name=hmac-auth"  \
    --form "config.algorithms=rsa-sha256" \
    --form "config.algorithms=rsa-sha512"

curl -X POST http://localhost:8001/consumers \
    --form "username=alice"

curl -X POST http://localhost:8001/consumers/alice/hmac-auth \
    --form "username=alice" \
    --form "public_key=@public_key.pem"
```

Finally, make a signed request :
```
export DATE="date: $(echo -n $(TZ=GMT date '+%a, %d %b %Y %T %Z'))"
export SIGNATURE=$(printf %s "${DATE}" | openssl dgst -binary -sha512 -sign private_key.pem | openssl base64 -A)
export AUTHORIZATION='authorization: username="alice", algorithm="rsa-sha512", headers="date", signature="'${SIGNATURE}'"'

curl -X GET http://localhost:8000 \
    --header "${DATE}" \
    --header "${AUTHORIZATION}"
```

### Possible improvements

Here are some improvements that we might want to implement after this one :
* Check public key validity during credential creation/update
* Rebrand the plugin to `HTTP Signature`
* Use `Signature` header to provide the signature (or let it be configurable)
* Implement `keyId` from the draft


### Issue reference

KAG-1934
Closes: #8530
