### PR TITLE
fix(balancer): query args not forwarded bug

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1389,9 +1389,7 @@ return {
       -- We overcome this behavior with our own logic, to preserve user
       -- desired semantics.
       -- perf: branch usually not taken, don't cache var outside
-      if byte(ctx.request_uri or var.request_uri, -1) == QUESTION_MARK then
-        var.upstream_uri = var.upstream_uri .. "?"
-      elseif var.is_args == "?" then
+      if byte(ctx.request_uri or var.request_uri, -1) == QUESTION_MARK or var.is_args == "?" then
         var.upstream_uri = var.upstream_uri .. "?" .. (var.args or "")
       end
 

--- a/spec/02-integration/05-proxy/32-query-params_spec.lua
+++ b/spec/02-integration/05-proxy/32-query-params_spec.lua
@@ -1,0 +1,69 @@
+local helpers = require "spec.helpers"
+local cjson   = require "cjson"
+
+for _, strategy in helpers.each_strategy() do
+  describe("query args specs [#" .. strategy .. "]", function()
+    local proxy_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "plugins",
+        "routes",
+        "services",
+      })
+
+      local service = assert(bp.services:insert({
+        url = helpers.mock_upstream_url
+      }))
+
+      local route = assert(bp.routes:insert({
+        service = service,
+        paths = { "/set-query-arg" }
+      }))
+
+      assert(bp.plugins:insert({
+        name = "request-transformer",
+        route = { id = route.id },
+        config = {
+          add = {
+            querystring = {"dummy:1"},
+          },
+        },
+      }))
+
+      helpers.start_kong({
+        database = strategy,
+        plugins = "bundled",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      })
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+    end)
+
+    it("does proxy set query args if URI does not contain arguments", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/set-query-arg?",
+        headers = {
+          ["Host"] = "mock_upstream",
+        },
+      })
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("1", json.uri_args.dummy)
+    end)
+  end)
+end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR fixes the issue described in #11325 

### Checklist

- [x] The Pull Request has tests
<!--
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
-->

### Full changelog

Replace query args handling code introduced in [this commit](https://github.com/Kong/kong/pull/7743/commits/9ed1547de5e0657f220c2659f8690f3dcf478041) to what it was prior to it.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #11325 
