### PR TITLE
refactor(router): clean the logic of `get_upstream_uri_v0()`

### DIFF
--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -150,22 +150,22 @@ local function get_upstream_uri_v0(matched_route, request_postfix, req_uri,
         end
 
         return sub(upstream_base, 1, -2)
-      end
+      end -- if request_postfix
 
-      if byte(request_postfix, 1, 1) == SLASH then
+      if byte(request_postfix, 1) == SLASH then
         -- double "/", so drop the first
         return sub(upstream_base, 1, -2) .. request_postfix
       end
 
       -- ends with / and strip_path = true, no double slash
       return upstream_base .. request_postfix
-    end
+    end -- if strip_path
 
     -- ends with / and strip_path = false
     -- we retain the incoming path, just prefix it with the upstream
     -- path, but skip the initial slash
     return upstream_base .. sub(req_uri, 2)
-  end
+  end -- byte(upstream_base, -1) == SLASH
 
   -- does not end with / and strip_path = true
   if strip_path then
@@ -175,14 +175,14 @@ local function get_upstream_uri_v0(matched_route, request_postfix, req_uri,
       end
 
       return upstream_base
-    end
+    end -- if request_postfix
 
-    if byte(request_postfix, 1, 1) == SLASH then
+    if byte(request_postfix, 1) == SLASH then
       return upstream_base .. request_postfix
     end
 
     return upstream_base .. "/" .. request_postfix
-  end
+  end -- if strip_path
 
   -- does not end with / and strip_path = false
   if req_uri == "/" then

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -134,7 +134,6 @@ end
 
 local function get_upstream_uri_v0(matched_route, request_postfix, req_uri,
                                    upstream_base)
-  local upstream_uri
 
   local strip_path = matched_route.strip_path or matched_route.strip_uri
 
@@ -143,58 +142,54 @@ local function get_upstream_uri_v0(matched_route, request_postfix, req_uri,
     if strip_path then
       if request_postfix == "" then
         if upstream_base == "/" then
-          upstream_uri = "/"
-
-        elseif byte(req_uri, -1) == SLASH then
-          upstream_uri = upstream_base
-
-        else
-          upstream_uri = sub(upstream_base, 1, -2)
+          return "/"
         end
 
-      elseif byte(request_postfix, 1, 1) == SLASH then
+        if byte(req_uri, -1) == SLASH then
+          return upstream_base
+        end
+
+        return sub(upstream_base, 1, -2)
+      end
+
+      if byte(request_postfix, 1, 1) == SLASH then
         -- double "/", so drop the first
-        upstream_uri = sub(upstream_base, 1, -2) .. request_postfix
-
-      else -- ends with / and strip_path = true, no double slash
-        upstream_uri = upstream_base .. request_postfix
+        return sub(upstream_base, 1, -2) .. request_postfix
       end
 
-    else -- ends with / and strip_path = false
-      -- we retain the incoming path, just prefix it with the upstream
-      -- path, but skip the initial slash
-      upstream_uri = upstream_base .. sub(req_uri, 2)
+      -- ends with / and strip_path = true, no double slash
+      return upstream_base .. request_postfix
     end
 
-  else -- does not end with /
-    -- does not end with / and strip_path = true
-    if strip_path then
-      if request_postfix == "" then
-        if #req_uri > 1 and byte(req_uri, -1) == SLASH then
-          upstream_uri = upstream_base .. "/"
-
-        else
-          upstream_uri = upstream_base
-        end
-
-      elseif byte(request_postfix, 1, 1) == SLASH then
-        upstream_uri = upstream_base .. request_postfix
-
-      else
-        upstream_uri = upstream_base .. "/" .. request_postfix
-      end
-
-    else -- does not end with / and strip_path = false
-      if req_uri == "/" then
-        upstream_uri = upstream_base
-
-      else
-        upstream_uri = upstream_base .. req_uri
-      end
-    end
+    -- ends with / and strip_path = false
+    -- we retain the incoming path, just prefix it with the upstream
+    -- path, but skip the initial slash
+    return upstream_base .. sub(req_uri, 2)
   end
 
-  return upstream_uri
+  -- does not end with / and strip_path = true
+  if strip_path then
+    if request_postfix == "" then
+      if #req_uri > 1 and byte(req_uri, -1) == SLASH then
+        return upstream_base .. "/"
+      end
+
+      return upstream_base
+    end
+
+    if byte(request_postfix, 1, 1) == SLASH then
+      return upstream_base .. request_postfix
+    end
+
+    return upstream_base .. "/" .. request_postfix
+  end
+
+  -- does not end with / and strip_path = false
+  if req_uri == "/" then
+    return upstream_base
+  end
+
+  return upstream_base .. req_uri
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The code of function `get_upstream_uri_v0()` is too complex,
this PR tries to clean the logic by using early `return`.

KAG-2148

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
