### PR TITLE
chore(deps): use kong's fork of pgmoon that fixes an issue when using SCRAM auth with OpenSSL 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@
 - Bumped OpenSSL from 1.1.1t to 3.1.1
   [#10180](https://github.com/Kong/kong/pull/10180)
   [#11140](https://github.com/Kong/kong/pull/11140)
+- Bumped pgmoon from 1.16.0 to 1.16.1 (Kong's fork)
+  [#11181](https://github.com/Kong/kong/pull/11181)
 
 ## 3.3.0
 

--- a/kong-3.4.0-0.rockspec
+++ b/kong-3.4.0-0.rockspec
@@ -22,7 +22,7 @@ dependencies = {
   "multipart == 0.5.9",
   "version == 1.0.1",
   "kong-lapis == 1.14.0.2",
-  "pgmoon == 1.16.0",
+  "kong-pgmoon == 1.16.1",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.8",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Temporary switch to Kong's fork since 3.4 is close and upstream may not merge our PR in time.
Changes included are in https://github.com/Kong/pgmoon/pull/30.

In the future, the Kong's fork should be unified into one, that re-based on a more recent version of
pgmoon upstream. Almost all of the features we put in our fork has been implemented in a different
way in upstream later.

This change should not be cherry-picked to EE.

### Checklist

- [na] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

chore(deps): use kong's fork of pgmoon that fixes an issue when using SCRAM auth with OpenSSL 3.x

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-1936
