### PR TITLE
chore(deps): bump resty.openssl from 0.8.23 to 0.8.25

### DIFF
--- a/CHANGELOG/unreleased/kong/11518.yaml
+++ b/CHANGELOG/unreleased/kong/11518.yaml
@@ -1,0 +1,7 @@
+message: "bump resty.openssl from 0.8.23 to 0.8.25"
+type: dependency
+scope: Core
+prs:
+  - 11518
+jiras:
+  - "FTI-5324"

--- a/CHANGELOG/unreleased/kong/11518.yaml
+++ b/CHANGELOG/unreleased/kong/11518.yaml
@@ -1,4 +1,4 @@
-message: "bump resty.openssl from 0.8.23 to 0.8.25"
+message: "Bumped resty.openssl from 0.8.23 to 0.8.25"
 type: dependency
 scope: Core
 prs:

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.6.3",
   "lua-messagepack == 0.5.2",
   "lua-resty-aws == 1.3.1",
-  "lua-resty-openssl == 0.8.23",
+  "lua-resty-openssl == 0.8.25",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.11.0",


### PR DESCRIPTION
### Summary

bugfixes:

- **pkey:** clear error stack when verification fails ([#121](https://github.com/fffonion/lua-resty-openssl/issues/121)) [6e58b28](https://github.com/fffonion/lua-resty-openssl/commit/6e58b28c3d42560631e0c8351befa1434b6fc542)

- **ssl:** support ngx_lua 10025 [abaa66e](https://github.com/fffonion/lua-resty-openssl/commit/abaa66ee07ce734580fd29ec6032157c998f6346)

Fix [FTI-5324](https://konghq.atlassian.net/browse/FTI-5324)

[FTI-5324]: https://konghq.atlassian.net/browse/FTI-5324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ