### PR TITLE
fix(aws-lambda): remove aws lambda plugin init function

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -355,29 +355,5 @@ function Plugins:get_handlers()
   return list
 end
 
-function Plugins:execute_plugin_init()
-  local handlers, err = self:get_handlers()
-  if not handlers then
-    return nil, err
-  end
-
-  local errors
-
-  for _, handler in ipairs(handlers) do
-    if implements(handler.handler, "init") then
-      local ok, err = pcall(handler.handler.init, handler.handler)
-      if not ok then
-        errors = errors or {}
-        errors[#errors + 1] = "on plugin '" .. handler.name .. "': " .. tostring(err)
-      end
-    end
-  end
-
-  if errors then
-    return nil, "error executing plugin init: " .. table.concat(errors, "; ")
-  end
-
-  return true
-end
 
 return Plugins

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -627,8 +627,6 @@ function Kong.init()
   -- Load plugins as late as possible so that everything is set up
   assert(db.plugins:load_plugin_schemas(config.loaded_plugins))
 
-  assert(db.plugins:execute_plugin_init())
-
   if is_stream_module then
     stream_api.load_handlers()
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The PR https://github.com/Kong/kong/pull/11350 adds a plugin init function handler. The PR tries to remove it, and find a way to workaround the AWS instance initialization.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [na] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* remove aws lambda plugin init function
