### PR TITLE
chore(deps): bump lua-ffi-zlib to 0.6 and remove zlib dev packages from artifact dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@
   [#11071](https://github.com/Kong/kong/pull/11071)
 - Bumped lua-resty-lmdb from 1.1.0 to 1.3.0
   [#11227](https://github.com/Kong/kong/pull/11227)
+- Bumped lua-ffi-zlib from 0.5 to 0.6
+  [#11373](https://github.com/Kong/kong/pull/11373)
 
 ### Known Issues
 - Some referenceable configuration fields, such as the `http_endpoint` field

--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -52,7 +52,6 @@ overrides:
     - ca-certificates
     - libpcre3
     - perl
-    - zlib1g-dev
     - libyaml-0-2
   rpm:
     depends:
@@ -61,7 +60,6 @@ overrides:
     - perl
     - perl-Time-HiRes
     - zlib
-    - zlib-devel
     - libyaml
     # Workaround for https://github.com/goreleaser/nfpm/issues/589
     - ${RPM_EXTRA_DEPS}

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "penlight == 1.13.1",
   "lua-resty-http == 0.17.1",
   "lua-resty-jit-uuid == 0.0.7",
-  "kong-lua-ffi-zlib == 0.6",
+  "lua-ffi-zlib == 0.6",
   "multipart == 0.5.9",
   "version == 1.0.1",
   "kong-lapis == 1.14.0.2",

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "penlight == 1.13.1",
   "lua-resty-http == 0.17.1",
   "lua-resty-jit-uuid == 0.0.7",
-  "lua-ffi-zlib == 0.5",
+  "kong-lua-ffi-zlib == 0.6",
   "multipart == 0.5.9",
   "version == 1.0.1",
   "kong-lapis == 1.14.0.2",


### PR DESCRIPTION
zlib1g-dev

Requires https://github.com/Kong/lua-ffi-zlib/pull/1

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-2241
