### PR TITLE
chore(ci): support additional paths in the build cache key

### DIFF
--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -8,8 +8,8 @@ inputs:
     description: 'String prefix applied to the build cache key'
     required: false
     default: 'build'
-  paths:
-    description: 'Additional paths (newline-delimited) to use in cache key generation'
+  extra:
+    description: 'Additional values/file hashes to use in the cache key'
     required: false
 
 outputs:
@@ -24,74 +24,42 @@ runs:
       id: cache-key
       shell: bash
       env:
-        EXTRA_PATHS: ${{ inputs.paths }}
+        EXTRA: ${{ inputs.extra }}
       run: |
-        echo "::group::Enumerate Paths"
-
-        LIST=$(mktemp)
-
-        add_file() {
-          local f=$1
-          echo "path spec: $f"
-
-          git ls-files \
-            --full-name \
-            --recurse-submodules \
-            "$f" \
-            >> "$LIST"
-        }
-
         # please keep these sorted
-        DEFAULT_PATHS=(
-          '.bazelignore'
-          '.bazelrc'
-          '.bazelversion'
-          '.github/actions/build-cache-key/**'
-          '.github/workflows/build.yml'
-          '.requirements'
-          'BUILD.bazel'
-          'WORKSPACE'
-          'bin/kong'
-          'bin/kong-health'
-          'build/**'
-          'kong-*.rockspec'
-          'kong.conf.default'
+        FILE_HASHES=(
+          ${{ hashFiles('.bazelignore') }}
+          ${{ hashFiles('.bazelrc') }}
+          ${{ hashFiles('.bazelversion') }}
+          ${{ hashFiles('.github/actions/build-cache-key/**') }}
+          ${{ hashFiles('.github/workflows/build.yml') }}
+          ${{ hashFiles('.requirements') }}
+          ${{ hashFiles('BUILD.bazel') }}
+          ${{ hashFiles('WORKSPACE') }}
+          ${{ hashFiles('bin/kong') }}
+          ${{ hashFiles('bin/kong-health') }}
+          ${{ hashFiles('build/**') }}
+          ${{ hashFiles('kong-*.rockspec') }}
+          ${{ hashFiles('kong.conf.default') }}
         )
 
-        for fname in "${DEFAULT_PATHS[@]}"; do
-          add_file "$fname"
-        done
+        if [[ -n ${EXTRA:-} ]]; then
+          OFFSET=${#FILE_HASHES[@]}
 
-        if [[ -n ${EXTRA_PATHS:-} ]]; then
-          readarray -t EXTRA <<< "$EXTRA_PATHS"
-
-          for fname in "${EXTRA[@]}"; do
-            if [[ -z ${fname:-} ]]; then
-              continue
-            fi
-
-            add_file "$fname"
-          done
+          readarray \
+            -O "$OFFSET" \
+            -t \
+            FILE_HASHES \
+          <<< "$EXTRA"
         fi
 
-        echo "::endgroup::"
+        NORMALIZED=$(
+          printf '%s\n' "${FILE_HASHES[@]}" \
+            | grep -vE '^$' \
+            | sort --stable --unique
+        )
 
-        echo "::group::Hash Files"
-
-        HASH=$(mktemp)
-
-        sort \
-          --stable \
-          --unique \
-          < "$LIST" \
-        | while read -r fname; do
-          sha256sum "$fname" | tee -a "$HASH"
-        done
-
-        echo "::endgroup::"
-
-        ALL=$(sha256sum "$HASH" | awk '{print $1}')
-
-        CACHE_KEY=${{ inputs.prefix }}::${ALL}
+        HASH=$(sha256sum - <<< "$NORMALIZED" | awk '{print $1}' )
+        CACHE_KEY=${{ inputs.prefix }}::${HASH}
         echo "cache-key: ${CACHE_KEY}"
         echo "CACHE_KEY=${CACHE_KEY}" >> $GITHUB_OUTPUT

--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'String prefix applied to the build cache key'
     required: false
     default: 'build'
+  paths:
+    description: 'Additional paths (newline-delimited) to use in cache key generation'
+    required: false
 
 outputs:
   cache-key:
@@ -20,26 +23,75 @@ runs:
     - name: Generate cache key
       id: cache-key
       shell: bash
+      env:
+        EXTRA_PATHS: ${{ inputs.paths }}
       run: |
+        echo "::group::Enumerate Paths"
+
+        LIST=$(mktemp)
+
+        add_file() {
+          local f=$1
+          echo "path spec: $f"
+
+          git ls-files \
+            --full-name \
+            --recurse-submodules \
+            "$f" \
+            >> "$LIST"
+        }
+
         # please keep these sorted
-        FILE_HASHES=(
-          ${{ hashFiles('.bazelignore') }}
-          ${{ hashFiles('.bazelrc') }}
-          ${{ hashFiles('.bazelversion') }}
-          ${{ hashFiles('.github/actions/build-cache-key/**') }}
-          ${{ hashFiles('.github/workflows/build.yml') }}
-          ${{ hashFiles('.requirements') }}
-          ${{ hashFiles('BUILD.bazel') }}
-          ${{ hashFiles('WORKSPACE') }}
-          ${{ hashFiles('bin/kong') }}
-          ${{ hashFiles('bin/kong-health') }}
-          ${{ hashFiles('build/**') }}
-          ${{ hashFiles('kong-*.rockspec') }}
-          ${{ hashFiles('kong.conf.default') }}
-          ${{ hashFiles('kong/**') }}
+        DEFAULT_PATHS=(
+          '.bazelignore'
+          '.bazelrc'
+          '.bazelversion'
+          '.github/actions/build-cache-key/**'
+          '.github/workflows/build.yml'
+          '.requirements'
+          'BUILD.bazel'
+          'WORKSPACE'
+          'bin/kong'
+          'bin/kong-health'
+          'build/**'
+          'kong-*.rockspec'
+          'kong.conf.default'
         )
 
-        HASH=$(sha256sum - <<< "${FILE_HASHES[*]}" | awk '{print $1}' )
-        CACHE_KEY=${{ inputs.prefix }}::${HASH}
+        for fname in "${DEFAULT_PATHS[@]}"; do
+          add_file "$fname"
+        done
+
+        if [[ -n ${EXTRA_PATHS:-} ]]; then
+          readarray -t EXTRA <<< "$EXTRA_PATHS"
+
+          for fname in "${EXTRA[@]}"; do
+            if [[ -z ${fname:-} ]]; then
+              continue
+            fi
+
+            add_file "$fname"
+          done
+        fi
+
+        echo "::endgroup::"
+
+        echo "::group::Hash Files"
+
+        HASH=$(mktemp)
+
+        sort \
+          --stable \
+          --unique \
+          < "$LIST" \
+        | while read -r fname; do
+          sha256sum "$fname" | tee -a "$HASH"
+        done
+
+        echo "::endgroup::"
+
+        ALL=$(sha256sum "$HASH" | awk '{print $1}')
+
+        CACHE_KEY=${{ inputs.prefix }}::${ALL}
         echo "cache-key: ${CACHE_KEY}"
         echo "CACHE_KEY=${CACHE_KEY}" >> $GITHUB_OUTPUT

--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -24,6 +24,7 @@ runs:
       id: cache-key
       shell: bash
       env:
+        PREFIX: ${{ inputs.prefix }}
         EXTRA: ${{ inputs.extra }}
       run: |
         # please keep these sorted
@@ -43,35 +44,19 @@ runs:
           ${{ hashFiles('kong.conf.default') }}
         )
 
-        echo "FILE_HASHES (init):"
-        printf '%q\n' "${FILE_HASHES[@]}"
-
         if [[ -n ${EXTRA:-} ]]; then
-          OFFSET=${#FILE_HASHES[@]}
-
-          echo "EXTRA:"
-          echo "$EXTRA"
-
           readarray \
-            -O "$OFFSET" \
+            -O "${#FILE_HASHES[@]}" \
             -t \
             FILE_HASHES \
           <<< "$EXTRA"
-
-          echo "FILE_HASHES (extended):"
-          printf '%q\n' "${FILE_HASHES[@]}"
         fi
 
-        NORMALIZED=$(
-          printf '%s\n' "${FILE_HASHES[@]}" \
-            | grep -vE '^$' \
-            | sort --stable --unique
+        HASH=$(printf '%s\n' "${FILE_HASHES[@]}" \
+          | grep -vE '^$' \
+          | sort --stable --unique \
+          | sha256sum - \
+          | awk '{print $1}'
         )
 
-        echo "FILE_HASHES (normalized):"
-        echo "$NORMALIZED"
-
-        HASH=$(sha256sum - <<< "$NORMALIZED" | awk '{print $1}' )
-        CACHE_KEY=${{ inputs.prefix }}::${HASH}
-        echo "cache-key: ${CACHE_KEY}"
-        echo "CACHE_KEY=${CACHE_KEY}" >> $GITHUB_OUTPUT
+        echo "CACHE_KEY=${PREFIX}::${HASH}" >> $GITHUB_OUTPUT

--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -50,7 +50,7 @@ runs:
           OFFSET=${#FILE_HASHES[@]}
 
           echo "EXTRA:"
-          printf '%q\n' "$EXTRA"
+          echo "$EXTRA"
 
           readarray \
             -O "$OFFSET" \

--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -43,14 +43,23 @@ runs:
           ${{ hashFiles('kong.conf.default') }}
         )
 
+        echo "FILE_HASHES (init):"
+        printf '%q\n' "${FILE_HASHES[@]}"
+
         if [[ -n ${EXTRA:-} ]]; then
           OFFSET=${#FILE_HASHES[@]}
+
+          echo "EXTRA:"
+          printf '%q\n' "$EXTRA"
 
           readarray \
             -O "$OFFSET" \
             -t \
             FILE_HASHES \
           <<< "$EXTRA"
+
+          echo "FILE_HASHES (extended):"
+          printf '%q\n' "${FILE_HASHES[@]}"
         fi
 
         NORMALIZED=$(
@@ -58,6 +67,9 @@ runs:
             | grep -vE '^$' \
             | sort --stable --unique
         )
+
+        echo "FILE_HASHES (normalized):"
+        echo "$NORMALIZED"
 
         HASH=$(sha256sum - <<< "$NORMALIZED" | awk '{print $1}' )
         CACHE_KEY=${{ inputs.prefix }}::${HASH}

--- a/.github/actions/build-cache-key/action.yml
+++ b/.github/actions/build-cache-key/action.yml
@@ -59,4 +59,4 @@ runs:
           | awk '{print $1}'
         )
 
-        echo "CACHE_KEY=${PREFIX}::${HASH}" >> $GITHUB_OUTPUT
+        echo "CACHE_KEY=${PREFIX}::${HASH}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
     - name: Generate cache key
       id: cache-key
       uses: ./.github/actions/build-cache-key
+      with:
+        extra: |
+          ${{ hashFiles('kong/**') }}
+          ${{ hashFiles('kong/**') }}
+          ${{ hashFiles('kong*.rockspec') }}
 
     - name: Lookup build cache
       id: cache-deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,6 @@ jobs:
     - name: Generate cache key
       id: cache-key
       uses: ./.github/actions/build-cache-key
-      with:
-        extra: |
-          ${{ hashFiles('kong/**') }}
-          ${{ hashFiles('kong/**') }}
-          ${{ hashFiles('kong*.rockspec') }}
 
     - name: Lookup build cache
       id: cache-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,8 @@ jobs:
       uses: ./.github/actions/build-cache-key
       with:
         prefix: ${{ matrix.label }}-build
+        paths: |
+          kong/**
 
     - name: Cache Packages
       id: cache-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,8 @@ jobs:
       uses: ./.github/actions/build-cache-key
       with:
         prefix: ${{ matrix.label }}-build
-        paths: |
-          kong/**
+        extra: |
+          ${{ hashFiles('kong/**') }}
 
     - name: Cache Packages
       id: cache-deps


### PR DESCRIPTION
This updates the `build-cache-key` action to accept additional paths to use when generating the cache key. The impetus for this change is to allow removal of `kong/**` from the default cache key so that it can be used selectively.

See also: https://github.com/Kong/kong/pull/11299#discussion_r1278828078

cc @fffonion lemme know what you think of this approach!