### PR TITLE
fix(dbless): accept table form in flattened foreign keys

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -220,7 +220,8 @@ function _M:communicate(premature)
       end
 
       if not pok or not res then
-        ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
+        ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ",
+                         (not pok and res) or err)
       end
 
       if next_data == data then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -728,7 +728,10 @@ local function get_unique_key(schema, entity, field, value)
     return value
   end
   local ws_id = ws_id_for(entity)
-  return ws_id .. ":" .. value
+  if type(value) == "table" then
+    value = value.id
+  end
+  return ws_id .. ":" .. tostring(value)
 end
 
 


### PR DESCRIPTION
This seems to happen only during Hybrid mode CP/DP communication. A test that will be merged as part of #11218 covers this code.
