### PR TITLE
chore(ci): upgrade test use master-ubuntu tag

### DIFF
--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -86,7 +86,7 @@ NEW_CONTAINER=$ENV_PREFIX-kong_new-1
 
 function prepare_container() {
     docker exec $1 apt-get update
-    docker exec $1 apt-get install -y build-essential curl m4
+    docker exec $1 apt-get install -y build-essential curl m4 unzip git
     docker exec $1 bash -c "ln -sf /usr/local/kong/include/* /usr/include"
     docker exec $1 bash -c "ln -sf /usr/local/kong/lib/* /usr/lib"
 }

--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -30,7 +30,7 @@ function get_current_version() {
     then
         echo $version_from_rockspec-ubuntu
     else
-        echo ubuntu
+        echo master-ubuntu
     fi
 }
 

--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -36,7 +36,7 @@ function get_current_version() {
 
 export OLD_KONG_VERSION=2.8.0
 export OLD_KONG_IMAGE=kong:$OLD_KONG_VERSION-ubuntu
-export NEW_KONG_IMAGE=kong:$(get_current_version kong)
+export NEW_KONG_IMAGE=kong/kong:$(get_current_version kong)
 
 function usage() {
     cat 1>&2 <<EOF


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Tries to fix upgrade test on master. The upgrade test is using `kong/kong:ubuntu` image tag which currently points at `3.4.0-ubuntu`. Change it to use `master-ubuntu` so that it can use the latest headers/shared libraries in the latest image based on master's commit.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
