### PR TITLE
feat(opentelemetry): make endpoint field referenceable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   The field `header_type`now accepts the `aws` value to handle this specific
   propagation header.
   [11075](https://github.com/Kong/kong/pull/11075)
+- **Opentelemetry**: Support the `endpoint` parameter as referenceable.
+  [#11220](https://github.com/Kong/kong/pull/11220)
 - **Ip-Restriction**: Add TCP support to the plugin.
   Thanks [@scrudge](https://github.com/scrudge) for contributing this change.
   [#10245](https://github.com/Kong/kong/pull/10245)

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -35,7 +35,7 @@ return {
     { config = {
       type = "record",
       fields = {
-        { endpoint = typedefs.url { required = true } }, -- OTLP/HTTP
+        { endpoint = typedefs.url { required = true, referenceable = true } }, -- OTLP/HTTP
         { headers = { description = "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.", type = "map",
           keys = typedefs.header_name,
           values = {

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -466,6 +466,7 @@ for _, strategy in helpers.each_strategy() do
     describe("#referenceable fields", function ()
       local mock
       lazy_setup(function()
+        helpers.setenv("TEST_OTEL_ENDPOINT", "http://127.0.0.1:" .. HTTP_SERVER_PORT)
         helpers.setenv("TEST_OTEL_ACCESS_KEY", "secret-1")
         helpers.setenv("TEST_OTEL_ACCESS_SECRET", "secret-2")
 
@@ -476,6 +477,7 @@ for _, strategy in helpers.each_strategy() do
         }, { "opentelemetry" }))
 
         setup_instrumentations("all", {
+          endpoint = "{vault://env/test_otel_endpoint}",
           headers = {
             ["X-Access-Key"] = "{vault://env/test_otel_access_key}",
             ["X-Access-Secret"] = "{vault://env/test_otel_access_secret}",
@@ -485,6 +487,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
+        helpers.unsetenv("TEST_OTEL_ENDPOINT")
         helpers.unsetenv("TEST_OTEL_ACCESS_KEY")
         helpers.unsetenv("TEST_OTEL_ACCESS_SECRET")
         helpers.stop_kong()


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com/pull/5809

### Full changelog

*  supports the `endpoint` parameter of the opentelemetry plugin as referenceable.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-2066
