### PR TITLE
fix(core): flush vault cache before rebuilding

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -642,6 +642,7 @@ do
       if plugins_hash ~= CURRENT_PLUGINS_HASH then
         local start = get_now_ms()
 
+        kong.vault.flush()
         plugins_iterator, err = new_plugins_iterator()
         if not plugins_iterator then
           return nil, err
@@ -659,7 +660,6 @@ do
 
       kong.core_cache:purge()
       kong.cache:purge()
-      kong.vault.flush()
 
       if router then
         ROUTER = router


### PR DESCRIPTION
### Summary

The vault cache was previously flushed only after the new configuration was processed.  This caused previous plugin instances not to see new vault values during initialization.  The problem was first visible in hybrid mode during SDET testing and the purpose of this commit is to verify that the problem goes away when the vault cache is flushed before the plugins iterator is rebuilt.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2029