### PR TITLE
feat(tests): use h2client to replace lua-http in spec.helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ endif
 
 ifeq ($(MACHINE), aarch64)
 GRPCURL_MACHINE ?= arm64
+H2CLIENT_MACHINE ?= arm64
 else
 GRPCURL_MACHINE ?= $(MACHINE)
+H2CLIENT_MACHINE ?= $(MACHINE)
 endif
 
 ifeq ($(MACHINE), aarch64)
@@ -41,6 +43,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
 GRPCURL_VERSION ?= 1.8.5
 BAZLISK_VERSION ?= 1.17.0
+H2CLIENT_VERSION ?= 0.2.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
 
@@ -60,6 +63,11 @@ bin/grpcurl:
 	@curl -s -S -L \
 		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(GRPCURL_MACHINE).tar.gz | tar xz -C bin;
 	@$(RM) bin/LICENSE
+
+bin/h2client:
+	@curl -s -S -L \
+		https://github.com/Kong/h2client/releases/download/v$(H2CLIENT_VERSION)/h2client_$(H2CLIENT_VERSION)_$(OS)_$(H2CLIENT_MACHINE).tar.gz | tar xz -C bin;
+
 
 check-bazel: bin/bazel
 ifndef BAZEL
@@ -88,7 +96,7 @@ install-dev-rocks: build-venv
 	  fi \
 	done;
 
-dev: build-venv install-dev-rocks bin/grpcurl
+dev: build-venv install-dev-rocks bin/grpcurl bin/h2client
 
 build-release: check-bazel
 	$(BAZEL) clean --expunge
@@ -113,11 +121,11 @@ install: dev
 
 clean: check-bazel
 	$(BAZEL) clean
-	$(RM) bin/bazel bin/grpcurl
+	$(RM) bin/bazel bin/grpcurl bin/h2client
 
 expunge: check-bazel
 	$(BAZEL) clean --expunge
-	$(RM) bin/bazel bin/grpcurl
+	$(RM) bin/bazel bin/grpcurl bin/h2client
 
 lint: dev
 	@$(VENV) luacheck -q .
@@ -159,7 +167,7 @@ remove:
 	$(warning 'remove' target is deprecated, please use `make dev` instead)
 	-@luarocks remove kong
 
-dependencies: bin/grpcurl
+dependencies: bin/grpcurl bin/h2client
 	$(warning 'dependencies' target is deprecated, this is now not needed when using `make dev`, but are kept for installation that are not built by Bazel)
 
 	for rock in $(DEV_ROCKS) ; do \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.1" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.5.0" "luacov 0.15.0"
+DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.1" "lua-llthreads2 0.1.6" "ldoc 1.5.0" "luacov 0.15.0"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1015,57 +1015,81 @@ local function gen_grpcurl_opts(opts_t)
 end
 
 
---- Creates an HTTP/2 client, based on the lua-http library.
+--- Creates an HTTP/2 client using golang's http2 package.
+--- Sets `KONG_TEST_DEBUG_HTTP2=1` env var to print debug messages.
 -- @function http2_client
 -- @param host hostname to connect to
 -- @param port port to connect to
--- @param tls boolean indicating whether to establish a tls session
--- @return http2 client
 local function http2_client(host, port, tls)
-  local host = assert(host)
   local port = assert(port)
   tls = tls or false
 
-  -- if Kong/lua-pack is loaded, unload it first
-  -- so lua-http can use implementation from compat53.string
-  package.loaded.string.unpack = nil
-  package.loaded.string.pack = nil
-
-  local request = require "http.request"
-  local req = request.new_from_uri({
-    scheme = tls and "https" or "http",
-    host = host,
-    port = port,
-  })
-  req.version = 2
-  req.tls = tls
-
-  if tls then
-    local http_tls = require "http.tls"
-    local openssl_ctx = require "openssl.ssl.context"
-    local n_ctx = http_tls.new_client_context()
-    n_ctx:setVerify(openssl_ctx.VERIFY_NONE)
-    req.ctx = n_ctx
+  -- Note: set `GODEBUG=http2debug=1` is helpful if you are debugging this go program
+  local tool_path = "bin/h2client"
+  local http2_debug
+  -- note: set env var "KONG_TEST_DEBUG_HTTP2" !! the "_TEST" will be dropped
+  if os.getenv("KONG_DEBUG_HTTP2") then
+    http2_debug = true
+    tool_path = "GODEBUG=http2debug=1 bin/h2client"
   end
 
-  local meta = getmetatable(req) or {}
+  local url = (tls and "https" or "http") .. "://" .. host .. ":" .. port
 
-  meta.__call = function(req, opts)
+  local meta = {}
+  meta.__call = function(_, opts)
     local headers = opts and opts.headers
     local timeout = opts and opts.timeout
 
-    for k, v in pairs(headers or {}) do
-      req.headers:upsert(k, v)
+    local cmd = string.format("%s -url %s -skip-verify", tool_path, url)
+    if headers then
+      local h = {}
+      for k, v in pairs(headers) do
+        table.insert(h, string.format("%s=%s", k, v))
+      end
+      cmd = cmd .. " -headers " .. table.concat(h, ",")
+    end
+    if timeout then
+      cmd = cmd .. " -timeout " .. timeout
     end
 
-    local headers, stream = req:go(timeout)
-    local body = stream:get_body_as_string()
-    return body, headers
+    if http2_debug then
+        print("HTTP/2 cmd:\n" .. cmd)
+    end
+
+    local ok, _, stdout, stderr = pl_utils.executeex(cmd)
+    assert(ok, stderr)
+
+    if http2_debug then
+      print("HTTP/2 debug:\n")
+      print(stderr)
+    end
+
+    local stdout_decoded = cjson.decode(stdout)
+    if not stdout_decoded then
+      error("Failed to decode h2client output: " .. stdout)
+    end
+
+    local headers = stdout_decoded.headers
+    headers.get = function(_, key)
+      if string.sub(key, 1, 1) == ":" then
+        key = string.sub(key, 2)
+      end
+      return headers[key]
+    end
+    setmetatable(headers, {
+      __index = function(headers, key)
+        for k, v in pairs(headers) do
+          if key:lower() == k:lower() then
+            return v
+          end
+        end
+      end
+    })
+    return stdout_decoded.body, headers
   end
 
-  return setmetatable(req, meta)
+  return setmetatable({}, meta)
 end
-
 
 --- returns a pre-configured cleartext `http2_client` for the Kong proxy port.
 -- @function proxy_client_h2c


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Adds a tool `h2client` https://github.com/Kong/h2client for us to easily test http2 requests, possibly also grpc(s) requests.
This removes the requirement of lua-http and possibly lua-curl so that our bump to openssl 3 won't break those libraries.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* chore(dev): install h2client in make dev
* feat(tests): use h2client to replace lua-http in spec.helpers

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
