### PR TITLE
chore(ci): add changelog automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,12 +11,21 @@ https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
 ### Checklist
 
 - [ ] The Pull Request has tests
-- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md) (Please ping @vm-001 if you need help)
+- [ ] Fill out the changelog form below or add `skip-changelog` label on your PR if changelog is not required
 - [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
 
-### Full changelog
 
-* [Implement ...]
+### Changelog
+
+[//]: # (changelog-anchor)
+```yaml
+message:
+type:
+scope:
+prs:
+issues:
+```
+[//]: # (changelog-anchor)
 
 ### Issue reference
 

--- a/.github/scripts/changelog-automation.js
+++ b/.github/scripts/changelog-automation.js
@@ -1,0 +1,105 @@
+const fs = require("fs")
+const yaml = require("js-yaml")
+
+
+function parse_pr_title(title) {
+    let result = title.match(/(\S+)\((\S+)\):\s*(.*)/i)
+    if (!result) {
+        return
+    }
+    return {
+        type: result[1],
+        scope: result[2],
+        message: result[3],
+    }
+}
+
+
+function parse_pr_description(description) {
+    let parsed = {}
+
+    // jira tickets
+    parsed.jiras = description.match(/(kag|fti)-\d+/gmi)
+
+    // extract changelog codeblock
+    let lines = description.split(/\r?\n/)
+    let idx_start = 0, idx_end = 0
+
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i] === "[//]: # (changelog-anchor)") {
+            if (idx_start === 0) {
+                idx_start = i
+            } else {
+                idx_end = i
+                break
+            }
+        }
+    }
+
+    let yaml_str = lines.slice(idx_start + 2, idx_end - 1).join("\n")
+    console.log("[override changelog]: \n" + yaml_str + "\n")
+    let doc = yaml.load(yaml_str)
+
+    Object.keys(doc).forEach(key => {
+        if (doc[key] !== null) {
+            parsed[key] = doc[key]
+        }
+    })
+
+    return parsed
+}
+
+
+try {
+    let title = fs.readFileSync("/tmp/pr-title.txt", "utf8")
+    let parsed_pr_title = parse_pr_title(title)
+    if (parsed_pr_title) {
+        if (parsed_pr_title.type === "feat") {
+            parsed_pr_title.type = "feature"
+        } else if (parsed_pr_title.type === "fix") {
+            parsed_pr_title.type = "bugfix"
+        } else if (parsed_pr_title.type === "chore" && parsed_pr_title.scope === "deps") {
+            parsed_pr_title.type = "dependency"
+            parsed_pr_title.scope = null
+        }
+
+        if (parsed_pr_title.scope && parsed_pr_title.scope.startsWith("plugin")) {
+            parsed_pr_title.scope = "Plugin"
+        }
+    }
+
+    let description = fs.readFileSync("/tmp/pr-description.txt", "utf8");
+    let parsed_pr_description = parse_pr_description(description)
+    console.log("[parsed pr description]: ")
+    console.log(parsed_pr_description)
+    console.log()
+
+    let property_indexs = {
+        message: 1,
+        type: 2,
+        scope: 3,
+        prs: 4,
+        jiras: 5,
+        issues: 6,
+    }
+
+    let changelog = Object.assign({}, parsed_pr_title, parsed_pr_description)
+    Object.keys(changelog).forEach((k) => changelog[k] == null && delete changelog[k]);
+    let changelog_yaml = yaml.dump(changelog, {
+        sortKeys: function (a, b) {
+            return property_indexs[a] < property_indexs[b] ? -1 : 1
+        }
+    })
+    changelog_yaml = changelog_yaml === "{}\n" ? "" : changelog_yaml
+    console.log("[generate changelog]:")
+    console.log(changelog_yaml)
+    console.log()
+
+    let pr = fs.readFileSync("/tmp/pr-number.txt", "utf8")
+    let filename = "/tmp/" + pr.trim() + ".yaml"
+    fs.writeFileSync(filename, changelog_yaml);
+    console.log("Successfully write changelog file at", filename)
+} catch (err) {
+    console.error(err);
+    process.exit(1);
+}

--- a/.github/workflows/changelog-command.yaml
+++ b/.github/workflows/changelog-command.yaml
@@ -1,0 +1,58 @@
+name: Changelog Commands
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  job:
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/update-changelog')
+    name: Update changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: retrive PR
+        run: |
+          pr_number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
+          echo ${pr_number} > /tmp/pr-number.txt
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}" > /tmp/pr.json
+          cat /tmp/pr.json | jq --raw-output .title > /tmp/pr-title.txt
+          cat /tmp/pr.json | jq --raw-output .body > /tmp/pr-description.txt
+          cat /tmp/pr-number.txt
+          cat /tmp/pr-title.txt
+          cat /tmp/pr-description.txt
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: install npm modules
+        run: |
+          npm install -g js-yaml
+
+      - name: update changelog
+        run: |
+          git fetch
+          git switch `cat /tmp/pr.json | jq --raw-output .head.ref`
+          git pull
+          pr_number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
+          export NODE_PATH=$(npm root --quiet -g)
+          node .github/scripts/changelog-automation.js
+          rm -f CHANGELOG/unreleased/${pr_number}.yaml
+          mv /tmp/${pr_number}.yaml CHANGELOG/unreleased/${pr_number}.yaml
+          git config --local user.email "$(git log -n 1 --pretty=format:%ae)"
+          git config --local user.name "$(git log -n 1 --pretty=format:%an)"
+          git add CHANGELOG/unreleased/${pr_number}.yaml
+          git diff --quiet HEAD || git commit -m "Update changelog file CHANGELOG/unreleased/${pr_number}.yaml"
+          git push
+
+      - name: leave a comment
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Changelog YAML updated."
+            })

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -9,8 +9,53 @@ on:
       - '.requirements'
 
 jobs:
+  add-changelog:
+    if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') && github.event_name == 'pull_request' && github.event.action == 'opened' }}
+    name: Auto add changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: install npm modules
+        run: |
+          npm install -g js-yaml
+
+      - name: parse description
+        run: |
+          echo "parsing PR description"
+          echo '${{ github.event.pull_request.number }}' > /tmp/pr-number.txt
+          echo '${{ github.event.pull_request.title }}' > /tmp/pr-title.txt
+          echo '${{ github.event.pull_request.body }}' > /tmp/pr-description.txt
+          export NODE_PATH=$(npm root --quiet -g)
+          node .github/scripts/changelog-automation.js
+
+      - name: add a changelog file
+        run: |
+          mv /tmp/${{ github.event.number }}.yaml CHANGELOG/unreleased/${{ github.event.pull_request.number }}.yaml
+          git config --local user.email "$(git log -n 1 --pretty=format:%ae)"
+          git config --local user.name "$(git log -n 1 --pretty=format:%an)"
+          git add CHANGELOG/unreleased/${{ github.event.pull_request.number }}.yaml
+          git commit -m "Add changelog file CHANGELOG/unreleased/${{ github.event.number }}.yaml"
+          git push
+
+      - name: leave a comment
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Changelog YAML Added."
+            })
+
   require-changelog:
     name: Is changelog required?
+    if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,21 +70,22 @@ jobs:
           files: 'CHANGELOG/unreleased/**/*.yaml'
 
       - name: Requires a changelog file if 'skip-changelog' label is not added
-        if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}
-        run: >
-          if [ "${{ steps.changelog-check.outputs.added_files_count }}" = "0" ]; then
-            echo "PR should contain a changelog file"
-            exit 1
-          fi
+        if: ${{ steps.changelog-check.outputs.added_files_count == 0 }}
+        run: |
+          echo "PR requires a changelog file, otherwise, add a 'skip-changelog' label."
+          exit 1
 
   validate-changelog:
+    if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}
     name: Validate changelog
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Validate changelogs
+      - name: validate changelogs
         uses: thiagodnf/yaml-schema-checker@228a5be72029114e3cd6301e0aaeef6b557fa033 # v0.0.8
         with:
           jsonSchemaFile: CHANGELOG/schema.json

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -71,10 +71,13 @@ Commands:
 
 Options:
   -h, --help                         display help for command
+  --from      (default unreleased)   folder of changelog entries, default unreleased
 
 Examples:
   changelog preview 1.0.0
   changelog release 1.0.0
+  changelog preview 1.0.0 --from 1.0.0   # preview a release note 1.0.0 based on the files in the 1.0.0 directory
+  changelog release 1.0.0 --from 1.0.0   # release a release note 1.0.0 based on the files in the 1.0.0 directory, aka re-generate
 ```
 
 **Preview a release note**

--- a/CHANGELOG/changelog
+++ b/CHANGELOG/changelog
@@ -84,7 +84,7 @@ end
 local function parse_jiras(jiras)
   local jira_items = {}
   for i, jira in ipairs(jiras or {}) do
-    jiras[i] = {
+    jira_items[i] = {
       id = jira,
       link = JIRA_BASE_URL .. jira
     }

--- a/CHANGELOG/changelog
+++ b/CHANGELOG/changelog
@@ -149,7 +149,7 @@ local function collect_files(folder)
 end
 
 
-local function collect_folder(system, folder)
+local function collect_sub_folder(system, sub_folder)
   local data = {
     features = {},
     bugfixes = {},
@@ -166,7 +166,7 @@ local function collect_folder(system, folder)
     deprecation = "deprecations",
   }
 
-  local files = collect_files(folder)
+  local files = collect_files(sub_folder)
   for _, filename in ipairs(files) do
     local content = assert(pl_file.read(filename))
     local entry = assert(lyaml.load(content))
@@ -195,10 +195,14 @@ local function collect_folder(system, folder)
   return data
 end
 
-local function collect_unreleased()
+local function collect_folder(folder)
+  if not pl_path.exists(absolute_path(folder)) then
+    error("folder: " .. folder .. " does not exist")
+  end
+
   local data = {}
 
-  data.kong = collect_folder("kong", absolute_path(UNRELEASED, "kong"))
+  data.kong = collect_sub_folder("kong", absolute_path(folder, "kong"))
 
   return data
 end
@@ -214,23 +218,26 @@ end
 
 -- command: release
 -- release a release note
-local function release(version)
+local function release(version, folder)
   -- mkdir unreleased path if not exists
   if not pl_path.exists(absolute_path(UNRELEASED)) then
     assert(pl_dir.makepath(absolute_path(UNRELEASED)))
   end
 
-  local data = collect_unreleased()
+  local data = collect_folder(folder)
   data.version = version
   local content = assert(generate_content(data))
   local target_path = absolute_path(version)
-  if pl_path.exists(target_path) then
+
+  if pl_path.exists(target_path) and version ~= folder then
     error("directory exists, please manually remove. " .. version)
   end
-  os.execute("mv " .. UNRELEASED .. " " .. target_path)
+  if folder == UNRELEASED then
+    os.execute("mv " .. UNRELEASED .. " " .. target_path)
+    assert(pl_dir.makepath(UNRELEASED))
+  end
   local filename = pl_path.join(target_path, "changelog.md")
   assert(pl_file.write(filename, content))
-  assert(pl_dir.makepath(UNRELEASED))
 
   print("Successfully generated release note.")
 end
@@ -238,8 +245,13 @@ end
 
 -- command: preview
 -- preview the release note
-local function preview(version)
-  local data = collect_unreleased()
+local function preview(version, folder)
+  -- mkdir unreleased path if not exists
+  if not pl_path.exists(absolute_path(UNRELEASED)) then
+    assert(pl_dir.makepath(absolute_path(UNRELEASED)))
+  end
+
+  local data = collect_folder(folder)
   data.version = version
   local content = assert(generate_content(data))
   print(content)
@@ -249,17 +261,19 @@ end
 local cmds = {
   release = function(args)
     local version = args[1]
+    local folder = args["from"]
     if not version then
       error("Missing version")
     end
-    release(version)
+    release(version, folder)
   end,
   preview = function(args)
     local version = args[1]
+    local folder = args["from"]
     if not version then
       error("Missing version")
     end
-    preview(version)
+    preview(version, folder)
   end,
 }
 
@@ -273,10 +287,13 @@ Commands:
 
 Options:
   -h, --help                         display help for command
+  --from      (default unreleased)   folder of changelog entries, default unreleased
 
 Examples:
   changelog preview 1.0.0
   changelog release 1.0.0
+  changelog preview 1.0.0 --from 1.0.0   # preview a release note 1.0.0 based on the files in the 1.0.0 directory
+  changelog release 1.0.0 --from 1.0.0   # release a release note 1.0.0 based on the files in the 1.0.0 directory, aka re-generate
 ]]
 
 local cmd_name = table.remove(args, 1)

--- a/CHANGELOG/changelog-template.yaml
+++ b/CHANGELOG/changelog-template.yaml
@@ -1,5 +1,6 @@
 message:
 type:
+scope:
 prs:
 jiras:
 issues:


### PR DESCRIPTION
Summary

Add changelog automation tool(implemented by GitHub workflow) to generate changelog file automatically based on the PR title. 

PR title is not always qualified to be the changelog. For example, https://github.com/Kong/kong/pull/11427 (_feat(http-log): add allow list for logged headers_), the user facing changelog should be more detailed by including the added fields.

```yaml
message: "**HTTP-Log**: add `enable_logged_headers_allow_list` and `logged_headers_allow_list` fields in HTTP Log plugin."
type: feature
scope: Plugin
prs:
  - 11427
```

Therefore, I add a changelog form in PULL_REQUEST_TEMPLATE.md to allow contributors and reviewers to override it: 
```
### Changelog

message:
type:
scope:
prs:
issues:
```

Once the changelog form is updated, people can easily re-generate changelog by leaving a comment( `/update-changelog` ) 