### PR TITLE
fix(build): add missing debug symbols in the default nginx binary for bazel output

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -186,14 +186,12 @@ CONFIGURE_OPTIONS = [
         "--with-debug",
         "--with-no-pool-patch",
         "--with-cc-opt=\"-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -g -O0\"",
-
     ],
     "//conditions:default": [],
 }) + select({
     "@kong//:fips_flag": [
         "--with-cc-opt=\"-I$$EXT_BUILD_DEPS$$/include\"",
         "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/lib -Wl,-Bsymbolic-functions -Wl,-z,relro\"",
-
     ],
     "//conditions:default": [],
 })

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -185,7 +185,8 @@ CONFIGURE_OPTIONS = [
     "@kong//:debug_flag": [
         "--with-debug",
         "--with-no-pool-patch",
-        "--with-cc-opt=\"-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC\"",
+        "--with-cc-opt=\"-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -ggdb3 -O0\"",
+
     ],
     "//conditions:default": [],
 }) + select({

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -193,6 +193,7 @@ CONFIGURE_OPTIONS = [
     "@kong//:fips_flag": [
         "--with-cc-opt=\"-I$$EXT_BUILD_DEPS$$/include\"",
         "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/lib -Wl,-Bsymbolic-functions -Wl,-z,relro\"",
+
     ],
     "//conditions:default": [],
 })

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -185,7 +185,7 @@ CONFIGURE_OPTIONS = [
     "@kong//:debug_flag": [
         "--with-debug",
         "--with-no-pool-patch",
-        "--with-cc-opt=\"-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -ggdb3 -O0\"",
+        "--with-cc-opt=\"-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -g -O0\"",
 
     ],
     "//conditions:default": [],


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Default bazel build output missing some c function debug symbol.
Before this patch:

![image](https://github.com/Kong/kong/assets/39181969/67e3668d-119a-4b75-96db-27f83d19fa3b)


After this Patch:
![image](https://github.com/Kong/kong/assets/39181969/5d061c65-96f4-4bc8-aebf-909292fd63ad)


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests （No Need）
- [x] There's an entry in the CHANGELOG （No Need）
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE （No Need）

### Full changelog

* [Implement ...]

### Issue reference

