### PR TITLE
chore(balancer): use less dramatic debug message

### DIFF
--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -105,7 +105,7 @@ local function load_upstreams_dict_into_memory()
   -- please refer to https://github.com/Kong/kong/pull/4301 and
   -- https://github.com/Kong/kong/pull/8974#issuecomment-1317788871
   if isempty(upstreams_dict) then
-    log(DEBUG, "empty upstreams dict. Could it be an uncatched database error?")
+    log(DEBUG, "no upstreams were specified")
   end
 
   return upstreams_dict


### PR DESCRIPTION
### Summary

When starting e.g. empty Kong this got logged:
```
2023/08/11 08:49:27 [debug] 40426#0: *5 [lua] upstreams.lua:108: empty upstreams dict. Could it be an uncatched database error?
```

It is a way too alarmistic. The most common case for upstreams dict to be empty is that people are not using balancer or that there is just no upstreams specified. E.g. only using routes and services.