### PR TITLE
fix(PDK): fix response body repeated when kong.response.get_raw_body() called multiple times

### DIFF
--- a/CHANGELOG/unreleased/kong/11424.yaml
+++ b/CHANGELOG/unreleased/kong/11424.yaml
@@ -1,0 +1,7 @@
+message: Fix response body gets repeated when `kong.response.get_raw_body()` is called multiple times in a request lifecycle.
+type: bugfix
+scope: PDK
+prs:
+  - 11424
+jiras:
+  - "FTI-5296"

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -609,6 +609,7 @@ local function new(self, major_version)
       end
 
       arg[1] = body_buffer
+      ngx.ctx.KONG_BODY_BUFFER = nil
       return body_buffer
     end
 

--- a/t/01-pdk/08-response/14-get_raw_body.t
+++ b/t/01-pdk/08-response/14-get_raw_body.t
@@ -88,8 +88,11 @@ Called 3 times
             local pdk = PDK.new()
             -- call pdk.response.get_raw_body() multiple times
             local body = pdk.response.get_raw_body()
+            assert(body == "hello, world!\n")
             local body = pdk.response.get_raw_body()
+            assert(body == "hello, world!\n")
             local body = pdk.response.get_raw_body()
+            assert(body == "hello, world!\n")
         }
     }
 --- request

--- a/t/01-pdk/08-response/14-get_raw_body.t
+++ b/t/01-pdk/08-response/14-get_raw_body.t
@@ -89,6 +89,7 @@ Called 3 times
             -- call pdk.response.get_raw_body() multiple times
             local body = pdk.response.get_raw_body()
             local body = pdk.response.get_raw_body()
+            local body = pdk.response.get_raw_body()
         }
     }
 --- request

--- a/t/01-pdk/08-response/14-get_raw_body.t
+++ b/t/01-pdk/08-response/14-get_raw_body.t
@@ -87,12 +87,18 @@ Called 3 times
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
             -- call pdk.response.get_raw_body() multiple times
-            local body = pdk.response.get_raw_body()
-            assert(body == "hello, world!\n")
-            local body = pdk.response.get_raw_body()
-            assert(body == "hello, world!\n")
-            local body = pdk.response.get_raw_body()
-            assert(body == "hello, world!\n")
+            ngx.ctx.called = (ngx.ctx.called or 0) + 1
+            for i = 1, 3 do
+                ngx.ctx.called2 = (ngx.ctx.called2 or 0) + 1
+                local body = pdk.response.get_raw_body()
+                if body then
+                    assert("hello, world!\n" == body)
+                end
+            end
+        }
+        log_by_lua_block {
+            assert(ngx.ctx.called == 2)
+            assert(ngx.ctx.called2 == 6)
         }
     }
 --- request

--- a/t/01-pdk/08-response/14-get_raw_body.t
+++ b/t/01-pdk/08-response/14-get_raw_body.t
@@ -73,3 +73,27 @@ Enhanced by Body Filter
 Called 3 times
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: response.get_raw_body() calls multiple times
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.print("hello, world!\n")
+        }
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+            -- call pdk.response.get_raw_body() multiple times
+            local body = pdk.response.get_raw_body()
+            local body = pdk.response.get_raw_body()
+        }
+    }
+--- request
+GET /t
+--- response_body
+hello, world!
+--- no_error_log
+[error]


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

ngx.ctx.KONG_BODY_BUFFER is not reset while reading the EOF chunk. When `kong.response.get_raw_body()` is called multiple times, the response body gets repeated.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5296
