### PR TITLE
fix(plugin/cors): Update plugin schema and docs

### DIFF
--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -31,7 +31,7 @@ return {
     { config = {
         type = "record",
         fields = {
-          { origins = { description = "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.", type = "array",
+          { origins = { description = "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `"*"` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.", type = "array",
               elements = {
                 type = "string",
                 custom_validator = validate_asterisk_or_regex,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
![image](https://github.com/Kong/kong/assets/49020899/24c8abab-2ac2-46b9-8993-879f9ea4f3ac)
![image](https://github.com/Kong/kong/assets/49020899/e9bbc264-b844-418b-a596-0122b8347e99)
In the example, none of the origins urls have **double quotes** . 
In the Configuration page, it says  If you want to allow all origins, **add `*` as a single value**.

Which makes people think that you only need to **set * without double quotes** as in the example

But in fact, it will cause kong to fail to start with an error of `error parsing declarative config file" /tmp/home/kong/kong.yml`
The correct origin should be "*" as shown in the image.
```yml
  config:
    origins:
      - "*"
```
![image](https://github.com/Kong/kong/assets/49020899/9450e392-c4e1-4116-a7b6-8e5cec701d08)


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog
update cros plugins shema and docs


* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
