### PR TITLE
docs(pdk): clarify kong.request.get_raw_body doc

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -716,7 +716,7 @@ local function new(self)
   -- @phases rewrite, access, response, admin_api
   -- @treturn string|nil The plain request body or nil if it does not fit into
   -- the NGINX temporary buffer.
-  -- @treturn string|nil An error message.
+  -- @treturn nil|string An error message.
   -- @usage
   -- -- Given a body with payload "Hello, Earth!":
   --

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -714,7 +714,9 @@ local function new(self)
   --
   -- @function kong.request.get_raw_body
   -- @phases rewrite, access, response, admin_api
-  -- @treturn string The plain request body.
+  -- @treturn string|nil The plain request body or nil if it does not fit into
+  -- the NGINX temporary buffer.
+  -- @treturn string|nil An error message.
   -- @usage
   -- -- Given a body with payload "Hello, Earth!":
   --


### PR DESCRIPTION
### Summary

The documentation for the `kong.request.get_raw_body` function [says that the function will return `nil` + an error message](https://github.com/Kong/kong/blob/65de2c30791538b043e352a7785c6ad37aa3e821/kong/pdk/request.lua#L711-L713) if the body doesn't fit into the NGINX temporary buffer, but this case is not reflected in the Lua doc `treturn` tags. I've completed the description if the first `treturn` tag and added a second one explaining the behavior previously described.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Compete the description of the first return value showing that it can be `nil` in the case that the body doesn't fit into the NGINX temporary buffer.
* Add missing second return value for the error emitted when the body didn't fit into the NGINX temporary buffer.
