### PR TITLE
tests(mlcache): skip flaky tests in mlcache test suite

### DIFF
--- a/t/05-mlcache/02-get.t
+++ b/t/05-mlcache/02-get.t
@@ -2379,6 +2379,7 @@ is stale: true
 
 
 === TEST 50: get() does not cache value in LRU indefinitely when retrieved from shm on last ms (see GH PR #58)
+--- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {

--- a/t/05-mlcache/03-peek.t
+++ b/t/05-mlcache/03-peek.t
@@ -100,6 +100,7 @@ ttl: nil
 
 
 === TEST 3: peek() returns the remaining ttl if a key has been fetched before
+--- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
### Summary

Just skips flaky tests in mlcache test suite. We need to enable them later.