### PR TITLE
fix(luajit): Add the LuaJIT ARM64 fix for HREFK patch.

### DIFF
--- a/build/openresty/patches/LuaJIT-2.1-20220411_06_arm64_fix_HREFK.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20220411_06_arm64_fix_HREFK.patch
@@ -1,0 +1,27 @@
+From 8fbd576fb9414a5fa70dfa6069733d3416a78269 Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Sun, 9 Jul 2023 21:15:01 +0200
+Subject: [PATCH] ARM64: Fix assembly of HREFK.
+
+Reported by caohongqing. #1026
+Fix contributed by Peter Cawley.
+---
+ src/lj_asm_arm64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bundle/LuaJIT-2.1-20220411/src/lj_asm_arm64.h b/bundle/LuaJIT-2.1-20220411/src/lj_asm_arm64.h
+index 805ea54b..95138fe9 100644
+--- a/bundle/LuaJIT-2.1-20220411/src/lj_asm_arm64.h
++++ b/bundle/LuaJIT-2.1-20220411/src/lj_asm_arm64.h
+@@ -938,7 +938,7 @@ static void asm_hrefk(ASMState *as, IRIns *ir)
+   IRIns *irkey = IR(kslot->op1);
+   int32_t ofs = (int32_t)(kslot->op2 * sizeof(Node));
+   int32_t kofs = ofs + (int32_t)offsetof(Node, key);
+-  int bigofs = !emit_checkofs(A64I_LDRx, ofs);
++  int bigofs = !emit_checkofs(A64I_LDRx, kofs);
+   Reg dest = (ra_used(ir) || bigofs) ? ra_dest(as, ir, RSET_GPR) : RID_NONE;
+   Reg node = ra_alloc1(as, ir->op1, RSET_GPR);
+   Reg key, idx = node;
+-- 
+2.41.0
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
The LuaJIT-2.1-20220411_05_arm64_fix_HREFK.patch is a recent merged PR in LuaJIT https://github.com/LuaJIT/LuaJIT/issues/1026, found in https://github.com/Kong/kong/pull/11191#issuecomment-1629196330. It is good to include it to get better support on ARM64.

Passes verification by the test in https://github.com/LuaJIT/LuaJIT/issues/1026.

Because this patch has not been merged in Openresty LuaJIT yet. To support ARM64 better, it is included in our own patches.
### Checklist

- [NA] The Pull Request has tests
- [NA] There's an entry in the CHANGELOG
- [NA] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-2063]_


[KAG-2063]: https://konghq.atlassian.net/browse/KAG-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ