### PR TITLE
[backport #11176] chore(build): upgrade Docker base image during build (#11176)

### DIFF
--- a/build/dockerfiles/apk.Dockerfile
+++ b/build/dockerfiles/apk.Dockerfile
@@ -17,7 +17,8 @@ ARG KONG_ARTIFACT=kong.${TARGETARCH}.apk.tar.gz
 ARG KONG_ARTIFACT_PATH=
 COPY ${KONG_ARTIFACT_PATH}${KONG_ARTIFACT} /tmp/kong.apk.tar.gz
 
-RUN apk add --virtual .build-deps tar gzip \
+RUN apk upgrade --update-cache \
+    && apk add --virtual .build-deps tar gzip \
     && tar -C / -xzf /tmp/kong.apk.tar.gz \
     && apk add --no-cache libstdc++ libgcc pcre perl tzdata libcap zlib zlib-dev bash yaml \
     && adduser -S kong \

--- a/build/dockerfiles/deb.Dockerfile
+++ b/build/dockerfiles/deb.Dockerfile
@@ -18,6 +18,8 @@ ARG KONG_ARTIFACT_PATH=
 COPY ${KONG_ARTIFACT_PATH}${KONG_ARTIFACT} /tmp/kong.deb
 
 RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y autoremove \
     && apt-get install -y --no-install-recommends /tmp/kong.deb \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \

--- a/build/dockerfiles/rpm.Dockerfile
+++ b/build/dockerfiles/rpm.Dockerfile
@@ -32,7 +32,8 @@ ARG KONG_ARTIFACT_PATH=
 COPY ${KONG_ARTIFACT_PATH}${KONG_ARTIFACT} /tmp/kong.rpm
 
 # hadolint ignore=DL3015
-RUN yum install -y /tmp/kong.rpm \
+RUN yum update -y \
+    && yum install -y /tmp/kong.rpm \
     && rm /tmp/kong.rpm \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 /usr/local/kong \


### PR DESCRIPTION
Backport https://github.com/Kong/kong/pull/11176.

Vulnerability scan related.

FTI-5195