### PR TITLE
fix(queue): add failing test for edge case max_batch_size=max_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
   [#11342](https://github.com/Kong/kong/pull/11342)
 - When the worker is in shutdown mode and more data is immediately available without waiting for `max_coalescing_delay`, queues are now cleared in batches.
   [#11376](https://github.com/Kong/kong/pull/11376)
+- A race condition in the plugin queue could potentially crash the worker when `max_entries` was set to `max_batch_size`.
+  [#11378](https://github.com/Kong/kong/pull/11378)
 - **AWS-Lambda**: fix an issue that the AWS-Lambda plugin cannot extract a json encoded proxy integration response.
   [#11413](https://github.com/Kong/kong/pull/11413)
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -254,11 +254,20 @@ function Queue:process_once()
     end
   end
 
+  local batch = {unpack(self.entries, self.front, self.front + entry_count - 1)}
+  for _ = 1, entry_count do
+    self:delete_frontmost_entry()
+  end
+  if self.queue_full then
+    self:log_info('queue resumed processing')
+    self.queue_full = false
+  end
+
   local start_time = now()
   local retry_count = 0
   while true do
     self:log_debug("passing %d entries to handler", entry_count)
-    ok, err = self.handler(self.handler_conf, {unpack(self.entries, self.front, self.front + entry_count - 1)})
+    ok, err = self.handler(self.handler_conf, batch)
     if ok then
       self:log_debug("handler processed %d entries sucessfully", entry_count)
       break
@@ -282,15 +291,6 @@ function Queue:process_once()
     -- The maximum time between retries is capped by the max_retry_delay configuration parameter.
     sleep(math_min(self.max_retry_delay, 2 ^ retry_count * self.initial_retry_delay))
     retry_count = retry_count + 1
-  end
-
-  -- Guard against queue shrinkage during handler invocation by using math.min below.
-  for _ = 1, math.min(entry_count, self:count()) do
-    self:delete_frontmost_entry()
-  end
-  if self.queue_full then
-    self:log_info('queue resumed processing')
-    self.queue_full = false
   end
 end
 


### PR DESCRIPTION
### Summary

When defining a very special edge case configuration having max_batch_size=max_entries, the queue can fail with an assertion error when removing the frontmost element. This happens especially when the callback repeatedly fails (eg. an unavailable backend system receiving data).

What happens:

1. we add max_batch_size elements, all of which "post" resources
2. the batch queue consumes all of those resources in `process_once` by `wait()`ing for them, but gets stuck processing/sending the batch
3. as `process_once` is stuck until `max_retry_time` passed, the function does not run `delete_frontmost_entry()` and thus actually moves the `front` reference
4. when enqueuing the next item, it tries to drop the oldest entry, but triggers the assertion in queue.lua as no resources are left

This commit fixes #11377 by removing currently processed elements out of the race condition window.

### Checklist

- [X] The Pull Request has tests
- [X] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

#11377 