### PR TITLE
feat(wasm): make wasm configurable

### DIFF
--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -768,16 +768,156 @@ describe("NGINX conf compiler", function()
 
       lazy_teardown(function() cleanup() end)
 
-      it("injects the wasm{} subsystem", function()
-        local conf = assert(conf_loader(nil, {
-          wasm = "on",
-          wasm_filters_path = temp_dir,
-        }))
-        assert.equal(conf.wasm_filters_path, temp_dir)
+      local _compile = function(cfg, config_compiler, debug)
+        local ngx_conf = config_compiler(assert(conf_loader(nil, cfg)))
+        if debug then
+          print(ngx_conf)
+        end
+        return ngx_conf
+      end
+      local ngx_cfg = function(cfg, debug) return _compile(cfg, prefix_handler.compile_nginx_conf, debug) end
 
-        local nginx_conf = prefix_handler.compile_nginx_conf(conf)
-        assert.matches("wasm {", nginx_conf)
-        assert.matches("module empty-filter " .. filter .. ";", nginx_conf, nil, true)
+      local debug = false
+      it("has no wasm{} block by default", function()
+        assert.not_matches("wasm {", ngx_cfg({ wasm = nil }, debug))
+      end)
+      it("injects global wasm{} block", function()
+        assert.matches("wasm {", ngx_cfg({ wasm = true }, debug))
+      end)
+      it("injects a filter", function()
+        assert.matches(("module empty-filter %s;"):format(filter), ngx_cfg({ wasm = true, wasm_filters_path = temp_dir }, debug), nil, true)
+      end)
+      it("injects a main block directive", function()
+        assert.matches("wasm {.+socket_connect_timeout 10s;.+}", ngx_cfg({ wasm = true, nginx_wasm_socket_connect_timeout="10s" }, debug))
+      end)
+      it("injects a shm_kv", function()
+        assert.matches("wasm {.+shm_kv counters 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_counters="10m" }, debug))
+      end)
+      it("injects multiple shm_kvs", function()
+        assert.matches(
+          "wasm {.+shm_kv cache 10m.+shm_kv counters 10m;.+}",
+          ngx_cfg({ wasm = true, nginx_wasm_shm_cache="10m", nginx_wasm_shm_counters="10m"}, debug)
+        )
+      end)
+      it("injects runtime-specific directives (wasmtime)", function()
+        assert.matches(
+          "wasm {.+wasmtime {.+flag flag1 on;.+flag flag2 1m;.+}.+",
+          ngx_cfg({
+            wasm = true,
+            nginx_wasm_wasmtime_flag1=true,
+            nginx_wasm_wasmtime_flag2="1m",
+          }, debug)
+        )
+      end)
+      it("injects runtime-specific directives (v8)", function()
+        assert.matches(
+          "wasm {.+v8 {.+flag flag1 on;.+flag flag2 1m;.+}.+",
+          ngx_cfg({
+            wasm = true,
+            nginx_wasm_v8_flag1=true,
+            nginx_wasm_v8_flag2="1m",
+          }, debug)
+        )
+      end)
+      it("injects runtime-specific directives (wasmer)", function()
+        assert.matches(
+          "wasm {.+wasmer {.+flag flag1 on;.+flag flag2 1m;.+}.+",
+          ngx_cfg({
+            wasm = true,
+            nginx_wasm_wasmer_flag1=true,
+            nginx_wasm_wasmer_flag2="1m",
+          }, debug)
+        )
+      end)
+      describe("injects inherited directives", function()
+        describe("lua_ssl_trusted_certificate", function()
+          it("with one cert", function()
+            assert.matches(
+              "wasm {.+tls_trusted_certificate spec/fixtures/kong_clustering_ca.crt.+}",
+              ngx_cfg({
+                wasm = true,
+                lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering_ca.crt",
+              }, debug)
+            )
+          end)
+          it("with more than one cert, picks first", function()
+            assert.matches(
+            "wasm {.+tls_trusted_certificate spec/fixtures/kong_clustering_ca.crt.+}",
+            ngx_cfg({
+              wasm = true,
+              lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering_ca.crt,spec/fixtures/kong_clustering.crt",
+            }, debug)
+            )
+          end)
+        end)
+        it("lua_ssl_verify_depth", function()
+          assert.matches(
+            "wasm {.+tls_verify_cert on;.+}",
+            ngx_cfg({
+              wasm = true,
+              lua_ssl_verify_depth = 2,
+            }, debug)
+          )
+          assert.matches(
+            "wasm {.+tls_verify_host on;.+}",
+            ngx_cfg({
+              wasm = true,
+              lua_ssl_verify_depth = 2,
+            }, debug)
+          )
+          assert.matches(
+            "wasm {.+tls_no_verify_warn on;.+}",
+            ngx_cfg({
+              wasm = true,
+              lua_ssl_verify_depth = 2,
+            }, debug)
+          )
+        end)
+        it("proxy_connect_timeout", function()
+          assert.matches(
+            "wasm {.+socket_connect_timeout 1s;.+}",
+            ngx_cfg({
+              wasm = true,
+              nginx_http_proxy_connect_timeout = "1s",
+            }, debug)
+          )
+        end)
+        it("proxy_read_timeout", function()
+          assert.matches(
+            "wasm {.+socket_read_timeout 1s;.+}",
+            ngx_cfg({
+              wasm = true,
+              nginx_http_proxy_read_timeout = "1s",
+            }, debug)
+          )
+        end)
+        it("proxy_send_timeout", function()
+          assert.matches(
+            "wasm {.+socket_send_timeout 1s;.+}",
+            ngx_cfg({
+              wasm = true,
+              nginx_http_proxy_send_timeout = "1s",
+            }, debug)
+          )
+        end)
+        it("proxy_buffer_size", function()
+          assert.matches(
+            "wasm {.+socket_buffer_size 1m;.+}",
+            ngx_cfg({
+              wasm = true,
+              nginx_http_proxy_buffer_size = "1m",
+            }, debug)
+          )
+        end)
+        it("large_client_header_buffers", function()
+          assert.matches(
+            "wasm {.+socket_large_buffers 4 24k;.+}",
+            ngx_cfg({
+              wasm = true,
+              nginx_http_large_client_header_buffers = "4 24k",
+            }, debug)
+          )
+        end)
       end)
     end)
   end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -1,11 +1,12 @@
 # This is a custom nginx configuration template for Kong specs
 
 pid pids/nginx.pid; # mandatory even for custom config templates
-error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if wasm and wasm_dynamic_module then
 load_module $(wasm_dynamic_module);
 > end
+
+error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 # injected nginx_main_* directives
 > for _, el in ipairs(nginx_main_directives) do
@@ -24,19 +25,48 @@ events {
 > end
 }
 
-> if wasm_modules_parsed and #wasm_modules_parsed > 0 then
+> if wasm then
 wasm {
-  shm_kv kong_wasm_rate_limiting_counters 12m;
+> for _, el in ipairs(nginx_wasm_main_shm_directives) do
+  shm_kv $(el.name) $(el.value);
+> end
 
 > for _, module in ipairs(wasm_modules_parsed) do
   module $(module.name) $(module.path);
 > end
-}
 
-
-env RUST_BACKTRACE=1;
-env WASMTIME_BACKTRACE_DETAILS=1;
+> for _, el in ipairs(nginx_wasm_main_directives) do
+  $(el.name) $(el.value);
 > end
+
+> if #nginx_wasm_wasmtime_directives > 0 then
+  wasmtime {
+> for _, el in ipairs(nginx_wasm_wasmtime_directives) do
+    flag $(el.name) $(el.value);
+> end
+  }
+> end -- wasmtime
+
+> if #nginx_wasm_v8_directives > 0 then
+  v8 {
+> for _, el in ipairs(nginx_wasm_v8_directives) do
+    flag $(el.name) $(el.value);
+> end
+  }
+> end -- v8
+
+> if #nginx_wasm_wasmer_directives > 0 then
+  wasmer {
+> for _, el in ipairs(nginx_wasm_wasmer_directives) do
+    flag $(el.name) $(el.value);
+> end
+  }
+> end -- wasmer
+
+}
+> end
+
+
 
 > if role == "control_plane" or #proxy_listeners > 0 or #admin_listeners > 0 or #status_listeners > 0 then
 http {


### PR DESCRIPTION
This PR introduces Wasm configuration through Kong config properties. The following new directive injections are introduced:
- Wasm global directives: applies to the `wasm {}` block, having global effect over the WebAssembly execution;
- Wasm runtime specific directives -- these apply to specific runtime blocks (`wasmtime {}`, `v8{}` and `wasmer{}`)
- Wasm HTTP directives: applies configurations to Wasm execution within the HTTP subsystem

This PR extends https://github.com/Kong/kong/pull/11000. 

KAG-1071