### PR TITLE
Revert "perf(router): iterate routes with for loop  (#11111)"

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -187,9 +187,7 @@ local function new_from_scratch(routes, get_exp_and_priority)
 
   local new_updated_at = 0
 
-  for i = 1, routes_n do
-    local r = routes[i]
-
+  for _, r in ipairs(routes) do
     local route = r.route
     local route_id = route.id
 
@@ -249,9 +247,7 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
   local new_updated_at = 0
 
   -- create or update routes
-  for i = 1, #routes do
-    local r = routes[i]
-
+  for _, r in ipairs(routes) do
     local route = r.route
     local route_id = route.id
 

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -288,8 +288,8 @@ do
     local v0              = 0
     local v1              = 0
 
-    for i = 1, #routes do
-      local r = routes[i].route
+    for _, route in ipairs(routes) do
+      local r = route.route
 
       local paths_t     = r.paths or empty_table
       local headers_t   = r.headers or empty_table


### PR DESCRIPTION
This reverts commit e8173ca30b902202e289e93ab34cf40a907fd3d6.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

See: https://github.com/Kong/kong/pull/11273#issuecomment-1670920688

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
