### PR TITLE
chore(deps): bump luasec from 1.3.1 to 1.3.2

### DIFF
--- a/CHANGELOG/unreleased/kong/11553.yaml
+++ b/CHANGELOG/unreleased/kong/11553.yaml
@@ -1,0 +1,4 @@
+message: "Bumped LuaSec from 1.3.1 to 1.3.2"
+type: dependency
+prs:
+  - 11553

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -13,7 +13,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.3",
-  "luasec == 1.3.1",
+  "luasec == 1.3.2",
   "luasocket == 3.0-rc1",
   "penlight == 1.13.1",
   "lua-resty-http == 0.17.1",


### PR DESCRIPTION
### Summary

* Fix: place EAI_OVERFLOW inside macro, unbreak build on <10.7 (Sergey Fedorov)
* Fix: Expand workaround for zero errno to OpenSSL 3.0.x (Kim Alvefur)
* Fix: reset block timeout at send or receive (MartinDahlberg)
