### PR TITLE
chore(build): bump nfpm to v2.31.0 + use tree nfpm type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,8 @@ jobs:
           echo "release-label=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
         fi
 
-        matrix_file=".github/matrix-commitly.yml"
-        if [ "$FULL_RELEASE" == "true" ]; then
-          matrix_file=".github/matrix-full.yml"
-        fi
+        # XXX revert before merging feat/wasmx!
+        matrix_file=".github/matrix-full.yml"
 
         if [ "${{ github.event.inputs.official }}" == "true" ]; then
           release_desc="$KONG_VERSION (official)"

--- a/build/dockerfiles/apk.Dockerfile
+++ b/build/dockerfiles/apk.Dockerfile
@@ -31,11 +31,8 @@ RUN apk add --virtual .build-deps tar gzip \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && if [ -d /usr/local/openresty/nginx/modules ]; then \
-        ln -sf /usr/local/openresty/nginx/modules /usr/local/kong/modules ; \
-       fi; \
     && apk del .build-deps \
-    kong version
+    && kong version
 
 COPY build/dockerfiles/entrypoint.sh /entrypoint.sh
 

--- a/build/dockerfiles/deb.Dockerfile
+++ b/build/dockerfiles/deb.Dockerfile
@@ -27,10 +27,7 @@ RUN apt-get update \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && if [ -d /usr/local/openresty/nginx/modules ]; then \
-        ln -sf /usr/local/openresty/nginx/modules /usr/local/kong/modules ; \
-       fi; \
-    kong version
+    && kong version
 
 COPY build/dockerfiles/entrypoint.sh /entrypoint.sh
 

--- a/build/dockerfiles/rpm.Dockerfile
+++ b/build/dockerfiles/rpm.Dockerfile
@@ -40,10 +40,7 @@ RUN yum install -y /tmp/kong.rpm \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && if [ -d /usr/local/openresty/nginx/modules ]; then \
-        ln -sf /usr/local/openresty/nginx/modules /usr/local/kong/modules ; \
-       fi; \
-    kong version
+    && kong version
 
 COPY build/dockerfiles/entrypoint.sh /entrypoint.sh
 

--- a/build/nfpm/repositories.bzl
+++ b/build/nfpm/repositories.bzl
@@ -36,15 +36,15 @@ nfpm_release_select = repository_rule(
 
 def nfpm_repositories():
     npfm_matrix = [
-        ["linux", "x86_64", "4c63031ddbef198e21c8561c438dde4c93c3457ffdc868d7d28fa670e0cc14e5"],
-        ["linux", "arm64", "2af1717cc9d5dcad5a7e42301dabc538acf5d12ce9ee39956c66f30215311069"],
-        ["Darwin", "x86_64", "fb3b8ab5595117f621c69cc51db71d481fbe733fa3c35500e1b64319dc8fd5b4"],
-        ["Darwin", "arm64", "9ca3ac6e0c4139a9de214f78040d1d11dd221496471696cc8ab5d357850ccc54"],
+        ["linux", "x86_64", "6dd3b07d4d6ee373baea5b5fca179ebf78dec38c9a55392bae34040e596e4de7"],
+        ["linux", "arm64", "0e711d333d7673462f0afff8a57d4c09a215b3d20d989b5e4271f6622f325ded"],
+        ["Darwin", "x86_64", "19954ef8e6bfa0607efccd0a97452b6d571830665bd76a2f9957413f93f9d8cd"],
+        ["Darwin", "arm64", "9fd82cda017cdfd49b010199a2eed966d0a645734d9a6bf932c4ef82c8c12c96"],
     ]
     for name, arch, sha in npfm_matrix:
         http_archive(
             name = "nfpm_%s_%s" % (name, arch),
-            url = "https://github.com/goreleaser/nfpm/releases/download/v2.23.0/nfpm_2.23.0_%s_%s.tar.gz" % (name, arch),
+            url = "https://github.com/goreleaser/nfpm/releases/download/v2.31.0/nfpm_2.31.0_%s_%s.tar.gz" % (name, arch),
             sha256 = sha,
             build_file = "//build/nfpm:BUILD.bazel",
         )

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -232,15 +232,16 @@ CONFIGURE_OPTIONS = [
     ],
     "//conditions:default": [],
 }) + select({
+    "@platforms//os:linux": [
+        # neded for wasmx module
+        # although this is centos7 specific, the flag will work on any GNU linker
+        # we place it here to skip macos, which uses darwin ld
+        # https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
+        "--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
+    ],
+}) + select({
     "@kong//:wasmx_static_mod": [
         "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_wasm_module",
-        # FIXME: this is a workaround for rhel/centos builds, when enabled breaks
-        #        the build for macos
-        #
-        # see:
-        # * https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
-        # * https://github.com/Kong/ngx_wasm_module/blob/e70a19f53e1dda99d016c5cfa393652720959afd/util/Dockerfiles/Dockerfile.amd64.centos7#L9-L11
-        #"--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
     ],
     "@kong//:wasmx_dynamic_mod": [
         "--with-compat",

--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -17,6 +17,7 @@ contents:
   dst: /usr/local/bin
 - src: nfpm-prefix/kong
   dst: /usr/local/kong
+  type: tree
 - src: nfpm-prefix/lib
   dst: /usr/local/lib
 - src: nfpm-prefix/etc/luarocks

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -66,6 +66,16 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6
@@ -155,6 +165,16 @@
   Needed    :
   - libc.so.6
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libdl.so.2
@@ -165,9 +185,7 @@
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
-  - libgcc_s.so.1
   - libc.so.6
-  - ld-linux-x86-64.so.2
   Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -66,6 +66,16 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6
@@ -155,6 +165,16 @@
   Needed    :
   - libc.so.6
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libdl.so.2
@@ -165,9 +185,7 @@
   - libssl.so.3
   - libcrypto.so.3
   - libz.so.1
-  - libgcc_s.so.1
   - libc.so.6
-  - ld-linux-x86-64.so.2
   Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
   Modules   :
   - lua-kong-nginx-module

--- a/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-18.04-amd64.txt
@@ -66,6 +66,16 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6
@@ -154,6 +164,8 @@
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
   - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -66,6 +66,16 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6
@@ -153,6 +163,8 @@
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
   - libm.so.6
+  - libdl.so.2
+  - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -59,6 +59,14 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -136,14 +136,6 @@
   - libc.so.6
   - ld-linux-aarch64.so.1
 
-- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
-  Needed    :
-  - libm.so.6
-  - libgcc_s.so.1
-  - libc.so.6
-  - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
-
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libcrypt.so.1
@@ -159,7 +151,6 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
-  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.0.8 7 Feb 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True


### PR DESCRIPTION
The `tree` type is a new feature of nfpm that we can leverage to improve
the packaging of artifacts.

Use `tree` type in nfpm config so that the directory tree is replicated
in the destination, preserving the symlinks. With the default `file`
type, only symlinks to regular files are preserved, while symlinks to
directories are not.
