### PR TITLE
refactor(router): categorize router fields to simplify logic

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -164,7 +164,7 @@ local function categorize_fields(fields)
     return fields, nil, nil
   end
 
-  local baisc = {}
+  local basic = {}
   local headers = {}
   local queries = {}
 
@@ -182,7 +182,7 @@ local function categorize_fields(fields)
     end
   end
 
-  return baisc, headers, queries
+  return basic, headers, queries
 end
 
 
@@ -471,6 +471,9 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
           end
         end
       end -- if type(v)
+
+      -- if v is nil or others, ignore
+
     end   -- for self.header_fields
   end   -- req_headers
 
@@ -504,6 +507,9 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
           end
         end
       end -- if type(v)
+
+      -- if v is nil or others, ignore
+
     end   -- for self.query_fields
   end   -- req_queries
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -166,30 +166,8 @@ local function is_http_headers_field(field)
 end
 
 
-local function has_header_matching_field(fields)
-  for _, field in ipairs(fields) do
-    if is_http_headers_field(field) then
-      return true
-    end
-  end
-
-  return false
-end
-
-
 local function is_http_queries_field(field)
   return field:sub(1, 13) == "http.queries."
-end
-
-
-local function has_query_matching_field(fields)
-  for _, field in ipairs(fields) do
-    if is_http_queries_field(field) then
-      return true
-    end
-  end
-
-  return false
 end
 
 
@@ -256,8 +234,6 @@ local function new_from_scratch(routes, get_exp_and_priority)
   end
 
   local fields, header_fields, query_fields = categorize_http_fields(inst:get_fields())
-  local match_headers = not isempty(header_fields)
-  local match_queries = not isempty(query_fields)
 
   return setmetatable({
       schema = CACHED_SCHEMA,
@@ -267,8 +243,8 @@ local function new_from_scratch(routes, get_exp_and_priority)
       fields = fields,
       header_fields = header_fields,
       query_fields = query_fields,
-      match_headers = match_headers,
-      match_queries = match_queries,
+      match_headers = not isempty(header_fields),
+      match_queries = not isempty(query_fields),
       updated_at = new_updated_at,
       rebuilding = false,
     }, _MT)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -9,7 +9,6 @@ local context = require("resty.router.context")
 local lrucache = require("resty.lrucache")
 local server_name = require("ngx.ssl").server_name
 local tb_new = require("table.new")
-local isempty = require("table.isempty")
 local utils = require("kong.router.utils")
 local yield = require("kong.tools.utils").yield
 
@@ -88,6 +87,7 @@ end
 local is_empty_field
 do
   local null    = ngx.null
+  local isempty = require("table.isempty")
 
   is_empty_field = function(f)
     return f == nil or f == null or isempty(f)
@@ -159,14 +159,14 @@ end
 
 
 local function categorize_fields(fields)
-  local headers = {}
-  local queries = {}
 
   if not is_http then
-    return fields, headers, queries
+    return fields, nil, nil
   end
 
   local baisc = {}
+  local headers = {}
+  local queries = {}
 
   for _, field in ipairs(fields) do
     local prefix = field:sub(1, 13)
@@ -234,8 +234,8 @@ local function new_from_scratch(routes, get_exp_and_priority)
       fields = fields,
       header_fields = header_fields,
       query_fields = query_fields,
-      match_headers = not isempty(header_fields),
-      match_queries = not isempty(query_fields),
+      match_headers = not is_empty_field(header_fields),
+      match_queries = not is_empty_field(query_fields),
       updated_at = new_updated_at,
       rebuilding = false,
     }, _MT)
@@ -322,8 +322,8 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
   old_router.fields = fields
   old_router.header_fields = header_fields,
   old_router.query_fields = query_fields,
-  old_router.match_headers = not isempty(header_fields)
-  old_router.match_queries = not isempty(query_fields)
+  old_router.match_headers = not is_empty_field(header_fields)
+  old_router.match_queries = not is_empty_field(query_fields)
   old_router.updated_at = new_updated_at
   old_router.rebuilding = false
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -158,10 +158,15 @@ local function add_atc_matcher(inst, route, route_id,
 end
 
 
-local function categorize_http_fields(fields)
-  local baisc = {}
+local function categorize_fields(fields)
   local headers = {}
   local queries = {}
+
+  if not is_http then
+    return fields, headers, queries
+  end
+
+  local baisc = {}
 
   for _, field in ipairs(fields) do
     local prefix = field:sub(1, 13)
@@ -219,7 +224,7 @@ local function new_from_scratch(routes, get_exp_and_priority)
     yield(true, phase)
   end
 
-  local fields, header_fields, query_fields = categorize_http_fields(inst:get_fields())
+  local fields, header_fields, query_fields = categorize_fields(inst:get_fields())
 
   return setmetatable({
       schema = CACHED_SCHEMA,
@@ -312,7 +317,7 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
     yield(true, phase)
   end
 
-  local fields, header_fields, query_fields = categorize_http_fields(inst:get_fields())
+  local fields, header_fields, query_fields = categorize_fields(inst:get_fields())
 
   old_router.fields = fields
   old_router.header_fields = header_fields,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -168,14 +168,17 @@ local function categorize_fields(fields)
   local headers = {}
   local queries = {}
 
+  -- 13 bytes, same len for "http.queries."
+  local PREFIX_LEN = #"http.headers."
+
   for _, field in ipairs(fields) do
-    local prefix = field:sub(1, 13)
+    local prefix = field:sub(1, PREFIX_LEN)
 
     if prefix == "http.headers." then
-      headers[field:sub(14)] = field
+      headers[field:sub(PREFIX_LEN + 1)] = field
 
     elseif prefix == "http.queries." then
-      queries[field:sub(14)] = field
+      queries[field:sub(PREFIX_LEN + 1)] = field
 
     else
       table.insert(basic, field)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -169,7 +169,7 @@ local function categorize_fields(fields)
   local queries = {}
 
   -- 13 bytes, same len for "http.queries."
-  local PREFIX_LEN = #"http.headers."
+  local PREFIX_LEN = 13 -- #"http.headers."
 
   for _, field in ipairs(fields) do
     local prefix = field:sub(1, PREFIX_LEN)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -158,29 +158,18 @@ local function add_atc_matcher(inst, route, route_id,
 end
 
 
-if is_http then
-
-
-local function is_http_headers_field(field)
-  return field:sub(1, 13) == "http.headers."
-end
-
-
-local function is_http_queries_field(field)
-  return field:sub(1, 13) == "http.queries."
-end
-
-
 local function categorize_http_fields(fields)
   local baisc = {}
   local headers = {}
   local queries = {}
 
   for _, field in ipairs(fields) do
-    if is_http_headers_field(field) then
+    local prefix = field:sub(1, 13)
+
+    if prefix == "http.headers." then
       headers[field:sub(14)] = field
 
-    elseif is_http_queries_field(field) then
+    elseif prefix == "http.queries." then
       queries[field:sub(14)] = field
 
     else
@@ -190,9 +179,6 @@ local function categorize_http_fields(fields)
 
   return baisc, headers, queries
 end
-
-
-end -- if is_http then
 
 
 local function new_from_scratch(routes, get_exp_and_priority)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -234,8 +234,6 @@ local function new_from_scratch(routes, get_exp_and_priority)
       fields = fields,
       header_fields = header_fields,
       query_fields = query_fields,
-      match_headers = not is_empty_field(header_fields),
-      match_queries = not is_empty_field(query_fields),
       updated_at = new_updated_at,
       rebuilding = false,
     }, _MT)
@@ -320,10 +318,8 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
   local fields, header_fields, query_fields = categorize_fields(inst:get_fields())
 
   old_router.fields = fields
-  old_router.header_fields = header_fields,
-  old_router.query_fields = query_fields,
-  old_router.match_headers = not is_empty_field(header_fields)
-  old_router.match_queries = not is_empty_field(query_fields)
+  old_router.header_fields = header_fields
+  old_router.query_fields = query_fields
   old_router.updated_at = new_updated_at
   old_router.rebuilding = false
 
@@ -454,7 +450,6 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
     end -- if field
 
-    ::continue::
   end   -- for self.fields
 
   if req_headers then
@@ -630,7 +625,7 @@ function _M:exec(ctx)
   local sni = server_name()
 
   local headers, headers_key
-  if self.match_headers then
+  if not is_empty_field(self.header_fields) then
     headers = get_http_params(get_headers, "headers", "lua_max_req_headers")
 
     headers["host"] = nil
@@ -639,7 +634,7 @@ function _M:exec(ctx)
   end
 
   local queries, queries_key
-  if self.match_queries then
+  if not is_empty_field(self.query_fields) then
     queries = get_http_params(get_uri_args, "queries", "lua_max_uri_args")
 
     queries_key = get_queries_key(queries)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -158,6 +158,9 @@ local function add_atc_matcher(inst, route, route_id,
 end
 
 
+if is_http then
+
+
 local function is_http_headers_field(field)
   return field:sub(1, 13) == "http.headers."
 end
@@ -188,6 +191,33 @@ local function has_query_matching_field(fields)
 
   return false
 end
+
+
+local tb_insert = table.insert
+
+
+local function categorize_http_fields(fields)
+  local baisc = {}
+  local headers = {}
+  local queries = {}
+
+  for _, field in ipairs(fields) do
+    if is_http_headers_field(field) then
+      tb_insert(headers, field)
+
+    elseif is_http_queries_field(field) then
+      tb_insert(queries, field)
+
+    else
+      tb_insert(basic, field)
+    end
+  end
+
+  return baisc, headers, queries
+end
+
+
+end -- if is_http then
 
 
 local function new_from_scratch(routes, get_exp_and_priority)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Categorize atc fields to `fields` `header_fields` `query_fields`, 
then we can simplify the logic in `select()`.
 
### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
