### PR TITLE
refactor(build): use kong_template_* rule for luarocks targets

### DIFF
--- a/build/luarocks/BUILD.bazel
+++ b/build/luarocks/BUILD.bazel
@@ -4,6 +4,9 @@ exports_files(
     [
         "BUILD.luarocks.bazel",
         "luarocks_wrap_script.lua",
+        "templates/luarocks_exec.sh",
+        "templates/luarocks_make.sh",
+        "templates/luarocks_target.sh",
     ],
     visibility = ["//visibility:public"],
 )

--- a/build/luarocks/BUILD.luarocks.bazel
+++ b/build/luarocks/BUILD.luarocks.bazel
@@ -1,6 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
-
-# load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+load("@kong//build:build_system.bzl", "kong_template_genrule")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
 filegroup(
@@ -11,9 +10,9 @@ filegroup(
     ),
 )
 
-# This rules is used to install luarocks to install rockspecs
-# we need a different rule to install luarocks in release artifact
-# so that we got correct interpreter path etc.
+# This rules is used to bootstrap luarocks to install rocks dependencies
+# A different rule is used to install luarocks in the release artifact
+# so that we got correct interpreter path, lua paths, etc.
 configure_make(
     name = "luarocks_host",
     configure_command = "configure",
@@ -37,102 +36,27 @@ configure_make(
     ],
 )
 
-# TODO: set cross compile CC/LD in luarocks_make
-
-genrule(
+kong_template_genrule(
     name = "luarocks_exec",
     srcs = [
-        "@openssl",
-        "@libexpat",
+        "@openssl//:openssl",
+        "@libexpat//:libexpat",
     ] + select({
         "@kong//:any-cross": ["@cross_deps_libyaml//:libyaml"],
         "//conditions:default": [
-            ":luarocks_host",
+            "@luarocks//:luarocks_host",
             "@openresty//:luajit",
         ],
     }),
-    outs = ["luarocks_exec.sh"],
-    cmd = ("LIB_RPATH='%s'/kong/lib" % KONG_VAR["INSTALL_DESTDIR"]) +
-          """
-WORKSPACE_PATH=$$(pwd)
-ROCKS_DIR=$$WORKSPACE_PATH/$$(dirname $@)/luarocks_tree
-if [ ! -d $$ROCKS_DIR ]; then
-    mkdir -p $$ROCKS_DIR
-fi
-# pre create the dir and file so bsd readlink is happy
-mkdir -p "$$ROCKS_DIR/../cache"
-CACHE_DIR=$$(readlink -f "$$ROCKS_DIR/../cache")
-touch "$$ROCKS_DIR/../luarocks_config.lua"
-ROCKS_CONFIG=$$(readlink -f "$$ROCKS_DIR/../luarocks_config.lua")
-
-OPENSSL_DIR=$$WORKSPACE_PATH/$$(echo '$(locations @openssl)' | awk '{print $$1}')
-EXPAT_DIR=$$WORKSPACE_PATH/$$(echo '$(locations @libexpat)' | awk '{print $$1}')
-
-# we use system libyaml on macos
-if [[ "$$OSTYPE" == "darwin"* ]]; then
-    YAML_DIR=$$(HOME=~$$(whoami) brew --prefix)/opt/libyaml
-elif [[ -d $$WORKSPACE_PATH/$(BINDIR)/external/cross_deps_libyaml/libyaml ]]; then
-    # TODO: is there a good way to use locations but doesn't break non-cross builds?
-    YAML_DIR=$$WORKSPACE_PATH/$(BINDIR)/external/cross_deps_libyaml/libyaml
-else
-    YAML_DIR=/usr
-fi
-
-CC=$(CC)
-LD=$(CC) # yes, not a typo
-if [[ $$CC != /* ]]; then
-    # point to our relative path of musl toolchain
-    CC=$$WORKSPACE_PATH/$$CC
-    LD=$$WORKSPACE_PATH/$$LD
-fi
-
-echo "
-rocks_trees = {
-    { name = [[system]], root = [[$$ROCKS_DIR]] }
-}
-local_cache = '$$CACHE_DIR'
-gcc_rpath = false -- disable default rpath, add our own
-variables = {
-    CC = '$$CC',
-    LD = '$$LD',
-    LDFLAGS = '-Wl,-rpath,$$LIB_RPATH',
-}
-" > $$ROCKS_CONFIG
-
-LUAROCKS_HOST=$$(echo '$(locations :luarocks_host)' | awk '{print $$1}')
-
-host_luajit=$$WORKSPACE_PATH/$$(echo $(locations @openresty//:luajit) | awk '{{print $$1}}')/bin/luajit
-
-cat << EOF > $@
-LIB_RPATH=$$LIB_RPATH
-WORKSPACE_PATH=$$WORKSPACE_PATH
-LUAROCKS_HOST=$$LUAROCKS_HOST
-ROCKS_DIR=$$ROCKS_DIR
-CACHE_DIR=$$CACHE_DIR
-ROCKS_CONFIG=$$ROCKS_CONFIG
-
-export LUAROCKS_CONFIG=$$ROCKS_CONFIG
-export CC=$$CC
-export LD=$$LD
-export EXT_BUILD_ROOT=$$WORKSPACE_PATH # for musl
-
-# force the interpreter here instead of invoking luarocks directly,
-# some distros has BINPRM_BUF_SIZE smaller than the shebang generated,
-# which is usually more than 160 bytes
-$$host_luajit $$WORKSPACE_PATH/$$LUAROCKS_HOST/bin/luarocks \\$$@ \\
-    OPENSSL_DIR=$$OPENSSL_DIR \\
-    CRYPTO_DIR=$$OPENSSL_DIR \\
-    EXPAT_DIR=$$EXPAT_DIR \\
-    YAML_DIR=$$YAML_DIR
-EOF
-""",
-    executable = True,
-    toolchains = [
-        "@bazel_tools//tools/cpp:current_cc_toolchain",
-    ],
+    is_executable = True,
+    output = "luarocks_exec.sh",
+    substitutions = {
+        "{{lib_rpath}}": "%s/kong/lib" % KONG_VAR["INSTALL_DESTDIR"],
+    },
+    template = "@//build/luarocks:templates/luarocks_exec.sh",
     tools = select({
         "@kong//:any-cross": [
-            ":luarocks_host",
+            "@luarocks//:luarocks_host",
             "@openresty//:luajit",
         ],
         "//conditions:default": [],
@@ -140,109 +64,45 @@ EOF
     visibility = ["//visibility:public"],
 )
 
-genrule(
+kong_template_genrule(
     name = "luarocks_make",
     srcs = [
         "@kong//:rockspec_srcs",
-        ":luarocks_exec",
-        ":luarocks_target",  # to avoid concurrency issue, run this after luarocks_target
+        "@luarocks//:luarocks_exec",
+        "@luarocks//:luarocks_target",  # to avoid concurrency issue, run this after luarocks_target
     ],
-    outs = ["luarocks_make.log"],
-    cmd = """
-        if [[ "$$OSTYPE" == "darwin"* ]]; then
-            export DEVELOPER_DIR=$$(xcode-select -p)
-            export SDKROOT=$$(xcrun --sdk macosx --show-sdk-path)
-        fi
-        mkdir -p $$(dirname $@)
-        # lyaml needs this and doesn't honor --no-doc
-        # the alternate will populate a non-existent HOME
-        # env var just to let ldoc happy
-        # alias LDOC command to true(1) command
-        export LDOC=true
-
-        $(location :luarocks_exec) make --no-doc 2>&1 >$@.tmp
-
-        # only generate the output when the command succeeds
-        mv $@.tmp $@
-    """,
+    is_executable = True,
+    output = "luarocks_make.log",
+    progress_message = "Luarocks: Install Kong rocks dependencies",
+    template = "@//build/luarocks:templates/luarocks_make.sh",
     visibility = ["//visibility:public"],
 )
 
 # install luarocks itself in target configuration
-genrule(
+kong_template_genrule(
     name = "luarocks_target",
-    srcs = [
-        ":luarocks_exec",
-    ] + select({
+    srcs = [":luarocks_exec"] + select({
         "@kong//:any-cross": [],
         "//conditions:default": [
-            ":luarocks_host",
+            "@luarocks//:luarocks_host",
             "@openresty//:luajit",
         ],
     }),
-    outs = ["luarocks_target.log"],
-    cmd = """
-    build_destdir={build_destdir}
-    install_destdir={install_destdir}
-    luarocks_version={luarocks_version}
-    workspace_path={workspace_path}
-    """.format(
-              build_destdir = KONG_VAR["BUILD_DESTDIR"],
-              install_destdir = KONG_VAR["INSTALL_DESTDIR"],
-              luarocks_version = KONG_VAR["LUAROCKS"],
-              workspace_path = KONG_VAR["WORKSPACE_PATH"],
-          ) +
-          """
-        mkdir -p $$(dirname $@)
-
-        # install luarocks
-        $(location :luarocks_exec) install "luarocks $${luarocks_version}" 2>&1 >$@.tmp
-
-        # use host configuration to invoke luarocks API to wrap a correct bin/luarocks script
-        rocks_tree=$${workspace_path}/$$(dirname '$(location @luarocks//:luarocks_exec)')/luarocks_tree
-        host_luajit=$${workspace_path}/$$(echo $(locations @openresty//:luajit) | awk '{{print $$1}}')/bin/luajit
-
-        host_luarocks_tree=$$(echo '$(locations luarocks_host)' | awk '{print $$1}')
-        export LUA_PATH="$${build_destdir}/share/lua/5.1/?.lua;$${build_destdir}/share/lua/5.1/?/init.lua;$${host_luarocks_tree}/share/lua/5.1/?.lua;$${host_luarocks_tree}/share/lua/5.1/?/init.lua;;"
-
-        ROCKS_CONFIG="luarocks_make_config.lua"
-        cat << EOF > $$ROCKS_CONFIG
-rocks_trees = {
-    { name = [[system]], root = [[$$rocks_tree]] }
-}
-EOF
-        export LUAROCKS_CONFIG=$$ROCKS_CONFIG
-
-        $${host_luajit} $(location @kong//build/luarocks:luarocks_wrap_script.lua) \
-                    luarocks $${rocks_tree} $${install_destdir} 2>&1 >>$@.tmp
-
-        # write the luarocks config with host configuration
-        mkdir -p $$rocks_tree/etc/luarocks
-        cat << EOF > $$rocks_tree/etc/luarocks/config-5.1.lua
--- LuaRocks configuration
-rocks_trees = {
-    { name = "user", root = home .. "/.luarocks" };
-    { name = "system", root = "$${install_destdir}" };
-}
-lua_interpreter = "luajit";
-variables = {
-    LUA_DIR = "$${install_destdir}/openresty/luajit";
-    LUA_INCDIR = "$${install_destdir}/openresty/luajit/include/luajit-2.1";
-    LUA_BINDIR = "$${install_destdir}/openresty/luajit/bin";
-}
-EOF
-
-        # TODO: this still doesn't work
-        sed -i -e "s|$$rocks_tree|$$install_destdir|g" $$rocks_tree/bin/luarocks
-
-        # only generate the output when the command succeeds
-        mv $@.tmp $@
-    """,
+    is_executable = True,
+    output = "luarocks_target.log",
+    progress_message = "Luarocks: Install luarocks on target system",
+    substitutions = {
+        "{{build_destdir}}": KONG_VAR["BUILD_DESTDIR"],
+        "{{install_destdir}}": KONG_VAR["INSTALL_DESTDIR"],
+        "{{luarocks_version}}": KONG_VAR["LUAROCKS"],
+        "{{workspace_path}}": KONG_VAR["WORKSPACE_PATH"],
+    },
+    template = "@//build/luarocks:templates/luarocks_target.sh",
     tools = [
-        "@kong//build/luarocks:luarocks_wrap_script.lua",
+        "@//build/luarocks:luarocks_wrap_script.lua",
     ] + select({
-        "@kong//:any-cross": [
-            ":luarocks_host",
+        "@//:any-cross": [
+            "@luarocks//:luarocks_host",
             "@openresty//:luajit",
         ],
         "//conditions:default": [],

--- a/build/luarocks/luarocks_repositories.bzl
+++ b/build/luarocks/luarocks_repositories.bzl
@@ -1,14 +1,12 @@
 """A module defining the third party dependency luarocks"""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
 def luarocks_repositories():
     version = KONG_VAR["LUAROCKS"]
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "luarocks",
         build_file = "//build/luarocks:BUILD.luarocks.bazel",
         strip_prefix = "luarocks-" + version,

--- a/build/luarocks/templates/luarocks_exec.sh
+++ b/build/luarocks/templates/luarocks_exec.sh
@@ -31,7 +31,7 @@ OPENSSL_DIR=$root_path/$openssl_path
 
 # we use system libyaml on macos
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    YAML_DIR=$(HOME=~$(whoami) brew --prefix)/opt/libyaml
+     YAML_DIR=$(HOME=~$(whoami) PATH=/opt/homebrew/bin:$PATH brew --prefix)/opt/libyaml
 elif [[ -d $cross_deps_libyaml_path ]]; then
     # TODO: is there a good way to use locations but doesn't break non-cross builds?
     YAML_DIR=$root_path/$cross_deps_libyaml_path
@@ -40,7 +40,7 @@ else
 fi
 
 if [[ $CC != /* ]]; then
-    # point to our relative path of musl toolchain
+    # point to our relative path of managed toolchain
     CC=$root_path/$CC
     LD=$root_path/$LD
 fi

--- a/build/luarocks/templates/luarocks_exec.sh
+++ b/build/luarocks/templates/luarocks_exec.sh
@@ -1,0 +1,97 @@
+#!/bin/bash -e
+
+# template variables starts
+libexpat_path="{{@libexpat//:libexpat}}"
+libxml2_path="invalid"
+openssl_path="{{@openssl//:openssl}}"
+luarocks_host_path="{{@luarocks//:luarocks_host}}"
+luajit_path="{{@openresty//:luajit}}"
+kongrocks_path="invalid"
+cross_deps_libyaml_path="{{@cross_deps_libyaml//:libyaml}}"
+CC={{CC}}
+LD={{LD}}
+LIB_RPATH={{lib_rpath}}
+# template variables ends
+
+root_path=$(pwd)
+
+ROCKS_DIR=$root_path/$(dirname $@)/luarocks_tree
+if [ ! -d $ROCKS_DIR ]; then
+    mkdir -p $ROCKS_DIR
+fi
+# pre create the dir and file so bsd readlink is happy
+mkdir -p "$ROCKS_DIR/../cache"
+CACHE_DIR=$(readlink -f "$ROCKS_DIR/../cache")
+touch "$ROCKS_DIR/../luarocks_config.lua"
+ROCKS_CONFIG=$(readlink -f "$ROCKS_DIR/../luarocks_config.lua")
+
+EXPAT_DIR=$root_path/$libexpat_path
+LIBXML2_DIR=$root_path/$libxml2_path
+OPENSSL_DIR=$root_path/$openssl_path
+
+# we use system libyaml on macos
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    YAML_DIR=$(HOME=~$(whoami) brew --prefix)/opt/libyaml
+elif [[ -d $cross_deps_libyaml_path ]]; then
+    # TODO: is there a good way to use locations but doesn't break non-cross builds?
+    YAML_DIR=$root_path/$cross_deps_libyaml_path
+else
+    YAML_DIR=/usr
+fi
+
+if [[ $CC != /* ]]; then
+    # point to our relative path of musl toolchain
+    CC=$root_path/$CC
+    LD=$root_path/$LD
+fi
+
+echo "
+rocks_trees = {
+    { name = [[system]], root = [[$ROCKS_DIR]] }
+}
+local_cache = '$CACHE_DIR'
+show_downloads = true
+gcc_rpath = false -- disable default rpath, add our own
+variables = {
+    CC = '$CC',
+    LD = '$LD',
+    LDFLAGS = '-Wl,-rpath,$LIB_RPATH',
+}
+" > $ROCKS_CONFIG
+
+LUAROCKS_HOST=$luarocks_host_path
+
+host_luajit=$root_path/$luajit_path/bin/luajit
+
+cat << EOF > $@
+LIB_RPATH=$LIB_RPATH
+LUAROCKS_HOST=$LUAROCKS_HOST
+ROCKS_DIR=$ROCKS_DIR
+CACHE_DIR=$CACHE_DIR
+ROCKS_CONFIG=$ROCKS_CONFIG
+
+export LUAROCKS_CONFIG=$ROCKS_CONFIG
+export CC=$CC
+export LD=$LD
+export EXT_BUILD_ROOT=$root_path # for musl
+
+# no idea why PATH is not preserved in ctx.actions.run_shell
+export PATH=$PATH
+
+if [[ $kongrocks_path == external* ]]; then
+    p=$root_path/external/kongrocks/rocks
+    echo "Using bundled rocks from \$p"
+    echo "If errors like 'No results matching query were found for Lua 5.1.' are shown, submit a PR to https://github.com/kong/kongrocks"
+    private_rocks_args="--only-server \$p"
+fi
+
+# force the interpreter here instead of invoking luarocks directly,
+# some distros has BINPRM_BUF_SIZE smaller than the shebang generated,
+# which is usually more than 160 bytes
+$host_luajit $root_path/$LUAROCKS_HOST/bin/luarocks \$private_rocks_args \$@ \\
+    OPENSSL_DIR=$OPENSSL_DIR \\
+    CRYPTO_DIR=$OPENSSL_DIR \\
+    EXPAT_DIR=$EXPAT_DIR \\
+    LIBXML2_DIR=$LIBXML2_DIR \\
+    YAML_DIR=$YAML_DIR
+EOF

--- a/build/luarocks/templates/luarocks_make.sh
+++ b/build/luarocks/templates/luarocks_make.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+# template variables starts
+luarocks_exec="{{@luarocks//:luarocks_exec}}"
+# template variables ends
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export DEVELOPER_DIR=$(xcode-select -p)
+    export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+fi
+mkdir -p $(dirname $@)
+# lyaml needs this and doesn't honor --no-doc
+# the alternate will populate a non-existent HOME
+# env var just to let ldoc happy
+# alias LDOC command to true(1) command
+export LDOC=true
+
+$luarocks_exec make --no-doc 2>&1 >$@.tmp
+
+# only generate the output when the command succeeds
+mv $@.tmp $@

--- a/build/luarocks/templates/luarocks_target.sh
+++ b/build/luarocks/templates/luarocks_target.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+
+# template variables starts
+workspace_path="{{workspace_path}}"
+luarocks_version="{{luarocks_version}}"
+install_destdir="{{install_destdir}}"
+build_destdir="{{build_destdir}}"
+
+luarocks_exec="{{@luarocks//:luarocks_exec}}"
+luajit_path="{{@openresty//:luajit}}"
+luarocks_host_path="{{@luarocks//:luarocks_host}}"
+luarocks_wrap_script="{{@//build/luarocks:luarocks_wrap_script.lua}}"
+# template variables ends
+
+mkdir -p $(dirname $@)
+
+
+# install luarocks
+$luarocks_exec install "luarocks $luarocks_version"
+
+# use host configuration to invoke luarocks API to wrap a correct bin/luarocks script
+rocks_tree=$workspace_path/$(dirname $luarocks_exec)/luarocks_tree
+host_luajit=$workspace_path/$luajit_path/bin/luajit
+
+host_luarocks_tree=$luarocks_host_path
+export LUA_PATH="$build_destdir/share/lua/5.1/?.lua;$build_destdir/share/lua/5.1/?/init.lua;$host_luarocks_tree/share/lua/5.1/?.lua;$host_luarocks_tree/share/lua/5.1/?/init.lua;;"
+
+ROCKS_CONFIG="luarocks_make_config.lua"
+cat << EOF > $ROCKS_CONFIG
+rocks_trees = {
+    { name = [[system]], root = [[$rocks_tree]] }
+}
+EOF
+export LUAROCKS_CONFIG=$ROCKS_CONFIG
+
+$host_luajit $luarocks_wrap_script \
+            luarocks $rocks_tree $install_destdir 2>&1 > $@.tmp
+
+# write the luarocks config with host configuration
+mkdir -p $rocks_tree/etc/luarocks
+cat << EOF > $rocks_tree/etc/luarocks/config-5.1.lua
+-- LuaRocks configuration
+rocks_trees = {
+        { name = "user", root = home .. "/.luarocks" };
+        { name = "system", root = "$install_destdir" };
+    }
+    lua_interpreter = "luajit";
+    variables = {
+    LUA_DIR = "$install_destdir/openresty/luajit";
+    LUA_INCDIR = "$install_destdir/openresty/luajit/include/luajit-2.1";
+    LUA_BINDIR = "$install_destdir/openresty/luajit/bin";
+}
+EOF
+
+# TODO: this still doesn't work
+sed -i -e "s|$rocks_tree|$install_destdir|g" $rocks_tree/bin/luarocks
+
+# only generate the output when the command succeeds
+mv $@.tmp $@

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -6,6 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("//build/luarocks:luarocks_repositories.bzl", "luarocks_repositories")
 load("//build/cross_deps:repositories.bzl", "cross_deps_repositories")
 load("//build/libexpat:repositories.bzl", "libexpat_repositories")
+load("//build:build_system.bzl", "github_release")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
 _SRCS_BUILD_FILE_CONTENT = """
@@ -51,72 +52,6 @@ def kong_github_repositories():
         pattern = "release.tar.gz",
         build_file_content = _DIST_BUILD_FILE_CONTENT,
     )
-
-def _copyright_header(ctx):
-    paths = ctx.execute(["find", ctx.path("."), "-type", "f"]).stdout.split("\n")
-
-    copyright_content = ctx.read(ctx.path(Label("@kong//:distribution/COPYRIGHT-HEADER"))).replace("--", " ")
-    copyright_content_js = "/*\n" + copyright_content + "*/\n\n"
-    copyright_content_html = "<!--\n" + copyright_content + "-->\n\n"
-    for path in paths:
-        if path.endswith(".js") or path.endswith(".map") or path.endswith(".css"):
-            content = ctx.read(path)
-            if not content.startswith(copyright_content_js):
-                # the default enabled |legacy_utf8| leads to a double-encoded utf-8
-                # while writing utf-8 content read by |ctx.read|, let's disable it
-                ctx.file(path, copyright_content_js + content, legacy_utf8 = False)
-
-        elif path.endswith(".html"):
-            content = ctx.read(path)
-            if not content.startswith(copyright_content_html):
-                # the default enabled |legacy_utf8| leads to a double-encoded utf-8
-                # while writing utf-8 content read by |ctx.read|, let's disable it
-                ctx.file(path, copyright_content_html + content, legacy_utf8 = False)
-
-def _github_release_impl(ctx):
-    ctx.file("WORKSPACE", "workspace(name = \"%s\")\n" % ctx.name)
-
-    if ctx.attr.build_file:
-        ctx.file("BUILD.bazel", ctx.read(ctx.attr.build_file))
-    elif ctx.attr.build_file_content:
-        ctx.file("BUILD.bazel", ctx.attr.build_file_content)
-
-    os_name = ctx.os.name
-    os_arch = ctx.os.arch
-
-    if os_arch == "aarch64":
-        os_arch = "arm64"
-    elif os_arch == "x86_64":
-        os_arch = "amd64"
-    elif os_arch != "amd64":
-        fail("Unsupported arch %s" % os_arch)
-
-    if os_name == "mac os x":
-        os_name = "macOS"
-    elif os_name != "linux":
-        fail("Unsupported OS %s" % os_name)
-
-    gh_bin = "%s" % ctx.path(Label("@gh_%s_%s//:bin/gh" % (os_name, os_arch)))
-    ret = ctx.execute([gh_bin, "release", "download", ctx.attr.tag, "-p", ctx.attr.pattern, "-R", ctx.attr.repo])
-
-    if ret.return_code != 0:
-        gh_token_set = "GITHUB_TOKEN is set, is it valid?"
-        if not ctx.os.environ.get("GITHUB_TOKEN", ""):
-            gh_token_set = "GITHUB_TOKEN is not set, is this a private repo?"
-        fail("Failed to download release (%s): %s, exit: %d" % (gh_token_set, ret.stderr, ret.return_code))
-
-    ctx.extract(ctx.attr.pattern)
-
-github_release = repository_rule(
-    implementation = _github_release_impl,
-    attrs = {
-        "tag": attr.string(mandatory = True),
-        "pattern": attr.string(mandatory = True),
-        "repo": attr.string(mandatory = True),
-        "build_file": attr.label(allow_single_file = True),
-        "build_file_content": attr.string(),
-    },
-)
 
 def protoc_repositories():
     http_archive(


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR refactors the luarocks build targets by using the improved `kong_template_file`  and `kong_template_genrule` rules so that we don't need to write shell scripts in multipl escapes and complex templates.

### Checklist

- [x] The Pull Request has tests
- [na] There's an entry in `CHANGELOG.md`
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-2351

EE sister PR https://github.com/Kong/kong-ee/pull/6294
KAG-1387
