### PR TITLE
fix(admin-gui): invalidate cache for `kconfig.js` when reload

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -757,6 +757,10 @@ function Kong.init_worker()
 
   kong.db:set_events_handler(worker_events)
 
+  if kong.configuration.admin_gui_listeners then
+    kong.cache:invalidate_local(constants.ADMIN_GUI_KCONFIG_CACHE_KEY)
+  end
+
   if process.type() == "privileged agent" then
     if kong.clustering then
       kong.clustering:init_worker()

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -715,3 +715,53 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
 
   end)
 end)
+
+describe("Admin GUI config", function ()
+  it("should be reloaded and invalidate kconfig.js cache", function()
+
+    assert(helpers.start_kong({
+      database = "off",
+      admin_gui_listen = "127.0.0.1:9012",
+      admin_gui_url = "http://test1.example.com"
+    }))
+
+    finally(function()
+      helpers.stop_kong()
+    end)
+
+    local client = assert(helpers.admin_gui_client(nil, 9012))
+
+    local res = assert(client:send {
+      method = "GET",
+      path = "/kconfig.js",
+    })
+    res = assert.res_status(200, res)
+    assert.matches("'ADMIN_GUI_URL': 'http://test1.example.com'", res, nil, true)
+
+    client:close()
+
+    assert(helpers.reload_kong("off", "reload --conf " .. helpers.test_conf_path .. " --nginx-conf spec/fixtures/default_nginx.template", {
+      database = "off",
+      admin_gui_listen = "127.0.0.1:9012",
+      admin_gui_url = "http://test2.example.com",
+      admin_gui_path = "/manager",
+    }))
+
+    ngx.sleep(1)    -- to make sure older workers are gone
+
+    client = assert(helpers.admin_gui_client(nil, 9012))
+    res = assert(client:send {
+      method = "GET",
+      path = "/kconfig.js",
+    })
+    assert.res_status(404, res)
+
+    res = assert(client:send {
+      method = "GET",
+      path = "/manager/kconfig.js",
+    })
+    res = assert.res_status(200, res)
+    assert.matches("'ADMIN_GUI_URL': 'http://test2.example.com'", res, nil, true)
+    client:close()
+  end)
+end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -429,6 +429,9 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript;
 
+    access_log ${{ADMIN_GUI_ACCESS_LOG}};
+    error_log ${{ADMIN_GUI_ERROR_LOG}};
+
 > local admin_gui_rewrite = admin_gui_path ~= "/"
 > local admin_gui_path_prefix = admin_gui_path
 > if admin_gui_path == "/" then

--- a/spec/fixtures/default_nginx.template
+++ b/spec/fixtures/default_nginx.template
@@ -433,6 +433,9 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript;
 
+    access_log ${{ADMIN_GUI_ACCESS_LOG}};
+    error_log ${{ADMIN_GUI_ERROR_LOG}};
+
 > local admin_gui_rewrite = admin_gui_path ~= "/"
 > local admin_gui_path_prefix = admin_gui_path
 > if admin_gui_path == "/" then


### PR DESCRIPTION
### Summary

The cache for `kconfig.js` won't be refreshed across the reload,
which may cause requests to `kconfig.js` still respond with the
old content when the configuration is changed. Force invalidating the
cache during the worker init procedure could fix it.

### Checklist

- [x] The Pull Request has tests
- [ ] ~There's an entry in the CHANGELOG~
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
