### PR TITLE
feat(router): support http queries in expression

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -544,6 +544,7 @@ end
 
 
 local get_headers_key
+--local get_queries_key
 do
   local tb_sort = table.sort
   local tb_concat = table.concat
@@ -573,6 +574,26 @@ do
 
     return headers_buf:get()
   end
+
+  --[[
+  local queries_buf = buffer.new(64)
+
+  get_queries_key = function(queries)
+    queries_buf:reset()
+
+    -- NOTE: DO NOT yield until headers_buf:get()
+    for name, value in pairs(queries) do
+      if type(value) == "table" then
+        tb_sort(value)
+        value = tb_concat(value, ", ")
+      end
+
+      queries_buf:putf("|%s=%s", name, value)
+    end
+
+    return queries_buf:get()
+  end
+  --]]
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -514,7 +514,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       end -- type(v)
 
     else  -- unknown field
-      error("unknown schema field: ".. field, 2)
+      error("unknown http schema field: ".. field, 2)
 
     end -- if field
 
@@ -732,7 +732,7 @@ function _M:select(_, _, _, scheme,
       assert(c:add_value(field, dst_port))
 
     else  -- unknown field
-      error("unknown schema field: ".. field, 2)
+      error("unknown stream schema field: ".. field, 2)
 
     end -- if field
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -483,8 +483,9 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
         -- the query parameter has no value, like /?foo,
         -- get_uri_arg will get a boolean `true`
+        -- we think it is equivalent to /?foo=
         elseif type(v) == "boolean" then
-          local res, err = c:add_value(field, tostring(v))
+          local res, err = c:add_value(field, "")
           if not res then
             return nil, err
           end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -514,7 +514,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       end -- type(v)
 
     else  -- unknown field
-      error("unknown http schema field: " .. field, 2)
+      error("unknown http schema field: " .. field)
 
     end -- if field
 
@@ -733,7 +733,7 @@ function _M:select(_, _, _, scheme,
       assert(c:add_value(field, dst_port))
 
     else  -- unknown field
-      error("unknown stream schema field: " .. field, 2)
+      error("unknown stream schema field: " .. field)
 
     end -- if field
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -838,6 +838,10 @@ function _M._set_ngx(mock_ngx)
     if mock_ngx.req.get_headers then
       get_headers = mock_ngx.req.get_headers
     end
+
+    if mock_ngx.req.get_uri_args then
+      get_headers = mock_ngx.req.get_uri_args
+    end
   end
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -466,8 +466,8 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
               return nil, err
             end
           end
-        end
-      end
+        end -- if type(v)
+      end   -- if v
 
     elseif req_queries and is_http_queries_field(field) then
       local n = field:sub(14)
@@ -501,6 +501,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
         end -- type(v)
       end   -- if v
     end -- if field
+
   end   -- for self.fields
 
   local matched = self.router:execute(c)
@@ -714,8 +715,9 @@ function _M:select(_, _, _, scheme,
     elseif field == "net.dst.port" then
       assert(c:add_value(field, dst_port))
 
-    end -- if
-  end -- for
+    end -- if field
+
+  end -- for self.fields
 
   local matched = self.router:execute(c)
   if not matched then
@@ -841,7 +843,7 @@ function _M._set_ngx(mock_ngx)
     end
 
     if mock_ngx.req.get_uri_args then
-      get_headers = mock_ngx.req.get_uri_args
+      get_uri_args = mock_ngx.req.get_uri_args
     end
   end
 end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -549,12 +549,12 @@ do
   local tb_sort = table.sort
   local tb_concat = table.concat
 
-  local headers_buf = buffer.new(64)
+  local str_buf = buffer.new(64)
 
   get_headers_key = function(headers)
-    headers_buf:reset()
+    str_buf:reset()
 
-    -- NOTE: DO NOT yield until headers_buf:get()
+    -- NOTE: DO NOT yield until str_buf:get()
     for name, value in pairs(headers) do
       local name = name:gsub("-", "_"):lower()
 
@@ -569,28 +569,26 @@ do
         value = value:lower()
       end
 
-      headers_buf:putf("|%s=%s", name, value)
+      str_buf:putf("|%s=%s", name, value)
     end
 
-    return headers_buf:get()
+    return str_buf:get()
   end
 
-  local queries_buf = buffer.new(64)
-
   get_queries_key = function(queries)
-    queries_buf:reset()
+    str_buf:reset()
 
-    -- NOTE: DO NOT yield until headers_buf:get()
+    -- NOTE: DO NOT yield until str_buf:get()
     for name, value in pairs(queries) do
       if type(value) == "table" then
         tb_sort(value)
         value = tb_concat(value, ", ")
       end
 
-      queries_buf:putf("|%s=%s", name, value)
+      str_buf:putf("|%s=%s", name, value)
     end
 
-    return queries_buf:get()
+    return str_buf:get()
   end
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -621,9 +621,9 @@ function _M:exec(ctx)
   local headers, headers_key
   if self.match_headers then
     local err
-    local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
-    headers, err = get_headers(lua_max_req_headers)
+    headers, err = get_headers()
     if err == "truncated" then
+      local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
       ngx_log(ngx_ERR, "router: not all request headers were read in order to determine the route as ",
                        "the request contains more than ", lua_max_req_headers, " headers, route selection ",
                        "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",
@@ -638,12 +638,13 @@ function _M:exec(ctx)
   local queries, queries_key
   if self.match_queries then
     local err
-    local lua_max_req_queries = 100
-    queries, err = get_uri_args(lua_max_req_queries)
+    queries, err = get_uri_args()
     if err == "truncated" then
+      local lua_max_uri_args = kong and kong.configuration and kong.configuration.lua_max_uri_args or 100
       ngx_log(ngx_ERR, "router: not all request queries were read in order to determine the route as ",
-                       "the request contains more than ", lua_max_req_queries, " queries, route selection ",
-                       "may be inaccurate")
+                       "the request contains more than ", lua_max_uri_args, " queries, route selection ",
+                       "may be inaccurate, consider increasing the 'lua_max_uri_args' configuration value ",
+                       "(currently at ", lua_max_uri_args, ")")
     end
 
     queries_key = get_queries_key(queries)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -497,8 +497,8 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
       -- multiple values for a single query parameter, like /?foo=bar&foo=baz
       elseif type(v) == "table" then
-        for idx = 1, #v do
-          local res, err = c:add_value(field, v[idx])
+        for _, v in ipairs(v) do
+          local res, err = c:add_value(field, v)
           if not res then
             return nil, err
           end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -481,10 +481,10 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
             return nil, err
           end
 
-        -- the query parameter has no value, like /?foo, get_uri_arg will get a boolean `false`
-        -- we treat as empty string here.
+        -- the query parameter has no value, like /?foo,
+        -- get_uri_arg will get a boolean `true`
         elseif type(v) == "boolean" then
-          local res, err = c:add_value(field, "")
+          local res, err = c:add_value(field, tostring(v))
           if not res then
             return nil, err
           end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -64,7 +64,7 @@ do
 
     ["String"] = {"net.protocol", "tls.sni",
                   "http.method", "http.host",
-                  "http.path", "http.raw_path",
+                  "http.path",
                   "http.headers.*",
                   "http.queries.*",
                  },

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -184,8 +184,8 @@ end
 
 
 local function has_query_matching_field(fields)
-  for i = 1, #fields do
-    if is_http_queries_field(fields[i]) then
+  for _, field in ipairs(fields) do
+    if is_http_queries_field(field) then
       return true
     end
   end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -456,17 +456,13 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       local h = field:sub(14)
       local v = req_headers[h]
 
-      if not v then
-        goto continue
-      end
-
       if type(v) == "string" then
         local res, err = c:add_value(field, v:lower())
         if not res then
           return nil, err
         end
 
-      else  -- type(v) == "table"
+      elseif type(v) == "table" then
         for idx = 1, #v do
           local res, err = c:add_value(field, v[idx]:lower())
           if not res then
@@ -482,10 +478,6 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
       local n = field:sub(14)
       local v = req_queries[n]
-
-      if not v then
-        goto continue
-      end
 
       -- the query parameter has only one value, like /?foo=bar
       if type(v) == "string" then
@@ -504,7 +496,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
         end
 
       -- multiple values for a single query parameter, like /?foo=bar&foo=baz
-      else
+      elseif type(v) == "table" then
         for idx = 1, #v do
           local res, err = c:add_value(field, v[idx])
           if not res then

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -31,7 +31,7 @@ local ngx_log       = ngx.log
 local get_phase     = ngx.get_phase
 local get_method    = ngx.req.get_method
 local get_headers   = ngx.req.get_headers
---local get_uri_args  = ngx.req.get_uri_args
+local get_uri_args  = ngx.req.get_uri_args
 local ngx_ERR       = ngx.ERR
 
 
@@ -544,7 +544,7 @@ end
 
 
 local get_headers_key
---local get_queries_key
+local get_queries_key
 do
   local tb_sort = table.sort
   local tb_concat = table.concat
@@ -575,7 +575,6 @@ do
     return headers_buf:get()
   end
 
-  --[[
   local queries_buf = buffer.new(64)
 
   get_queries_key = function(queries)
@@ -593,7 +592,6 @@ do
 
     return queries_buf:get()
   end
-  --]]
 end
 
 
@@ -620,7 +618,6 @@ function _M:exec(ctx)
     headers_key = get_headers_key(headers)
   end
 
-  --[[
   local queries, queries_key
   if self.match_queries then
     local err
@@ -633,9 +630,8 @@ function _M:exec(ctx)
                        "(currently at ", lua_max_req_queries, ")")
     end
 
-    --queries_key = get_queries_key(queries)
+    queries_key = get_queries_key(queries)
   end
-  --]]
 
   req_uri = strip_uri_args(req_uri)
 
@@ -644,7 +640,7 @@ function _M:exec(ctx)
   local cache_key = (req_method or "") .. "|" ..
                     (req_uri    or "") .. "|" ..
                     (req_host   or "") .. "|" ..
-                    (sni        or "") .. (headers_key or "") --.. (queries_key or "")
+                    (sni        or "") .. (headers_key or "") .. (queries_key or "")
 
   local match_t = self.cache:get(cache_key)
   if not match_t then
@@ -658,7 +654,7 @@ function _M:exec(ctx)
     local err
     match_t, err = self:select(req_method, req_uri, req_host, req_scheme,
                           nil, nil, nil, nil,
-                          sni, headers)
+                          sni, headers, queries)
     if not match_t then
       if err then
         ngx_log(ngx_ERR, "router returned an error: ", err,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -621,9 +621,9 @@ function _M:exec(ctx)
   local headers, headers_key
   if self.match_headers then
     local err
-    headers, err = get_headers()
+    local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
+    headers, err = get_headers(lua_max_req_headers)
     if err == "truncated" then
-      local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
       ngx_log(ngx_ERR, "router: not all request headers were read in order to determine the route as ",
                        "the request contains more than ", lua_max_req_headers, " headers, route selection ",
                        "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",
@@ -638,9 +638,9 @@ function _M:exec(ctx)
   local queries, queries_key
   if self.match_queries then
     local err
-    queries, err = get_uri_args()
+    local lua_max_req_queries = 100
+    queries, err = get_uri_args(lua_max_req_queries)
     if err == "truncated" then
-      local lua_max_req_queries = 100
       ngx_log(ngx_ERR, "router: not all request queries were read in order to determine the route as ",
                        "the request contains more than ", lua_max_req_queries, " queries, route selection ",
                        "may be inaccurate")

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -31,7 +31,7 @@ local ngx_log       = ngx.log
 local get_phase     = ngx.get_phase
 local get_method    = ngx.req.get_method
 local get_headers   = ngx.req.get_headers
-local get_uri_args  = ngx.req.get_uri_args
+--local get_uri_args  = ngx.req.get_uri_args
 local ngx_ERR       = ngx.ERR
 
 
@@ -599,6 +599,23 @@ function _M:exec(ctx)
     headers_key = get_headers_key(headers)
   end
 
+  --[[
+  local queries, queries_key
+  if self.match_queries then
+    local err
+    queries, err = get_uri_args()
+    if err == "truncated" then
+      local lua_max_req_queries = kong and kong.configuration and kong.configuration.lua_max_req_queries or 100
+      ngx_log(ngx_ERR, "router: not all request queries were read in order to determine the route as ",
+                       "the request contains more than ", lua_max_req_queries, " queries, route selection ",
+                       "may be inaccurate, consider increasing the 'lua_max_req_queries' configuration value ",
+                       "(currently at ", lua_max_req_queries, ")")
+    end
+
+    --queries_key = get_queries_key(queries)
+  end
+  --]]
+
   req_uri = strip_uri_args(req_uri)
 
   -- cache lookup
@@ -606,7 +623,7 @@ function _M:exec(ctx)
   local cache_key = (req_method or "") .. "|" ..
                     (req_uri    or "") .. "|" ..
                     (req_host   or "") .. "|" ..
-                    (sni        or "") .. (headers_key or "")
+                    (sni        or "") .. (headers_key or "") --.. (queries_key or "")
 
   local match_t = self.cache:get(cache_key)
   if not match_t then

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -650,10 +650,12 @@ function _M:exec(ctx)
 
   -- cache lookup
 
-  local cache_key = (req_method or "") .. "|" ..
-                    (req_uri    or "") .. "|" ..
-                    (req_host   or "") .. "|" ..
-                    (sni        or "") .. (headers_key or "|") .. (queries_key or "|")
+  local cache_key = (req_method  or "") .. "|" ..
+                    (req_uri     or "") .. "|" ..
+                    (req_host    or "") .. "|" ..
+                    (sni         or "") .. "|" ..
+                    (headers_key or "") .. "|" ..
+                    (queries_key or "")
 
   local match_t = self.cache:get(cache_key)
   if not match_t then

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -510,7 +510,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       -- if v is nil or others, goto continue
 
     else  -- unknown field
-      error("unknown http schema field: " .. field)
+      error("unknown router matching schema field: " .. field)
 
     end -- if field
 
@@ -731,7 +731,7 @@ function _M:select(_, _, _, scheme,
       assert(c:add_value(field, dst_port))
 
     else  -- unknown field
-      error("unknown stream schema field: " .. field)
+      error("unknown router matching schema field: " .. field)
 
     end -- if field
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -410,6 +410,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
                    _, _,
                    _, _,
                    sni, req_headers, req_queries)
+
   check_select_params(req_method, req_uri, req_host, req_scheme,
                       nil, nil,
                       nil, nil,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -623,11 +623,10 @@ function _M:exec(ctx)
     local err
     queries, err = get_uri_args()
     if err == "truncated" then
-      local lua_max_req_queries = kong and kong.configuration and kong.configuration.lua_max_req_queries or 100
+      local lua_max_req_queries = 100
       ngx_log(ngx_ERR, "router: not all request queries were read in order to determine the route as ",
                        "the request contains more than ", lua_max_req_queries, " queries, route selection ",
-                       "may be inaccurate, consider increasing the 'lua_max_req_queries' configuration value ",
-                       "(currently at ", lua_max_req_queries, ")")
+                       "may be inaccurate")
     end
 
     queries_key = get_queries_key(queries)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -514,7 +514,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       end -- type(v)
 
     else  -- unknown field
-      error("unknown http schema field: ".. field, 2)
+      error("unknown http schema field: " .. field, 2)
 
     end -- if field
 
@@ -732,7 +732,7 @@ function _M:select(_, _, _, scheme,
       assert(c:add_value(field, dst_port))
 
     else  -- unknown field
-      error("unknown stream schema field: ".. field, 2)
+      error("unknown stream schema field: " .. field, 2)
 
     end -- if field
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -649,7 +649,7 @@ function _M:exec(ctx)
   local cache_key = (req_method or "") .. "|" ..
                     (req_uri    or "") .. "|" ..
                     (req_host   or "") .. "|" ..
-                    (sni        or "") .. (headers_key or "") .. (queries_key or "")
+                    (sni        or "") .. (headers_key or "|") .. (queries_key or "|")
 
   local match_t = self.cache:get(cache_key)
   if not match_t then

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -500,7 +500,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
         end -- type(v)
       end   -- if v
     end -- if field
-  end
+  end   -- for self.fields
 
   local matched = self.router:execute(c)
   if not matched then

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -463,13 +463,15 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
         end
 
       elseif type(v) == "table" then
-        for idx = 1, #v do
-          local res, err = c:add_value(field, v[idx]:lower())
+        for _, v in ipairs(v) do
+          local res, err = c:add_value(field, v:lower())
           if not res then
             return nil, err
           end
         end
       end -- if type(v)
+
+      -- if v is nil or others, goto continue
 
     elseif is_http_queries_field(field) then
       if not req_queries then
@@ -503,7 +505,9 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
             return nil, err
           end
         end
-      end -- type(v)
+      end -- if type(v)
+
+      -- if v is nil or others, goto continue
 
     else  -- unknown field
       error("unknown http schema field: " .. field)

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1750,9 +1750,9 @@ function _M.new(routes, cache, cache_neg)
       local headers
       if match_headers then
         local err
-        headers, err = get_headers()
+        local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
+        headers, err = get_headers(lua_max_req_headers)
         if err == "truncated" then
-          local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
           log(ERR, "router: not all request headers were read in order to determine the route as ",
                     "the request contains more than ", lua_max_req_headers, " headers, route selection ",
                     "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1750,9 +1750,9 @@ function _M.new(routes, cache, cache_neg)
       local headers
       if match_headers then
         local err
-        local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
-        headers, err = get_headers(lua_max_req_headers)
+        headers, err = get_headers()
         if err == "truncated" then
+          local lua_max_req_headers = kong and kong.configuration and kong.configuration.lua_max_req_headers or 100
           log(ERR, "router: not all request headers were read in order to determine the route as ",
                     "the request contains more than ", lua_max_req_headers, " headers, route selection ",
                     "may be inaccurate, consider increasing the 'lua_max_req_headers' configuration value ",

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -65,7 +65,7 @@ end
 local function check_select_params(req_method, req_uri, req_host, req_scheme,
                                    src_ip, src_port,
                                    dst_ip, dst_port,
-                                   sni, req_headers)
+                                   sni, req_headers, req_queries)
   if req_method and type(req_method) ~= "string" then
     error("method must be a string", 2)
   end
@@ -95,6 +95,9 @@ local function check_select_params(req_method, req_uri, req_host, req_scheme,
   end
   if req_headers and type(req_headers) ~= "table" then
     error("headers must be a table", 2)
+  end
+  if req_queries and type(req_queries) ~= "table" then
+    error("queries must be a table", 2)
   end
 end
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4502,7 +4502,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             router_ignore_sni = assert(new_router(use_case_ignore_sni))
           end)
 
-          it("[sni]", function()
+          it_trad_only("[sni]", function()
             local match_t = router:select(nil, nil, nil, "tcp", nil, nil, nil, nil,
                                           "www.example.org")
             assert.truthy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4878,7 +4878,7 @@ do
           service = service,
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
-            expression = [[http.path == "/foo/bar" && http.queries.a == "true"]],
+            expression = [[http.path == "/foo/bar" && http.queries.a == ""]],
             priority = 100,
           },
         },
@@ -4896,11 +4896,11 @@ do
       router = assert(new_router(use_case))
     end)
 
-    it("select() should matches http.queries", function()
+    it("select() should match http.queries", function()
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "1"})
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
-      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "true"})
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = ""})
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2", }})
@@ -4908,7 +4908,7 @@ do
       assert.same(use_case[3].route, match_t.route)
     end)
 
-    it("exec() should matches http.queries", function()
+    it("exec() should match http.queries", function()
     end)
 
   end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4904,17 +4904,20 @@ do
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
 
-      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "",})
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = ""})
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
 
-      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = true,})
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = true})
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
 
-      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2",}})
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2"}})
       assert.truthy(match_t)
       assert.same(use_case[3].route, match_t.route)
+
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "x"})
+      assert.falsy(match_t)
     end)
 
     it("exec() should match http.queries", function()
@@ -4949,6 +4952,14 @@ do
       local match_t = router:exec()
       assert.spy(get_uri_args).was_called(1)
       assert.same(use_case[3].route, match_t.route)
+
+      local _ngx = mock_ngx("GET", "/foo/bar", { host = "domain.org"}, { a = "x"})
+      local get_uri_args = spy.on(_ngx.req, "get_uri_args")
+
+      router._set_ngx(_ngx)
+      local match_t = router:exec()
+      assert.spy(get_uri_args).was_called(1)
+      assert.falsy(match_t)
     end)
 
   end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4857,14 +4857,14 @@ end
 do
   local flavor = "expressions"
 
-  describe("#only Router (flavor = " .. flavor .. ")", function()
+  describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
 
     local use_case, router
 
     lazy_setup(function()
       use_case = {
-        -- one query
+        -- query has one value
         {
           service = service,
           route   = {
@@ -4896,7 +4896,7 @@ do
       router = assert(new_router(use_case))
     end)
 
-    it("[should matches http.queries]", function()
+    it("select() should matches http.queries", function()
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "1"})
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
@@ -4906,6 +4906,9 @@ do
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2", }})
       assert.truthy(match_t)
       assert.same(use_case[3].route, match_t.route)
+    end)
+
+    it("exec() should matches http.queries", function()
     end)
 
   end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4912,7 +4912,7 @@ do
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
 
-      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2"}})
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"2", "10"}})
       assert.truthy(match_t)
       assert.same(use_case[3].route, match_t.route)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4873,7 +4873,7 @@ do
             priority = 100,
           },
         },
-        -- query has no value
+        -- query has no value or is empty string
         {
           service = service,
           route   = {
@@ -4882,7 +4882,7 @@ do
             priority = 100,
           },
         },
-        -- query has multi values
+        -- query has multiple values
         {
           service = service,
           route   = {
@@ -4900,9 +4900,15 @@ do
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = "1"})
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
+
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = ""})
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
+
+      local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = true})
+      assert.truthy(match_t)
+      assert.same(use_case[2].route, match_t.route)
+
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, nil, {a = {"1", "2", }})
       assert.truthy(match_t)
       assert.same(use_case[3].route, match_t.route)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2580,12 +2580,12 @@ do
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foobar",
-          query   = "a=1&a=2",
+          query   = "a=2&a=10",
         })
         assert.res_status(200, res)
       end)
 
-      it("query does not match  multiple values", function()
+      it("query does not match multiple values", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foobar",

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2598,5 +2598,4 @@ do
 
   end   -- strategy
 
-
-end
+end -- http expression 'http.queries.*'

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2453,3 +2453,150 @@ for _, strategy in helpers.each_strategy() do
 end
 end
 end
+
+
+-- http expression 'http.queries.*'
+do
+  local function reload_router(flavor)
+    _G.kong = {
+      configuration = {
+        router_flavor = flavor,
+      },
+    }
+
+    helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
+
+    package.loaded["spec.helpers"] = nil
+    package.loaded["kong.global"] = nil
+    package.loaded["kong.cache"] = nil
+    package.loaded["kong.db"] = nil
+    package.loaded["kong.db.schema.entities.routes"] = nil
+    package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
+
+    helpers = require "spec.helpers"
+
+    helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  end
+
+
+  local flavor = "expressions"
+
+  for _, strategy in helpers.each_strategy() do
+    describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
+      local proxy_client
+
+      reload_router(flavor)
+
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+        })
+
+        local service = bp.services:insert {
+          name = "global-cert",
+        }
+
+        bp.routes:insert {
+          protocols = { "http" },
+          expression = [[http.path == "/foo/bar" && http.queries.a == "1"]],
+          priority = 100,
+          service   = service,
+        }
+
+        bp.routes:insert {
+          protocols = { "http" },
+          expression = [[http.path == "/foo" && http.queries.a == ""]],
+          priority = 100,
+          service   = service,
+        }
+
+        bp.routes:insert {
+          protocols = { "http" },
+          expression = [[http.path == "/foobar" && any(http.queries.a) == "2"]],
+          priority = 100,
+          service   = service,
+        }
+
+        assert(helpers.start_kong({
+          router_flavor = flavor,
+          database    = strategy,
+          nginx_conf  = "spec/fixtures/custom_nginx.template",
+        }))
+
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      before_each(function()
+        proxy_client = helpers.proxy_client()
+      end)
+
+      after_each(function()
+        if proxy_client then
+          proxy_client:close()
+        end
+      end)
+
+      it("query has wrong value", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foo/bar",
+          query   = "a=x",
+        })
+        assert.res_status(404, res)
+      end)
+
+      it("query has one value", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foo/bar",
+          query   = "a=1",
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("query value is empty string", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foo",
+          query   = "a=",
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("query has no value", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foo",
+          query   = "a&b=999",
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("query has multiple values", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foobar",
+          query   = "a=1&a=2",
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("query does not match  multiple values", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/foobar",
+          query   = "a=10&a=20",
+        })
+        assert.res_status(404, res)
+      end)
+
+    end)
+
+  end   -- strategy
+
+
+end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR will replace #11072.
I will add change log entry after 3.4 release.

KAG-2050
KAG-2289

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* add new schema field `http.queries.*`
* add `queries_key` for cache
* use param `lua_max_uri_args`
* check unknown field in `select()`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
