### PR TITLE
fix(proxy): remove kong branding from kong HTML error template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
 - Added a `User=` specification to the systemd unit definition so that
   Kong can be controlled by systemd again.
   [#11066](https://github.com/Kong/kong/pull/11066)
+- Remove kong branding from kong HTML error template.
+  [#11150](https://github.com/Kong/kong/pull/11150)
 
 #### Admin API
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1422,10 +1422,10 @@ do
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kong Error</title>
+    <title>Error</title>
   </head>
   <body>
-    <h1>Kong Error</h1>
+    <h1>Error</h1>
     <p>%s.</p>
   </body>
 </html>

--- a/spec/02-integration/05-proxy/12-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_default_type_spec.lua
@@ -15,10 +15,10 @@ local HTML_TEMPLATE = [[
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kong Error</title>
+    <title>Error</title>
   </head>
   <body>
-    <h1>Kong Error</h1>
+    <h1>Error</h1>
     <p>%s.</p>
   </body>
 </html>]]

--- a/t/01-pdk/08-response/13-error.t
+++ b/t/01-pdk/08-response/13-error.t
@@ -165,10 +165,10 @@ Content-Type: text/html; charset=utf-8
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kong Error</title>
+    <title>Error</title>
   </head>
   <body>
-    <h1>Kong Error</h1>
+    <h1>Error</h1>
     <p>An invalid response was received from the upstream server.</p>
   </body>
 </html>
@@ -475,10 +475,10 @@ Content-Type: text/html; charset=utf-8
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kong Error</title>
+    <title>Error</title>
   </head>
   <body>
-    <h1>Kong Error</h1>
+    <h1>Error</h1>
     <p>An invalid response was received from the upstream server.</p>
   </body>
 </html>


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

remove kong branding from kong HTML error template
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
FTI-4560

