### PR TITLE
chore(deps): bump lua-resty-aws to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
 - **AWS-Lambda**: fix an issue that the AWS-Lambda plugin cannot extract a json encoded proxy integration response.
   [#11413](https://github.com/Kong/kong/pull/11413)
 
+### Dependencies
+
+- Bumped lua-resty-openssl from 1.3.0 to 1.3.1
+  [#11419](https://github.com/Kong/kong/pull/11419)
+
 ## 3.4.0
 
 ### Breaking Changes

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.0",
   "lua-resty-healthcheck == 1.6.2",
   "lua-messagepack == 0.5.2",
-  "lua-resty-aws == 1.3.0",
+  "lua-resty-aws == 1.3.1",
   "lua-resty-openssl == 0.8.23",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Bumps lua-resty-aws from 1.3.0 to 1.3.1

> 1.3.1 (17-Aug-2023)
> fix: fix v4 signing request should correctly canonicalized query table as well https://github.com/Kong/lua-resty-aws/pull/76

### Checklist

- [na] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Bump lua-resty-aws version from 1.3.0 to 1.3.1

### Issue reference

