### PR TITLE
fix(vaults): use separate cache for secrets

### DIFF
--- a/kong/global.lua
+++ b/kong/global.lua
@@ -227,7 +227,7 @@ local function get_lru_size(kong_config)
 end
 
 
-function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
+function _GLOBAL.init_cache(shm_name, kong_config, cluster_events, worker_events, lru_size)
   local db_cache_ttl = kong_config.db_cache_ttl
   local db_cache_neg_ttl = kong_config.db_cache_neg_ttl
   local page = 1
@@ -239,7 +239,7 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
    end
 
   return kong_cache.new({
-    shm_name        = "kong_db_cache",
+    shm_name        = shm_name,
     cluster_events  = cluster_events,
     worker_events   = worker_events,
     ttl             = db_cache_ttl,
@@ -248,33 +248,7 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     page            = page,
     cache_pages     = cache_pages,
     resty_lock_opts = LOCK_OPTS,
-    lru_size        = get_lru_size(kong_config),
-  })
-end
-
-
-function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
-  local db_cache_ttl = kong_config.db_cache_ttl
-  local db_cache_neg_ttl = kong_config.db_cache_neg_ttl
-  local page = 1
-  local cache_pages = 1
-
-  if kong_config.database == "off" then
-    db_cache_ttl = 0
-    db_cache_neg_ttl = 0
-  end
-
-  return kong_cache.new({
-    shm_name        = "kong_core_db_cache",
-    cluster_events  = cluster_events,
-    worker_events   = worker_events,
-    ttl             = db_cache_ttl,
-    neg_ttl         = db_cache_neg_ttl or db_cache_ttl,
-    resurrect_ttl   = kong_config.resurrect_ttl,
-    page            = page,
-    cache_pages     = cache_pages,
-    resty_lock_opts = LOCK_OPTS,
-    lru_size        = get_lru_size(kong_config),
+    lru_size        = lru_size or get_lru_size(kong_config),
   })
 end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -743,7 +743,7 @@ function Kong.init_worker()
   end
   kong.cluster_events = cluster_events
 
-  local cache, err = kong_global.init_cache(kong.configuration, cluster_events, worker_events)
+  local cache, err = kong_global.init_cache("kong_db_cache", kong.configuration, cluster_events, worker_events)
   if not cache then
     stash_init_worker_error("failed to instantiate 'kong.cache' module: " ..
                             err)
@@ -751,13 +751,21 @@ function Kong.init_worker()
   end
   kong.cache = cache
 
-  local core_cache, err = kong_global.init_core_cache(kong.configuration, cluster_events, worker_events)
+  local core_cache, err = kong_global.init_cache("kong_core_db_cache", kong.configuration, cluster_events, worker_events)
   if not core_cache then
     stash_init_worker_error("failed to instantiate 'kong.core_cache' module: " ..
-                            err)
+      err)
     return
   end
   kong.core_cache = core_cache
+
+  local vault_cache, err = kong_global.init_cache("kong_vault_cache", kong.configuration, cluster_events, worker_events)
+  if not vault_cache then
+    stash_init_worker_error("failed to instantiate 'kong.vault_cache' module: " ..
+      err)
+    return
+  end
+  kong.vault_cache = vault_cache
 
   kong.db:set_events_handler(worker_events)
 

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -409,7 +409,7 @@ local function new(self)
     local config, hash = get_config(base_config, opts.config, schema)
 
     return retrieve_value(strategy, config, hash, reference, opts.resource, name,
-                          opts.version, opts.key, self and self.core_cache,
+                          opts.version, opts.key, self and self.vault_cache,
                           rotation, cache_only)
   end
 
@@ -417,7 +417,7 @@ local function new(self)
   local function config_secret(reference, opts, rotation, cache_only)
     local prefix = opts.name
     local vaults = self.db.vaults
-    local cache = self.core_cache
+    local cache = self.vault_cache
     local vault
     local err
     if cache then
@@ -852,7 +852,7 @@ local function new(self)
 
 
   local function flush_config_cache(data)
-    local cache = self.core_cache
+    local cache = self.vault_cache
     if cache then
       local vaults = self.db.vaults
       local old_entity = data.old_entity

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -683,6 +683,10 @@ do
       if plugins_hash ~= CURRENT_PLUGINS_HASH then
         local start = get_now_ms()
 
+        -- Flush vaults LRU cache so that no stale vault references are used.
+        -- kong.vault_cache does not need to be purged as it always uses parsed
+        -- vault references as keys.
+        kong.vault.flush()
         plugins_iterator, err = new_plugins_iterator()
         if not plugins_iterator then
           return nil, err
@@ -713,7 +717,6 @@ do
 
       kong.core_cache:purge()
       kong.cache:purge()
-      kong.vault.flush()
 
       if router then
         ROUTER = router

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -23,6 +23,8 @@ lua_shared_dict kong_core_db_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_core_db_cache_miss     12m;
 lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
+lua_shared_dict kong_vault_cache            200k;
+lua_shared_dict kong_vault_cache_miss       200k;
 
 underscores_in_headers on;
 > if ssl_ciphers then

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -45,6 +45,9 @@ http {
 > if database == "off" then
     lua_shared_dict kong_db_cache_miss_2 12m;
 > end
+    lua_shared_dict kong_vault_cache      200k;
+    lua_shared_dict kong_vault_cache_miss 200k;
+
     lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_cluster_events 5m;
     lua_shared_dict kong_healthchecks   5m;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -94,6 +94,8 @@ http {
     lua_shared_dict kong_core_db_cache_miss     12m;
     lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss          12m;
+    lua_shared_dict kong_vault_cache            200k;
+    lua_shared_dict kong_vault_cache_miss       200k;
 > if role == "control_plane" then
     lua_shared_dict kong_clustering             5m;
 > end
@@ -937,6 +939,8 @@ stream {
     lua_shared_dict stream_kong_core_db_cache_miss     12m;
     lua_shared_dict stream_kong_db_cache               ${{MEM_CACHE_SIZE}};
     lua_shared_dict stream_kong_db_cache_miss          12m;
+    lua_shared_dict kong_vault_cache                   200k;
+    lua_shared_dict kong_vault_cache_miss              200k;
 
 > if ssl_ciphers then
     ssl_ciphers ${{SSL_CIPHERS}};

--- a/spec/fixtures/default_nginx.template
+++ b/spec/fixtures/default_nginx.template
@@ -52,6 +52,9 @@ http {
 > if role == "control_plane" then
     lua_shared_dict kong_clustering             5m;
 > end
+    lua_shared_dict kong_vault_cache            200k;
+    lua_shared_dict kong_vault_cache_miss       200k;
+
     lua_shared_dict kong_mock_upstream_loggers  10m;
 
     underscores_in_headers on;


### PR DESCRIPTION
### Summary

Secrets retrieved from vaults are now stored in a separate cache.  This prevents them from being flashed during reconfigurations.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2057