### PR TITLE
fix(dependency_services): support bash 3.x

### DIFF
--- a/scripts/dependency_services/common.sh
+++ b/scripts/dependency_services/common.sh
@@ -37,33 +37,44 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# [service_name_in_docker_compose]="env_var_name_1:port_1_in_docker_compose env_var_name_2:port_2_in_docker_compose"
-declare -A ports=(
-    ["postgres"]="PG_PORT:5432"
-    ["redis"]="REDIS_PORT:6379 REDIS_SSL_PORT:6380"
-    ["grpcbin"]="GRPCBIN_PORT:9000 GRPCBIN_SSL_PORT:9001"
-    ["zipkin"]="ZIPKIN_PORT:9411"
-    # ["opentelemetry"]="OTELCOL_HTTP_PORT:4318 OTELCOL_ZPAGES_PORT:55679"
-)
+# Initialize parallel arrays for service names and port definitions
+services=()
+port_defs=()
+
+# Add elements to the parallel arrays
+services+=("postgres")
+port_defs+=("PG_PORT:5432")
+
+services+=("redis")
+port_defs+=("REDIS_PORT:6379 REDIS_SSL_PORT:6380")
+
+services+=("grpcbin")
+port_defs+=("GRPCBIN_PORT:9000 GRPCBIN_SSL_PORT:9001")
+
+services+=("zipkin")
+port_defs+=("ZIPKIN_PORT:9411")
 
 _kong_added_envs=""
 
-# not all env variable needs all three prefix in all times, but we add all of them
-# for simplicity: there's no side effect after all
+# Not all env variables need all three prefixes, but we add all of them for simplicity
 env_prefixes="KONG_ KONG_TEST_ KONG_SPEC_TEST_"
 
-for svc in "${!ports[@]}"; do
-    for port_def in ${ports[$svc]}; do
+for ((i = 0; i < ${#services[@]}; i++)); do
+    svc="${services[i]}"
+
+    for port_def in ${port_defs[i]}; do
         env_name=$(echo $port_def |cut -d: -f1)
         private_port=$(echo $port_def |cut -d: -f2)
-        exposed_port=$($DOCKER_COMPOSE port $svc $private_port | cut -d: -f2)
-        if [ -z $exposed_port ]; then
+        exposed_port="$($DOCKER_COMPOSE port "$svc" "$private_port" | cut -d: -f2)"
+
+        if [ -z "$exposed_port" ]; then
             echo "Port $env_name for service $svc unknown"
             continue
         fi
+
         for prefix in $env_prefixes; do
             _kong_added_envs="$_kong_added_envs ${prefix}${env_name}"
-            echo "export ${prefix}${env_name}=$exposed_port" >> $KONG_SERVICE_ENV_FILE
+            echo "export ${prefix}${env_name}=$exposed_port" >> "$KONG_SERVICE_ENV_FILE"
         done
     done
 done


### PR DESCRIPTION
macOS ships bash 3.x by default

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [na] The Pull Request has tests
- [na] There's an entry in the CHANGELOG
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
