### PR TITLE
perf(plugin-iterator): vault.update only once per request

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -301,12 +301,12 @@ local function execute_init_worker_plugins_iterator(plugins_iterator, ctx)
 end
 
 
-local function execute_global_plugins_iterator(plugins_iterator, phase, ctx)
+local function execute_global_plugins_iterator(plugins_iterator, phase, ctx, skip_vault_update)
   if not plugins_iterator.has_plugins then
     return
   end
 
-  local iterator, plugins = plugins_iterator:get_global_iterator(phase)
+  local iterator, plugins = plugins_iterator:get_global_iterator(phase, skip_vault_update)
   if not iterator then
     return
   end
@@ -1007,7 +1007,7 @@ function Kong.rewrite()
     plugins_iterator = runloop.get_updated_plugins_iterator()
   end
 
-  execute_global_plugins_iterator(plugins_iterator, "rewrite", ctx)
+  execute_global_plugins_iterator(plugins_iterator, "rewrite", ctx, is_https)
 
   ctx.KONG_REWRITE_ENDED_AT = get_updated_now_ms()
   ctx.KONG_REWRITE_TIME = ctx.KONG_REWRITE_ENDED_AT - ctx.KONG_REWRITE_START

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -284,15 +284,24 @@ local function get_next_global_or_collected_plugin(plugins, i)
   if i > plugins[0] then
     return nil
   end
-  local cfg = kong.vault.update(plugins[i])
-  return i, plugins[i - 1], cfg
+
+  return i, plugins[i-1], plugins[i]
 end
 
 
-local function get_global_iterator(self, phase)
+local function get_global_iterator(self, phase, skip_vault_update)
   local plugins = self.globals[phase]
-  if plugins[0] == 0 then
+  local count = plugins[0]
+  if count == 0 then
     return nil
+  end
+
+  if not skip_vault_update then
+    local i = 2
+    while i <= count do
+      kong.vault.update(plugins[i])
+      i = i + 2
+    end
   end
 
   return get_next_global_or_collected_plugin, plugins
@@ -329,7 +338,7 @@ local function get_next_and_collect(ctx, i)
   if combos then
     cfg = load_configuration_through_combos(ctx, combos, plugin)
     if cfg then
-      cfg = kong.vault.update(cfg)
+      kong.vault.update(cfg)
       local handler = plugin.handler
       local collected = ctx.plugins
       for j = 1, DOWNSTREAM_PHASES_COUNT do


### PR DESCRIPTION
### Summary

Originally `kong.vault.update` was called on plugin iterator only once per request, but this had a bug that it was only done with collecting plugin iterator. This bug was fixed, but it made `kong.vault.update` to be called on every phase on every plugin config that was about to be executed. This commit changes it so that `kong.vault.update` is only called once per request (on both collected plugins and the global plugins iterator).