### PR TITLE
feat(acme): add scan_count to redis storage schema

### DIFF
--- a/CHANGELOG/unreleased/kong/11532.yaml
+++ b/CHANGELOG/unreleased/kong/11532.yaml
@@ -1,0 +1,5 @@
+message: "add scan_count to redis storage schema"
+type: feature
+scope: Plugin
+prs:
+  - 11532

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   "lua-resty-openssl == 0.8.25",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.11.0",
+  "lua-resty-acme == 0.12.0",
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.5",
   "lpeg == 1.0.2",

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -97,9 +97,13 @@ return {
     },
   },
 
+  -- Any dataplane older than 3.5.0
   [3005000000] = {
+    acme = {
+      "storage_config.redis.scan_count",
+    },
     cors = {
       "private_network",
-    }
-  }
+    },
+  },
 }

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -52,6 +52,7 @@ local REDIS_STORAGE_SCHEMA = {
       custom_validator = validate_namespace
     }
   },
+  { scan_count = { type = "number", required = false, default = 10, description = "The number of keys to return in Redis SCAN calls." } },
 }
 
 local CONSUL_STORAGE_SCHEMA = {

--- a/spec/03-plugins/29-acme/05-redis_storage_spec.lua
+++ b/spec/03-plugins/29-acme/05-redis_storage_spec.lua
@@ -106,6 +106,37 @@ describe("Plugin: acme (storage.redis)", function()
       assert.equal(0, #keys)
     end)
 
+    it("redis namespace list with scan count", function()
+      local config1 = {
+        host = helpers.redis_host,
+        port = helpers.redis_port,
+        database = 0,
+        namespace = "namespace1",
+        scan_count = 20,
+      }
+
+      local storage1, err = redis_storage.new(config1)
+      assert.is_nil(err)
+      assert.not_nil(storage1)
+
+      for i=1,50 do
+        local err = storage1:set(string.format("scan-count:%02d", i), i, 10)
+        assert.is_nil(err)
+      end
+
+
+      local keys, err = storage1:list("scan-count")
+      assert.is_nil(err)
+      assert.is_table(keys)
+      assert.equal(50, #keys)
+
+      table.sort(keys)
+
+      for i=1,50 do
+        assert.equal(string.format("scan-count:%02d", i), keys[i])
+      end
+    end)
+
     it("redis namespace isolation", function()
       local config0 = {
         host = helpers.redis_host,


### PR DESCRIPTION
### Summary

SRE has started seeing entries in the Redis slowlog related to retrieving keys for `kong_acme:renew_config`.  lua-resty-acme was recently changed to use Redis `scan` instead of `keys` for performance reasons. See the lua-resty-acme PR for more details https://github.com/fffonion/lua-resty-acme/pull/106.

This PR exposes a new configuration field for Redis storage that controls how many keys are returned in a `scan` call and bumps lua-resty-acme to 0.12.0.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

@fffonion 