### PR TITLE
style(router/compat): always use uint64 in compatible priority

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -349,8 +349,8 @@ do
 end
 
 
-local PLAIN_HOST_ONLY_BIT = lshift(0x01ULL, 60)
-local REGEX_URL_BIT       = lshift(0x01ULL, 51)
+local PLAIN_HOST_ONLY_BIT = lshift_uint64(0x01ULL, 60)
+local REGEX_URL_BIT       = lshift_uint64(0x01ULL, 51)
 
 
 -- convert a route to a priority value for use in the ATC router


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

In Lua `number` can not support `uint64`, `lshift(1, 60)` has potential risk,
this PR change it to cdata `uint64` to make it safer.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
