### PR TITLE
refactor(router/compat): reuse table in group_by

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -5,6 +5,7 @@ local bit = require("bit")
 local buffer = require("string.buffer")
 local atc = require("kong.router.atc")
 local tb_new = require("table.new")
+local tb_clear = require("table.clear")
 local tb_nkeys = require("table.nkeys")
 local uuid = require("resty.jit-uuid")
 local utils = require("kong.tools.utils")
@@ -315,18 +316,24 @@ local function get_exp_and_priority(route)
 end
 
 
+local GROUPED_PATHS = {}
+
 -- group array-like table t by the function f, returning a table mapping from
 -- the result of invoking f on one of the elements to the actual elements.
 local function group_by(t, f)
-  local result = {}
-  for _, value in ipairs(t) do
+  local result = GROUPED_PATHS
+  tb_clear(result)
+
+  for i = 1, #t do
+    local value = t[i]
     local key = f(value)
-    if result[key] then
-      tb_insert(result[key], value)
-    else
-      result[key] = { value }
+
+    if not result[key] then
+      result[key] = {}
     end
+    tb_insert(result[key], value)
   end
+
   return result
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Reuse table in function `group_by()` to avoid small table overhead.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
