### PR TITLE
fix(conf_loader): cluster_cert/cluster_ca_cert should be base64 decoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@
   The issue only affects scenarios where the same Go plugin is applied to different Route
   or Service entities.
   [#11306](https://github.com/Kong/kong/pull/11306)
+- Fix an issue where cluster_cert or cluster_ca_cert is inserted into lua_ssl_trusted_certificate before being base64 decoded.
+  [#11385](https://github.com/Kong/kong/pull/11385)
 
 #### Admin API
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1179,6 +1179,45 @@ local function check_and_parse(conf, opts)
     end
   end
 
+  if conf.role == "control_plane" or conf.role == "data_plane" then
+    local cluster_cert = conf.cluster_cert
+    local cluster_cert_key = conf.cluster_cert_key
+    local cluster_ca_cert = conf.cluster_ca_cert
+
+    if not cluster_cert or not cluster_cert_key then
+      errors[#errors + 1] = "cluster certificate and key must be provided to use Hybrid mode"
+
+    else
+      if not exists(cluster_cert) then
+        cluster_cert = try_decode_base64(cluster_cert)
+        conf.cluster_cert = cluster_cert
+        local _, err = openssl_x509.new(cluster_cert)
+        if err then
+          errors[#errors + 1] = "cluster_cert: failed loading certificate from " .. cluster_cert
+        end
+      end
+
+      if not exists(cluster_cert_key) then
+        cluster_cert_key = try_decode_base64(cluster_cert_key)
+        conf.cluster_cert_key = cluster_cert_key
+        local _, err = openssl_pkey.new(cluster_cert_key)
+        if err then
+          errors[#errors + 1] = "cluster_cert_key: failed loading key from " .. cluster_cert_key
+        end
+      end
+    end
+
+    if cluster_ca_cert and not exists(cluster_ca_cert) then
+      cluster_ca_cert = try_decode_base64(cluster_ca_cert)
+      conf.cluster_ca_cert = cluster_ca_cert
+      local _, err = openssl_x509.new(cluster_ca_cert)
+      if err then
+        errors[#errors + 1] = "cluster_ca_cert: failed loading certificate from " ..
+                              cluster_ca_cert
+      end
+    end
+  end
+
   if conf.role == "control_plane" then
     if #conf.admin_listen < 1 or strip(conf.admin_listen[1]) == "off" then
       errors[#errors + 1] = "admin_listen must be specified when role = \"control_plane\""
@@ -1248,45 +1287,6 @@ local function check_and_parse(conf, opts)
 
   if conf.cluster_max_payload < 4194304 then
     errors[#errors + 1] = "cluster_max_payload must be 4194304 (4MB) or greater"
-  end
-
-  if conf.role == "control_plane" or conf.role == "data_plane" then
-    local cluster_cert = conf.cluster_cert
-    local cluster_cert_key = conf.cluster_cert_key
-    local cluster_ca_cert = conf.cluster_ca_cert
-
-    if not cluster_cert or not cluster_cert_key then
-      errors[#errors + 1] = "cluster certificate and key must be provided to use Hybrid mode"
-
-    else
-      if not exists(cluster_cert) then
-        cluster_cert = try_decode_base64(cluster_cert)
-        conf.cluster_cert = cluster_cert
-        local _, err = openssl_x509.new(cluster_cert)
-        if err then
-          errors[#errors + 1] = "cluster_cert: failed loading certificate from " .. cluster_cert
-        end
-      end
-
-      if not exists(cluster_cert_key) then
-        cluster_cert_key = try_decode_base64(cluster_cert_key)
-        conf.cluster_cert_key = cluster_cert_key
-        local _, err = openssl_pkey.new(cluster_cert_key)
-        if err then
-          errors[#errors + 1] = "cluster_cert_key: failed loading key from " .. cluster_cert_key
-        end
-      end
-    end
-
-    if cluster_ca_cert and not exists(cluster_ca_cert) then
-      cluster_ca_cert = try_decode_base64(cluster_ca_cert)
-      conf.cluster_ca_cert = cluster_ca_cert
-      local _, err = openssl_x509.new(cluster_ca_cert)
-      if err then
-        errors[#errors + 1] = "cluster_ca_cert: failed loading certificate from " ..
-                              cluster_ca_cert
-      end
-    end
   end
 
   if conf.upstream_keepalive_pool_size < 0 then

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1070,6 +1070,38 @@ describe("Configuration loader", function()
           assert.matches(".ca_combined", conf.lua_ssl_trusted_certificate_combined)
         end)
 
+        it("autoload base64 cluster_cert or cluster_ca_cert for data plane in lua_ssl_trusted_certificate", function()
+          local ssl_fixtures = require "spec.fixtures.ssl"
+          local cert = ssl_fixtures.cert
+          local cacert = ssl_fixtures.cert_ca
+          local key = ssl_fixtures.key
+          local conf, _, errors = conf_loader(nil, {
+            role = "data_plane",
+            database = "off",
+            cluster_cert = ngx.encode_base64(cert),
+            cluster_cert_key = ngx.encode_base64(key),
+          })
+          assert.is_nil(errors)
+          assert.contains(
+            cert,
+            conf.lua_ssl_trusted_certificate
+          )
+
+          local conf, _, errors = conf_loader(nil, {
+            role = "data_plane",
+            database = "off",
+            cluster_mtls = "pki",
+            cluster_cert = ngx.encode_base64(cert),
+            cluster_cert_key = ngx.encode_base64(key),
+            cluster_ca_cert = ngx.encode_base64(cacert),
+          })
+          assert.is_nil(errors)
+          assert.contains(
+            cacert,
+            conf.lua_ssl_trusted_certificate
+          )
+        end)
+
         it("validates proxy_server", function()
           local conf, _, errors = conf_loader(nil, {
             proxy_server = "http://cool:pwd@localhost:2333",


### PR DESCRIPTION
                  before being inserted into lua_ssl_trusted_certificate

Fix https://konghq.atlassian.net/browse/FTI-4883

