### PR TITLE
fix(cache): make acl entities group cache warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   [#11306](https://github.com/Kong/kong/pull/11306)
 - Fix an issue where cluster_cert or cluster_ca_cert is inserted into lua_ssl_trusted_certificate before being base64 decoded.
   [#11385](https://github.com/Kong/kong/pull/11385)
+- Fix cache warmup mechanism not working in `acls` plugin groups config entity scenario.
+  [#11414](https://github.com/Kong/kong/pull/11414)
 
 #### Plugins
 

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -1,8 +1,8 @@
 local utils = require "kong.tools.utils"
 local constants = require "kong.constants"
 local buffer = require "string.buffer"
-local acl_groups
-if utils.load_module_if_exists("kong.plugins.acl") then
+local acl_groups = require "kong.plugins.acl.groups"
+if utils.load_module_if_exists("kong.plugins.acl.groups") then
   acl_groups = require "kong.plugins.acl.groups"
 end
 
@@ -141,7 +141,8 @@ function cache_warmup.single_dao(dao)
       return nil, err
     end
 
-    if entity_name == "acl" and acl_groups then
+    if entity_name == "acls" and acl_groups ~= nil then
+      log(NOTICE, "warmup acl groups cache for consumer id: ", entity.consumer.id , "...")
       acl_groups.warmup_groups_cache(entity.consumer.id)
     end
 

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -143,9 +143,11 @@ function cache_warmup.single_dao(dao)
 
     if entity_name == "acls" and acl_groups ~= nil then
       log(NOTICE, "warmup acl groups cache for consumer id: ", entity.consumer.id , "...")
-      acl_groups.warmup_groups_cache(entity.consumer.id)
+      local _, err = acl_groups.warmup_groups_cache(entity.consumer.id)
+      if err then
+        log(NOTICE, "warmup acl groups cache for consumer id: ", entity.consumer.id , " err: ", err)
+      end
     end
-
   end
 
   if entity_name == "services" and host_count > 0 then

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -136,6 +136,11 @@ function cache_warmup.single_dao(dao)
     if not ok then
       return nil, err
     end
+
+    if entity_name == "acl" then
+      kong.plugins.acl.groups.warmup_groups_cache(entity.consumer.id)
+    end
+
   end
 
   if entity_name == "services" and host_count > 0 then

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -1,7 +1,7 @@
 local utils = require "kong.tools.utils"
 local constants = require "kong.constants"
 local buffer = require "string.buffer"
-local acl_groups = require "kong.plugins.acl.groups"
+local acl_groups
 if utils.load_module_if_exists("kong.plugins.acl.groups") then
   acl_groups = require "kong.plugins.acl.groups"
 end

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -1,6 +1,10 @@
 local utils = require "kong.tools.utils"
 local constants = require "kong.constants"
 local buffer = require "string.buffer"
+local acl_groups
+if utils.load_module_if_exists("kong.plugins.acl") then
+  acl_groups = require "kong.plugins.acl.groups"
+end
 
 
 local cache_warmup = {}
@@ -137,8 +141,8 @@ function cache_warmup.single_dao(dao)
       return nil, err
     end
 
-    if entity_name == "acl" then
-      kong.plugins.acl.groups.warmup_groups_cache(entity.consumer.id)
+    if entity_name == "acl" and acl_groups then
+      acl_groups.warmup_groups_cache(entity.consumer.id)
     end
 
   end

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -196,6 +196,16 @@ local function group_in_groups(groups_to_check, groups)
   end
 end
 
+local function warmup_groups_cache(consumer_id)
+  local cache_key = kong.db.acls:cache_key(consumer_id)
+  local _, err = kong.cache:get(cache_key, nil,
+                                         load_groups_into_memory,
+                                         { id = consumer_id })
+  if err then
+    return nil, err
+  end
+end
+
 
 return {
   get_current_consumer_id = get_current_consumer_id,
@@ -203,4 +213,5 @@ return {
   get_authenticated_groups = get_authenticated_groups,
   consumer_in_groups = consumer_in_groups,
   group_in_groups = group_in_groups,
+  warmup_groups_cache = warmup_groups_cache,
 }

--- a/spec/03-plugins/18-acl/02-access_spec.lua
+++ b/spec/03-plugins/18-acl/02-access_spec.lua
@@ -1347,6 +1347,14 @@ for _, strategy in helpers.each_strategy() do
 
     describe("cache warmup acls group", function()
       it("cache warmup acls group", function()
+        assert(helpers.restart_kong {
+          plugins    = "bundled, ctx-checker",
+          database   = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          db_cache_warmup_entities = "keyauth_credentials,consumers,acls",
+        })
+
+        proxy_client = helpers.proxy_client()
         local res = assert(proxy_client:get("/request", {
           headers = {
             ["Host"] = "acl14.com"

--- a/spec/03-plugins/18-acl/02-access_spec.lua
+++ b/spec/03-plugins/18-acl/02-access_spec.lua
@@ -711,10 +711,39 @@ for _, strategy in helpers.each_strategy() do
         }
       }
 
+      local route14 = bp.routes:insert({
+        hosts = { "acl14.com" }
+      })
+
+      local acl_prefunction_code = "        local consumer_id = \"" .. tostring(consumer2.id) .. "\"\n" .. [[
+        local cache_key = kong.db.acls:cache_key(consumer_id)
+
+        -- we must use shadict to get the cache, because the `kong.cache` was hooked by `kong.plugins.pre-function` 
+        local raw_groups, err = ngx.shared.kong_db_cache:get("kong_db_cache"..cache_key)
+        if raw_groups then
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, "failed to get cache: ", err)
+          ngx.exit(500)
+        end
+          
+      ]]
+
+      bp.plugins:insert {
+        route = { id = route14.id },
+        name = "pre-function",
+        config = {
+          access = {
+            acl_prefunction_code,
+          },
+        }
+      }
+
       assert(helpers.start_kong({
         plugins    = "bundled, ctx-checker",
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
+        db_cache_warmup_entities = "keyauth_credentials,consumers,acls",
       }))
     end)
 
@@ -1315,6 +1344,18 @@ for _, strategy in helpers.each_strategy() do
         assert.same({ message = "You cannot consume this service" }, json)
       end)
     end)
+
+    describe("cache warmup acls group", function()
+      it("cache warmup acls group", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl14.com"
+          }
+        }))
+        assert.res_status(200, res)
+      end)
+    end)
+  
   end)
 
   describe("Plugin: ACL (access) [#" .. strategy .. "] anonymous", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

kong acl plugin will need to get all consumer groups by customer id (because consumer group and acl plugin config some complex connection), these entities can not be warmed up by Kong, The "warm up" mechanism mainly ensures that all entities are loaded into the cache and enables more precise SQL queries (based on cache key definitions) https://github.com/Kong/kong/blob/master/kong/plugins/acl/daos.lua#L8. However, for scenarios where it is necessary to iterate through all entities under a consumer ID, caching is not possible. https://github.com/Kong/kong/blob/master/kong/plugins/acl/groups.lua#L45

So this PR tries a patch warmup mechanism to support `acls` entities config.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog


### Issue reference
FTI-5275
<!--- If it fixes an open issue, please link to the issue here. -->
