### PR TITLE
fix(build): add default condition to platform select()

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -239,6 +239,7 @@ CONFIGURE_OPTIONS = [
         # https://github.com/Kong/ngx_wasm_module/commit/e70a19f53e1dda99d016c5cfa393652720959afd
         "--with-ld-opt=\"-Wl,--allow-multiple-definition\"",
     ],
+    "//conditions:default": [],
 }) + select({
     "@kong//:wasmx_flag": [
         "--with-cc-opt=\"-DNGX_WASM_HOST_PROPERTY_NAMESPACE=kong\"",


### PR DESCRIPTION
Before this, non-Linux users would get this error:

```
(11:16:26) INFO: Current date is 2023-07-27
(11:16:26) ERROR: /path/path/path/path/external/openresty/BUILD.bazel:346:15: configurable attribute "configure_options" in @openresty//:openresty doesn't match this configuration. Would a default condition help?

Conditions checked:
 @platforms//os:linux

To see a condition's definition, run: bazel query --output=build <condition label>.

This instance of @openresty//:openresty has configuration identifier 77dabcd. To inspect its configuration, run: bazel config 77dabcd.

For more help, see https://bazel.build/docs/configurable-attributes#faq-select-choose-condition.

(11:16:26) ERROR: Analysis of target '//build:venv' failed; build aborted: 
(11:16:26) INFO: Elapsed time: 0.111s
(11:16:26) INFO: 0 processes.
(11:16:26) FAILED: Build did NOT complete successfully (0 packages loaded, 0 t\
argets configured)
source: no such file or directory: bazel-bin/build/kong-dev-venv.sh
```