### PR TITLE
fix(cmd): remove the restriction that some configuration fields are not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,8 @@
   Thanks [@backjo](https://github.com/backjo) for contributing this change.
   [#10723](https://github.com/Kong/kong/pull/10729)
 - Make `kong vault get` CLI command work in dbless mode by injecting the necessary directives into the kong cli nginx.conf.
-Meanwhile, the following Kong configurations cannot reference vaults as they are required for vaults initializing:
-`prefix`, `vaults`, `database`, `lmdb_environment_path`, `lmdb_map_size`, `lua_ssl_trusted_certificate`, `lua_ssl_protocols`, `nginx_http_lua_ssl_protocols`, `nginx_stream_lua_ssl_protocols`, `vault_*`.
-  [#10675](https://github.com/Kong/kong/pull/10675)
+  [#11127](https://github.com/Kong/kong/pull/11127)
+  [#11291](https://github.com/Kong/kong/pull/11291)
 
 #### Admin API
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -618,9 +618,8 @@ local CONF_SENSITIVE = {
 }
 
 
--- List of setttings whose values can't reference vaults
--- because they'll be used before the vaults even ready
-local CONF_NO_VAULT = {
+-- List of confs necessary for compiling injected nginx conf
+local CONF_BASIC = {
   prefix = true,
   vaults = true,
   database = true,
@@ -1743,7 +1742,7 @@ local function load(path, custom_conf, opts)
   -- before executing the main `resty` cmd, i.e. still in `bin/kong`
   if opts.pre_cmd then
     for k, v in pairs(conf) do
-      if not CONF_NO_VAULT[k] then
+      if not CONF_BASIC[k] then
         conf[k] = nil
       end
     end
@@ -1825,9 +1824,6 @@ local function load(path, custom_conf, opts)
       for k, v in pairs(conf) do
         v = parse_value(v, "string")
         if vault.is_reference(v) then
-          if CONF_NO_VAULT[k] then
-            return nil, fmt("the value of %s can't reference vault", k)
-          end
           if refs then
             refs[k] = v
           else


### PR DESCRIPTION
allowd to reference vaults introduced by [#11127](https://github.com/Kong/kong/pull/11127)
[FTI-4937](https://konghq.atlassian.net/browse/FTI-4937)



[FTI-4937]: https://konghq.atlassian.net/browse/FTI-4937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ