### PR TITLE
chore(ci): add filter for changelog workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -3,6 +3,10 @@ name: Changelog
 on:
   pull_request:
     types: [ "opened", "synchronize", "labeled", "unlabeled" ]
+    paths:
+      - 'kong/**'
+      - '**.rockspec'
+      - '.requirements'
 
 jobs:
   require-changelog:


### PR DESCRIPTION
Summary:

Add path filter for changelog workflow to skip the workflow when PR does not touch specific paths.