### PR TITLE
fix(admin-gui): remove unnecessary `admin_gui_origin` from kong_defaults

### DIFF
--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -193,7 +193,6 @@ tracing_instrumentations = off
 tracing_sampling_rate = 0.01
 
 admin_gui_url =
-admin_gui_origin =    # for internal use only, can not be configured manually
 admin_gui_path = /
 admin_gui_api_url =
 


### PR DESCRIPTION
We noticed the comment line in `kong_defaults.lua` will also be treated as a string. This may cause unexcepted behavior.

The `admin_gui_origin` is unnecessary since this config item is not directly facing the end user, so it's safe to remove it.


### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
