### PR TITLE
chore(template): remove wasm dev items

### DIFF
--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -25,8 +25,6 @@ events {
 
 > if wasm and wasm_modules_parsed and #wasm_modules_parsed > 0 then
 wasm {
-  shm_kv kong_wasm_rate_limiting_counters 12m;
-
 > for _, module in ipairs(wasm_modules_parsed) do
   module $(module.name) $(module.path);
 > end

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -31,9 +31,6 @@ wasm {
   module $(module.name) $(module.path);
 > end
 }
-
-env RUST_BACKTRACE=1;
-env WASMTIME_BACKTRACE_DETAILS=1;
 > end
 
 > if role == "control_plane" or #proxy_listeners > 0 or #admin_listeners > 0 or #status_listeners > 0 then

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -32,10 +32,6 @@ wasm {
   module $(module.name) $(module.path);
 > end
 }
-
-
-env RUST_BACKTRACE=1;
-env WASMTIME_BACKTRACE_DETAILS=1;
 > end
 
 > if role == "control_plane" or #proxy_listeners > 0 or #admin_listeners > 0 or #status_listeners > 0 then

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -26,8 +26,6 @@ events {
 
 > if wasm_modules_parsed and #wasm_modules_parsed > 0 then
 wasm {
-  shm_kv kong_wasm_rate_limiting_counters 12m;
-
 > for _, module in ipairs(wasm_modules_parsed) do
   module $(module.name) $(module.path);
 > end


### PR DESCRIPTION
This removes things that were used during early development and should not be present in the final template.