### PR TITLE
[Backport release/3.4.x] fix(wasm): remove hardcoded isolation level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
 
 ## Unreleased
 
+### Fixes
+
+#### Core
+
+- Removed a hardcoded proxy-wasm isolation level setting that was preventing the
+  `nginx_http_proxy_wasm_isolation` configuration value from taking effect.
+  [#11407](https://github.com/Kong/kong/pull/11407)
+
 ## 3.4.0
 
 ### Breaking Changes

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2062,7 +2062,6 @@
 # - `wasm_call`
 # - `module`
 # - `proxy_wasm`
-# - `proxy_wasm_isolation`
 # - `resolver_add`
 # - `proxy_wasm_request_headers_in_access`
 # - `shm_queue`

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -49,7 +49,6 @@ local sha256 = utils.sha256_bin
 
 local VERSION_KEY = "filter_chains:version"
 local TTL_ZERO = { ttl = 0 }
-local ATTACH_OPTS = {}
 
 
 ---
@@ -576,7 +575,6 @@ local function enable(kong_config)
   _G.dns_client = _G.dns_client or dns(kong_config)
 
   proxy_wasm = proxy_wasm or require "resty.wasmx.proxy_wasm"
-  ATTACH_OPTS.isolation = proxy_wasm.isolations.FILTER
 
   ENABLED = true
   STATUS = STATUS_ENABLED
@@ -670,7 +668,7 @@ function _M.attach(ctx)
 
   ctx.ran_wasm = true
 
-  local ok, err = proxy_wasm.attach(chain.c_plan, ATTACH_OPTS)
+  local ok, err = proxy_wasm.attach(chain.c_plan)
   if not ok then
     log(CRIT, "failed attaching ", chain.label, " filter chain to request: ", err)
     return kong.response.error(500)


### PR DESCRIPTION
Backport of #11407

This was added during local development to work around a bug but is no longer desired and disallows setting the isolation level via kong.conf.
