### PR TITLE
fix(doc): add missing description to proxy-cache schema field

### DIFF
--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -75,6 +75,7 @@ return {
             elements = { type = "string" },
           }},
           { response_headers = {
+            description = "Caching related diagnostic headers that should be included in cached responses",
             type = "record",
             fields = {
               { age  = {type = "boolean",  default = true} },


### PR DESCRIPTION
### Summary

The `description` field was missing from #10445, causing the reference documentation to be incomplete.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
