### PR TITLE
chore(dev): remove h2client README.md when building kong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ bin/grpcurl:
 bin/h2client:
 	@curl -s -S -L \
 		https://github.com/Kong/h2client/releases/download/v$(H2CLIENT_VERSION)/h2client_$(H2CLIENT_VERSION)_$(OS)_$(H2CLIENT_MACHINE).tar.gz | tar xz -C bin;
+	@$(RM) bin/README.md
 
 
 check-bazel: bin/bazel


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

`make dev` will extract `h2client` to the repo's `bin` directory. However, it will also put the `README.md` over there.

See example here:

```bash
~ $ tar -tf h2client_0.4.0_darwin_arm64.tar.gz
README.md
h2client
```

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* remove h2client README.md when building kong

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5230
