### PR TITLE
fix(aws-lambda): add better type and error handling on proxy integration mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@
 
 ## Unreleased
 
-# Fixes
+### Additions
+
+#### Core
+
+#### Plugins
+
+- **AWS-Lambda**: the AWS-Lambda plugin has been refactored by using `lua-resty-aws` as an
+  underlying AWS library. The refactor simplifies the AWS-Lambda plugin code base and
+  adding support for multiple IAM authenticating scenarios.
+  [#11350](https://github.com/Kong/kong/pull/11350)
+
+### Fixes
 
 #### Core
 
@@ -26,8 +37,10 @@
 
 #### Plugins
 
-- For OAuth2 plugin, `scope` has been taken into account as a new criterion of the request validation. When refreshing token with `refresh_token`, the scopes associated with the `refresh_token` provided in the request must be same with or a subset of the scopes configured in the OAuth2 plugin instance hit by the request.
+- **OAuth2**: For OAuth2 plugin, `scope` has been taken into account as a new criterion of the request validation. When refreshing token with `refresh_token`, the scopes associated with the `refresh_token` provided in the request must be same with or a subset of the scopes configured in the OAuth2 plugin instance hit by the request.
   [#11342](https://github.com/Kong/kong/pull/11342)
+- **AWS-Lambda**: fix an issue that the AWS-Lambda plugin cannot extract a json encoded proxy integration response.
+  [#11413](https://github.com/Kong/kong/pull/11413)
 
 ## 3.4.0
 

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -93,9 +93,18 @@ end
 
 
 local function extract_proxy_response(content)
-  local serialized_content, err = cjson.decode(content)
-  if not serialized_content then
-    return nil, err
+  local serialized_content, err
+  if type(content) == "string" then
+    serialized_content, err = cjson.decode(content)
+    if not serialized_content then
+      return nil, err
+    end
+
+  elseif type(content) == "table" then
+    serialized_content = content
+
+  else
+    return nil, "proxy response must be json format"
   end
 
   local ok, err = validate_custom_response(serialized_content)

--- a/spec/03-plugins/27-aws-lambda/08-sam-integration_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/08-sam-integration_spec.lua
@@ -122,7 +122,7 @@ if sam.get_os_architecture() ~= "aarch64" then
             method  = "GET",
             path    = "/",
             headers = {
-              host = "lambda2com"
+              host = "lambda2.com"
             }
           })
           assert.res_status(201, res)

--- a/spec/03-plugins/27-aws-lambda/08-sam-integration_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/08-sam-integration_spec.lua
@@ -57,6 +57,26 @@ if sam.get_os_architecture() ~= "aarch64" then
             log_type      = "None",
           },
         }
+
+        local route2 = bp.routes:insert {
+          hosts = { "lambda2.com" },
+        }
+
+        bp.plugins:insert {
+          name     = "aws-lambda",
+          route    = { id = route2.id },
+          config   = {
+            host          = "localhost",
+            port          = sam_port,
+            disable_https = true,
+            aws_key       = "mock-key",
+            aws_secret    = "mock-secret",
+            aws_region    = "us-east-1",
+            function_name = "HelloWorldFunction",
+            log_type      = "None",
+            is_proxy_integration = true,
+          },
+        }
       end)
 
       lazy_teardown(function()
@@ -95,6 +115,19 @@ if sam.get_os_architecture() ~= "aarch64" then
             }
           })
           assert.res_status(200, res)
+        end)
+
+        it("can extract proxy response correctly", function ()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              host = "lambda2com"
+            }
+          })
+          assert.res_status(201, res)
+          local body = assert.response(res).has.jsonbody()
+          assert.equal("hello world", body.message)
         end)
       end)
     end)

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -40,15 +40,18 @@ local fixtures = {
                       ngx.header["Content-Length"] = 0
 
                     elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
+                      ngx.header["Content-Type"] = "application/json"
                       ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
 
                     elseif string.match(ngx.var.uri, "functionWithNotBase64EncodedResponse") then
+                      ngx.header["Content-Type"] = "application/json"
                       ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA=\", \"isBase64Encoded\": false}")
 
                     elseif string.match(ngx.var.uri, "functionWithIllegalBase64EncodedResponse") then
                       ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA=\", \"isBase64Encoded\": \"abc\"}")
 
                     elseif string.match(ngx.var.uri, "functionWithMultiValueHeadersResponse") then
+                      ngx.header["Content-Type"] = "application/json"
                       ngx.say("{\"statusCode\": 200, \"headers\": { \"Age\": \"3600\"}, \"multiValueHeaders\": {\"Access-Control-Allow-Origin\": [\"site1.com\", \"site2.com\"]}}")
 
                     elseif string.match(ngx.var.uri, "functionEcho") then

--- a/spec/fixtures/sam-app/hello_world/app.py
+++ b/spec/fixtures/sam-app/hello_world/app.py
@@ -34,7 +34,7 @@ def lambda_handler(event, context):
     #     raise e
 
     return {
-        "statusCode": 200,
+        "statusCode": 201,
         "body": json.dumps({
             "message": "hello world",
             # "location": ip.text.replace("\n", "")


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
This PR adds better type handling and error handling for proxy integration mode. One change comes from #11350 is that if lambda function's response body is `application/json` then it will be automatically decoded by AWS lib. We handle this situation better and make sure it gets tested in our integration test.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Fix the problem that lambda cannot extract a json encoded proxy integration response
