### PR TITLE
test(oauth2): fix flaky test

### DIFF
--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -267,6 +267,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       local service20   = admin_api.services:insert()
       local service21   = admin_api.services:insert()
 
+
       local route1 = assert(admin_api.routes:insert({
         hosts     = { "oauth2.com" },
         protocols = { "http", "https" },
@@ -4204,7 +4205,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
   describe("Plugin: oauth2 (ttl) with #"..strategy, function()
     lazy_setup(function()
       local route11 = assert(admin_api.routes:insert({
-        hosts     = { "oauth2_21.com" },
+        hosts     = { "oauth2_21.refresh.com" },
         protocols = { "http", "https" },
         service   = admin_api.services:insert(),
       }))
@@ -4222,7 +4223,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       }
 
       local route12 = assert(admin_api.routes:insert({
-        hosts     = { "oauth2_22.com" },
+        hosts     = { "oauth2_22.refresh.com" },
         protocols = { "http", "https" },
         service   = admin_api.services:insert(),
       }))
@@ -4253,7 +4254,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
 
     describe("refresh token", function()
       it("is deleted after defined TTL", function()
-        local token = provision_token("oauth2_21.com", nil, "clientid7890", "secret7890")
+        local token = provision_token("oauth2_21.refresh.com", nil, "clientid7890", "secret7890")
         local token_entity = db.oauth2_tokens:select_by_access_token(token.access_token)
         assert.is_table(token_entity)
 
@@ -4265,7 +4266,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       end)
 
       it("is not deleted when when TTL is 0 == never", function()
-        local token = provision_token("oauth2_22.com", nil, "clientid7890", "secret7890")
+        local token = provision_token("oauth2_22.refresh.com", nil, "clientid7890", "secret7890")
         local token_entity = db.oauth2_tokens:select_by_access_token(token.access_token)
         assert.is_table(token_entity)
 


### PR DESCRIPTION
### Summary

In this PR, a flaky test which is caused by a conflict between routes with the same `host` field is fixed by change one of them to a local particular name

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
