### PR TITLE
fix(tracing): record http.status_code when request is not proxied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,8 +154,10 @@
   [#11066](https://github.com/Kong/kong/pull/11066)
 - Fix a bug that caused sampling rate to be applied to individual spans producing split traces.
   [#11135](https://github.com/Kong/kong/pull/11135)
-- Fix a bug that caused spans to not be instrumented with http.status_code when the request was not proxied upstream.
-  [#11152](https://github.com/Kong/kong/pull/11152)
+- Fix a bug that caused spans to not be instrumented with http.status_code when the request was not proxied to an upstream.
+  Thanks [@backjo](https://github.com/backjo) for contributing this change.
+  [#11152](https://github.com/Kong/kong/pull/11152),
+  [#11406](https://github.com/Kong/kong/pull/11406)
 - Fix a bug that caused the router to fail in `traditional_compatible` mode when a route with multiple paths and no service was created.
   [#11158](https://github.com/Kong/kong/pull/11158)
 - Fix an issue where the router of flavor `expressions` can not work correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,8 @@
   [#11066](https://github.com/Kong/kong/pull/11066)
 - Fix a bug that caused sampling rate to be applied to individual spans producing split traces.
   [#11135](https://github.com/Kong/kong/pull/11135)
+- Fix a bug that caused spans to not be instrumented with http.status_code when the request was not proxied upstream.
+  [#11152](https://github.com/Kong/kong/pull/11152)
 - Fix a bug that caused the router to fail in `traditional_compatible` mode when a route with multiple paths and no service was created.
   [#11158](https://github.com/Kong/kong/pull/11158)
 - Fix an issue where the router of flavor `expressions` can not work correctly

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1480,6 +1480,7 @@ return {
   header_filter = {
     before = function(ctx)
       if not ctx.KONG_PROXIED then
+        instrumentation.runloop_before_header_filter(ngx.status)
         return
       end
 

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -65,6 +65,13 @@ for _, strategy in helpers.each_strategy() do
                          hosts = { "status" },
                          strip_path = false })
 
+      local np_route = bp.routes:insert({
+        service = http_srv,
+        protocols = { "http" },
+        paths = { "/noproxy" },
+        strip_path = false
+      })
+
       bp.plugins:insert({
         name = tcp_trace_plugin_name,
         config = {
@@ -74,10 +81,19 @@ for _, strategy in helpers.each_strategy() do
         }
       })
 
+      bp.plugins:insert({
+        name = "request-termination",
+        route = np_route,
+        config = {
+          status_code = 418,
+          message = "No coffee for you. I'm a teapot.",
+        }
+      })
+
       assert(helpers.start_kong {
         database = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
-        plugins = "tcp-trace-exporter",
+        plugins = "bundled, tcp-trace-exporter",
         tracing_instrumentations = types,
         tracing_sampling_rate = 1,
       })
@@ -310,6 +326,38 @@ for _, strategy in helpers.each_strategy() do
         assert_has_span("kong", spans)
         assert_has_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
 
+        assert_has_no_span("kong.balancer", spans)
+        assert_has_no_span("kong.database.query", spans)
+        assert_has_no_span("kong.router", spans)
+        assert_has_no_span("kong.dns", spans)
+        assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
+      end)
+
+      it("contains the expected kong span with status code when request is not proxied", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/noproxy",
+        })
+        assert.res_status(418, r)
+
+        -- Getting back the TCP server input
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- Making sure it's alright
+        local spans = cjson.decode(res)
+        local kong_span = assert_has_span("kong", spans)
+
+        assert_has_attributes(kong_span, {
+          ["http.method"]    = "GET",
+          ["http.flavor"]    = "1.1",
+          ["http.status_code"] = "418",
+          ["http.route"] = "/noproxy",
+          ["http.url"] = "http://0.0.0.0/noproxy",
+        })
+        assert_has_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
         assert_has_no_span("kong.balancer", spans)
         assert_has_no_span("kong.database.query", spans)
         assert_has_no_span("kong.router", spans)


### PR DESCRIPTION
### Summary

This PR invokes instrumentation when kong requests are not proxied to the upstream, so that the
relevant span attributes are set on all requests.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Fix: record `http.status_code` even when request is not proxied.
* Test case.

### Issue reference

Fixes #11141
Closes #11152 
KAG-2346
