### PR TITLE
docs(DEVELOPER): clarify permission for Github Access Token

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -139,7 +139,7 @@ brew install libyaml
 ```
 
 Now, we have to set environment variable `GITHUB_TOKEN` to download some essential repos.
-You can follow [Managing your personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to generate an access token.
+You can follow [Managing your personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to generate an access token. It does not need to have any other permission than `Public Repositories (read-only)`.
 
 ```bash
 # export GITHUB_TOKEN=ghp_xxxxxx_your_access_token


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When setting up Kong `DEVELOPER.md` points to Github Documentation to generate a Github Access Token in order to download some essential repos. However it does not explicitly state what permissions the token should grant.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* `DEVELOPER.md`: Mention that no additional permission are needed when setting up Kong 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
N/A
