### PR TITLE
chore: add schema-change-noteworthy label to redis schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -177,6 +177,7 @@ schema-change-noteworthy:
 - plugins-ee/**/daos.lua
 - plugins-ee/**/schema.lua
 - kong/db/dao/*.lua
+- kong/enterprise_edition/redis/init.lua
 
 build/bazel:
 - '**/*.bazel'


### PR DESCRIPTION
Include `schema-change-noteworthy` label in PRs that change `kong/enterprise_edition/redis/init.lua`.