### PR TITLE
feat(wasm): integrate with kong's DNS resolver

### DIFF
--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -1,6 +1,7 @@
 local _M = {}
 
 local utils = require "kong.tools.utils"
+local dns = require "kong.tools.dns"
 local clear_tab = require("table.clear")
 
 ---@module 'resty.http.proxy_wasm'
@@ -523,6 +524,9 @@ function _M.init(kong_config)
   if not modules or #modules == 0 then
     return
   end
+
+  -- setup a DNS client for ngx_wasm_module
+  _G.dns_client = dns(kong_config)
 
   proxy_wasm = require "resty.http.proxy_wasm"
   ENABLED = true

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -3,6 +3,10 @@ server_tokens off;
 
 error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
+> if wasm then
+proxy_wasm_lua_resolver on;
+> end
+
 lua_package_path       '${{LUA_PACKAGE_PATH}};;';
 lua_package_cpath      '${{LUA_PACKAGE_CPATH}};;';
 lua_socket_pool_size   ${{LUA_SOCKET_POOL_SIZE}};

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -44,6 +44,10 @@ http {
 
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
+> if wasm then
+    proxy_wasm_lua_resolver on;
+> end
+
     lua_package_path       '${{LUA_PACKAGE_PATH}};;';
     lua_package_cpath      '${{LUA_PACKAGE_CPATH}};;';
     lua_socket_pool_size   ${{LUA_SOCKET_POOL_SIZE}};


### PR DESCRIPTION
This integrates Kong's DNS resolver into wasmx. See the [docs](https://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md#proxy_wasm_lua_resolver) for more info on how this works.

KAG-2084