### PR TITLE
Update kong.conf.default

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1569,7 +1569,7 @@
                                  # Services updates.
 
 #worker_state_update_frequency = 5
-                                 # Defines how often the worker state changes are
+                                 # Defines (in seconds) how often the worker state changes are
                                  # checked with a background job. When a change
                                  # is detected, a new router or balancer will be
                                  # built, as needed. Raising this value will


### PR DESCRIPTION
### Summary

Added 'seconds' as the metric used when defining the `worker_state_update_frequency` property.

Related to https://github.com/Kong/kong-ee/pull/5147 which was rejected initially due to the change needed in CE instead of EE. Also initially attempted to make the change in https://github.com/Kong/docs.konghq.com/pull/5462 but this was not othe correct spot either. Side note: Working with internal teams to improve this process when docs are sourced from different files in different repositories. :-) 

### Checklist

- [] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/5462