### PR TITLE
fix(db/declarative): fix TTL not working in DB-less and Hybrid mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - Removed a hardcoded proxy-wasm isolation level setting that was preventing the
   `nginx_http_proxy_wasm_isolation` configuration value from taking effect.
   [#11407](https://github.com/Kong/kong/pull/11407)
+- Fix TTL not working in DB-less and Hybrid mode.
+  [#11464](https://github.com/Kong/kong/pull/11464)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,6 @@
 - Removed a hardcoded proxy-wasm isolation level setting that was preventing the
   `nginx_http_proxy_wasm_isolation` configuration value from taking effect.
   [#11407](https://github.com/Kong/kong/pull/11407)
-- Fix TTL not working in DB-less and Hybrid mode.
-  [#11464](https://github.com/Kong/kong/pull/11464)
 
 #### Plugins
 

--- a/CHANGELOG/unreleased/kong/11464.yaml
+++ b/CHANGELOG/unreleased/kong/11464.yaml
@@ -1,4 +1,4 @@
-message: Fix an issue that TTL does not work in DB-less and Hybrid mode
+message: Fix an issue that the TTL of the key-auth plugin didnt work in DB-less and Hybrid mode.
 type: bugfix
 scope: Core
 prs:

--- a/CHANGELOG/unreleased/kong/11464.yaml
+++ b/CHANGELOG/unreleased/kong/11464.yaml
@@ -1,6 +1,6 @@
 message: Fix TTL not working in DB-less and Hybrid mode
 type: bugfix
-scope: db/declarative
+scope: Core
 prs:
   - 11464
 jiras:

--- a/CHANGELOG/unreleased/kong/11464.yaml
+++ b/CHANGELOG/unreleased/kong/11464.yaml
@@ -1,4 +1,4 @@
-message: Fix TTL not working in DB-less and Hybrid mode
+message: Fix an issue that TTL does not work in DB-less and Hybrid mode
 type: bugfix
 scope: Core
 prs:

--- a/CHANGELOG/unreleased/kong/11464.yaml
+++ b/CHANGELOG/unreleased/kong/11464.yaml
@@ -1,0 +1,7 @@
+message: Fix TTL not working in DB-less and Hybrid mode
+type: bugfix
+scope: db/declarative
+prs:
+  - 11464
+jiras:
+  - "FTI-4512"

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -775,11 +775,6 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
-        if self.schema.ttl and row.ttl and row.ttl ~= null then
-            local ttl_value = row.ttl - ngx.time()
-            row.ttl = ttl_value > 0 and ttl_value or 0
-        end
-
         return row
       end
 
@@ -1435,6 +1430,11 @@ function DAO:row_to_entity(row, options)
     else
       entity.ws_id = ws_id
     end
+  end
+
+  if self.schema.ttl and entity.ttl and entity.ttl ~= null then
+      local ttl_value = entity.ttl - ngx.time()
+      entity.ttl = ttl_value > 0 and ttl_value or 0
   end
 
   return entity

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -775,6 +775,11 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
+        if self.schema.ttl and row.ttl and row.ttl ~= null then
+            local ttl_value = row.ttl - ngx.time()
+            row.ttl = ttl_value > 0 and ttl_value or 0
+        end
+
         return row
       end
 

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -1132,15 +1132,12 @@ function DAO:insert(entity, options)
     return nil, tostring(err_t), err_t
   end
 
-  -- ngx.log(ngx.ERR, "+ debug: insert:  ", cjson.encode(entity_to_insert))
-  -- ttl : 3600 relative value
   local row, err_t = self.strategy:insert(entity_to_insert, options)
   if not row then
     return nil, tostring(err_t), err_t
   end
 
   local ws_id = row.ws_id
-  -- ttl: 3600 relative value
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1446,19 +1443,12 @@ function DAO:row_to_entity(row, options)
       entity.ws_id = ws_id
     end
   end
---[[ xiaochen
-  if self.schema.ttl and entity.ttl and entity.ttl ~= null then
-      local ttl_value = entity.ttl - ngx.time()
-      entity.ttl = ttl_value > 0 and ttl_value or 0
-  end
-  ]]
 
   return entity
 end
 
 
 function DAO:post_crud_event(operation, entity, old_entity, options)
-    -- "for insert" old_entity=nil
   if options and options.no_broadcast_crud_event then
     return
   end

--- a/kong/db/declarative/export.lua
+++ b/kong/db/declarative/export.lua
@@ -142,7 +142,7 @@ local function export_from_db_impl(emitter, skip_ws, skip_disabled_entities, exp
     if db[name].pagination then
       page_size = db[name].pagination.max_page_size
     end
-    for row, err in db[name]:each(page_size, GLOBAL_QUERY_OPTS) do
+    for row, err in db[name]:each_for_export(page_size, GLOBAL_QUERY_OPTS) do
       if not row then
         end_transaction(db)
         kong.log.err(err)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -839,16 +839,16 @@ local function flatten(self, input)
       end
 
       if schema.ttl then
-        local ttl_value = entry.ttl
-        if ttl_value and ttl_value ~= 0 and ttl_value ~= null then
+        local expired_at = entry.ttl
+        if expired_at and expired_at ~= 0 and expired_at ~= null then
           if entry.updated_at then
-            ttl_value = ttl_value + entry.updated_at
+            expired_at = expired_at + entry.updated_at
           elseif entry.created_at then
-            ttl_value = ttl_value + entry.created_at
+            expired_at = expired_at + entry.created_at
           else
-            ttl_value = ttl_value + now_updated()
+            expired_at = expired_at + now_updated()
           end
-          flat_entry.ttl = ttl_value
+          flat_entry.ttl = expired_at
         end
       end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -842,11 +842,11 @@ local function flatten(self, input)
         local ttl_value = entry.ttl
         if ttl_value and ttl_value ~= 0 and ttl_value ~= null then
           if entry.updated_at then
-              ttl_value = ttl_value + entry.updated_at
+            ttl_value = ttl_value + entry.updated_at
           elseif entry.created_at then
-              ttl_value = ttl_value + entry.created_at
+            ttl_value = ttl_value + entry.created_at
           else
-              ttl_value = ttl_value + now_updated()
+            ttl_value = ttl_value + now_updated()
           end
           flat_entry.ttl = ttl_value
         end

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -216,11 +216,7 @@ local function select_by_key(schema, key)
 
   if entity and entity.ttl then
     local ttl_value = entity.ttl - now()
-    if ttl_value > 0 then
-        entity.ttl = ttl_value
-    else
-        entity.ttl = 0
-    end
+    entity.ttl = ttl_value > 0 and ttl_value or 0
   end
 
   return entity

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -17,6 +17,7 @@ local tostring = tostring
 local tonumber = tonumber
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
+local now = ngx.now
 local null = ngx.null
 local unmarshall = marshaller.unmarshall
 local lmdb_get = lmdb.get
@@ -212,6 +213,15 @@ local function select_by_key(schema, key)
   end
 
   entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
+
+  if entity and entity.ttl then
+    local ttl_value = entity.ttl - now()
+    if ttl_value > 0 then
+        entity.ttl = ttl_value
+    else
+        entity.ttl = 0
+    end
+  end
 
   return entity
 end

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -213,6 +213,11 @@ local function select_by_key(schema, key)
 
   entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
+  if schema.ttl and entity and entity.ttl and entity.ttl ~= null then
+    local ttl_value = entity.ttl - ngx.time()
+    entity.ttl = ttl_value > 0 and ttl_value or 0
+  end
+
   return entity
 end
 

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -214,11 +214,6 @@ local function select_by_key(schema, key)
 
   entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
-  if entity and entity.ttl then
-    local ttl_value = entity.ttl - now()
-    entity.ttl = ttl_value > 0 and ttl_value or 0
-  end
-
   return entity
 end
 

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -54,6 +54,19 @@ local function ws(schema, options)
 end
 
 
+local function process_ttl_field(entity)
+  if entity and entity.ttl and entity.ttl ~= null then
+    local ttl_value = entity.ttl - ngx.time()
+    if ttl_value > 0 then
+      entity.ttl = ttl_value
+    else
+      entity = nil  -- do not return the expired entity
+    end
+  end
+  return entity
+end
+
+
 -- Returns a dict of entity_ids tagged according to the given criteria.
 -- Currently only the following kinds of keys are supported:
 -- * A key like `services|<ws_id>|@list` will only return service keys
@@ -157,6 +170,7 @@ local function page_for_key(self, key, size, offset, options)
   yield()
 
   local ret = {}
+  local ret_idx = 1
   local schema = self.schema
   local schema_name = schema.name
 
@@ -194,7 +208,16 @@ local function page_for_key(self, key, size, offset, options)
       return nil, "stale data detected while paginating"
     end
 
-    ret[i - offset + 1] = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
+    item = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
+
+    if schema.ttl then
+      item = process_ttl_field(item)
+    end
+
+    if item then
+      ret[ret_idx] = item
+      ret_idx = ret_idx + 1
+    end
   end
 
   if offset then
@@ -213,9 +236,8 @@ local function select_by_key(schema, key)
 
   entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
-  if schema.ttl and entity and entity.ttl and entity.ttl ~= null then
-    local ttl_value = entity.ttl - ngx.time()
-    entity.ttl = ttl_value > 0 and ttl_value or 0
+  if schema.ttl then
+    entity = process_ttl_field(entity)
   end
 
   return entity

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -208,14 +208,12 @@ local function page_for_key(self, key, size, offset, options)
       return nil, "stale data detected while paginating"
     end
 
-    item = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
-
     if schema.ttl then
       item = process_ttl_field(item)
     end
 
     if item then
-      ret[ret_idx] = item
+      ret[ret_idx] = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
       ret_idx = ret_idx + 1
     end
   end
@@ -234,11 +232,14 @@ local function select_by_key(schema, key)
     return nil, err
   end
 
-  entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
-
   if schema.ttl then
     entity = process_ttl_field(entity)
+    if not entity then
+      return nil
+    end
   end
+
+  entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
   return entity
 end

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -17,7 +17,6 @@ local tostring = tostring
 local tonumber = tonumber
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
-local now = ngx.now
 local null = ngx.null
 local unmarshall = marshaller.unmarshall
 local lmdb_get = lmdb.get

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -481,7 +481,7 @@ local function page(self, size, token, foreign_key, foreign_entity_name, options
     statement_name = "page" .. suffix
   end
 
-  if options.export then
+  if options and options.export then
     statement_name = statement_name .. "_for_export"
   end
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1090,6 +1090,7 @@ function _M.new(connector, schema, errors)
   self.statements["truncate_global"] = self.statements["truncate"]
 
   local add_statement
+  local add_statement_for_export
   do
     local function add(name, opts, add_ws)
       local orig_argn = opts.argn

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1033,7 +1033,7 @@ function _M.new(connector, schema, errors)
     select_expressions = concat {
       select_expressions, ",",
       "FLOOR(EXTRACT(EPOCH FROM (",
-        ttl_escaped, " AT TIME ZONE 'UTC'",
+        ttl_escaped, " AT TIME ZONE 'UTC' - CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
       "))) AS ", ttl_escaped
     }
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1033,7 +1033,7 @@ function _M.new(connector, schema, errors)
     select_expressions = concat {
       select_expressions, ",",
       "FLOOR(EXTRACT(EPOCH FROM (",
-        ttl_escaped, " AT TIME ZONE 'UTC' - CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
+        ttl_escaped, " AT TIME ZONE 'UTC'",
       "))) AS ", ttl_escaped
     }
 

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("Plugin: key-auth (access) [#" .. strategy .. "] auto-expiring keys", function()
     -- Give a bit of time to reduce test flakyness on slow setups
-    local ttl = 10
+    local ttl = 30
     local inserted_at
     local proxy_client
 

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("Plugin: key-auth (access) [#" .. strategy .. "] auto-expiring keys", function()
     -- Give a bit of time to reduce test flakyness on slow setups
-    local ttl = 30
+    local ttl = 10
     local inserted_at
     local proxy_client
 
@@ -101,6 +101,8 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
       ngx.update_time()
       local elapsed = ngx.now() - inserted_at
 
+      ngx.sleep(ttl - elapsed)
+
       helpers.wait_until(function()
         proxy_client = helpers.http_client("127.0.0.1", 9002)
         res = assert(proxy_client:send {
@@ -114,7 +116,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
 
         proxy_client:close()
         return res and res.status == 401
-      end, ttl - elapsed + 1)
+      end, 5)
 
     end)
   end)

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -1,8 +1,4 @@
 local helpers = require "spec.helpers"
-local cjson   = require "cjson"
-local meta    = require "kong.meta"
-local utils   = require "kong.tools.utils"
-
 
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("Plugin: key-auth (access) [#" .. strategy .. "] auto-expiring keys", function()

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -1,0 +1,112 @@
+local helpers = require "spec.helpers"
+local cjson   = require "cjson"
+local meta    = require "kong.meta"
+local utils   = require "kong.tools.utils"
+
+
+for _, strategy in helpers.each_strategy({"postgres"}) do
+  describe("Plugin: key-auth (access) [#" .. strategy .. "] auto-expiring keys", function()
+    -- Give a bit of time to reduce test flakyness on slow setups
+    local ttl = 20
+    local inserted_at
+    local proxy_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
+
+      local r = bp.routes:insert {
+        hosts = { "key-ttl.com" },
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = { id = r.id },
+      }
+
+      local user_jafar = bp.consumers:insert {
+        username = "Jafar",
+      }
+
+      bp.keyauth_credentials:insert({
+        key = "kong",
+        consumer = { id = user_jafar.id },
+      }, { ttl = ttl })
+
+      ngx.update_time()
+      inserted_at = ngx.now()
+
+      assert(helpers.start_kong({
+        role = "control_plane",
+        database = strategy,
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+        cluster_listen = "127.0.0.1:9005",
+        cluster_telemetry_listen = "127.0.0.1:9006",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "servroot2",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+        cluster_control_plane = "127.0.0.1:9005",
+        cluster_telemetry_endpoint = "127.0.0.1:9006",
+        proxy_listen = "0.0.0.0:9002",
+      }))
+    end)
+
+    lazy_teardown(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+
+      helpers.stop_kong("servroot2")
+      helpers.stop_kong()
+    end)
+
+    it("authenticate for up to 'ttl'", function()
+      proxy_client = helpers.http_client("127.0.0.1", 9002)
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path  = "/status/200",
+        headers = {
+          ["Host"] = "key-ttl.com",
+          ["apikey"] = "kong",
+        }
+      })
+
+      assert.res_status(200, res)
+
+      proxy_client:close()
+
+      ngx.update_time()
+      local elapsed = ngx.now() - inserted_at
+
+      helpers.wait_until(function()
+        proxy_client = helpers.http_client("127.0.0.1", 9002)
+        res = assert(proxy_client:send {
+          method  = "GET",
+          path  = "/status/200",
+          headers = {
+            ["Host"] = "key-ttl.com",
+            ["apikey"] = "kong",
+          }
+        })
+
+        proxy_client:close()
+        return res and res.status == 401
+      end, ttl - elapsed + 1)
+
+    end)
+  end)
+end

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         route = { id = r.id },
       }
 
-      local user_jafar = bp.consumers:insert {
+      bp.consumers:insert {
         username = "Jafar",
       }
 

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("Plugin: key-auth (access) [#" .. strategy .. "] auto-expiring keys", function()
     -- Give a bit of time to reduce test flakyness on slow setups
-    local ttl = 20
+    local ttl = 10
     local inserted_at
     local proxy_client
 
@@ -71,19 +71,20 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
     end)
 
     it("authenticate for up to 'ttl'", function()
-      proxy_client = helpers.http_client("127.0.0.1", 9002)
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path  = "/status/200",
-        headers = {
-          ["Host"] = "key-ttl-hybrid.com",
-          ["apikey"] = "kong",
-        }
-      })
+      helpers.wait_until(function()
+        proxy_client = helpers.http_client("127.0.0.1", 9002)
+        res = assert(proxy_client:send {
+          method  = "GET",
+          path  = "/status/200",
+          headers = {
+            ["Host"] = "key-ttl-hybrid.com",
+            ["apikey"] = "kong",
+          }
+        })
 
-      assert.res_status(200, res)
-
-      proxy_client:close()
+        proxy_client:close()
+        return res and res.status == 200
+      end, 5)
 
       ngx.update_time()
       local elapsed = ngx.now() - inserted_at

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -17,7 +17,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
       })
 
       local r = bp.routes:insert {
-        hosts = { "key-ttl.com" },
+        hosts = { "key-ttl-hybrid.com" },
       }
 
       bp.plugins:insert {
@@ -76,7 +76,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         method  = "GET",
         path  = "/status/200",
         headers = {
-          ["Host"] = "key-ttl.com",
+          ["Host"] = "key-ttl-hybrid.com",
           ["apikey"] = "kong",
         }
       })
@@ -94,7 +94,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
           method  = "GET",
           path  = "/status/200",
           headers = {
-            ["Host"] = "key-ttl.com",
+            ["Host"] = "key-ttl-hybrid.com",
             ["apikey"] = "kong",
           }
         })

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -71,6 +71,8 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
     end)
 
     it("authenticate for up to 'ttl'", function()
+      local res
+
       helpers.wait_until(function()
         proxy_client = helpers.http_client("127.0.0.1", 9002)
         res = assert(proxy_client:send {


### PR DESCRIPTION
### Summary

* Previously, in DB-less and Hybrid mode, the ttl/updated_at fields were not copied from the original entities to the flattened entities. As a result, the entities were loaded without the TTL field. 
* Additionally, for loading the TTL field, the "off" DB strategy (lmdb) did not support automatic calculation of the remaining expiration time. 


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* copy the ttl field from original entities to flatten entities
* transform the absolute ttl value to relative within the new function each_for_export(), then declarative config exports its configuration using `for ... in each_for_export` instead of  `for ... in each()`
* add DAO:each_for_export() based on DAO:each() to export the entity with the absolute ttl
  * add the `options.export` field to enable this feature in pg:page()
  * add extra pg SQL statements "page_XXX_`for_export`{_global}"
* the off strategy:
  * turn the absolute ttl to relative for the upper user (cred.ttl) in off:select()/:page()
  * does not return the expired entity(cred) to the upper user, which makes it identical with the PG strategy.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4512
