### PR TITLE
fix(router/expressions): http redirection can't work with "expressions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
 - Fix an issue where the router of flavor `expressions` can not work correctly
   when `route.protocols` is set to `grpc` or `grpcs`.
   [#11082](https://github.com/Kong/kong/pull/11082)
+- Fix an issue where the router of flavor `expressions` can not configure https redirection.
+  [#11166](https://github.com/Kong/kong/pull/11166)
 
 #### Admin API
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -304,8 +304,8 @@ end
 
 local function get_exp_and_priority(route)
   if route.expression then
-    ngx_log(ngx_ERR, "expecting a traditional route while expression is given. ",
-                 "Likely it's a misconfiguration. Please check router_flavor")
+    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route). ",
+                     "Likely it's a misconfiguration. Please check the 'router_flavor' config in kong.conf")
   end
 
   local exp      = get_expression(route)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -304,7 +304,7 @@ end
 
 local function get_exp_and_priority(route)
   if route.expression then
-    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route). ",
+    ngx_log(ngx_ERR, "expecting a traditional route while it's not (probably an expressions route). ",
                      "Likely it's a misconfiguration. Please check the 'router_flavor' config in kong.conf")
   end
 

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -31,7 +31,14 @@ local function get_exp_and_priority(route)
     return
   end
 
-  local gen = gen_for_field("net.protocol", OP_EQUAL, route.protocols,
+  local protocols = route.protocols
+
+  -- give the chance for http redirection (301/302/307/308/426)
+  if #protocols == 1 and protocols[1] == "https" then
+    return exp, route.priority
+  end
+
+  local gen = gen_for_field("net.protocol", OP_EQUAL, protocols,
                             function(_, p)
                               return PROTOCOLS_OVERRIDE[p] or p
                             end)

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -34,7 +34,7 @@ local function get_exp_and_priority(route)
   local protocols = route.protocols
 
   -- give the chance for http redirection (301/302/307/308/426)
-  if #protocols == 1 and protocols[1] == "https" then
+  if protocols and #protocols == 1 and protocols[1] == "https" then
     return exp, route.priority
   end
 

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -17,7 +17,6 @@ end
 local mock_tls_server_port = helpers.get_available_port()
 
 local fixtures = {
-  --dns_mock = helpers.dns_mock.new({ mocks_only = true }),
   http_mock = {
     test_upstream_tls_server = fmt([[
       server {
@@ -595,7 +594,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  -- XXX: now flavor "expressions" do not support tcp/tls
+  -- XXX: now flavor "expressions" does not support tcp/tls
   if flavor ~= "expressions" then
   describe("TLS proxy [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     lazy_setup(function()

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -77,8 +77,7 @@ local function gen_route(flavor, r)
 end
 
 
---for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
-for _, flavor in ipairs({ "traditional", "traditional_compatible",  }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
 for _, strategy in helpers.each_strategy() do
   describe("SSL [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     local proxy_client
@@ -596,6 +595,8 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
+  -- XXX: now flavor "expressions" do not support tcp/tls
+  if flavor ~= "expressions" then
   describe("TLS proxy [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -690,8 +691,11 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
   end)
+  end   -- if flavor ~= "expressions" then
 
   describe("SSL [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
+
+    reload_router(flavor)
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -744,6 +748,8 @@ for _, strategy in helpers.each_strategy() do
   end)
 
   describe("kong.runloop.certificate invalid SNI [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
+    reload_router(flavor)
+
     lazy_setup(function()
       assert(helpers.start_kong {
         router_flavor = flavor,
@@ -809,4 +815,4 @@ for _, strategy in helpers.each_strategy() do
 
   end)
 end
-end
+end   -- for flavor

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -44,6 +44,8 @@ local function reload_router(flavor)
   helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
 
   package.loaded["spec.helpers"] = nil
+  package.loaded["kong.global"] = nil
+  package.loaded["kong.cache"] = nil
   package.loaded["kong.db"] = nil
   package.loaded["kong.db.schema.entities.routes"] = nil
   package.loaded["kong.db.schema.entities.routes_subschemas"] = nil

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -16,6 +16,8 @@ local function reload_router(flavor)
   helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
 
   package.loaded["spec.helpers"] = nil
+  package.loaded["kong.global"] = nil
+  package.loaded["kong.cache"] = nil
   package.loaded["kong.db"] = nil
   package.loaded["kong.db.schema.entities.routes"] = nil
   package.loaded["kong.db.schema.entities.routes_subschemas"] = nil

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -16,6 +16,8 @@ local function reload_router(flavor)
   helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
 
   package.loaded["spec.helpers"] = nil
+  package.loaded["kong.global"] = nil
+  package.loaded["kong.cache"] = nil
   package.loaded["kong.db"] = nil
   package.loaded["kong.db.schema.entities.routes"] = nil
   package.loaded["kong.db.schema.entities.routes_subschemas"] = nil


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

KAG-1251

This is a follow up of #11082.

if `route.protocols` has only `https`, we will not add `net.protocol` to expression.
This will give the runloop a chance to check http redirection.

Note:
Now `expressions` does not support `tcp/tls`, so we skip these test cases.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
