### PR TITLE
refactor(runloop/events): gather stream config logic

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1724,32 +1724,8 @@ end
 
 
 do
-  local cjson = require "cjson.safe"
-
-  function Kong.stream_config_listener()
-    local sock, err = ngx.req.socket()
-    if not sock then
-      kong.log.crit("unable to obtain request socket: ", err)
-      return
-    end
-
-    local data, err = sock:receive("*a")
-    if not data then
-      ngx_log(ngx_CRIT, "unable to receive reconfigure data: ", err)
-      return
-    end
-
-    local reconfigure_data, err = cjson.decode(data)
-    if not reconfigure_data then
-      ngx_log(ngx_ERR, "failed to json decode reconfigure data: ", err)
-      return
-    end
-
-    local ok, err = kong.worker_events.post("declarative", "reconfigure", reconfigure_data)
-    if ok ~= "done" then
-      ngx_log(ngx_ERR, "failed to rebroadcast reconfigure event in stream: ", err or ok)
-    end
-  end
+  local events = require "kong.runloop.events"
+  Kong.stream_config_listener = events.stream_config_listener
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1725,7 +1725,7 @@ end
 
 do
   local events = require "kong.runloop.events"
-  Kong.stream_config_listener = events.stream_config_listener
+  Kong.stream_config_listener = events.stream_reconfigure_listener
 end
 
 

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -468,7 +468,7 @@ do
 
     -- only http should notify stream
     if not IS_HTTP_SUBSYSTEM or
-       #kong.configuration.stream_listeners <= 0
+       #kong.configuration.stream_listeners == 0
     then
       return true
     end

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -446,8 +446,13 @@ local stream_reconfigure_listener
 do
   local buffer = require "string.buffer"
 
+  -- `kong.configuration.prefix` is already normalized to an absolute path,
+  -- but `ngx.config.prefix()` is not
+  local PREFIX = kong.configuration and
+                 kong.configuration.prefix or
+                 require("pl.path").abspath(ngx.config.prefix())
+  local STREAM_CONFIG_SOCK = "unix:" .. PREFIX .. "/stream_config.sock"
   local IS_HTTP_SUBSYSTEM  = ngx.config.subsystem == "http"
-  local STREAM_CONFIG_SOCK = "unix:" .. ngx.config.prefix() .. "/stream_config.sock"
 
   local function broadcast_reconfigure_event(data)
     return kong.worker_events.post("declarative", "reconfigure", data)

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -444,7 +444,7 @@ end
 local declarative_reconfigure_notify
 local stream_reconfigure_listener
 do
-  local cjson = require"cjson.safe"
+  local buffer = require "string.buffer"
 
   local function broadcast_reconfigure_event(data)
     return kong.worker_events.post("declarative", "reconfigure", data)
@@ -470,8 +470,8 @@ do
 
     -- update stream if necessary
 
-    local json, err = cjson.encode(reconfigure_data)
-    if not json then
+    local str, err = buffer.encode(reconfigure_data)
+    if not str then
       return nil, err
     end
 
@@ -484,14 +484,14 @@ do
     -- send to stream_reconfigure_listener()
 
     local bytes
-    bytes, err = sock:send(json)
+    bytes, err = sock:send(str)
     sock:close()
 
     if not bytes then
       return nil, err
     end
 
-    assert(bytes == #json,
+    assert(bytes == #str,
            "incomplete reconfigure data sent to the stream subsystem")
 
     return true
@@ -510,7 +510,7 @@ do
       return
     end
 
-    local reconfigure_data, err = cjson.decode(data)
+    local reconfigure_data, err = buffer.decode(data)
     if not reconfigure_data then
       ngx.log(ngx.ERR, "failed to json decode reconfigure data: ", err)
       return

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -450,7 +450,6 @@ do
     return kong.worker_events.post("declarative", "reconfigure", data)
   end
 
-  -- init.lua
   stream_reconfigure_listener = function()
     local sock, err = ngx.req.socket()
     if not sock then
@@ -532,6 +531,9 @@ return {
   -- exposed only for tests
   _register_balancer_events = _register_balancer_events,
 
+  -- init.lua
   stream_reconfigure_listener = stream_reconfigure_listener,
+
+  -- db/declarative/import.lua
   declarative_reconfigure_notify = declarative_reconfigure_notify,
 }

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -446,12 +446,12 @@ local stream_reconfigure_listener
 do
   local buffer = require "string.buffer"
 
+  local IS_HTTP_SUBSYSTEM  = ngx.config.subsystem == "http"
+  local STREAM_CONFIG_SOCK = "unix:" .. ngx.config.prefix() .. "/stream_config.sock"
+
   local function broadcast_reconfigure_event(data)
     return kong.worker_events.post("declarative", "reconfigure", data)
   end
-
-  local IS_HTTP_SUBSYSTEM = ngx.config.subsystem == "http"
-  local STREAM_CONFIG_SOCK = "unix:" .. ngx.config.prefix() .. "/stream_config.sock"
 
   declarative_reconfigure_notify = function(reconfigure_data)
 

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -441,39 +441,13 @@ local function _register_balancer_events(f)
 end
 
 
-local stream_reconfigure_listener
 local declarative_reconfigure_notify
+local stream_reconfigure_listener
 do
   local cjson = require"cjson.safe"
 
   local function broadcast_reconfigure_event(data)
     return kong.worker_events.post("declarative", "reconfigure", data)
-  end
-
-  stream_reconfigure_listener = function()
-    local sock, err = ngx.req.socket()
-    if not sock then
-      kong.log.crit("unable to obtain request socket: ", err)
-      return
-    end
-
-    local data, err = sock:receive("*a")
-    if not data then
-      ngx.log(ngx.CRIT, "unable to receive reconfigure data: ", err)
-      return
-    end
-
-    local reconfigure_data, err = cjson.decode(data)
-    if not reconfigure_data then
-      ngx.log(ngx.ERR, "failed to json decode reconfigure data: ", err)
-      return
-    end
-
-    -- call reconfigure_handler in each worker's stream subsystem
-    local ok, err = broadcast_reconfigure_event(reconfigure_data)
-    if ok ~= "done" then
-      ngx.log(ngx.ERR, "failed to rebroadcast reconfigure event in stream: ", err or ok)
-    end
   end
 
   local IS_HTTP_SUBSYSTEM = ngx.config.subsystem == "http"
@@ -522,18 +496,45 @@ do
 
     return true
   end
+
+  stream_reconfigure_listener = function()
+    local sock, err = ngx.req.socket()
+    if not sock then
+      kong.log.crit("unable to obtain request socket: ", err)
+      return
+    end
+
+    local data, err = sock:receive("*a")
+    if not data then
+      ngx.log(ngx.CRIT, "unable to receive reconfigure data: ", err)
+      return
+    end
+
+    local reconfigure_data, err = cjson.decode(data)
+    if not reconfigure_data then
+      ngx.log(ngx.ERR, "failed to json decode reconfigure data: ", err)
+      return
+    end
+
+    -- call reconfigure_handler in each worker's stream subsystem
+    local ok, err = broadcast_reconfigure_event(reconfigure_data)
+    if ok ~= "done" then
+      ngx.log(ngx.ERR, "failed to rebroadcast reconfigure event in stream: ", err or ok)
+    end
+  end
 end
 
 
 return {
+  -- runloop/handler.lua
   register_events = register_events,
 
-  -- exposed only for tests
-  _register_balancer_events = _register_balancer_events,
+  -- db/declarative/import.lua
+  declarative_reconfigure_notify = declarative_reconfigure_notify,
 
   -- init.lua
   stream_reconfigure_listener = stream_reconfigure_listener,
 
-  -- db/declarative/import.lua
-  declarative_reconfigure_notify = declarative_reconfigure_notify,
+  -- exposed only for tests
+  _register_balancer_events = _register_balancer_events,
 }

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -505,7 +505,7 @@ do
   stream_reconfigure_listener = function()
     local sock, err = ngx.req.socket()
     if not sock then
-      kong.log.crit("unable to obtain request socket: ", err)
+      ngx.log(ngx.CRIT, "unable to obtain request socket: ", err)
       return
     end
 

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -448,7 +448,7 @@ do
 
   -- `kong.configuration.prefix` is already normalized to an absolute path,
   -- but `ngx.config.prefix()` is not
-  local PREFIX = kong.configuration and
+  local PREFIX = kong and kong.configuration and
                  kong.configuration.prefix or
                  require("pl.path").abspath(ngx.config.prefix())
   local STREAM_CONFIG_SOCK = "unix:" .. PREFIX .. "/stream_config.sock"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When dp received the config data from cp, it will load the data into lmdb cache, then invoke "reconfigure".

The "reconfigure" action will happen in both http and stream subsystem, but the code scatter in different lua modules,
This PR move the logic into one place.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* use `string.buffer` to replace `lua-cjson`
* normalize `ngx.config.prefix()` path
* move logic into `runloop/events.lua`
* remove `kong.log.crit`, using `ngx.log`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
