### PR TITLE
feat(dist): re-enable ngx_devel_kit_module

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -133,7 +133,6 @@ CONFIGURE_OPTIONS = [
     "--without-http_redis_module",
     "--without-http_rds_json_module",
     "--without-http_rds_csv_module",
-    "--without-ngx_devel_kit_module",
     "--with-luajit=$$EXT_BUILD_DEPS$$/luajit",
     "--with-cc-opt=\"-I$$EXT_BUILD_DEPS$$/pcre/include\"",
     "--with-cc-opt=\"-I$$EXT_BUILD_DEPS$$/openssl/include\"",


### PR DESCRIPTION
### Summary

Re-enables `ngx_devel_kit_module`.

This was originally disabled in:
https://github.com/Kong/kong/pull/10315

NDK is needed for `set_by_lua`, which is the reason we re-enable it, even when Kong doesn't use it, and can only be used through Nginx configuration injections or custom Kong Nginx templates.

### Issues Resolved

Fix #11455

[KAG-2458](https://konghq.atlassian.net/browse/KAG-2458)

[KAG-2458]: https://konghq.atlassian.net/browse/KAG-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ