### PR TITLE
fix(oauth2): fix a bug that refresh_token could be shared across instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   `max_retry_delay` must now be `number`s greater than 0.001
   (seconds).
   [#10840](https://github.com/Kong/kong/pull/10840)
+- For OAuth2 plugin, `scope` has been taken into account as a new creteria of the request validation. When refreshing token with `refresh_token`, the scopes associated with the `refresh_token` provided in the request must be same with or a subset of the scopes configured in the OAuth2 plugin instance hit by the request. 
+  [#11342](https://github.com/Kong/kong/pull/11342)
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
   `max_retry_delay` must now be `number`s greater than 0.001
   (seconds).
   [#10840](https://github.com/Kong/kong/pull/10840)
-- For OAuth2 plugin, `scope` has been taken into account as a new creteria of the request validation. When refreshing token with `refresh_token`, the scopes associated with the `refresh_token` provided in the request must be same with or a subset of the scopes configured in the OAuth2 plugin instance hit by the request. 
+- For OAuth2 plugin, `scope` has been taken into account as a new criterion of the request validation. When refreshing token with `refresh_token`, the scopes associated with the `refresh_token` provided in the request must be same with or a subset of the scopes configured in the OAuth2 plugin instance hit by the request. 
   [#11342](https://github.com/Kong/kong/pull/11342)
 
 ### Additions

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -780,9 +780,9 @@ local function issue_token(conf)
 
           if not response_params[ERROR] then
             response_params = generate_token(conf, kong.router.get_service(),
-                                            client,
-                                            token.authenticated_userid,
-                                            token.scope, state, false, token)
+                                             client,
+                                             token.authenticated_userid,
+                                             token.scope, state, false, token)
             -- Delete old token if refresh token not persisted
             if not conf.reuse_refresh_token then
               kong.db.oauth2_tokens:delete({ id = token.id })

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -767,8 +767,8 @@ local function issue_token(conf)
         else
           -- Check scopes
           if token.scope then
-            for v in token.scope:gmatch("%S+") do
-              if not table_contains(conf.scopes, v) then
+            for scope in token.scope:gmatch("%S+") do
+              if not table_contains(conf.scopes, scope) then
                 response_params = {
                   [ERROR] = "invalid_scope",
                   error_description = "scope mismatch",

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -771,7 +771,7 @@ local function issue_token(conf)
               if not table_contains(conf.scopes, scope) then
                 response_params = {
                   [ERROR] = "invalid_scope",
-                  error_description = "scope mismatch",
+                  error_description = "Scope mismatch",
                 }
                 break
               end

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -265,6 +265,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       local service18   = admin_api.services:insert()
       local service19   = admin_api.services:insert()
       local service20   = admin_api.services:insert()
+      local service21   = admin_api.services:insert()
 
       local route1 = assert(admin_api.routes:insert({
         hosts     = { "oauth2.com" },
@@ -396,6 +397,12 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         hosts       = { "oauth2_20.com" },
         protocols   = { "http", "https" },
         service     = service20,
+      }))
+
+      local route21 = assert(admin_api.routes:insert({
+        hosts       = { "oauth2_21.com" },
+        protocols   = { "http", "https" },
+        service     = service21,
       }))
 
       local service_grpc = assert(admin_api.services:insert {
@@ -597,7 +604,15 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       admin_api.oauth2_plugins:insert({
         route = { id = route20.id },
         config   = {
-          scopes                   = { "scope18", "scope20" },
+          scopes                   = { "scope20" },
+          global_credentials       = true,
+        }
+      })
+
+      admin_api.oauth2_plugins:insert({
+        route = { id = route21.id },
+        config   = {
+          scopes                   = { "scope20", "scope21" },
           global_credentials       = true,
         }
       })
@@ -2950,97 +2965,147 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         })
         assert.res_status(401, res)
       end)
-      describe("refreshing token", function()
-        local request_client, token
-        it("fails when scope is mismatching", function ()
-          -- provision code
-          local code, body, res
-          request_client = helpers.proxy_ssl_client()
-          body = {
-              provision_key = "provision123",
-              client_id = "clientid123",
-              response_type = "code",
-              scope = "scope18",
-              state = "hello",
-              authenticated_userid = "userid123",
-          }
-          res = assert(request_client:send {
-            method = "POST",
-            path = "/oauth2/authorize",
-            body = body,
-            headers = kong.table.merge({
-              ["Host"] = "oauth2_18.com",
-              ["Content-Type"] = "application/json"
-            })
-          })
-          res = assert(cjson.decode(assert.res_status(200, res)))
-          if res.redirect_uri then
-            local iterator, err = ngx.re.gmatch(res.redirect_uri, "^http://google\\.com/kong\\?code=([\\w]{32,32})&state=hello$")
-            assert.is_nil(err)
-            local m, err = iterator()
-            assert.is_nil(err)
-            code = m[1]
-          end
 
-          -- provision token
-          body = {
-            code = code,
+      it("refreshing token fails when scope is mismatching", function ()
+        -- provision code
+        local code, body, res
+        local request_client = helpers.proxy_ssl_client()
+        body = {
+            provision_key = "provision123",
             client_id = "clientid123",
-            client_secret = "secret123",
-            grant_type = "authorization_code",
-            redirect_uri = "http://google.com/kong",
-          }
-          res = assert(request_client:send {
-            method  = "POST",
-            path    = "/oauth2/token",
-            body    = body,
-            headers = {
-              ["Host"]         = "oauth2_18.com",
-              ["Content-Type"] = "application/json"
-            }
+            response_type = "code",
+            scope = "scope18",
+            state = "hello",
+            authenticated_userid = "userid123",
+        }
+        res = assert(request_client:send {
+          method = "POST",
+          path = "/oauth2/authorize",
+          body = body,
+          headers = kong.table.merge({
+            ["Host"] = "oauth2_18.com",
+            ["Content-Type"] = "application/json"
           })
-          token = assert(cjson.decode(assert.res_status(200, res)))
+        })
+        res = assert(cjson.decode(assert.res_status(200, res)))
+        if res.redirect_uri then
+          local iterator, err = ngx.re.gmatch(res.redirect_uri, "^http://google\\.com/kong\\?code=([\\w]{32,32})&state=hello$")
+          assert.is_nil(err)
+          local m, err = iterator()
+          assert.is_nil(err)
+          code = m[1]
+        end
 
-          -- refresh token with mismatching scope
-          res = assert(request_client:send {
-            method  = "POST",
-            path    = "/oauth2/token",
-            body    = {
-              refresh_token    = token.refresh_token,
-              client_id        = "clientid123",
-              client_secret    = "secret123",
-              grant_type       = "refresh_token",
-            },
-            headers = {
-              ["Host"]         = "oauth2_19.com",
-              ["Content-Type"] = "application/json"
-            }
-          })
-          res = assert(cjson.decode(assert.res_status(400, res)))
-          assert.same({
-            error = "invalid_scope",
-            error_description = "scope mismatch"
-          }, res)
-        end)
-        it("succeeds when scope is a subset", function()
-          -- refresh token with mismatching scope
-          local res = assert(request_client:send {
-            method  = "POST",
-            path    = "/oauth2/token",
-            body    = {
-              refresh_token    = token.refresh_token,
-              client_id        = "clientid123",
-              client_secret    = "secret123",
-              grant_type       = "refresh_token",
-            },
-            headers = {
-              ["Host"]         = "oauth2_20.com",
-              ["Content-Type"] = "application/json"
-            }
-          })
-          assert(cjson.decode(assert.res_status(200, res)))
-        end)
+        -- provision token
+        body = {
+          code = code,
+          client_id = "clientid123",
+          client_secret = "secret123",
+          grant_type = "authorization_code",
+          redirect_uri = "http://google.com/kong",
+        }
+        res = assert(request_client:send {
+          method  = "POST",
+          path    = "/oauth2/token",
+          body    = body,
+          headers = {
+            ["Host"]         = "oauth2_18.com",
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local token = assert(cjson.decode(assert.res_status(200, res)))
+
+        -- refresh token with mismatching scope
+        res = assert(request_client:send {
+          method  = "POST",
+          path    = "/oauth2/token",
+          body    = {
+            refresh_token    = token.refresh_token,
+            client_id        = "clientid123",
+            client_secret    = "secret123",
+            grant_type       = "refresh_token",
+          },
+          headers = {
+            ["Host"]         = "oauth2_19.com",
+            ["Content-Type"] = "application/json"
+          }
+        })
+        res = assert(cjson.decode(assert.res_status(400, res)))
+        assert.same({
+          error = "invalid_scope",
+          error_description = "Scope mismatch"
+        }, res)
+        request_client:close()
       end)
+
+      it("refreshing token succeeds when scope is a subset", function()
+        -- provision code
+        local code, body, res
+        local request_client = helpers.proxy_ssl_client()
+        body = {
+            provision_key = "provision123",
+            client_id = "clientid123",
+            response_type = "code",
+            scope = "scope20",
+            state = "hello",
+            authenticated_userid = "userid123",
+        }
+        res = assert(request_client:send {
+          method = "POST",
+          path = "/oauth2/authorize",
+          body = body,
+          headers = kong.table.merge({
+            ["Host"] = "oauth2_20.com",
+            ["Content-Type"] = "application/json"
+          })
+        })
+        res = assert(cjson.decode(assert.res_status(200, res)))
+        if res.redirect_uri then
+          local iterator, err = ngx.re.gmatch(res.redirect_uri, "^http://google\\.com/kong\\?code=([\\w]{32,32})&state=hello$")
+          assert.is_nil(err)
+          local m, err = iterator()
+          assert.is_nil(err)
+          code = m[1]
+        end
+
+        -- provision token
+        body = {
+          code = code,
+          client_id = "clientid123",
+          client_secret = "secret123",
+          grant_type = "authorization_code",
+          redirect_uri = "http://google.com/kong",
+        }
+        res = assert(request_client:send {
+          method  = "POST",
+          path    = "/oauth2/token",
+          body    = body,
+          headers = {
+            ["Host"]         = "oauth2_20.com",
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local token = assert(cjson.decode(assert.res_status(200, res)))
+
+        -- refresh token with mismatching scope
+        local res = assert(request_client:send {
+          method  = "POST",
+          path    = "/oauth2/token",
+          body    = {
+            refresh_token    = token.refresh_token,
+            client_id        = "clientid123",
+            client_secret    = "secret123",
+            grant_type       = "refresh_token",
+          },
+          headers = {
+            ["Host"]         = "oauth2_21.com",
+            ["Content-Type"] = "application/json"
+          }
+        })
+        assert(cjson.decode(assert.res_status(200, res)))
+        request_client:close()
+      end)
+
       it("fails when a correct access_token is being sent in the wrong header", function()
         local token = provision_token("oauth2_11.com",nil,"clientid1011","secret1011")
 

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -3022,7 +3022,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
             error_description = "scope mismatch"
           }, res)
         end)
-        it("successes when scope is a subset", function()
+        it("succeeds when scope is a subset", function()
           -- refresh token with mismatching scope
           local res = assert(request_client:send {
             method  = "POST",

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -3038,7 +3038,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
               ["Content-Type"] = "application/json"
             }
           })
-          res = assert(cjson.decode(assert.res_status(200, res)))
+          assert(cjson.decode(assert.res_status(200, res)))
         end)
       end)
       it("fails when a correct access_token is being sent in the wrong header", function()


### PR DESCRIPTION
### Summary

With `global_credential=true`, `access_token` can be shared across services, as well as `refresh_token` currently. This means that a `refresh_token` belonging to a service can be used to refresh tokens belonging to another service, which is consider as a bug. In this PR, the scope is taken into account as a new creteria of the request validation. Scopes associated with a token provided in the request will be compared with those configured in the Oauth2 instance hit by that request.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-5173
