### PR TITLE
fix(acme): fix a bug that `account_key` is not optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
   [#11378](https://github.com/Kong/kong/pull/11378)
 - **AWS-Lambda**: fix an issue that the AWS-Lambda plugin cannot extract a json encoded proxy integration response.
   [#11413](https://github.com/Kong/kong/pull/11413)
+- **Acme**: fix `account_key` is not optional.
+  [#11410](https://github.com/Kong/kong/pull/11410)
 
 ### Dependencies
 

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -79,7 +79,7 @@ local VAULT_STORAGE_SCHEMA = {
 }
 
 local ACCOUNT_KEY_SCHEMA = {
-  { key_id = { type = "string", required = true, description = "The Key ID." } },
+  { key_id = { type = "string", description = "The Key ID." } },
   { key_set = { type = "string", description = "The ID of the key set to associate the Key ID with." } }
 }
 
@@ -242,6 +242,18 @@ local schema = {
           end
           if _G.kong and kong.configuration.role == "control_plane" and field == "shm" then
             return nil, "\"shm\" storage can't be used in Hybrid mode"
+          end
+          return true
+        end
+      }
+    },
+    {
+      custom_entity_check = {
+        field_sources = { "config.account_key", },
+        fn = function(entity)
+          local field = entity.config.account_key
+          if field and type(field) == "table" and (not field.key_id or type(field.key_id) ~= "string" )then
+            return nil, "account_key.key_id must be set if account_key is set"
           end
           return true
         end

--- a/spec/03-plugins/29-acme/04-schema_spec.lua
+++ b/spec/03-plugins/29-acme/04-schema_spec.lua
@@ -89,6 +89,22 @@ describe("Plugin: acme (schema)", function()
           }
         },
     },
+    ----------------------------------------
+    {
+      name = "accepts valid account_key without key_id",
+      input = {
+        account_email = "example@example.com",
+        api_uri = "https://api.acme.org",
+        account_key = {
+          key_set = "my-key-set",
+        }
+      },
+      error = {
+        ["@entity"] = {
+          'account_key.key_id must be set if account_key is set'
+        },
+      },
+    },
   }
 
   for _, t in ipairs(tests) do


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
- fix ACCOUNT_KEY_SCHEMA field key_id
- add custom_entity_check to enforce required key_id in schema.lua
- update acme schema_spec.lua to include test case for validating account_key without key_id

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-1778](https://konghq.atlassian.net/browse/KAG-1778)

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_


[KAG-1778]: https://konghq.atlassian.net/browse/KAG-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ