### PR TITLE
refactor(core): wrapper of now_ms and start_time_ms

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -110,7 +110,6 @@ local ngx_INFO         = ngx.INFO
 local ngx_DEBUG        = ngx.DEBUG
 local is_http_module   = ngx.config.subsystem == "http"
 local is_stream_module = ngx.config.subsystem == "stream"
-local start_time       = ngx.req.start_time
 local worker_id        = ngx.worker.id
 local type             = type
 local error            = error
@@ -125,8 +124,11 @@ local set_current_peer = ngx_balancer.set_current_peer
 local set_timeouts     = ngx_balancer.set_timeouts
 local set_more_tries   = ngx_balancer.set_more_tries
 local enable_keepalive = ngx_balancer.enable_keepalive
-local time_ns          = utils.time_ns
-local get_now_ms       = utils.get_now_ms
+
+
+local time_ns            = utils.time_ns
+local get_now_ms         = utils.get_now_ms
+local get_start_time_ms  = utils.get_start_time_ms
 local get_updated_now_ms = utils.get_updated_now_ms
 
 
@@ -906,7 +908,7 @@ end
 function Kong.preread()
   local ctx = get_ctx_table(fetch_table(CTX_NS, CTX_NARR, CTX_NREC))
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = start_time() * 1000
+    ctx.KONG_PROCESSING_START = get_start_time_ms()
   end
 
   if not ctx.KONG_PREREAD_START then
@@ -979,7 +981,7 @@ function Kong.rewrite()
   end
 
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = start_time() * 1000
+    ctx.KONG_PROCESSING_START = get_start_time_ms()
   end
 
   if not ctx.KONG_REWRITE_START then
@@ -1354,7 +1356,7 @@ end
 function Kong.header_filter()
   local ctx = ngx.ctx
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = start_time() * 1000
+    ctx.KONG_PROCESSING_START = get_start_time_ms()
   end
 
   if not ctx.workspace then
@@ -1507,7 +1509,7 @@ function Kong.log()
     ctx.KONG_LOG_START_NS = time_ns()
     if is_stream_module then
       if not ctx.KONG_PROCESSING_START then
-        ctx.KONG_PROCESSING_START = start_time() * 1000
+        ctx.KONG_PROCESSING_START = get_start_time_ms()
       end
 
       if ctx.KONG_PREREAD_START and not ctx.KONG_PREREAD_ENDED_AT then
@@ -1616,7 +1618,7 @@ end
 
 local function serve_content(module)
   local ctx = ngx.ctx
-  ctx.KONG_PROCESSING_START = start_time() * 1000
+  ctx.KONG_PROCESSING_START = get_start_time_ms()
   ctx.KONG_ADMIN_CONTENT_START = ctx.KONG_ADMIN_CONTENT_START or get_now_ms()
   ctx.KONG_PHASE = PHASES.admin_api
 
@@ -1648,7 +1650,7 @@ function Kong.admin_header_filter()
   local ctx = ngx.ctx
 
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = start_time() * 1000
+    ctx.KONG_PROCESSING_START = get_start_time_ms()
   end
 
   if not ctx.KONG_ADMIN_HEADER_FILTER_START then

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1798,6 +1798,7 @@ local get_updated_now_ms
 do
   local now           = ngx.now
   local update_time   = ngx.update_time
+  local start_time    = ngx.req.start_time
 
   function get_now_ms()
     return now() * 1000 -- time is kept in seconds with millisecond resolution.
@@ -1807,8 +1808,13 @@ do
     update_time()
     return now() * 1000 -- time is kept in seconds with millisecond resolution.
   end
+
+  function get_start_time_ms()
+    return start_time() * 1000 -- time is kept in seconds with millisecond resolution.
+  end
 end
 _M.get_now_ms         = get_now_ms
 _M.get_updated_now_ms = get_updated_now_ms
+_M.get_start_time_ms  = get_start_time_ms
 
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1795,6 +1795,7 @@ _M.sha256_base64url = sha256_base64url
 
 local get_now_ms
 local get_updated_now_ms
+local get_start_time_ms
 do
   local now           = ngx.now
   local update_time   = ngx.update_time

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1792,15 +1792,23 @@ _M.sha256_hex       = sha256_hex
 _M.sha256_base64    = sha256_base64
 _M.sha256_base64url = sha256_base64url
 
+
+local get_now_ms
 local get_updated_now_ms
 do
   local now           = ngx.now
   local update_time   = ngx.update_time
+
+  function get_now_ms()
+    return now() * 1000 -- time is kept in seconds with millisecond resolution.
+  end
+
   function get_updated_now_ms()
     update_time()
     return now() * 1000 -- time is kept in seconds with millisecond resolution.
   end
 end
+_M.get_now_ms         = get_now_ms
 _M.get_updated_now_ms = get_updated_now_ms
 
 return _M


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

We have introduced a wrapper function `get_updated_now_ms()` in #10355,
so I think that we can do the same thing for `now()` and `start_time()`.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
