### PR TITLE
fix(dbless): perform uniqueness checks on unique fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 
 #### Core
 
+- Declarative config now performs proper uniqueness checks against its inputs:
+  previously, it would silently drop entries with conflicting primary/endpoint
+  keys, or accept conflicting unique fields silently.
+  [#11199](https://github.com/Kong/kong/pull/11199)
 - Fixed a bug that causes `POST /config?flatten_errors=1` to throw an exception
   and return a 500 error under certain circumstances.
   [#10896](https://github.com/Kong/kong/pull/10896)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -504,6 +504,11 @@ local function get_key_for_uuid_gen(entity, item, schema, parent_fk, child_key)
     return
   end
 
+  if schema.cache_key then
+    local key = build_cache_key(entity, item, schema, parent_fk, child_key)
+    return pk_name, key
+  end
+
   if schema.endpoint_key and item[schema.endpoint_key] ~= nil then
     local key = item[schema.endpoint_key]
 
@@ -530,10 +535,6 @@ local function get_key_for_uuid_gen(entity, item, schema, parent_fk, child_key)
 
     -- generate a PK based on the endpoint_key
     return pk_name, key
-  end
-
-  if schema.cache_key then
-    return pk_name, build_cache_key(entity, item, schema, parent_fk, child_key)
   end
 
   return pk_name

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -360,6 +360,7 @@ local function populate_references(input, known_entities, by_id, by_key, expecte
           errs[entity][i] = uniqueness_error_msg(entity, "primary key", item_id)
         else
           by_id[entity][item_id] = item
+          table.insert(by_id[entity], item_id)
         end
       end
 
@@ -752,7 +753,10 @@ local function flatten(self, input)
 
     local schema = all_schemas[entity]
     entities[entity] = {}
-    for id, entry in pairs(entries) do
+
+    for _, id in ipairs(entries) do
+      local entry = entries[id]
+
       local flat_entry = {}
       for name, field in schema:each_field(entry) do
         if field.type == "foreign" and type(entry[name]) == "string" then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -377,10 +377,9 @@ local function validate_references(self, input)
   local by_id = {}
   local by_key = {}
   local expected = {}
+  local errs = {}
 
   populate_references(input, self.known_entities, by_id, by_key, expected)
-
-  local errors = {}
 
   for a, as in pairs(expected) do
     yield(true)
@@ -394,20 +393,20 @@ local function validate_references(self, input)
         local found = find_entity(key, b, by_key, by_id)
 
         if not found then
-          errors[a] = errors[a] or {}
-          errors[a][k.at] = errors[a][k.at] or {}
+          errs[a] = errs[a] or {}
+          errs[a][k.at] = errs[a][k.at] or {}
           local msg = "invalid reference '" .. k.key .. ": " ..
                       (type(k.value) == "string"
                       and k.value or cjson_encode(k.value)) ..
                       "' (no such entry in '" .. b .. "')"
-          insert(errors[a][k.at], msg)
+          insert(errs[a][k.at], msg)
         end
       end
     end
   end
 
-  if next(errors) then
-    return nil, errors
+  if next(errs) then
+    return nil, errs
   end
 
   return by_id, by_key

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -36,6 +36,9 @@ local function search_directive(tbl, directive_name, directive_value)
 end
 
 
+local DATABASE = os.getenv("KONG_DATABASE") or "postgres"
+
+
 describe("Configuration loader", function()
   it("loads the defaults", function()
     local conf = assert(conf_loader())
@@ -261,7 +264,7 @@ describe("Configuration loader", function()
 
     local conf = assert(conf_loader("spec/fixtures/to-strip.conf"))
 
-    assert.equal("postgres", conf.database)
+    assert.equal(DATABASE, conf.database)
     assert.equal("debug", conf.log_level)
   end)
   it("overcomes penlight's list_delim option", function()
@@ -722,6 +725,7 @@ describe("Configuration loader", function()
           ssl_cipher_suite = "old",
           client_ssl = "on",
           role = "control_plane",
+          database = "postgres",
           status_listen = "127.0.0.1:123 ssl",
           proxy_listen = "127.0.0.1:456 ssl",
           admin_listen = "127.0.0.1:789 ssl"
@@ -1040,6 +1044,7 @@ describe("Configuration loader", function()
         it("doesn't load cluster_cert or cluster_ca_cert for control plane", function()
           local conf, _, errors = conf_loader(nil, {
             role = "control_plane",
+            database = "postgres",
             cluster_cert = "spec/fixtures/kong_clustering.crt",
             cluster_cert_key = "spec/fixtures/kong_clustering.key",
             cluster_ca_cert = "spec/fixtures/kong_clustering_ca.crt",
@@ -1368,7 +1373,7 @@ describe("Configuration loader", function()
       os.getenv = function() end -- luacheck: ignore
 
       local conf = assert(conf_loader(helpers.test_conf_path))
-      assert.equal("postgres", conf.database)
+      assert.equal(DATABASE, conf.database)
     end)
     it("honors path if provided even if a default file exists", function()
       conf_loader.add_default_path("spec/fixtures/to-strip.conf")
@@ -1382,7 +1387,7 @@ describe("Configuration loader", function()
       os.getenv = function() end -- luacheck: ignore
 
       local conf = assert(conf_loader(helpers.test_conf_path))
-      assert.equal("postgres", conf.database)
+      assert.equal(DATABASE, conf.database)
     end)
   end)
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -822,10 +822,21 @@ describe("Admin API #off", function()
 
       assert.response(res).has.status(201)
 
+
+      res = client:get("/upstreams/foo/targets")
+      assert.response(res).has.status(200)
+
+      local json = assert.response(res).has.jsonbody()
+      assert.is_table(json.data)
+      assert.same(1, #json.data)
+      assert.is_table(json.data[1])
+
+      local id = assert.is_string(json.data[1].id)
+
       helpers.wait_until(function()
         local res = assert(client:send {
           method = "PUT",
-          path = "/upstreams/foo/targets/c830b59e-59cc-5392-adfd-b414d13adfc4/10.20.30.40/unhealthy",
+          path = "/upstreams/foo/targets/" .. id .. "/10.20.30.40/unhealthy",
         })
 
         return pcall(function()

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -465,6 +465,8 @@ for _, strategy in helpers.each_strategy() do
       -- remove the upstream
       if strategy ~= "off" then
         bu.remove_upstream(bp, upstream_id)
+      else
+        bp.done()
       end
 
       -- add the upstream again

--- a/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/daos.lua
@@ -1,0 +1,31 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  {
+    name = "ck_vs_ek_testcase",
+    primary_key = { "id" },
+    endpoint_key = "name",
+    cache_key = { "route", "service" },
+    fields = {
+      { id = typedefs.uuid },
+      { name = typedefs.utf8_name }, -- this typedef declares 'unique = true'
+      { service = { type = "foreign", reference = "services", on_delete = "cascade",
+                    default = ngx.null, unique = true }, },
+      { route   = { type = "foreign", reference = "routes", on_delete = "cascade",
+                    default = ngx.null, unique = true }, },
+    },
+    entity_checks = {
+      { mutually_exclusive = {
+          "service",
+          "route",
+        }
+      },
+      { at_least_one_of = {
+          "service",
+          "route",
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/handler.lua
@@ -1,0 +1,4 @@
+return {
+  PRIORITY = 1,
+  VERSION = "1.0",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/migrations/000_base_cache_key_vs_endpoint_key.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/migrations/000_base_cache_key_vs_endpoint_key.lua
@@ -1,0 +1,25 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS "ck_vs_ek_testcase" (
+        "id"          UUID  PRIMARY KEY,
+        "name"        TEXT,
+        "route_id"    UUID  REFERENCES "routes" ("id") ON DELETE CASCADE,
+        "service_id"  UUID  REFERENCES "services" ("id") ON DELETE CASCADE,
+        "cache_key"   TEXT  UNIQUE
+      );
+
+      DO $$
+      BEGIN
+        CREATE UNIQUE INDEX IF NOT EXISTS "ck_vs_ek_testcase_name_idx"
+          ON "ck_vs_ek_testcase" ("name");
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE UNIQUE INDEX IF NOT EXISTS "ck_vs_ek_testcase_cache_key_idx"
+          ON "ck_vs_ek_testcase" ("cache_key");
+      END$$;
+    ]],
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/migrations/init.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/migrations/init.lua
@@ -1,0 +1,3 @@
+return {
+  "000_base_unique_foreign",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache-key-vs-endpoint-key/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "cache-key-vs-endpoint-key",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

DB-less mode wasn't performing proper uniqueness checks on declarative config inputs. This is especially problematic on
primary and endpoint keys. This would cause entities to be silently dropped: in the event of conflicting keys, the last one lexically present in the input file would take precedence.

For other unique fields, when using Hybrid mode you would eventually get a database error as the DB would have the uniqueness constraint set, but for pure DB-less you would get inconsistent data.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG

### Full changelog

* Declarative config now performs proper uniqueness checks against its inputs: previously, it would silently drop entries with conflicting primary/endpoint keys, or accept conflicting unique fields silently.
