### PR TITLE
feat(clustering): add cluster compat logic for wasm

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -73,10 +73,11 @@ function _M.new(clustering)
 end
 
 
-function _M:init_worker(plugins_list)
+function _M:init_worker(basic_info)
   -- ROLE = "data_plane"
 
-  self.plugins_list = plugins_list
+  self.plugins_list = basic_info.plugins
+  self.filters = basic_info.filters
 
   -- only run in process which worker_id() == 0
   assert(ngx.timer.at(0, function(premature)
@@ -147,6 +148,7 @@ function _M:communicate(premature)
   _, err = c:send_binary(cjson_encode({ type = "basic_info",
                                         plugins = self.plugins_list,
                                         process_conf = configuration,
+                                        filters = self.filters,
                                         labels = labels, }))
   if err then
     ngx_log(ngx_ERR, _log_prefix, "unable to send basic information to control plane: ", uri,

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -101,15 +101,27 @@ function _M:init_worker()
     return { name = p.name, version = p.handler.VERSION, }
   end, plugins_list)
 
+  local filters = {}
+  if kong.db.filter_chains.filters then
+    for _, filter in ipairs(kong.db.filter_chains.filters) do
+      filters[filter.name] = { name = filter.name }
+    end
+  end
+
+  local basic_info = {
+    plugins = plugins_list,
+    filters = filters,
+  }
+
   local role = self.conf.role
 
   if role == "control_plane" then
-    self:init_cp_worker(plugins_list)
+    self:init_cp_worker(basic_info)
     return
   end
 
   if role == "data_plane" then
-    self:init_dp_worker(plugins_list)
+    self:init_dp_worker(basic_info)
   end
 end
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -210,6 +210,7 @@ local constants = {
     { KONG_VERSION_INCOMPATIBLE   = "kong_version_incompatible", },
     { PLUGIN_SET_INCOMPATIBLE     = "plugin_set_incompatible", },
     { PLUGIN_VERSION_INCOMPATIBLE = "plugin_version_incompatible", },
+    { FILTER_SET_INCOMPATIBLE     = "filter_set_incompatible", },
   },
   CLUSTERING_TIMEOUT = 5000, -- 5 seconds
   CLUSTERING_PING_INTERVAL = 30, -- 30 seconds

--- a/spec/01-unit/01-db/01-schema/13-cluster_status_spec.lua
+++ b/spec/01-unit/01-db/01-schema/13-cluster_status_spec.lua
@@ -45,7 +45,7 @@ describe("plugins", function()
     local ok, err = validate({ sync_status = "aaa", })
     assert.is_nil(ok)
 
-    assert.equal("expected one of: unknown, normal, kong_version_incompatible, plugin_set_incompatible, plugin_version_incompatible", err.sync_status)
+    assert.equal("expected one of: unknown, normal, kong_version_incompatible, plugin_set_incompatible, plugin_version_incompatible, filter_set_incompatible", err.sync_status)
   end)
 
   it("accepts correct value", function()

--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -41,6 +41,7 @@ local function expect_status(prefix, exp)
       end
 
       assert.is_table(body.data)
+      local found
       for _, dp in ipairs(body.data) do
         if dp.id == id then
           found = dp

--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -1,0 +1,261 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson.safe"
+local STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
+local admin = require "spec.fixtures.admin_api"
+
+local HEADER = "X-Proxy-Wasm"
+
+local json = cjson.encode
+
+local function get_node_id(prefix)
+  local data = helpers.wait_for_file_contents(prefix .. "/kong.id")
+  data = data:gsub("%s*(.-)%s*", "%1")
+  assert(utils.is_valid_uuid(data), "invalid kong node ID found in " .. prefix)
+  return data
+end
+
+
+local function expect_status(prefix, exp)
+  local id = get_node_id(prefix)
+  local msg = "waiting for clustering sync status to equal"
+              .. " '" .. exp .. "' for data plane"
+
+  assert
+    .eventually(function()
+      local cp_client = helpers.admin_client()
+
+      local res = cp_client:get("/clustering/data-planes/")
+      res:read_body()
+
+      cp_client:close()
+
+      local body = assert.response(res).has.jsonbody()
+
+      if res.status ~= 200 then
+        return nil, {
+          msg = "bad http status",
+          exp = 200,
+          got = res.status,
+        }
+      end
+
+      assert.is_table(body.data)
+      for _, dp in ipairs(body.data) do
+        if dp.id == id then
+          found = dp
+          break
+        end
+      end
+
+      if not found then
+        return nil, {
+          msg = "dp with id " .. id .. " not found in response",
+          res = body,
+        }
+
+      elseif found.sync_status ~= exp then
+        return nil, {
+          msg = "unexpected sync_status",
+          exp = exp,
+          got = found.sync_status,
+          dp  = found,
+        }
+      end
+
+      return true
+    end)
+    .is_truthy(msg)
+end
+
+
+describe("#wasm - hybrid mode", function()
+  local cp_prefix = "cp"
+  local cp_errlog = cp_prefix .. "/logs/error.log"
+
+  local dp_prefix = "dp"
+
+  lazy_setup(function()
+    local _, db = helpers.get_db_utils("postgres", {
+      "services",
+      "routes",
+      "filter_chains",
+      "clustering_data_planes",
+    })
+
+    db.clustering_data_planes:truncate()
+
+    assert(helpers.start_kong({
+      role                = "control_plane",
+      database            = "postgres",
+      prefix              = cp_prefix,
+      cluster_cert        = "spec/fixtures/kong_clustering.crt",
+      cluster_cert_key    = "spec/fixtures/kong_clustering.key",
+      db_update_frequency = 0.1,
+      cluster_listen      = "127.0.0.1:9005",
+      nginx_conf          = "spec/fixtures/custom_nginx.template",
+      wasm                = true,
+    }))
+  end)
+
+  lazy_teardown(function()
+    helpers.stop_kong(cp_prefix, true)
+  end)
+
+  describe("[happy path]", function()
+    local client
+
+    lazy_setup(function()
+      assert(helpers.start_kong({
+        role                  = "data_plane",
+        database              = "off",
+        prefix                = dp_prefix,
+        cluster_cert          = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key      = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        admin_listen          = "off",
+        nginx_conf            = "spec/fixtures/custom_nginx.template",
+        wasm                  = true,
+      }))
+
+      client = helpers.proxy_client()
+    end)
+
+    lazy_teardown(function()
+      if client then client:close() end
+      helpers.stop_kong(dp_prefix)
+    end)
+
+    it("syncs wasm filter chains to the data plane", function()
+      local service = admin.services:insert({})
+      local host = "wasm-" .. utils.random_string() .. ".test"
+
+      admin.routes:insert({
+        service = service,
+        hosts = { host },
+      })
+
+      local params = {
+        headers = {
+          host = host,
+        }
+      }
+
+      assert
+        .eventually(function()
+          local res = client:get("/status/200", params)
+          return res.status == 200, {
+            exp = 200,
+            got = res.status,
+            res = res:read_body(),
+          }
+        end)
+        .is_truthy("service/route are ready on the data plane")
+
+      local value = utils.random_string()
+
+      local filter = admin.filter_chains:insert({
+        service = { id = service.id },
+        filters = {
+          {
+            name = "response_transformer",
+            config = json {
+              append = {
+                headers = {
+                  HEADER .. ":" .. value,
+                },
+              },
+            }
+          }
+        }
+      })
+
+      assert
+        .eventually(function()
+          local res = client:get("/status/200", params)
+          res:read_body()
+
+          if res.status ~= 200 then
+            return {
+              msg = "bad http status",
+              exp = 200,
+              got = res.status,
+              res = res:read_body(),
+            }
+          end
+
+          if res.headers[HEADER] ~= value then
+            return nil, {
+              msg = "missing/incorrect " .. HEADER .. " header",
+              exp = value,
+              got = res.headers[HEADER] or "<NIL>",
+            }
+          end
+
+          return true
+        end)
+        .is_truthy("wasm filter is configured on the data plane")
+
+      admin.filter_chains:remove({ id = filter.id })
+
+      assert
+        .eventually(function()
+          local res = client:get("/status/200", params)
+          res:read_body()
+
+          if res.status ~= 200 then
+            return {
+              msg = "bad http status",
+              exp = 200,
+              got = res.status,
+              res = res:read_body(),
+            }
+          end
+
+          if res.headers[HEADER] ~= nil then
+            return nil, {
+              msg = "expected " .. HEADER .. " header to be absent",
+              exp = "<NIL>",
+              got = res.headers[HEADER],
+            }
+          end
+
+          return true
+        end)
+        .is_truthy("wasm filter has been removed from the data plane")
+
+      expect_status(dp_prefix, STATUS.NORMAL)
+    end)
+  end)
+
+  describe("data planes with wasm disabled", function()
+    lazy_setup(function()
+      helpers.clean_logfile(cp_errlog)
+
+      assert(helpers.start_kong({
+        role                  = "data_plane",
+        database              = "off",
+        prefix                = dp_prefix,
+        cluster_cert          = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key      = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        admin_listen          = "off",
+        nginx_conf            = "spec/fixtures/custom_nginx.template",
+        wasm                  = "off",
+      }))
+    end)
+
+
+    lazy_teardown(function()
+      helpers.stop_kong(dp_prefix, true)
+    end)
+
+    it("does not sync configuration", function()
+      assert.logfile(cp_errlog).has.line(
+        [[unable to send updated configuration to data plane: data plane is missing one or more wasm filters]],
+        true, 5)
+
+      expect_status(dp_prefix, STATUS.FILTER_SET_INCOMPATIBLE)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

This adds basic cluster compatibility checks for wasm filters. The logic is similar to how plugin checks work today. That is, if a wasm filter is present on the control plane but _not_ on the data plane, config updates will not be sent to the data plane, and the control plane will set a (new) sync status for the data plane accordingly.

This is accomplished by adding a new `filters` attribute to the basic_info payload that is sent by the data plane when initiating a connection to the control plane. The `filters` attribute is a map of strings to objects with a single `name` attribute:

```json
{
  "my-filter": {
    "name": "my-filter",
  },
  "my-other-filter": {
    "name": "my-other-filter",
  }
}
```

Using a map instead of an array was done for convenience of member lookup (since we would probably convert the array to a map anyways), but I get that it looks a little silly/redundant in its current form. Open to changing this if there are objections.

Down the road we can potentially come up with some scheme for more granular checks (i.e. a version or checksum field), but right now we just check if a filter is present or absent.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->


### Checklist

- [x] The Pull Request has tests
- [ ] ~There's an entry in the CHANGELOG~
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~


### Issue reference

KAG-499