### PR TITLE
fix(tests): revive HTTP/2.0 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ bazel-*
 
 worktree/
 bin/bazel
+bin/h2client

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
 GRPCURL_VERSION ?= 1.8.5
 BAZLISK_VERSION ?= 1.17.0
-H2CLIENT_VERSION ?= 0.2.0
+H2CLIENT_VERSION ?= 0.4.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
 

--- a/spec/02-integration/05-proxy/27-unbuffered_spec.lua
+++ b/spec/02-integration/05-proxy/27-unbuffered_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 local random = require "resty.random"
 local rstring = require "resty.string"
 
+
 -- HTTP 1.1 Chunked Body (5 MB)
 local function chunked_random_body()
   local chunk = "2000" .."\r\n" .. rstring.to_hex(random.bytes(4096)) .. "\r\n"
@@ -19,6 +20,25 @@ local function chunked_random_body()
 
     return chunk
   end
+end
+
+
+--- HTTP 2.0 Body (5 MB)
+local function random_body()
+  return rstring.to_hex(random.bytes(5*1024*1024/2))
+end
+
+
+local function http2_client_post(host, port, path, request_body, http_version)
+  local client = helpers.http2_client(host, port, true)
+
+  local response_body, response = client({
+    path = path,
+    body = request_body,
+    http_version = http_version or "HTTP/2.0",
+  })
+
+  return tonumber(response.status), response, response_body
 end
 
 
@@ -88,10 +108,10 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("request latency", function()
-      local buffered_latency
-      local unbuffered_latency
-      local unbuffered_request_latency
-      local unbuffered_response_latency
+      local buffered_latency = 0
+      local unbuffered_latency = 0
+      local unbuffered_request_latency = 0
+      local unbuffered_response_latency = 0
 
       it("is calculated for buffered", function()
         warmup_client:post("/buffered/post", { body = "warmup" })
@@ -129,7 +149,6 @@ for _, strategy in helpers.each_strategy() do
         assert.equal(200, res.status)
 
         unbuffered_latency = tonumber(res.headers["X-Kong-Proxy-Latency"])
-
         assert.is_number(unbuffered_latency)
       end)
 
@@ -272,197 +291,143 @@ for _, strategy in helpers.each_strategy() do
 end
 
 
-if false then
-  -- TODO: needs Lua cURL and that needs curl headers
-  -- TODO: removed because it makes tests red on master
-  local curl = require("cURL") -- luacheck: ignore
+for _, http_version in pairs({ "HTTP/1.1", "HTTP/2.0" }) do
 
+  for _, strategy in helpers.each_strategy() do
+    describe("HTTP #" .. http_version .. " buffered requests/response [#" .. strategy .. "]", function()
+      local warmup_client
+      local proxy_ip
+      local proxy_port
 
-  --- Curl HTTP Body (5 MB)
-  local function ramdom_body()
-    return rstring.to_hex(random.bytes(5*1024*1024/2))
-  end
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services"
+        })
 
+        local service = bp.services:insert()
 
-  local HTTP_VERSIONS = {
-    CURL_HTTP_VERSION_NONE = 0,
-    CURL_HTTP_VERSION_1_0 = 1,
-    CURL_HTTP_VERSION_1_1 = 2,
-    CURL_HTTP_VERSION_2_0 = 3,
-    CURL_HTTP_VERSION_2TLS = 4,
-    CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE = 5
-  }
+        bp.routes:insert({
+          protocols = { "http", "https" },
+          paths = { "/buffered" },
+          request_buffering = true,
+          response_buffering = true,
+          service = service,
+        })
 
+        bp.routes:insert({
+          protocols = { "http", "https" },
+          paths = { "/unbuffered" },
+          request_buffering = false,
+          response_buffering = false,
+          service = service,
+        })
 
-  local function curl_post(url, body, http_version)
-    http_version = http_version or HTTP_VERSIONS["CURL_HTTP_VERSION_2_0"]
+        bp.routes:insert({
+          protocols = { "http", "https" },
+          paths = { "/unbuffered-request" },
+          request_buffering = false,
+          response_buffering = true,
+          service = service,
+        })
 
-    local c = curl.easy{
-      url = url,
-      ssl_verifypeer = false,
-      ssl_verifyhost = false,
-      post = true,
-      postfields = body,
-      --[curl.OPT_VERBOSE] = true,
-      [curl.OPT_HEADER] = true,
-      [curl.OPT_HTTP_VERSION] = http_version,
-    }
-    local response = {}
-    c:setopt_writefunction(table.insert, response)
-    c:perform()
+        bp.routes:insert({
+          protocols = { "http", "https" },
+          paths = { "/unbuffered-response" },
+          request_buffering = true,
+          response_buffering = false,
+          service = service,
+        })
 
-    local status  = c:getinfo_response_code()
-    local full_response = table.concat(response)
-    local raw_headers = string.sub(full_response, 1, c:getinfo(curl.INFO_HEADER_SIZE))
-    local return_body = string.sub(full_response, c:getinfo(curl.INFO_HEADER_SIZE))
+        assert(helpers.start_kong {
+          database = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        })
 
-    --parse headers
-    local return_headers = {}
-    for header in string.gmatch(raw_headers, "[%w%-]+:[^\n]+") do
-      local index = string.find(header, ":")
-      return_headers[string.lower(string.sub(header, 1, index-1))] = string.sub(header, index+2)
-    end
+      end)
 
-    return status, return_headers, return_body
-  end
+      lazy_teardown(function()
+        warmup_client:close()
+        helpers.stop_kong()
+      end)
 
+      before_each(function()
+        proxy_ip = helpers.get_proxy_ip(true, true)
+        proxy_port = helpers.get_proxy_port(true, true)
+        warmup_client = helpers.proxy_client()
+      end)
 
-  for _, version in pairs({ "CURL_HTTP_VERSION_1_1", "CURL_HTTP_VERSION_2_0" }) do
-    local http_version = HTTP_VERSIONS[version]
-    for _, strategy in helpers.each_strategy() do
-      describe("HTTP #" .. version .. " buffered requests/response [#" .. strategy .. "]", function()
-        local warmup_client
-        local base_url
-        local proxy_ip
-        local proxy_port
+      describe("request latency", function()
+        local buffered_latency = 0
+        local unbuffered_latency = 0
+        local unbuffered_request_latency = 0
+        local unbuffered_response_latency = 0
+        local status, headers, _
 
-        lazy_setup(function()
-          local bp = helpers.get_db_utils(strategy, {
-            "routes",
-            "services"
-          })
-
-          local service = bp.services:insert()
-
-          bp.routes:insert({
-            protocols = { "http", "https" },
-            paths = { "/buffered" },
-            request_buffering = true,
-            response_buffering = true,
-            service = service,
-          })
-
-          bp.routes:insert({
-            protocols = { "http", "https" },
-            paths = { "/unbuffered" },
-            request_buffering = false,
-            response_buffering = false,
-            service = service,
-          })
-
-          bp.routes:insert({
-            protocols = { "http", "https" },
-            paths = { "/unbuffered-request" },
-            request_buffering = false,
-            response_buffering = true,
-            service = service,
-          })
-
-          bp.routes:insert({
-            protocols = { "http", "https" },
-            paths = { "/unbuffered-response" },
-            request_buffering = true,
-            response_buffering = false,
-            service = service,
-          })
-
-          assert(helpers.start_kong {
-            database = strategy,
-            nginx_conf = "spec/fixtures/custom_nginx.template",
-          })
-
+        it("is calculated for buffered", function()
+          warmup_client:post("/buffered/post", { body = "warmup" })
+          status, headers, _ = http2_client_post(
+            proxy_ip, proxy_port,
+            "/buffered/post", random_body(),
+            http_version
+          )
+          assert.equal(200, status)
+          buffered_latency = tonumber(headers["x-kong-proxy-latency"])
+          assert.is_number(buffered_latency)
         end)
 
-        lazy_teardown(function()
-          warmup_client:close()
-          helpers.stop_kong()
+        it("is calculated for unbuffered", function()
+          warmup_client:post("/unbuffered/post", { body = "warmup" })
+          status, headers, _ = http2_client_post(
+            proxy_ip, proxy_port,
+            "/unbuffered/post", random_body(),
+            http_version
+          )
+          assert.equal(200, status)
+          unbuffered_latency = tonumber(headers["x-kong-proxy-latency"])
+          assert.is_number(unbuffered_latency)
         end)
 
-        before_each(function()
-          proxy_ip = helpers.get_proxy_ip(true, true)
-          proxy_port = helpers.get_proxy_port(true, true)
-          warmup_client = helpers.proxy_client()
-          base_url = "https://" .. proxy_ip .. ":" .. proxy_port
+        it("is calculated for unbuffered request", function()
+          warmup_client:post("/unbuffered-request/post", { body = "warmup" })
+          status, headers, _ = http2_client_post(
+            proxy_ip, proxy_port,
+            "/unbuffered-request/post", random_body(),
+            http_version
+          )
+          assert.equal(200, status)
+          unbuffered_request_latency = tonumber(headers["x-kong-proxy-latency"])
+          assert.is_number(unbuffered_request_latency)
         end)
 
-        describe("request latency", function()
-          local buffered_latency
-          local unbuffered_latency
-          local unbuffered_request_latency
-          local unbuffered_response_latency
-          local status, headers, _
+        it("is calculated for unbuffered response", function()
+          warmup_client:post("/unbuffered-response/post", { body = "warmup" })
+          status, headers, _ = http2_client_post(
+            proxy_ip, proxy_port,
+            "/unbuffered-response/post", random_body(),
+            http_version
+          )
+          assert.equal(200, status)
+          unbuffered_response_latency = tonumber(headers["x-kong-proxy-latency"])
+          assert.is_number(unbuffered_response_latency)
+        end)
 
-          it("is calculated for buffered", function()
-            warmup_client:post("/buffered/post", { body = "warmup" })
-            status, headers, _ = curl_post(
-              base_url .. "/buffered/post", ramdom_body(),
-              http_version
-            )
-            assert.equal(200, status)
-            buffered_latency = tonumber(headers["x-kong-proxy-latency"])
-            assert.is_number(buffered_latency)
-          end)
+        it("is greater for buffered than unbuffered", function()
+          assert.equal(true, buffered_latency > unbuffered_latency)
+        end)
 
-          it("is calculated for unbuffered", function()
-            warmup_client:post("/unbuffered/post", { body = "warmup" })
-            status, headers, _ = curl_post(
-              base_url .. "/unbuffered/post", ramdom_body(),
-              http_version
-            )
-            assert.equal(200, status)
-            unbuffered_latency = tonumber(headers["x-kong-proxy-latency"])
-            assert.is_number(unbuffered_latency)
-          end)
+        it("is greater for buffered than unbuffered request", function()
+          assert.equal(true, buffered_latency > unbuffered_request_latency)
+        end)
 
-          it("is calculated for unbuffered request", function()
-            warmup_client:post("/unbuffered-request/post", { body = "warmup" })
-            status, headers, _ = curl_post(
-              base_url .. "/unbuffered-request/post", ramdom_body(),
-              http_version
-            )
-            assert.equal(200, status)
-            unbuffered_request_latency = tonumber(headers["x-kong-proxy-latency"])
-            assert.is_number(unbuffered_request_latency)
-          end)
+        it("is greater for unbuffered response than unbuffered", function()
+          assert.equal(true, unbuffered_response_latency > unbuffered_latency)
+        end)
 
-          it("is calculated for unbuffered response", function()
-            warmup_client:post("/unbuffered-response/post", { body = "warmup" })
-            status, headers, _ = curl_post(
-              base_url .. "/unbuffered-response/post", ramdom_body(),
-              http_version
-            )
-            assert.equal(200, status)
-            unbuffered_response_latency = tonumber(headers["x-kong-proxy-latency"])
-            assert.is_number(unbuffered_response_latency)
-          end)
-
-          it("is greater for buffered than unbuffered", function()
-            assert.equal(true, buffered_latency > unbuffered_latency)
-          end)
-
-          it("is greater for buffered than unbuffered request", function()
-            assert.equal(true, buffered_latency > unbuffered_request_latency)
-          end)
-
-          it("is greater for unbuffered response than unbuffered", function()
-            assert.equal(true, unbuffered_response_latency > unbuffered_latency)
-          end)
-
-          it("is greater for unbuffered response than unbuffered request", function()
-            assert.equal(true, unbuffered_response_latency > unbuffered_request_latency)
-          end)
+        it("is greater for unbuffered response than unbuffered request", function()
+          assert.equal(true, unbuffered_response_latency > unbuffered_request_latency)
         end)
       end)
-    end
+    end)
   end
 end


### PR DESCRIPTION
### Summary

As we need to use curl as http clients in tests that use HTTP/2.0, we need to add it to our base images.  This ensures that tests that require curl have it available in all situations (i.e. during migration and upgrade tests, pongo based tests etc.).

This is a revised version of the reversal PR #10599 which switched off the tests for #10595

### Checklist

- [X] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-1105