### PR TITLE
fix(router): don't fail on route with multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@
 
 ### Fixes
 
-
 #### Core
 
 - Fixed a bug that causes `POST /config?flatten_errors=1` to throw an exception
@@ -73,6 +72,8 @@
   [#11150](https://github.com/Kong/kong/pull/11150)
 - Fix a bug that caused sampling rate to be applied to individual spans producing split traces.
   [#11135](https://github.com/Kong/kong/pull/11135)
+- Fix a bug that caused the router to fail in `traditional_compatible` mode when a route with multiple paths and no service was created.
+  [#11158](https://github.com/Kong/kong/pull/11158)
 
 #### Admin API
 
@@ -135,17 +136,17 @@
 - Bumped OpenSSL from 1.1.1t to 3.1.1
   [#10180](https://github.com/Kong/kong/pull/10180)
   [#11140](https://github.com/Kong/kong/pull/11140)
-  
+
 ## 3.3.0
 
 ### Breaking Changes
 
 #### Core
 
-- The `traditional_compat` router mode has been made more compatible with the
+- The `traditional_compatible` router mode has been made more compatible with the
   behavior of `traditional` mode by splitting routes with multiple paths into
   multiple atc routes with separate priorities.  Since the introduction of the new
-  router in Kong Gateway 3.0, `traditional_compat` mode assigned only one priority
+  router in Kong Gateway 3.0, `traditional_compatible` mode assigned only one priority
   to each route, even if different prefix path lengths and regular expressions
   were mixed in a route. This was not how multiple paths were handled in the
   `traditional` router and the behavior has now been changed so that a separate

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -341,7 +341,7 @@ local function split_route_by_path_into(route_and_service, routes_and_services_s
   end
 
   -- make sure that route_and_service contains only the two expected entries, route and service
-  assert(tb_nkeys(route_and_service) == 2)
+  assert(tb_nkeys(route_and_service) == 1 or tb_nkeys(route_and_service) == 2)
 
   local grouped_paths = group_by(
     original_route.paths,

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4729,5 +4729,20 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
       end)
 
     end)
+
+    it("[can create route with multiple paths and no service]", function()
+      local use_case = {
+        -- regex + prefix
+        {
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+            paths = {
+              "/foo",
+              "/foo/bar/baz"
+            },
+          },
+        }}
+      assert(new_router(use_case))
+    end)
   end)
 end


### PR DESCRIPTION
### Summary

In `traditional_compatible` mode, the router would fail to work if a route with multiple paths but no service would be created.

### Checklist

- [X] The Pull Request has tests
- [X] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fixes KAG-1961
