### PR TITLE
chore(security): add .grype.yaml to ignore negeligible vulnerabilities

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,4 @@
+ignore:
+- fix-state: unknown
+- fix-state: wont-fix
+


### PR DESCRIPTION



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Our release GHA workflow scans generated Docker images and reports vulnerabilities.

Some of the vulnerabilities are negligible and some won't be fixed by upstream. This PR adds a Grype configuration to ignore those vulnerabilities.

According to https://github.com/anchore/grype#configuration and https://github.com/marketplace/actions/anchore-container-scan#additional-configuration, we put the `.grype.yaml` in the root of the repo.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* add `.grype.yaml` to ignore negligible and won't-fix vulnerabilities

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5195
