### PR TITLE
chore(*): change amazonlinux-2 2022 to 2023

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
         path: /usr/local/git
         key: ${{ matrix.label }}-git-2.30.0
 
-    # el-7,8, amazonlinux-2,2022, debian-10 doesn't have git 2.18+, so we need to install it manually
+    # el-7,8, amazonlinux-2,2023, debian-10 doesn't have git 2.18+, so we need to install it manually
     - name: Install newer Git
       if: (matrix.package == 'rpm' || matrix.image == 'debian:10') && steps.cache-git.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Just a typo fix. Found when doing CE2EE merge.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] There's an entry in the CHANGELOG
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* change amazonlinux-2 2022 to 2023

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-5230
