### PR TITLE
tests(*): http mock support specifying customized init_by_lua_block code

### DIFF
--- a/spec/02-integration/01-helpers/03-http_mock_spec.lua
+++ b/spec/02-integration/01-helpers/03-http_mock_spec.lua
@@ -229,7 +229,7 @@ describe("http_mock config", function()
         ]],
       },
     }, {
-      init_by_lua_block = [[
+      init = [[
         -- Test that the mock is injected
         test_value = "hello world"
       ]]

--- a/spec/helpers/http_mock.lua
+++ b/spec/helpers/http_mock.lua
@@ -61,8 +61,7 @@ end
 -- @tparam[opt=false] bool opts.log_opts.collect_resp whether to log responses
 -- @tparam[opt=false] bool opts.log_opts.collect_resp_body whether to log response bodies
 -- @tparam[opt=true] bool opts.log_opts.collect_err: whether to log errors
--- @tparam[opt=""] string opts.init_by_lua_block the lua code injected into the init_by_lua_block
-
+-- @tparam[opt] string opts.init_by_lua_block: the lua code injected into the init_by_lua_block
 -- @treturn http_mock a mock instance
 -- @treturn string the port the mock server listens to
 -- @usage

--- a/spec/helpers/http_mock.lua
+++ b/spec/helpers/http_mock.lua
@@ -61,7 +61,7 @@ end
 -- @tparam[opt=false] bool opts.log_opts.collect_resp whether to log responses
 -- @tparam[opt=false] bool opts.log_opts.collect_resp_body whether to log response bodies
 -- @tparam[opt=true] bool opts.log_opts.collect_err: whether to log errors
--- @tparam[opt] string opts.init_by_lua_block: the lua code injected into the init_by_lua_block
+-- @tparam[opt] string opts.init: the lua code injected into the init_by_lua_block
 -- @treturn http_mock a mock instance
 -- @treturn string the port the mock server listens to
 -- @usage
@@ -161,7 +161,7 @@ function http_mock.new(listens, routes, opts)
     listens = listens,
     routes = routes,
     directives = directives,
-    init_by_lua_block = opts.init_by_lua_block,
+    init = opts.init,
     log_opts = log_opts,
     logs = {},
     tls = opts.tls,

--- a/spec/helpers/http_mock.lua
+++ b/spec/helpers/http_mock.lua
@@ -61,6 +61,8 @@ end
 -- @tparam[opt=false] bool opts.log_opts.collect_resp whether to log responses
 -- @tparam[opt=false] bool opts.log_opts.collect_resp_body whether to log response bodies
 -- @tparam[opt=true] bool opts.log_opts.collect_err: whether to log errors
+-- @tparam[opt=""] string opts.init_by_lua_block the lua code injected into the init_by_lua_block
+
 -- @treturn http_mock a mock instance
 -- @treturn string the port the mock server listens to
 -- @usage
@@ -160,7 +162,7 @@ function http_mock.new(listens, routes, opts)
     listens = listens,
     routes = routes,
     directives = directives,
-    init_block = opts.init_block,
+    init_by_lua_block = opts.init_by_lua_block,
     log_opts = log_opts,
     logs = {},
     tls = opts.tls,

--- a/spec/helpers/http_mock.lua
+++ b/spec/helpers/http_mock.lua
@@ -160,6 +160,7 @@ function http_mock.new(listens, routes, opts)
     listens = listens,
     routes = routes,
     directives = directives,
+    init_block = opts.init_block,
     log_opts = log_opts,
     logs = {},
     tls = opts.tls,

--- a/spec/helpers/http_mock/template.lua
+++ b/spec/helpers/http_mock/template.lua
@@ -24,8 +24,8 @@ events {
 http {
   lua_shared_dict mock_logs $(shm_size);
 
-# if log_opts.err then
   init_by_lua_block {
+# if log_opts.err then
     -- disable warning of global variable
     local g_meta = getmetatable(_G)
     setmetatable(_G, nil)
@@ -43,7 +43,7 @@ http {
 
     function assert(truthy, err) -- luacheck: ignore
       if truthy then
-        return truthy
+        return original_assert(truthy, err)
       end
 
       if ngx.ctx then
@@ -66,9 +66,12 @@ http {
     err_patched = true -- luacheck: ignore
 
     setmetatable(_G, g_meta)
+# end
+# if init_block then
+$(init_block)
+# end
   }
 
-# end
   server {
     listen 0.0.0.0:$(debug.port);
     server_name mock_debug;
@@ -142,7 +145,7 @@ http {
         local method = ngx.req.get_method()
         local uri = ngx.var.request_uri
         local headers = ngx.req.get_headers(nil, true)
-        
+
 
         ngx.req.read_body()
         local body

--- a/spec/helpers/http_mock/template.lua
+++ b/spec/helpers/http_mock/template.lua
@@ -63,8 +63,8 @@ http {
 
     setmetatable(_G, g_meta)
 # end
-# if init_block then
-$(init_block)
+# if init_by_lua_block then
+$(init_by_lua_block)
 # end
   }
 

--- a/spec/helpers/http_mock/template.lua
+++ b/spec/helpers/http_mock/template.lua
@@ -63,8 +63,8 @@ http {
 
     setmetatable(_G, g_meta)
 # end
-# if init_by_lua_block then
-$(init_by_lua_block)
+# if init then
+$(init)
 # end
   }
 

--- a/spec/helpers/http_mock/template.lua
+++ b/spec/helpers/http_mock/template.lua
@@ -41,16 +41,12 @@ http {
       table.insert(err_t, {err, debug.traceback("", 3)})
     end
 
-    function assert(truthy, err) -- luacheck: ignore
-      if truthy then
-        return original_assert(truthy, err)
-      end
-
-      if ngx.ctx then
+    function assert(truthy, err, ...) -- luacheck: ignore
+      if not truthy and ngx.ctx then
         insert_err(err)
       end
 
-      return original_assert(truthy, err)
+      return original_assert(truthy, err, ...)
     end
 
     original_error = error -- luacheck: ignore


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This commits has two changes:
- Let http mock support specifying customized init_by_lua_block code
- Fix the global patched assert function behavior to keep it same as the original one.

I'm writing some tests for the EE project and it will be useful if we can specify customized init code to run some code at init phase. 

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
