### PR TITLE
chore(build): do not download wasm runtime unless requested

### DIFF
--- a/build/nfpm/repositories.bzl
+++ b/build/nfpm/repositories.bzl
@@ -37,7 +37,7 @@ nfpm_release_select = repository_rule(
 def nfpm_repositories():
     npfm_matrix = [
         ["linux", "x86_64", "6dd3b07d4d6ee373baea5b5fca179ebf78dec38c9a55392bae34040e596e4de7"],
-        ["linux", "arm64", "0e711d333d7673462f0afff8a57d4c09a215b3d20d989b5e4271f6622f325ded"],
+        ["linux", "arm64", "e6487dca9d9e9b1781fe7fa0a3d844e70cf12d92f3b5fc0c4ff771aa776b05ca"],
         ["Darwin", "x86_64", "19954ef8e6bfa0607efccd0a97452b6d571830665bd76a2f9957413f93f9d8cd"],
         ["Darwin", "arm64", "9fd82cda017cdfd49b010199a2eed966d0a645734d9a6bf932c4ef82c8c12c96"],
     ]

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -273,6 +273,29 @@ CONFIGURE_OPTIONS = [
     "//conditions:default": [],
 })
 
+wasmx_build_data = select({
+    "@kong//:wasmx_flag": [
+        "@ngx_wasm_module//:all_srcs",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_v8": [
+        "@v8//:all_srcs",
+        "@openresty//:wasmx_v8_ar",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmer": [
+        "@wasmer//:all_srcs",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmtime": [
+        "@wasmtime//:all_srcs",
+    ],
+    "//conditions:default": [],
+})
+
 # TODO: set prefix to populate pid_path, conf_path, log_path etc
 
 filegroup(
@@ -295,12 +318,7 @@ configure_make(
         "@lua-resty-lmdb//:all_srcs",
         "@lua-resty-events//:all_srcs",
         "@openresty_binding//:all_srcs",
-        "@ngx_wasm_module//:all_srcs",
-        "@v8//:all_srcs",
-        "@wasmer//:all_srcs",
-        "@wasmtime//:all_srcs",
-        "@openresty//:wasmx_v8_ar",
-    ],
+    ] + wasmx_build_data,
     configure_command = "configure",
     configure_in_place = True,
     configure_options = CONFIGURE_OPTIONS,


### PR DESCRIPTION
This change makes it such that we are no longer unconditionally downloading every wasm runtime when building.