### PR TITLE
docs(changelog): move some entries to correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,17 +81,6 @@
 
 - '/schemas' endpoint returns additional information about cross-field validation as part of the schema. This should help tools that use the Admin API to perform better client-side validation.
 
-#### Plugins
-
-- Validation for queue related parameters has been
-  improved. `max_batch_size`, `max_entries` and `max_bytes` are now
-  `integer`s instead of `number`s.  `initial_retry_delay` and
-  `max_retry_delay` must now be `number`s greater than 0.001
-  (seconds).
-  [#10840](https://github.com/Kong/kong/pull/10840)
-- **Acme**: Fixed string concatenation on cert renewal errors
-  [#11364](https://github.com/Kong/kong/pull/11364)
-
 ### Additions
 
 #### Core
@@ -203,6 +192,14 @@
   [#10559](https://github.com/Kong/kong/pull/10559)
 - **Zipkin**: Fixed an issue that traces not being generated correctly when instrumentations are enabled.
   [#10983](https://github.com/Kong/kong/pull/10983)
+- **Acme**: Fixed string concatenation on cert renewal errors
+  [#11364](https://github.com/Kong/kong/pull/11364)
+- Validation for queue related parameters has been
+  improved. `max_batch_size`, `max_entries` and `max_bytes` are now
+  `integer`s instead of `number`s.  `initial_retry_delay` and
+  `max_retry_delay` must now be `number`s greater than 0.001
+  (seconds).
+  [#10840](https://github.com/Kong/kong/pull/10840)
 
 #### PDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,6 @@
 
 - **CentOS packages are now removed from the release and are no longer supported in future versions.**
 
-#### Core
-
-- '/schemas' endpoint returns additional information about cross-field validation as part of the schema. This should help tools that use the Admin API to perform better client-side validation.
-
 ### Additions
 
 #### Core
@@ -91,6 +87,9 @@
   [#11244](https://github.com/Kong/kong/pull/11244)
 - Add beta support for WebAssembly/proxy-wasm
   [#11218](https://github.com/Kong/kong/pull/11218)
+- '/schemas' endpoint returns additional information about cross-field validation as part of the schema.
+  This should help tools that use the Admin API to perform better client-side validation.
+  [#11108](https://github.com/Kong/kong/pull/11108)
 
 #### Admin API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,13 +91,9 @@
   This should help tools that use the Admin API to perform better client-side validation.
   [#11108](https://github.com/Kong/kong/pull/11108)
 
-#### Admin API
-
 #### Kong Manager
 - First release of the Kong Manager Open Source Edition.
   [#11131](https://github.com/Kong/kong/pull/11131)
-
-#### Status API
 
 #### Plugins
 
@@ -110,8 +106,6 @@
 - **Ip-Restriction**: Add TCP support to the plugin.
   Thanks [@scrudge](https://github.com/scrudge) for contributing this change.
   [#10245](https://github.com/Kong/kong/pull/10245)
-
-#### PDK
 
 #### Performance
 
@@ -200,8 +194,6 @@
   (seconds).
   [#10840](https://github.com/Kong/kong/pull/10840)
 
-#### PDK
-
 ### Changed
 
 #### Core
@@ -225,10 +217,6 @@
 - Remove the database information from the status API when operating in dbless
   mode or data plane.
   [#10995](https://github.com/Kong/kong/pull/10995)
-
-#### PDK
-
-#### Plugins
 
 ### Dependencies
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Move entries from `Deprecations` to `Additions` or `Fixes`,
and remove some empty sections.

These change log entries belongs to 3.4, should we back port this PR to 3.4 branch? 

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
