### PR TITLE
fix(runloop): upstream ssl failure when plugins use response handler

### DIFF
--- a/CHANGELOG/unreleased/kong/11502.yaml
+++ b/CHANGELOG/unreleased/kong/11502.yaml
@@ -1,0 +1,7 @@
+message: Fix upstream ssl failure when plugins use response handler
+type: bugfix
+scope: Core
+prs:
+  - 11502
+jiras:
+  - "FTI-5347"

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -168,6 +168,7 @@ build = {
     ["kong.runloop.log_level"] = "kong/runloop/log_level.lua",
     ["kong.runloop.certificate"] = "kong/runloop/certificate.lua",
     ["kong.runloop.plugins_iterator"] = "kong/runloop/plugins_iterator.lua",
+    ["kong.runloop.upstream_ssl"] = "kong/runloop/upstream_ssl.lua",
     ["kong.runloop.balancer"] = "kong/runloop/balancer/init.lua",
     ["kong.runloop.balancer.balancers"] = "kong/runloop/balancer/balancers.lua",
     ["kong.runloop.balancer.consistent_hashing"] = "kong/runloop/balancer/consistent_hashing.lua",

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -6,9 +6,9 @@ local Router       = require "kong.router"
 local balancer     = require "kong.runloop.balancer"
 local events       = require "kong.runloop.events"
 local wasm         = require "kong.runloop.wasm"
+local upstream_ssl = require "kong.runloop.upstream_ssl"
 local reports      = require "kong.reports"
 local constants    = require "kong.constants"
-local certificate  = require "kong.runloop.certificate"
 local concurrency  = require "kong.concurrency"
 local lrucache     = require "resty.lrucache"
 local ktls         = require "resty.kong.tls"
@@ -72,7 +72,6 @@ local NOOP = function() end
 
 
 local ERR   = ngx.ERR
-local CRIT  = ngx.CRIT
 local NOTICE = ngx.NOTICE
 local WARN  = ngx.WARN
 local INFO  = ngx.INFO
@@ -110,10 +109,7 @@ local STREAM_TLS_PASSTHROUGH_SOCK
 
 
 local set_authority
-local set_upstream_cert_and_key = ktls.set_upstream_cert_and_key
-local set_upstream_ssl_verify = ktls.set_upstream_ssl_verify
-local set_upstream_ssl_verify_depth = ktls.set_upstream_ssl_verify_depth
-local set_upstream_ssl_trusted_store = ktls.set_upstream_ssl_trusted_store
+local set_service_ssl = upstream_ssl.set_service_ssl
 
 if is_http_module then
   set_authority = require("resty.kong.grpc").set_authority
@@ -763,9 +759,6 @@ end
 
 local balancer_prepare
 do
-  local get_certificate = certificate.get_certificate
-  local get_ca_certificate_store = certificate.get_ca_certificate_store
-
   local function sleep_once_for_balancer_init()
     ngx.sleep(0)
     sleep_once_for_balancer_init = NOOP
@@ -814,60 +807,7 @@ do
     ctx.route            = route
     ctx.balancer_data    = balancer_data
 
-    if service then
-      local res, err
-      local client_certificate = service.client_certificate
-
-      if client_certificate then
-        local cert, err = get_certificate(client_certificate)
-        if not cert then
-          log(ERR, "unable to fetch upstream client TLS certificate ",
-                   client_certificate.id, ": ", err)
-          return
-        end
-
-        res, err = set_upstream_cert_and_key(cert.cert, cert.key)
-        if not res then
-          log(ERR, "unable to apply upstream client TLS certificate ",
-                   client_certificate.id, ": ", err)
-        end
-      end
-
-      local tls_verify = service.tls_verify
-      if tls_verify then
-        res, err = set_upstream_ssl_verify(tls_verify)
-        if not res then
-          log(CRIT, "unable to set upstream TLS verification to: ",
-                   tls_verify, ", err: ", err)
-        end
-      end
-
-      local tls_verify_depth = service.tls_verify_depth
-      if tls_verify_depth then
-        res, err = set_upstream_ssl_verify_depth(tls_verify_depth)
-        if not res then
-          log(CRIT, "unable to set upstream TLS verification to: ",
-                   tls_verify, ", err: ", err)
-          -- in case verify can not be enabled, request can no longer be
-          -- processed without potentially compromising security
-          return kong.response.exit(500)
-        end
-      end
-
-      local ca_certificates = service.ca_certificates
-      if ca_certificates then
-        res, err = get_ca_certificate_store(ca_certificates)
-        if not res then
-          log(CRIT, "unable to get upstream TLS CA store, err: ", err)
-
-        else
-          res, err = set_upstream_ssl_trusted_store(res)
-          if not res then
-            log(CRIT, "unable to set upstream TLS CA store, err: ", err)
-          end
-        end
-      end
-    end
+    set_service_ssl(ctx)
 
     if is_stream_module and scheme == "tcp" then
       local res, err = disable_proxy_ssl()

--- a/kong/runloop/upstream_ssl.lua
+++ b/kong/runloop/upstream_ssl.lua
@@ -1,0 +1,116 @@
+local certificate  = require "kong.runloop.certificate"
+local balancers    = require "kong.runloop.balancer.balancers"
+local ktls         = require "resty.kong.tls"
+
+
+local kong         = kong
+local ngx          = ngx
+local log          = ngx.log
+local ERR          = ngx.ERR
+local CRIT         = ngx.CRIT
+
+local get_certificate                = certificate.get_certificate
+local get_ca_certificate_store       = certificate.get_ca_certificate_store
+local set_upstream_cert_and_key      = ktls.set_upstream_cert_and_key
+local set_upstream_ssl_verify        = ktls.set_upstream_ssl_verify
+local set_upstream_ssl_verify_depth  = ktls.set_upstream_ssl_verify_depth
+local set_upstream_ssl_trusted_store = ktls.set_upstream_ssl_trusted_store
+
+
+local function set_service_ssl(ctx)
+  local service = ctx and ctx.service 
+
+  if service then
+    local res, err
+    local client_certificate = service.client_certificate
+
+    if client_certificate then
+      local cert, err = get_certificate(client_certificate)
+      if not cert then
+        log(ERR, "unable to fetch upstream client TLS certificate ",
+                 client_certificate.id, ": ", err)
+        return
+      end
+
+      res, err = set_upstream_cert_and_key(cert.cert, cert.key)
+      if not res then
+        log(ERR, "unable to apply upstream client TLS certificate ",
+                 client_certificate.id, ": ", err)
+      end
+    end
+
+    local tls_verify = service.tls_verify
+    if tls_verify then
+      res, err = set_upstream_ssl_verify(tls_verify)
+      if not res then
+        log(CRIT, "unable to set upstream TLS verification to: ",
+                 tls_verify, ", err: ", err)
+      end
+    end
+
+    local tls_verify_depth = service.tls_verify_depth
+    if tls_verify_depth then
+      res, err = set_upstream_ssl_verify_depth(tls_verify_depth)
+      if not res then
+        log(CRIT, "unable to set upstream TLS verification to: ",
+                 tls_verify, ", err: ", err)
+        -- in case verify can not be enabled, request can no longer be
+        -- processed without potentially compromising security
+        return kong.response.exit(500)
+      end
+    end
+
+    local ca_certificates = service.ca_certificates
+    if ca_certificates then
+      res, err = get_ca_certificate_store(ca_certificates)
+      if not res then
+        log(CRIT, "unable to get upstream TLS CA store, err: ", err)
+
+      else
+        res, err = set_upstream_ssl_trusted_store(res)
+        if not res then
+          log(CRIT, "unable to set upstream TLS CA store, err: ", err)
+        end
+      end
+    end
+  end
+end
+
+local function fallback_upstream_client_cert(ctx, upstream)
+  if not ctx then
+    return
+  end
+
+  upstream = upstream or (ctx.balancer_data and ctx.balancer_data.upstream)
+
+  if not upstream then
+    return
+  end
+
+  if ctx.service and not ctx.service.client_certificate then
+    -- service level client_certificate is not set
+    local cert, res, err
+    local client_certificate = upstream.client_certificate
+
+    -- does the upstream object contains a client certificate?
+    if client_certificate then
+      cert, err = get_certificate(client_certificate)
+      if not cert then
+        log(ERR, "unable to fetch upstream client TLS certificate ",
+                 client_certificate.id, ": ", err)
+        return
+      end
+
+      res, err = set_upstream_cert_and_key(cert.cert, cert.key)
+      if not res then
+        log(ERR, "unable to apply upstream client TLS certificate ",
+                 client_certificate.id, ": ", err)
+      end
+    end
+  end
+end
+
+return {
+  set_service_ssl = set_service_ssl,
+  fallback_upstream_client_cert = fallback_upstream_client_cert,
+}

--- a/kong/runloop/upstream_ssl.lua
+++ b/kong/runloop/upstream_ssl.lua
@@ -1,5 +1,4 @@
 local certificate  = require "kong.runloop.certificate"
-local balancers    = require "kong.runloop.balancer.balancers"
 local ktls         = require "resty.kong.tls"
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -284,7 +284,16 @@ server {
         default_type         '';
         set $kong_proxy_mode 'http';
 
-        rewrite_by_lua_block       {;}
+        rewrite_by_lua_block       {
+          -- ngx.localtion.capture will create a new nginx request,
+          -- so the overwritten client cert and key info get lost.
+          -- we need to re-set them here to the new nginx request.
+          local ctx = ngx.ctx
+          local upstream_ssl = require("kong.runloop.upstream_ssl")
+
+          upstream_ssl.set_service_ssl(ctx)
+          upstream_ssl.fallback_upstream_client_cert(ctx)
+        }
         access_by_lua_block        {;}
         header_filter_by_lua_block {;}
         body_filter_by_lua_block   {;}

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -286,7 +286,7 @@ server {
 
         rewrite_by_lua_block       {
           -- ngx.localtion.capture will create a new nginx request,
-          -- so the overwritten client cert and key info get lost.
+          -- so the upstream ssl-related info attached to the `r` gets lost.
           -- we need to re-set them here to the new nginx request.
           local ctx = ngx.ctx
           local upstream_ssl = require("kong.runloop.upstream_ssl")

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -430,6 +430,7 @@ for _, strategy in helpers.each_strategy() do
           assert(proxy_client:close())
 
           -- buffered_proxying
+          local res_cert_buffered
           if subsystems == "http" then
             local res = assert(proxy_client:send {
               path    = "/mtls-buffered-proxying",
@@ -438,7 +439,7 @@ for _, strategy in helpers.each_strategy() do
               }
             })
             assert.res_status(200, res)
-            local res_cert = res.headers["X-Cert"]
+            res_cert_buffered = res.headers["X-Cert"]
             assert(proxy_client:close())
           end
 
@@ -470,6 +471,7 @@ for _, strategy in helpers.each_strategy() do
           assert.not_equals(res_cert, res_cert2)
 
           -- buffered_proxying
+          local res_cert2_buffered
           if subsystems == "http" then
             res = assert(proxy_client2:send {
               path    = "/mtls-buffered-proxying",
@@ -478,8 +480,8 @@ for _, strategy in helpers.each_strategy() do
               }
             })
             assert.res_status(200, res)
-            local res_cert2 = res.headers["X-Cert"]
-            assert.not_equals(res_cert, res_cert2)
+            res_cert2_buffered = res.headers["X-Cert"]
+            assert.not_equals(res_cert_buffered, res_cert2_buffered)
           end
 
           -- restore old
@@ -869,8 +871,7 @@ for _, strategy in helpers.each_strategy() do
           if subsystems == "http" then
             helpers.wait_until(function()
               local proxy_client = get_proxy_client(subsystems, 19001)
-              local err
-              res, err = proxy_client:send {
+              res = proxy_client:send {
                 path    = "/tls-buffered-proxying",
                 headers = {
                   ["Host"] = "example.com",
@@ -1024,7 +1025,7 @@ for _, strategy in helpers.each_strategy() do
           if subsystems == "http" then
             helpers.wait_until(function()
               local proxy_client = get_proxy_client(subsystems, 19001)
-              local res, err = proxy_client:send {
+              local res = proxy_client:send {
                 path    = "/tls-buffered-proxying",
                 headers = {
                   ["Host"] = "example.com",

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -432,6 +432,7 @@ for _, strategy in helpers.each_strategy() do
           -- buffered_proxying
           local res_cert_buffered
           if subsystems == "http" then
+            local proxy_client = get_proxy_client(subsystems, 19000)
             local res = assert(proxy_client:send {
               path    = "/mtls-buffered-proxying",
               headers = {

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -336,7 +336,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         -- buffered_proxying
-        if subsystems = "http" then
+        if subsystems == "http" then
           it("accessing protected upstream, buffered_proxying = true", function()
             local proxy_client = get_proxy_client(subsystems, 19000)
             local res = assert(proxy_client:send {
@@ -390,7 +390,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         -- buffered_proxying
-        if subsystems = "http" then
+        if subsystems == "http" then
           it("accessing protected upstream, buffered_proxying = true", function()
             helpers.wait_until(function()
               local proxy_client = get_proxy_client(subsystems, 19000)

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -89,6 +89,20 @@ local function gen_route(flavor, r)
   return r
 end
 
+local function gen_plugin(route)
+  return {
+    name = "pre-function",
+    route = { id = route.id },
+    config = {
+      access = {
+        [[
+          kong.service.request.enable_buffering()
+        ]]
+      }
+    }
+  }
+end
+
 
 for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
 for _, strategy in helpers.each_strategy() do
@@ -103,6 +117,8 @@ for _, strategy in helpers.each_strategy() do
     local tls_service_mtls, tls_service_tls
     local tls_upstream
     local tls_service_mtls_upstream
+
+    local route_mtls_buffered_proxying, route_tls_buffered_proxying, route_mtls_upstream_buffered_proxying
 
     reload_router(flavor)
 
@@ -171,6 +187,30 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "example.com", },
         paths = { "/mtls-upstream", },
       })))
+
+      route_mtls_buffered_proxying = assert(bp.routes:insert(gen_route(flavor,{
+        service = { id = service_mtls.id, },
+        hosts = { "example.com", },
+        paths = { "/mtls-buffered-proxying", },
+      })))
+
+      route_tls_buffered_proxying = assert(bp.routes:insert(gen_route(flavor,{
+        service = { id = service_tls.id, },
+        hosts = { "example.com", },
+        paths = { "/tls-buffered-proxying", },
+      })))
+
+      route_mtls_upstream_buffered_proxying = assert(bp.routes:insert(gen_route(flavor,{
+        service = { id = service_mtls_upstream.id, },
+        hosts = { "example.com", },
+        paths = { "/mtls-upstream-buffered-proxying", },
+      })))
+
+      -- use pre-function to enable buffered_proxying in order to trigger the
+      -- `ngx.location.capture("/kong_buffered_http")` in `Kong.response()`
+      assert(bp.plugins:insert(gen_plugin(route_mtls_buffered_proxying)))
+      assert(bp.plugins:insert(gen_plugin(route_tls_buffered_proxying)))
+      assert(bp.plugins:insert(gen_plugin(route_mtls_upstream_buffered_proxying)))
 
       -- tls
       tls_service_mtls = assert(bp.services:insert({
@@ -294,6 +334,23 @@ for _, strategy in helpers.each_strategy() do
           assert.matches("400 No required SSL certificate was sent", body, nil, true)
           assert(proxy_client:close())
         end)
+
+        -- buffered_proxying
+        if subsystems = "http" then
+          it("accessing protected upstream, buffered_proxying = true", function()
+            local proxy_client = get_proxy_client(subsystems, 19000)
+            local res = assert(proxy_client:send {
+              path    = "/mtls-buffered-proxying",
+              headers = {
+                ["Host"] = "example.com",
+              }
+            })
+
+            local body = assert.res_status(400, res)
+            assert.matches("400 No required SSL certificate was sent", body, nil, true)
+            assert(proxy_client:close())
+          end)
+        end
       end)
 
       describe(subsystems .. " #db client certificate supplied via service.client_certificate", function()
@@ -332,6 +389,28 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
         end)
 
+        -- buffered_proxying
+        if subsystems = "http" then
+          it("accessing protected upstream, buffered_proxying = true", function()
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19000)
+              local path = "/mtls-buffered-proxying"
+              local res = assert(proxy_client:send {
+                path    = path,
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                local body = assert.res_status(200, res)
+                assert.equals("it works", body)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+          end)
+        end
+
         it("send updated client certificate", function ()
           local proxy_client = get_proxy_client(subsystems, 19000)
           local path
@@ -349,6 +428,19 @@ for _, strategy in helpers.each_strategy() do
           assert.res_status(200, res)
           local res_cert = res.headers["X-Cert"]
           assert(proxy_client:close())
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            local res = assert(proxy_client:send {
+              path    = "/mtls-buffered-proxying",
+              headers = {
+                ["Host"] = "example.com",
+              }
+            })
+            assert.res_status(200, res)
+            local res_cert = res.headers["X-Cert"]
+            assert(proxy_client:close())
+          end
 
           res = admin_client:patch("/certificates/" .. certificate.id, {
             body = {
@@ -376,6 +468,20 @@ for _, strategy in helpers.each_strategy() do
           assert.res_status(200, res)
           local res_cert2 = res.headers["X-Cert"]
           assert.not_equals(res_cert, res_cert2)
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            res = assert(proxy_client2:send {
+              path    = "/mtls-buffered-proxying",
+              headers = {
+                ["Host"] = "example.com",
+              }
+            })
+            assert.res_status(200, res)
+            local res_cert2 = res.headers["X-Cert"]
+            assert.not_equals(res_cert, res_cert2)
+          end
+
           -- restore old
           res = admin_client:patch("/certificates/" .. certificate.id, {
             body = {
@@ -416,6 +522,26 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
 
           assert.matches("400 No required SSL certificate was sent", body, nil, true)
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client= get_proxy_client(subsystems, 19000)
+              res = assert(proxy_client:send {
+                path    = "/mtls-buffered-proxying",
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                body = assert.res_status(400, res)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+
+            assert.matches("400 No required SSL certificate was sent", body, nil, true)
+          end
         end)
       end)
     end)
@@ -435,6 +561,23 @@ for _, strategy in helpers.each_strategy() do
           assert.matches("400 No required SSL certificate was sent", body, nil, true)
           assert(proxy_client:close())
         end)
+
+        -- buffered_proxying
+        if subsystems == "http" then
+          it("accessing protected upstream, buffered_proxying = true", function()
+            local proxy_client= get_proxy_client(subsystems, 19002)
+            local res = assert(proxy_client:send {
+              path    = "/mtls-upstream-buffered-proxying",
+              headers = {
+                ["Host"] = "example.com",
+              }
+            })
+
+            local body = assert.res_status(400, res)
+            assert.matches("400 No required SSL certificate was sent", body, nil, true)
+            assert(proxy_client:close())
+          end)
+        end
       end)
 
       describe("#db client certificate supplied via upstream.client_certificate", function()
@@ -479,6 +622,28 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
         end)
 
+        -- buffered_proxying
+        if subsystems == "http" then
+          it("accessing protected upstream, buffered_proxying = true", function()
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19002)
+              local path = "/mtls-upstream-buffered-proxying"
+              local res = assert(proxy_client:send {
+                path    = path,
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                local body = assert.res_status(200, res)
+                assert.equals("it works", body)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+          end)
+        end
+
         it("remove client_certificate removes access", function()
           local upstream_id
           if subsystems == "http" then
@@ -514,6 +679,26 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
 
           assert.matches("400 No required SSL certificate was sent", body, nil, true)
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19002)
+              res = assert(proxy_client:send {
+                path    = "/mtls-upstream-buffered-proxying",
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                body = assert.res_status(400, res)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+
+            assert.matches("400 No required SSL certificate was sent", body, nil, true)
+          end
         end)
       end)
 
@@ -572,6 +757,28 @@ for _, strategy in helpers.each_strategy() do
             end)
           end, 10)
         end)
+
+        -- buffered_proxying
+        if subsystems == "http" then
+          it("access is allowed because Service.client_certificate overrides Upstream.client_certificate, buffered_proxy = true", function()
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19002)
+              local path = "/mtls-upstream-buffered-proxying"
+              local res = assert(proxy_client:send {
+                path    = path,
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                local body = assert.res_status(200, res)
+                assert.equals("it works", body)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+          end)
+        end
       end)
     end)
 
@@ -595,6 +802,23 @@ for _, strategy in helpers.each_strategy() do
           assert.equals("it works", body)
           assert(proxy_client:close())
         end)
+
+        -- buffered_proxying
+        if subsystems == "http" then
+          it("default is off, buffered_proxying = true", function()
+            local proxy_client = get_proxy_client(subsystems, 19001)
+            local path = "/tls-buffered-proxying"
+            local res = proxy_client:send {
+              path    = path,
+              headers = {
+                ["Host"] = "example.com",
+              }
+            }
+            local body = assert.res_status(200, res)
+            assert.equals("it works", body)
+            assert(proxy_client:close())
+          end)
+        end
 
         it("#db turn it on, request is blocked", function()
           local service_tls_id
@@ -638,6 +862,26 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
           
           if subsystems == "http" then
+            assert.equals("An invalid response was received from the upstream server", body)
+          end
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19001)
+              local err
+              res, err = proxy_client:send {
+                path    = "/tls-buffered-proxying",
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              }
+              return pcall(function()
+                body = assert.res_status(502, res)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+
             assert.equals("An invalid response was received from the upstream server", body)
           end
         end)
@@ -685,6 +929,26 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
 
           assert.equals("it works", body)
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19001)
+              local path = "/tls-buffered-proxying"
+              local res = proxy_client:send {
+                path    = path,
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              }
+              return pcall(function()
+                body = assert.res_status(200, res)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+
+            assert.equals("it works", body)
+          end
         end)
       end)
 
@@ -755,6 +1019,25 @@ for _, strategy in helpers.each_strategy() do
           if subsystems == "http" then
             assert.equals("An invalid response was received from the upstream server", body)
           end
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19001)
+              local res, err = proxy_client:send {
+                path    = "/tls-buffered-proxying",
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              }
+
+              return pcall(function()
+                 body = assert.res_status(502, res)
+                 assert(proxy_client:close())
+              end)
+            end, 10)
+            assert.equals("An invalid response was received from the upstream server", body)
+          end
         end)
 
         it("request is allowed through if depth limit is sufficient", function()
@@ -798,6 +1081,27 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
 
           assert.equals("it works", body)
+
+          -- buffered_proxying
+          if subsystems == "http" then
+            helpers.wait_until(function()
+              local proxy_client = get_proxy_client(subsystems, 19001)
+              local path = "/tls-buffered-proxying"
+              res = assert(proxy_client:send {
+                path    = path,
+                headers = {
+                  ["Host"] = "example.com",
+                }
+              })
+
+              return pcall(function()
+                body = assert.res_status(200, res)
+                assert(proxy_client:close())
+              end)
+            end, 10)
+
+            assert.equals("it works", body)
+          end
         end)
       end)
     end)


### PR DESCRIPTION
## Summary

If a plugin has response() handler, in `Kong.response` it will emits a subrequest by calling `ngx.location.capture("/kong_buffered_http", options)`. `ngx.location.capture` will create a new nginx request, so the overwritten ssl info (client key & cert etc.) get lost in the new nginx request.

To fix this, those ssl info need to be re-set in the new request context. We choose to do this in the early rewrite phase of the new request before `Kong.balancer()` getting executed.

The normal flow is as below:

```
Kong.access.before            Kong.access.after             Kong.balancer(first try)    Kong.balancer(retry)
       v                             v                                     |                 v
balancer_prepare              balancer.execute(try_count=0)                |          balancer.execute(try_count~=0)
       v                             v                                     |                 |
set service ssl config        set upstream ssl config                      v                 v
                 \                /                                  init upstream ssl connection
                  \              /                                              |
                   v            v                                               v
                   ---------------                   set onto              ------------
                   | downstream r|        --------------------------->     |upstream c|
                   ---------------                                         ------------
```

For the buffered_proxying case, `ngx.location.capture` will create a new request, so the flow diagram become:

```
Kong.access.before            Kong.access.after             Kong.balancer(first try)    Kong.balancer(retry)
       v                             v                                     |                 v
balancer_prepare              balancer.execute(try_count=0)                |          balancer.execute(try_count~=0)
       v                             v                                     |                 |
set service ssl config        set upstream ssl config                      v                 v
                 \                /                                  init upstream ssl connection
                  \              /                                              |
                   v            v                                               v
                   ---------------                   set onto              ------------
                   | downstream r|        --------------------------->     |upstream c|
                   ---------------                                         ------------
ngx.location.capture     |
.........................+.............................................................................................
                         | ctx
                         | vars
                         v
                   ---------------                   set onto              ------------
                   |    sub r    |        --------------------------->     |upstream c|
                   ---------------                                         ------------
                         ^                                                      ^
                         |                                                      |
            -----------------------------                               ------------------
            |       Kong.rewrite        |                               |  Kong.balancer |
            |  set service ssl config   |                               |  same as above |
            |  set upstream ssl config  |                               ------------------
            -----------------------------
```

[FTI-5347](https://konghq.atlassian.net/browse/FTI-5347)


[FTI-5347]: https://konghq.atlassian.net/browse/FTI-5347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ