### PR TITLE
refactor(plugins/grpc-web): use string buffer to concat strings

### DIFF
--- a/kong/plugins/grpc-web/deco.lua
+++ b/kong/plugins/grpc-web/deco.lua
@@ -169,7 +169,7 @@ function deco:frame(ftype, msg)
   local f = grpc_frame(ftype, msg)
 
   if self.text_encoding == "base64" then
-    f = ngx.encode_base64(f)
+    f = encode_base64(f)
   end
 
   return f

--- a/kong/plugins/grpc-web/handler.lua
+++ b/kong/plugins/grpc-web/handler.lua
@@ -44,7 +44,7 @@ function grpc_web:access(conf)
 
   local uri
   if conf.pass_stripped_path then
-    uri = ngx.var.upstream_uri
+    uri = ngx_var.upstream_uri
     ngx.req.set_uri(uri)
   else
     uri = kong_request_get_path()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`string.buffer` is better than `table.concat`, we have already done the same thing in other place.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* use `string.buffer` to replace `table.concat`
* use localized `ngx.var` and `ngx.encode_base64`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
