### PR TITLE
fix(response): fix response status code is not real upstream status when using kong.response function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - Fix an issue that query parameters are not forwarded in proxied request.
   Thanks [@chirag-manwani](https://github.com/chirag-manwani) for contributing this change.
   [#11328](https://github.com/Kong/kong/pull/11328)
+- Fix response status code is not real upstream status when using kong.response function.
+  [#11437](https://github.com/Kong/kong/pull/11437)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - Fix an issue that query parameters are not forwarded in proxied request.
   Thanks [@chirag-manwani](https://github.com/chirag-manwani) for contributing this change.
   [#11328](https://github.com/Kong/kong/pull/11328)
-- Fix response status code is not real upstream status when using kong.response function.
+- Fix an issue that response status code is not real upstream status when using kong.response function.
   [#11437](https://github.com/Kong/kong/pull/11437)
 
 #### Plugins

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1296,7 +1296,7 @@ do
     local res = ngx.location.capture("/kong_buffered_http", options)
     if res.truncated and options.method ~= ngx.HTTP_HEAD then
       ctx.KONG_PHASE = PHASES.error
-      ngx.status = 502
+      ngx.status = res.status or 502
       return kong_error_handlers(ctx)
     end
 

--- a/spec/02-integration/05-proxy/07-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/07-upstream_timeouts_spec.lua
@@ -32,6 +32,21 @@ for _, strategy in helpers.each_strategy() do
 
         route.service = bp.services:insert(service)
 
+        if route.enable_buffering then
+          route.enable_buffering = nil
+          bp.plugins:insert({
+            name = "pre-function",
+            service = { id = route.service.id },
+            config = {
+              access = {
+                [[
+                  kong.service.request.enable_buffering()
+                ]],
+              },
+            }
+          })
+        end
+
         if not route.protocols then
           route.protocols = { "http" }
         end
@@ -73,6 +88,17 @@ for _, strategy in helpers.each_strategy() do
             read_timeout   = 1, -- ms
           },
         },
+        {
+          methods = { "PUT" },
+          service = {
+            name            = "api-4",
+            protocol        = "http",
+            host            = "konghq.com",
+            port            = 81,
+            connect_timeout = 1, -- ms
+          },
+          enable_buffering = true,
+        },
       }
 
       bp.plugins:insert {
@@ -83,7 +109,7 @@ for _, strategy in helpers.each_strategy() do
       }
 
       assert(helpers.start_kong({
-        plugins    = "ctx-checker-last",
+        plugins    = "bundled, ctx-checker-last",
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
@@ -161,5 +187,22 @@ for _, strategy in helpers.each_strategy() do
         assert.equal(504, res.status)
       end)
     end)
+
+    describe("upstream_connect_timeout with enable_buffering", function()
+      it("sets upstream send timeout value", function()
+        local res = assert(proxy_client:send {
+          method  = "PUT",
+          path    = "/put",
+          body    = {
+            huge  = string.rep("a", 2^25)
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        assert.equal(504, res.status)
+      end)
+    end)
+
+
   end)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When kong uses `kong_buffered_http` and upstream timeout, the return status code needs to return 504 (which return by `ngx.location.capture`), not 502. 
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog



### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5320
