### PR TITLE
refactor(db/declarative): remove sha256 in `unique_field_key`

### DIFF
--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -21,7 +21,6 @@ local null = ngx.null
 local md5 = ngx.md5
 local get_phase = ngx.get_phase
 local yield = utils.yield
-local sha256 = utils.sha256_hex
 
 
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
@@ -136,10 +135,6 @@ local function unique_field_key(schema_name, ws_id, field, value, unique_across_
   if unique_across_ws then
     ws_id = ""
   end
-
-  -- LMDB imposes a default limit of 511 for keys, but the length of our unique
-  -- value might be unbounded, so we'll use a checksum instead of the raw value
-  value = sha256(value)
 
   return schema_name .. "|" .. ws_id .. "|" .. field .. ":" .. value
 end

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -2,17 +2,8 @@ require("spec.helpers") -- for kong.log
 local declarative = require "kong.db.declarative"
 local conf_loader = require "kong.conf_loader"
 
-local to_hex = require("resty.string").to_hex
-local resty_sha256 = require "resty.sha256"
-
 local null = ngx.null
 
-
-local function sha256(s)
-  local sha = resty_sha256:new()
-  sha:update(s)
-  return to_hex(sha:final())
-end
 
 describe("declarative", function()
   describe("parse_string", function()
@@ -61,12 +52,12 @@ keyauth_credentials:
     it("utilizes the schema name, workspace id, field name, and checksum of the field value", function()
       local key = unique_field_key("services", "123", "fieldname", "test", false)
       assert.is_string(key)
-      assert.equals("services|123|fieldname:" .. sha256("test"), key)
+      assert.equals("services|123|fieldname:test", key)
     end)
 
     it("omits the workspace id when 'unique_across_ws' is 'true'", function()
       local key = unique_field_key("services", "123", "fieldname", "test", true)
-      assert.equals("services||fieldname:" .. sha256("test"), key)
+      assert.equals("services||fieldname:test", key)
     end)
   end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Since we have implemented the sha256 feature in lua-resty-lmdb(https://github.com/Kong/lua-resty-lmdb/pull/27),
should we remove this call in Kong?


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md) (Please ping @vm-001 if you need help)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
