### PR TITLE
docs(kong.conf.default): ssl_ciphers description (#6035)

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -734,6 +734,8 @@
                                  # the pattern defined by `openssl ciphers`.
                                  # This value is ignored if `ssl_cipher_suite`
                                  # is not `custom`.
+                                 # If you use DHE ciphers, you must also 
+                                 # configure the `ssl_dhparam` parameter.
 
 #ssl_protocols = TLSv1.1 TLSv1.2 TLSv1.3
                                  # Enables the specified protocols for


### PR DESCRIPTION
### Summary

The description of ssl_ciphers was confusing if you were using DHE ciphers because you'd also have to use another parameter. This fixes the description.

This is a cherry-pick of Kong/kong-ee#6035

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* `kong.conf.default` update