### PR TITLE
chore(cd): skip send slack message for daily build failure

### DIFF
--- a/.github/workflows/release-and-tests-fail-bot.yml
+++ b/.github/workflows/release-and-tests-fail-bot.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   notify_failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.event != "schedule" }}
     steps:
     - name: Generate Slack Payload
       id: generate-payload


### PR DESCRIPTION
Github doesn't treat the author of commit as actor to scheduled workflow run, so sending slack message doesn't make sense.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
