### PR TITLE
style(router): need not to localize ngx.* in cold path

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -25,12 +25,6 @@ local byte = string.byte
 local bor, band, lshift = bit.bor, bit.band, bit.lshift
 
 
-local ngx       = ngx
-local ngx_log   = ngx.log
-local ngx_WARN  = ngx.WARN
-local ngx_ERR   = ngx.ERR
-
-
 local DOT              = byte(".")
 local TILDE            = byte("~")
 local ASTERISK         = byte("*")
@@ -235,7 +229,7 @@ local function get_priority(route)
     match_weight = match_weight + 1
 
     if headers_count > MAX_HEADER_COUNT then
-      ngx_log(ngx_WARN, "too many headers in route ", route.id,
+      ngx.log(ngx.WARN, "too many headers in route ", route.id,
                         " headers count capped at 255 when sorting")
       headers_count = MAX_HEADER_COUNT
     end
@@ -304,7 +298,7 @@ end
 
 local function get_exp_and_priority(route)
   if route.expression then
-    ngx_log(ngx_ERR, "expecting a traditional route while it's not (probably an expressions route). ",
+    ngx.log(ngx.ERR, "expecting a traditional route while it's not (probably an expressions route). ",
                      "Likely it's a misconfiguration. Please check the 'router_flavor' config in kong.conf")
   end
 

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -11,10 +11,6 @@ local OP_EQUAL    = "=="
 local LOGICAL_AND = atc.LOGICAL_AND
 
 
-local ngx_log = ngx.log
-local ngx_ERR = ngx.ERR
-
-
 -- map to normal protocol
 local PROTOCOLS_OVERRIDE = {
   tls_passthrough = "tcp",
@@ -26,7 +22,7 @@ local PROTOCOLS_OVERRIDE = {
 local function get_exp_and_priority(route)
   local exp = route.expression
   if not exp then
-    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route). ",
+    ngx.log(ngx.ERR, "expecting an expression route while it's not (probably a traditional route). ",
                      "Likely it's a misconfiguration. Please check the 'router_flavor' config in kong.conf")
     return
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`ngx.log` and other `ngx.*` are in cold path, localization of them is unnecessary.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
