### PR TITLE
chore(ci): use the new bin/kong in NEW_CONTAINER to fix upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -3,6 +3,7 @@ name: Upgrade Tests
 on:
   pull_request:
     paths:
+    - 'scripts/upgrade-tests/**'
     - 'kong/db/migrations/**'
     - 'spec/05-migration/**'
     - 'kong/enterprise_edition/db/migrations/**'

--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -101,6 +101,7 @@ function build_containers() {
     docker exec -w /kong $OLD_CONTAINER make dev CRYPTO_DIR=/usr/local/kong
     # Kong version >= 3.3 moved non Bazel-built dev setup to make dev-legacy
     docker exec -w /kong $NEW_CONTAINER make dev-legacy CRYPTO_DIR=/usr/local/kong
+    docker exec ${NEW_CONTAINER} ln -sf /kong/bin/kong /usr/local/bin/kong
 }
 
 function initialize_test_list() {


### PR DESCRIPTION
### Summary

The `bin/kong` used in NEW_CONTAINER is not the latest version. If it gets updated, tests may fail.
