### PR TITLE
tests(*): yet another compilation of flakiness fixes

### DIFF
--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -288,6 +288,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("broadcasts an event with a delay", function()
+        ngx.update_time()
         local cluster_events_1 = assert(kong_cluster_events.new {
           db = db,
           node_id = uuid_1,

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -348,14 +348,23 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
 
-        -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
-        local res = assert(admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. cache_key,
-          headers = {}
-        })
-        assert.res_status(200, res)
+        local cache_key
+        helpers.wait_until(function()
+          -- Check that cache is populated
+          cache_key = db.oauth2_tokens:cache_key(token.access_token)
+          local res = assert(admin_client:send {
+            method  = "GET",
+            path    = "/cache/" .. cache_key,
+            headers = {}
+          })
+
+          -- Discard body in case we need to retry. Otherwise the connection will mess up.
+          res:read_body()
+          if res.status ~= 200 then
+            assert.logfile().has.no.line("[error]", true)
+          end
+          return 200 == res.status
+        end, 5)
 
         local res = db.oauth2_tokens:select_by_access_token(token.access_token)
         local token_id = res.id


### PR DESCRIPTION
This PR contains 2 flaky test fixes. **PLEASE DO NOT SQUASH WHEN MERGING.**

Those flaky tests are found when trying to introduce FIPS tests.

[chore(tests): update time for time sensitive tests](https://github.com/Kong/kong/commit/fd345517f7c43dcf54b83735839118016f460fbd)

[chore(tests): wait_until for flaky test](https://github.com/Kong/kong/commit/a1c4f781a72dd41d3642cb58728798b9ad7158d8)