### PR TITLE
revert(api): remove /plugins/schema/:name

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -3,6 +3,7 @@ local utils = require "kong.tools.utils"
 local reports = require "kong.reports"
 local endpoints = require "kong.api.endpoints"
 local arguments = require "kong.api.arguments"
+local api_helpers = require "kong.api.api_helpers"
 
 
 local ngx = ngx
@@ -117,6 +118,23 @@ return {
 
   ["/plugins/:plugins"] = {
     PATCH = patch_plugin
+  },
+
+  ["/plugins/schema/:name"] = {
+    GET = function(self, db)
+      kong.log.deprecation("/plugins/schema/:name endpoint is deprecated, ",
+                           "please use /schemas/plugins/:name instead", {
+                             after = "1.2.0",
+                             removal = "4.0.0",
+                           })
+      local subschema = db.plugins.schema.subschemas[self.params.name]
+      if not subschema then
+        return kong.response.exit(404, { message = "No plugin named '" .. self.params.name .. "'" })
+      end
+
+      local copy = api_helpers.schema_to_jsonable(subschema.fields.config)
+      return kong.response.exit(200, copy)
+    end
   },
 
   ["/plugins/enabled"] = {


### PR DESCRIPTION
Partially reverts #10846

Even though we have been emitting deprecation warnings when the endpoint
was used, we didn't remove it in 3.0, and doing it now can be a surprise
breaking change for someone. In fact, someone had to update a project
which was relying on that path, that is linked in #10846

This reverts the removal and replaces the deprecation version with 4.0
instead of 3.0. This PR does not revert the changes in our tests to use
the new endpoint instead of the deprecated one.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
