### PR TITLE
fix(postgres): close socket actively when timeout happens during query

### DIFF
--- a/CHANGELOG/unreleased/kong/11480.yaml
+++ b/CHANGELOG/unreleased/kong/11480.yaml
@@ -1,0 +1,7 @@
+message: Fix a problem that abnormal socket connection will be reused when querying Postgres database.
+type: bugfix
+scope: Core
+prs:
+  - 11480
+jiras:
+  - "FTI-5322"

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -529,7 +529,7 @@ function _mt:query(sql, operation)
     operation = "write"
   end
 
-  local conn
+  local conn, is_new_conn
   local res, err, partial, num_queries
 
   local ok
@@ -547,6 +547,7 @@ function _mt:query(sql, operation)
       self:release_query_semaphore_resource(operation)
       return nil, err
     end
+    is_new_conn = true
   end
 
   res, err, partial, num_queries = conn:query(sql)
@@ -564,7 +565,7 @@ function _mt:query(sql, operation)
     end
     self.store_connection(nil, operation)
 
-  else
+  elseif is_new_conn then
     local keepalive_timeout = self:get_keepalive_timeout(operation)
     setkeepalive(conn, keepalive_timeout)
   end

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -396,6 +396,50 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
+  describe("#testme :query() [#" .. strategy .. "]", function()
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {})
+    end)
+
+    postgres_only("establish new connection when error occurred", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.cycle_aware_deep_copy(helpers.test_conf)
+      conf.pg_ro_host = conf.pg_host
+      conf.pg_ro_user = conf.pg_user
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+      assert(db:init_connector())
+      assert(db:connect())
+
+      local res, err = db.connector:query("SELECT now();")
+      assert.not_nil(res)
+      assert.is_nil(err)
+
+      local old_conn = db.connector:get_stored_connection("write")
+      assert.not_nil(old_conn)
+
+      local res, err = db.connector:query("SELECT * FROM not_exist_table;")
+      assert.is_nil(res)
+      assert.not_nil(err)
+
+      local new_conn = db.connector:get_stored_connection("write")
+      assert.is_nil(new_conn)
+
+      local res, err = db.connector:query("SELECT now();")
+      assert.not_nil(res)
+      assert.is_nil(err)
+
+      local res, err = db.connector:query("SELECT now();")
+      assert.not_nil(res)
+      assert.is_nil(err)
+
+      assert(db:close())
+    end)
+  end)
 
   describe(":setkeepalive() [#" .. strategy .. "]", function()
     lazy_setup(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Currently, we do set/keep socket keepalive after every Postgres SQL query, based on keepalive timeout configured or `lua_socket_keepalive_timeout`(default 60s). 
This could go wrong under some cases, when a query encounters read timeout when trying to receive data from a database with high load, the query ends on Kong's side but the query result may be sent back after timeout happens, and the result data will be lingering inside the socket buffer, and the socket itself get reused for subsequent query, then the subsequent query might get the uncorrect result from the previous query. 

The PR checks the query result's err string, and if `timeout` happens, it'll try to close the socket actively so that the subsequent query will establish new clean ones.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/CHANGELOG/README.md) (Please ping @vm-001 if you need help)
~~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-5322
