### PR TITLE
feat(nginx): enable http_gzip_static_module in openresty build

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -120,6 +120,7 @@ CONFIGURE_OPTIONS = [
     "--with-http_v2_module",
     "--with-stream_realip_module",  # >= 1.11.4
     "--with-stream_ssl_preread_module",  # >= 1.11.5
+    "--with-http_gzip_static_module",
     "--without-http_encrypted_session_module",
     "--without-http_xss_module",
     "--without-http_coolkit_module",


### PR DESCRIPTION
### Summary

Enable nginx's http_gzip_static_module during OpenResty build

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/CHANGELOG/README.md) (Please ping @vm-001 if you need help)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

#11476