### PR TITLE
fix(admin-gui): make admin_gui_ssl_cert_key sensitive (#11332)

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -613,6 +613,7 @@ local CONF_SENSITIVE = {
   ssl_cert_key = true,
   client_ssl_cert_key = true,
   admin_ssl_cert_key = true,
+  admin_gui_ssl_cert_key = true,
   status_ssl_cert_key = true,
   debug_ssl_cert_key = true,
 }


### PR DESCRIPTION
... to prevent it been printed to console unexpectedly

(cherry picked from commit 5741a18a8d7e7243610682c8299c2f69bf3892c1)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
