### PR TITLE
fix(luajit): fix LuaJIT arm64 SIGILL crash.

### DIFF
--- a/build/openresty/patches/LuaJIT-2.1-20220411_05_arm64_sigill.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20220411_05_arm64_sigill.patch
@@ -1,0 +1,26 @@
+From 56f0ff1a7bcb3bacdefa3c0f4b0a6a3efcf90bd5 Mon Sep 17 00:00:00 2001
+From: Zhongwei Yao <zhongwei.yao@konghq.com>
+Date: Tue, 4 Jul 2023 15:20:19 -0800
+Subject: [PATCH] Fix fuse case for LDP instuction on Arm64 when offset is
+ negative.
+
+---
+ src/lj_emit_arm64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bundle/LuaJIT-2.1-20220411/src/lj_emit_arm64.h b/bundle/LuaJIT-2.1-20220411/src/lj_emit_arm64.h
+index 0ddba4a3..e19a8e4a 100644
+--- a/bundle/LuaJIT-2.1-20220411/src/lj_emit_arm64.h
++++ b/bundle/LuaJIT-2.1-20220411/src/lj_emit_arm64.h
+@@ -143,7 +143,7 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
+       goto nopair;
+     }
+     if (ofsm >= (int)((unsigned int)-64<<sc) && ofsm <= (63<<sc)) {
+-      *as->mcp = aip | A64F_N(rn) | ((ofsm >> sc) << 15) |
++      *as->mcp = aip | A64F_N(rn) | (((ofsm >> sc)&0x7f) << 15) |
+ 	(ai ^ ((ai == A64I_LDRx || ai == A64I_STRx) ? 0x50000000 : 0x90000000));
+       return;
+     }
+-- 
+2.41.0
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
This fix removes the blocker to enable JIT on arm64 platform like MacOS M1/M2 chips. And the patch is under up-streaming processing. Once the LuaJIT-2.1-20220411_05_arm64_sigill.patch has been merged in upstream, we can pull the latest upstream and remove this internal maintained patch.

### Checklist

- [NA] The Pull Request has tests
- [NA] There's an entry in the CHANGELOG
- [NA] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
