### PR TITLE
chore(cd): skip verify image test on fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,7 @@ jobs:
     needs: [metadata, build-images]
     name: Verify Manifest - Image ${{ matrix.label }}
     runs-on: ubuntu-22.04
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Forks doesn't have access to secrets, thus docker images won't upload then verify image can't run.

