### PR TITLE
chore(cd): build RPM packages in container matching the distro

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -4,7 +4,7 @@ build-packages:
 # image: docker image name if the build is running in side a container 
 # package: package type
 # package-type: the nfpm packaging target, //:kong_{package} target; only used when package is rpm
-# bazel_args: additional bazel build flags 
+# bazel-args: additional bazel build flags 
 # check-manifest-suite: the check manifest suite as defined in scripts/explain_manifest/config.py
 
 # Ubuntu
@@ -20,7 +20,7 @@ build-packages:
 - label: ubuntu-22.04-arm64
   os: ubuntu-22.04
   package: deb
-  bazel_args: --platforms=//:generic-crossbuild-aarch64
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
   check-manifest-suite: ubuntu-22.04-arm64
 
 # Debian
@@ -79,7 +79,7 @@ build-images:
 # package: package type
 # artifact-from: label of build-packages to use
 # artifact-from-alt: another label of build-packages to use for downloading package (to build multi-arch image)
-# docker_platforms: comma separated list of docker buildx platforms to build for
+# docker-platforms: comma separated list of docker buildx platforms to build for
 
 # Ubuntu
 - label: ubuntu
@@ -87,7 +87,7 @@ build-images:
   package: deb
   artifact-from: ubuntu-22.04
   artifact-from-alt: ubuntu-22.04-arm64
-  docker_platforms: linux/amd64, linux/arm64
+  docker-platforms: linux/amd64, linux/arm64
 
 # Debian
 - label: debian

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -1,9 +1,4 @@
 build-packages:
-# As a general rule, binaries built on one Linux distro will only
-# work on other Linux distros that are the same age or newer.
-# Therefore, if we want to make binaries that run on most Linux distros,
-# we have to use an old enough distro.
-
 # label: used to distinguish artifacts for later use
 # os: the github actions runner label to pick from
 # image: docker image name if the build is running in side a container 
@@ -13,7 +8,8 @@ build-packages:
 
 # Ubuntu
 - label: ubuntu-20.04
-  os: ubuntu-20.04
+  os: ubuntu-22.04
+  image: ubuntu:20.04
   package: deb
   check-manifest-suite: ubuntu-20.04-amd64
 - label: ubuntu-22.04
@@ -51,6 +47,11 @@ build-packages:
   image: centos:7
   package: rpm
   check-manifest-suite: el7-amd64
+- label: rhel-8
+  os: ubuntu-22.04
+  image: rockylinux:8
+  package: rpm
+  check-manifest-suite: el8-amd64
 
 # Amazon Linux
 - label: amazonlinux-2
@@ -58,6 +59,11 @@ build-packages:
   image: amazonlinux:2
   package: rpm
   check-manifest-suite: amazonlinux-2-amd64
+- label: amazonlinux-2023
+  os: ubuntu-22.04
+  image: amazonlinux:2023
+  package: rpm
+  check-manifest-suite: amazonlinux-2023-amd64
 
 build-images:
 # Only build images for the latest version of each major release.
@@ -87,7 +93,7 @@ build-images:
 - label: rhel
   base-image: registry.access.redhat.com/ubi8
   package: rpm
-  artifact-from: rhel-7
+  artifact-from: rhel-8
 
 smoke-tests:
 - label: ubuntu
@@ -151,7 +157,7 @@ release-packages:
   artifact: kong.el7.amd64.rpm
 - label: rhel-8
   package: rpm
-  artifact-from: rhel-7
+  artifact-from: rhel-8
   artifact-version: 8
   artifact-type: rhel
   artifact: kong.el8.amd64.rpm
@@ -165,7 +171,7 @@ release-packages:
   artifact: kong.aws2.amd64.rpm
 - label: amazonlinux-2023
   package: rpm
-  artifact-from: amazonlinux-2
+  artifact-from: amazonlinux-2023
   artifact-version: 2023
   artifact-type: amazonlinux
   artifact: kong.aws2023.amd64.rpm

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -3,6 +3,7 @@ build-packages:
 # os: the github actions runner label to pick from
 # image: docker image name if the build is running in side a container 
 # package: package type
+# package-type: the nfpm packaging target, //:kong_{package} target; only used when package is rpm
 # bazel_args: additional bazel build flags 
 # check-manifest-suite: the check manifest suite as defined in scripts/explain_manifest/config.py
 
@@ -39,6 +40,7 @@ build-packages:
   os: ubuntu-22.04
   image: centos:7
   package: rpm
+  package-type: el7
   check-manifest-suite: el7-amd64
 
 # RHEL
@@ -46,11 +48,13 @@ build-packages:
   os: ubuntu-22.04
   image: centos:7
   package: rpm
+  package-type: el7
   check-manifest-suite: el7-amd64
 - label: rhel-8
   os: ubuntu-22.04
   image: rockylinux:8
   package: rpm
+  package-type: el8
   check-manifest-suite: el8-amd64
 
 # Amazon Linux
@@ -58,11 +62,13 @@ build-packages:
   os: ubuntu-22.04
   image: amazonlinux:2
   package: rpm
+  package-type: aws2
   check-manifest-suite: amazonlinux-2-amd64
 - label: amazonlinux-2023
   os: ubuntu-22.04
   image: amazonlinux:2023
   package: rpm
+  package-type: aws2023
   check-manifest-suite: amazonlinux-2023-amd64
 
 build-images:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,12 +216,12 @@ jobs:
     - name: Build Kong dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-        bazel build --config release //build:kong --verbose_failures ${{ matrix.bazel_args }}
+        bazel build --config release //build:kong --verbose_failures ${{ matrix.bazel-args }}
 
     - name: Package Kong - ${{ matrix.package }}
       if: matrix.package != 'rpm' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-        bazel build --config release :kong_${{ matrix.package }} --verbose_failures ${{ matrix.bazel_args }}
+        bazel build --config release :kong_${{ matrix.package }} --verbose_failures ${{ matrix.bazel-args }}
 
     - name: Package Kong - rpm
       if: matrix.package == 'rpm' && steps.cache-deps.outputs.cache-hit != 'true'
@@ -235,7 +235,7 @@ jobs:
           export RPM_SIGNING_KEY_FILE=$RPM_SIGNING_KEY_FILE
         fi
 
-        bazel build --config release :kong_${{ matrix.package-type }} --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
+        bazel build --config release :kong_${{ matrix.package-type }} --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel-args }}
 
     - name: Bazel Debug Outputs
       if: failure()
@@ -326,7 +326,7 @@ jobs:
           type=raw,enable=${{ matrix.label == 'ubuntu' }},${{ github.sha }}
 
     - name: Set up QEMU
-      if: matrix.docker_platforms != ''
+      if: matrix.docker-platforms != ''
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
@@ -335,7 +335,7 @@ jobs:
     - name: Set platforms
       id: docker_platforms_arg
       run: |
-        platforms="${{ matrix.docker_platforms }}"
+        platforms="${{ matrix.docker-platforms }}"
         if [[ -z "$platforms" ]]; then
           platforms="linux/amd64"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get update && sudo apt-get install -y \
+        sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 automake \
                 build-essential \
                 curl \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,31 +224,7 @@ jobs:
         bazel build --config release :kong_${{ matrix.package }} --verbose_failures ${{ matrix.bazel_args }}
 
     - name: Package Kong - rpm
-      if: |
-        (
-          matrix.package == 'rpm' &&
-          ! startsWith(matrix.label, 'amazonlinux')
-        ) && steps.cache-deps.outputs.cache-hit != 'true'
-      env:
-        RELEASE_SIGNING_GPG_KEY: ${{ secrets.RELEASE_SIGNING_GPG_KEY }}
-        NFPM_RPM_PASSPHRASE: ${{ secrets.RELEASE_SIGNING_GPG_KEY_PASSPHRASE }}
-      # TODO: use separate build targets for each OS
-      run: |
-        if [ -n "${RELEASE_SIGNING_GPG_KEY:-}" ]; then
-          RPM_SIGNING_KEY_FILE=$(mktemp)
-          echo "$RELEASE_SIGNING_GPG_KEY" > $RPM_SIGNING_KEY_FILE
-          export RPM_SIGNING_KEY_FILE=$RPM_SIGNING_KEY_FILE
-        fi
-
-        bazel build --config release :kong_el8 --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
-        bazel build --config release :kong_el7 --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
-
-    - name: Package Amazon Linux
-      if: |
-        (
-          matrix.package == 'rpm' &&
-          startsWith(matrix.label, 'amazonlinux')
-        ) && steps.cache-deps.outputs.cache-hit != 'true'
+      if: matrix.package == 'rpm' && steps.cache-deps.outputs.cache-hit != 'true'
       env:
         RELEASE_SIGNING_GPG_KEY: ${{ secrets.RELEASE_SIGNING_GPG_KEY }}
         NFPM_RPM_PASSPHRASE: ${{ secrets.RELEASE_SIGNING_GPG_KEY_PASSPHRASE }}
@@ -259,8 +235,7 @@ jobs:
           export RPM_SIGNING_KEY_FILE=$RPM_SIGNING_KEY_FILE
         fi
 
-        bazel build --config release :kong_aws2    --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
-        bazel build --config release :kong_aws2023 --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
+        bazel build --config release :kong_${{ matrix.package-type }} --action_env=RPM_SIGNING_KEY_FILE --action_env=NFPM_RPM_PASSPHRASE ${{ matrix.bazel_args }}
 
     - name: Bazel Debug Outputs
       if: failure()

--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -51,6 +51,14 @@ targets = {
         libcxx_max_version="3.4.24",
         cxxabi_max_version="1.3.11",
     ),
+    "amazonlinux-2023-amd64": ExpectSuite(
+        name="Amazon Linux 2023 (amd64)",
+        manifest="fixtures/amazonlinux-2023-amd64.txt",
+        libc_max_version="2.34",
+        # gcc 11.2.1
+        libcxx_max_version="3.4.29",
+        cxxabi_max_version="1.3.13",
+    ),
     "el7-amd64": ExpectSuite(
         name="Redhat 7 (amd64)",
         manifest="fixtures/el7-amd64.txt",
@@ -59,6 +67,15 @@ targets = {
         # gcc 4.8.5
         libcxx_max_version="3.4.19",
         cxxabi_max_version="1.3.7",
+    ),
+    "el8-amd64": ExpectSuite(
+        name="Redhat 8 (amd64)",
+        manifest="fixtures/el8-amd64.txt",
+        use_rpath=True,
+        libc_max_version="2.28",
+        # gcc 8.5.0
+        libcxx_max_version="3.4.25",
+        cxxabi_max_version="1.3.11",
     ),
     "ubuntu-20.04-amd64": ExpectSuite(
         name="Ubuntu 20.04 (amd64)",

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
@@ -1,0 +1,166 @@
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  - libstdc++.so.6
+  - libm.so.6
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libcrypt.so.2
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  OpenSSL   : OpenSSL 3.1.1 30 May 2023
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -1,0 +1,177 @@
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libdl.so.2
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  Rpath     : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libpthread.so.0
+  - libm.so.6
+  - libdl.so.2
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  - libstdc++.so.6
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libdl.so.2
+  - libpthread.so.0
+  - libcrypt.so.1
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  OpenSSL   : OpenSSL 3.1.1 30 May 2023
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Previously we were releasing rhel8 and amazonlinux2022/3 packages from its previous version of distro,
namely rhel7 and amazonlinux2 packages. Because normally libraries are backward compatible, they will just work.
This is also the approach that pypi's prebuilt images are using.

To be able to correctly verify the package and precisely use matching libraries that doesn't rely on backward
compatibility, we now move those packages to build on its matching docker container. This also matches what
we are already doing in EE.

We also move to package only one RPM package for each matrix to reduce the boilterplate code and size of artifact.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-206
