### PR TITLE
fix(admin): fix admin api /tags/:tag return empty object instead of an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,8 @@
 - Fix an issue where `/schemas/plugins/validate` endpoint fails to validate valid plugin configuration
   when the key of `custom_fields_by_lua` contains dot character(s).
   [#11091](https://github.com/Kong/kong/pull/11091)
+- Fix an issue that the `data` of Admin API `/tags/:tag` response becomes empty object when no data.
+  [#11213](https://github.com/Kong/kong/pull/11213)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,7 @@
 - Fix an issue where `/schemas/plugins/validate` endpoint fails to validate valid plugin configuration
   when the key of `custom_fields_by_lua` contains dot character(s).
   [#11091](https://github.com/Kong/kong/pull/11091)
-- Fix an issue that the `data` of Admin API `/tags/:tag` response becomes empty object when no data.
+- Fix an issue with the `/tags/:tag` Admin API returning a JSON object (`{}`) instead of an array (`[]`) for empty data sets.
   [#11213](https://github.com/Kong/kong/pull/11213)
 
 #### Plugins

--- a/kong/db/dao/tags.lua
+++ b/kong/db/dao/tags.lua
@@ -1,3 +1,4 @@
+local cjson = require "cjson"
 local Tags = {}
 
 function Tags:page_by_tag(tag, size, offset, options)
@@ -10,6 +11,9 @@ function Tags:page_by_tag(tag, size, offset, options)
   local rows, err_t, offset = self.strategy:page_by_tag(tag, size, offset, options)
   if err_t then
     return rows, tostring(err_t), err_t
+  end
+  if type(rows) == "table" then
+    setmetatable(rows, cjson.array_mt)
   end
   return rows, nil, nil, offset
 end

--- a/spec/02-integration/04-admin_api/14-tags_spec.lua
+++ b/spec/02-integration/04-admin_api/14-tags_spec.lua
@@ -200,6 +200,16 @@ describe("Admin API - tags", function()
         assert.equals(2, #json.data)
       end)
 
+      it("/tags/:tags with a not exist tag", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/tags/does-not-exist"
+        })
+        local body = assert.res_status(200, res)
+        local ok = string.find(body, '"data":[]', nil, true)
+        assert.truthy(ok)
+      end)
+
       it("/tags/:tags with invalid :tags value", function()
         local res = assert(client:send {
           method = "GET",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5221
