### PR TITLE
chore(test): fix flaky tests

### DIFF
--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -332,6 +332,8 @@ for _, strategy in helpers.each_strategy() do
 
         assert(cluster_events_1:subscribe("nbf_channel", cb, false)) -- false to not start auto polling
 
+        -- we need accurate time, otherwise the test would be flaky
+        ngx.update_time()
         assert(cluster_events_2:broadcast("nbf_channel", "hello world"))
 
         assert(cluster_events_1:poll())


### PR DESCRIPTION
### Summary

#### chore(test): flakiness caused by assuming order

Generally, if the API definition does not require data ordering, we should not make assumptions about the ordering. Otherwise, the test could be flaky.

#### fix(test): flakiness due to time

We should always update the time before a time-sensitive test.
sleep implicitly updates time, but we need an accurate start time before sleep.

Thanks to @ADD-SP's help.

### Issue reference

Fix KAG-2417
