### PR TITLE
fix(utils): yield to sleep only when the ngx.sleep is available

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1652,15 +1652,22 @@ do
   local get_phase = ngx.get_phase
   local ngx_sleep = _G.native_ngx_sleep or ngx.sleep
 
+  local SLEEP_PHASES = {
+    rewrite = true,
+    access = true,
+    content = true,
+    timer = true,
+    ssl_certificate = true,
+    ssl_session_fetch = true,
+    ssl_client_hello = true,
+    preread = true,
+  }
+
   local YIELD_ITERATIONS = 1000
   local counter = YIELD_ITERATIONS
 
   function _M.yield(in_loop, phase)
-    if ngx.IS_CLI then
-      return
-    end
-    phase = phase or get_phase()
-    if phase == "init" or phase == "init_worker" then
+    if ngx.IS_CLI or SLEEP_PHASES[phase or get_phase()] == nil then
       return
     end
     if in_loop then


### PR DESCRIPTION
### Summary

Previously the sleeping was skipped with `utils.yield` only on phases `init` and `init_worker`, and on CLI, but there are a lot more phases in Nginx where the ngx.sleep is not allowed. This changes the `utils.yield` to skip `ngx.sleep`ing on such phases. I checked that there was as many phases where it was allowed as there was phases where it was disallowed, so I ended up with a list of where it is allowed as that is easier to update by just looking: https://github.com/openresty/lua-nginx-module#ngxsleep (+ the preread phase).