### PR TITLE
refactor(runloop/wasm): optimize hash_chain_entity with string.buffer

### DIFF
--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -55,9 +55,7 @@ local tostring = tostring
 local ipairs = ipairs
 local type = type
 local assert = assert
-local concat = table.concat
 local insert = table.insert
-local sha256 = utils.sha256_bin
 local cjson_encode = cjson.encode
 local cjson_decode = cjson.decode
 local fmt = string.format
@@ -106,10 +104,14 @@ local STATUS = STATUS_DISABLED
 
 local hash_chain
 do
+  local buffer = require "string.buffer"
+
+  local sha256 = utils.sha256_bin
+
   local HASH_DISABLED = sha256("disabled")
   local HASH_NONE     = sha256("none")
 
-  local buf = {}
+  local buf = buffer.new()
 
   ---@param chain kong.db.schema.entities.filter_chain
   ---@return string
@@ -121,16 +123,16 @@ do
       return HASH_DISABLED
     end
 
-    local n = 0
-    for _, filter in ipairs(chain.filters) do
-      buf[n + 1] = filter.name
-      buf[n + 2] = tostring(filter.enabled)
-      buf[n + 3] = tostring(filter.enabled and sha256(filter.config))
-      n = n + 3
+    local filters = chain.filters
+    for i = 1, #filters do
+      local filter = filters[i]
+
+      buf:put(filter.name)
+      buf:put(tostring(filter.enabled))
+      buf:put(tostring(filter.enabled and sha256(filter.config)))
     end
 
-    local s = concat(buf, "", 1, n)
-    clear_tab(buf)
+    local s = buf:get()
 
     return sha256(s)
   end

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -134,7 +134,7 @@ do
 
     local s = buf:get()
 
-    buf:free()
+    buf:reset()
 
     return sha256(s)
   end

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -134,6 +134,8 @@ do
 
     local s = buf:get()
 
+    buf:free()
+
     return sha256(s)
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

We already use `string.buffer` in many fields successfully, especially for replacing `string.concat`.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* introduce `string.buffer`
* remove useless `clear_tab` `concat`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
