### PR TITLE
fix(wasm): return early on error in init_worker

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -870,6 +870,7 @@ function Kong.init_worker()
   if not ok then
     err = "wasm nginx worker initialization failed: " .. tostring(err)
     stash_init_worker_error(err)
+    return
   end
 end
 


### PR DESCRIPTION
This makes wasm's init_worker error-handling conformant with the rest of the logic in Kong.init_worker().