### PR TITLE
feat(build): add wasmx to arm64 build matrix

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -20,7 +20,7 @@ build-packages:
 - label: ubuntu-22.04-arm64
   os: ubuntu-22.04
   package: deb
-  bazel-args: --platforms=//:generic-crossbuild-aarch64 --//:wasmx=false
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
   check-manifest-suite: ubuntu-22.04-arm64
 
 # Debian

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -238,6 +238,30 @@ config_setting(
 )
 
 config_setting(
+    name = "wasmx_v8_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "v8",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "wasmx_v8_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "v8",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "wasmx_wasmer",
     flag_values = {
         ":wasmx": "true",
@@ -247,7 +271,55 @@ config_setting(
 )
 
 config_setting(
+    name = "wasmx_wasmer_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "wasmer",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "wasmx_wasmer_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "wasmer",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "wasmx_wasmtime",
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "wasmtime",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "wasmx_wasmtime_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
+    flag_values = {
+        ":wasmx": "true",
+        ":wasm_runtime": "wasmtime",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "wasmx_wasmtime_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
     flag_values = {
         ":wasmx": "true",
         ":wasm_runtime": "wasmtime",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -46,14 +46,23 @@ install_webui_cmd = select({
 })
 
 wasmx_vm_deps = select({
-    "@kong//:wasmx_v8": [
-        "@v8//:lib",
+    "@kong//:wasmx_v8_x86_64": [
+        "@v8-x86_64//:lib",
     ],
-    "@kong//:wasmx_wasmer": [
-        "@wasmer//:lib",
+    "@kong//:wasmx_v8_aarch64": [
+        "@v8-aarch64//:lib",
     ],
-    "@kong//:wasmx_wasmtime": [
-        "@wasmtime//:lib",
+    "@kong//:wasmx_wasmer_x86_64": [
+        "@wasmer-x86_64//:lib",
+    ],
+    "@kong//:wasmx_wasmer_aarch64": [
+        "@wasmer-aarch64//:lib",
+    ],
+    "@kong//:wasmx_wasmtime_x86_64": [
+        "@wasmtime-x86_64//:lib",
+    ],
+    "@kong//:wasmx_wasmtime_aarch64": [
+        "@wasmtime-aarch64//:lib",
     ],
     "//conditions:default": [],
 })

--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -75,15 +75,6 @@ def _load_vars(ctx):
         content += '"WASMER_OS": "linux",'
         content += '"WASMTIME_OS": "linux",'
 
-    if ctx.os.arch == "amd64" or ctx.os.arch == "x86_64":
-        content += '"V8_ARCH": "x86_64",'
-        content += '"WASMER_ARCH": "amd64",'
-        content += '"WASMTIME_ARCH": "x86_64",'
-    elif ctx.os.arch == "aarch64":
-        content += '"V8_ARCH": "FIXME",'  # no releases available atm
-        content += '"WASMER_ARCH": "aarch64",'
-        content += '"WASMTIME_ARCH": "aarch64",'
-
     ctx.file("BUILD.bazel", "")
     ctx.file("variables.bzl", "KONG_VAR = {\n" + content + "\n}")
 

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -254,21 +254,39 @@ CONFIGURE_OPTIONS = [
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_v8": [
-        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/v8/include\"",
-        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/v8/lib\"",
+    "@kong//:wasmx_v8_x86_64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/v8-x86_64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/v8-x86_64/lib\"",
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_wasmer": [
-        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmer/include\"",
-        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmer/lib\"",
+    "@kong//:wasmx_v8_aarch64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/v8-aarch64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/v8-aarch64/lib\"",
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_wasmtime": [
-        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmtime/include\"",
-        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmtime/lib\"",
+    "@kong//:wasmx_wasmer_x86_64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmer-x86_64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmer-x86_64/lib\"",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmer_aarch64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmer-aarch64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmer-aarch64/lib\"",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmtime_x86_64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmtime-x86_64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmtime-x86_64/lib\"",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmtime_aarch64": [
+        "--with-cc-opt=\"-I$$EXT_BUILD_ROOT$$/external/wasmtime-aarch64/include\"",
+        "--with-ld-opt=\"-L$$EXT_BUILD_ROOT$$/external/wasmtime-aarch64/lib\"",
     ],
     "//conditions:default": [],
 })
@@ -279,19 +297,33 @@ wasmx_build_data = select({
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_v8": [
-        "@v8//:all_srcs",
-        "@openresty//:wasmx_v8_ar",
+    "@kong//:wasmx_v8_x86_64": [
+        "@v8-x86_64//:all_srcs",
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_wasmer": [
-        "@wasmer//:all_srcs",
+    "@kong//:wasmx_v8_aarch64": [
+        "@v8-aarch64//:all_srcs",
     ],
     "//conditions:default": [],
 }) + select({
-    "@kong//:wasmx_wasmtime": [
-        "@wasmtime//:all_srcs",
+    "@kong//:wasmx_wasmer_x86_64": [
+        "@wasmer-x86_64//:all_srcs",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmer_aarch64": [
+        "@wasmer-aarch64//:all_srcs",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmtime_x86_64": [
+        "@wasmtime-x86_64//:all_srcs",
+    ],
+    "//conditions:default": [],
+}) + select({
+    "@kong//:wasmx_wasmtime_aarch64": [
+        "@wasmtime-aarch64//:all_srcs",
     ],
     "//conditions:default": [],
 })
@@ -323,28 +355,51 @@ configure_make(
     configure_in_place = True,
     configure_options = CONFIGURE_OPTIONS,
     env = select({
-        "@kong//:wasmx_v8": {
+        "@kong//:wasmx_v8_x86_64": {
             "NGX_WASM_RUNTIME": "v8",
-            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/v8/lib",
-            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/v8/include",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/v8-x86_64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/v8-x86_64/include",
             # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L43
-            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/v8/lib/libwee8.a -lv8bridge -lstdc++ -lm -ldl -lpthread",
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/v8-x86_64/lib/libwee8.a -lv8bridge -lstdc++ -lm -ldl -lpthread",
             # see the above comments and source for this dummy ar script
             "AR": "$(execpath @openresty//:wasmx_v8_ar)",
         },
-        "@kong//:wasmx_wasmer": {
-            "NGX_WASM_RUNTIME": "wasmer",
-            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmer/lib",
-            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmer/include",
-            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
-            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmer/lib/libwasmer.a -lm -ldl -lpthread",
+        "@kong//:wasmx_v8_aarch64": {
+            "NGX_WASM_RUNTIME": "v8",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/v8-aarch64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/v8-aarch64/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L43
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/v8-aarch64/lib/libwee8.a -lv8bridge -lstdc++ -lm -ldl -lpthread",
+            # see the above comments and source for this dummy ar script
+            "AR": "$(execpath @openresty//:wasmx_v8_ar)",
         },
-        "@kong//:wasmx_wasmtime": {
-            "NGX_WASM_RUNTIME": "wasmtime",
-            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmtime/lib",
-            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmtime/include",
+        "@kong//:wasmx_wasmer_x86_64": {
+            "NGX_WASM_RUNTIME": "wasmer",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmer-x86_64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmer-x86_64/include",
             # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
-            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmtime/lib/libwasmtime.a -lm -ldl -lpthread",
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmer-x86_64/lib/libwasmer.a -lm -ldl -lpthread",
+        },
+        "@kong//:wasmx_wasmer_aarch64": {
+            "NGX_WASM_RUNTIME": "wasmer",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmer-aarch64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmer-aarch64/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmer-aarch64/lib/libwasmer.a -lm -ldl -lpthread",
+        },
+        "@kong//:wasmx_wasmtime_x86_64": {
+            "NGX_WASM_RUNTIME": "wasmtime",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmtime-x86_64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmtime-x86_64/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmtime-x86_64/lib/libwasmtime.a -lm -ldl -lpthread",
+        },
+        "@kong//:wasmx_wasmtime_aarch64": {
+            "NGX_WASM_RUNTIME": "wasmtime",
+            "NGX_WASM_RUNTIME_LIB": "$$EXT_BUILD_ROOT$$/external/wasmtime-aarch64/lib",
+            "NGX_WASM_RUNTIME_INC": "$$EXT_BUILD_ROOT$$/external/wasmtime-aarch64/include",
+            # https://github.com/Kong/ngx_wasm_module/blob/0f07c712c48d410190ec5e0cc0b34fdfd190387d/t/10-build/003-dynamic_module.t#L30
+            "NGX_WASM_RUNTIME_LD_OPT": "$$EXT_BUILD_ROOT$$/external/wasmtime-aarch64/lib/libwasmtime.a -lm -ldl -lpthread",
         },
         "//conditions:default": {},
     }),

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -13,9 +13,6 @@ def wasmx_repositories():
     wasmtime_os = KONG_VAR["WASMTIME_OS"]
     wasmer_os = KONG_VAR["WASMER_OS"]
     v8_os = KONG_VAR["V8_OS"]
-    wasmtime_arch = KONG_VAR["WASMTIME_ARCH"]
-    wasmer_arch = KONG_VAR["WASMER_ARCH"]
-    v8_arch = KONG_VAR["V8_ARCH"]
 
     maybe(
         new_git_repository,
@@ -45,13 +42,12 @@ filegroup(
 
     maybe(
         http_archive,
-        name = "v8",
+        name = "v8-x86_64",
         urls = [
             "https://github.com/Kong/ngx_wasm_runtimes/releases/download/v8-" +
-            v8_version + "/ngx_wasm_runtime-v8-" + v8_version + "-" + v8_os + "-" +
-            v8_arch + ".tar.gz",
+            v8_version + "/ngx_wasm_runtime-v8-" + v8_version + "-" + v8_os + "-x86_64.tar.gz",
         ],
-        strip_prefix = "v8-" + v8_version + "-" + v8_os + "-" + v8_arch,
+        strip_prefix = "v8-" + v8_version + "-" + v8_os + "-x86_64",
         build_file_content = """
 filegroup(
     name = "all_srcs",
@@ -69,10 +65,33 @@ filegroup(
 
     maybe(
         http_archive,
-        name = "wasmer",
+        name = "v8-aarch64",
+        urls = [
+            "https://github.com/Kong/ngx_wasm_runtimes/releases/download/v8-" +
+            v8_version + "/ngx_wasm_runtime-v8-" + v8_version + "-" + v8_os + "-aarch64.tar.gz",
+        ],
+        strip_prefix = "v8-" + v8_version + "-" + v8_os + "-aarch64",
+        build_file_content = """
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["include/**", "lib/**"]),
+    visibility = ["//visibility:public"]
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(["**/*.a"]),
+    visibility = ["//visibility:public"]
+)
+""",
+    )
+
+    maybe(
+        http_archive,
+        name = "wasmer-x86_64",
         urls = [
             "https://github.com/wasmerio/wasmer/releases/download/v" +
-            wasmer_version + "/wasmer-" + wasmer_os + "-" + wasmer_arch + ".tar.gz",
+            wasmer_version + "/wasmer-" + wasmer_os + "-x86_64.tar.gz",
         ],
         build_file_content = """
 filegroup(
@@ -91,12 +110,57 @@ filegroup(
 
     maybe(
         http_archive,
-        name = "wasmtime",
+        name = "wasmer-aarch64",
+        urls = [
+            "https://github.com/wasmerio/wasmer/releases/download/v" +
+            wasmer_version + "/wasmer-" + wasmer_os + "-aarch64.tar.gz",
+        ],
+        build_file_content = """
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["include/**", "lib/**"]),
+    visibility = ["//visibility:public"]
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(["**/*.so", "**/*.dylib"]),
+    visibility = ["//visibility:public"]
+)
+""",
+    )
+
+    maybe(
+        http_archive,
+        name = "wasmtime-x86_64",
         urls = [
             "https://github.com/bytecodealliance/wasmtime/releases/download/v" +
-            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" + wasmtime_os + "-c-api.tar.xz",
+            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-x86_64-" + wasmtime_os + "-c-api.tar.xz",
         ],
-        strip_prefix = "wasmtime-v" + wasmtime_version + "-" + wasmtime_arch + "-" + wasmtime_os + "-c-api",
+        strip_prefix = "wasmtime-v" + wasmtime_version + "-x86_64-" + wasmtime_os + "-c-api",
+        build_file_content = """
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["include/**", "lib/**"]),
+    visibility = ["//visibility:public"]
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(["**/*.so", "**/*.dylib"]),
+    visibility = ["//visibility:public"]
+)
+""",
+    )
+
+    maybe(
+        http_archive,
+        name = "wasmtime-aarch64",
+        urls = [
+            "https://github.com/bytecodealliance/wasmtime/releases/download/v" +
+            wasmtime_version + "/wasmtime-v" + wasmtime_version + "-aarch64-" + wasmtime_os + "-c-api.tar.xz",
+        ],
+        strip_prefix = "wasmtime-v" + wasmtime_version + "-aarch64-" + wasmtime_os + "-c-api",
         build_file_content = """
 filegroup(
     name = "all_srcs",

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -47,6 +47,14 @@
   - ld-linux-aarch64.so.1
   Runpath   : /usr/local/kong/lib
 
+- Path      : /usr/local/kong/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6
@@ -139,6 +147,14 @@
   - libc.so.6
   - ld-linux-aarch64.so.1
 
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
   - libcrypt.so.1
@@ -154,6 +170,7 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
+  - ngx_wasm_module
   OpenSSL   : OpenSSL 3.1.1 30 May 2023
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True


### PR DESCRIPTION
After much trial and error, I could not make cross-compilation work by injecting the arch via `kong_bindings.bzl`, so this was the next best/most realistic thing.

The code duplication is pretty blah. Happy to hear recs on how I can cut down on this.