### PR TITLE
refactor(plugins/jwt): use encode_base64url in resty.core

### DIFF
--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -154,14 +154,15 @@ end
 -- @param len Number of parts to retrieve
 -- @return A table of strings
 local function tokenize(str, div, len)
-  local result, pos = {}, 0
+  local result, idx, pos = {}, 1, 0
 
   local iter = function()
     return find(str, div, pos, true)
   end
 
   for st, sp in iter do
-    result[#result + 1] = sub(str, pos, st-1)
+    result[idx] = sub(str, pos, st - 1)
+    idx = idx + 1
     pos = sp + 1
     len = len - 1
     if len <= 1 then
@@ -169,7 +170,7 @@ local function tokenize(str, div, len)
     end
   end
 
-  result[#result + 1] = sub(str, pos)
+  result[idx] = sub(str, pos)
   return result
 end
 

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -6,6 +6,7 @@
 -- @see https://github.com/x25/luajwt
 
 local json = require "cjson"
+local b64 = require("ngx.base64")
 local openssl_digest = require "resty.openssl.digest"
 local openssl_hmac = require "resty.openssl.hmac"
 local openssl_pkey = require "resty.openssl.pkey"
@@ -26,8 +27,8 @@ local assert = assert
 local tostring = tostring
 local setmetatable = setmetatable
 local getmetatable = getmetatable
-local encode_base64 = ngx.encode_base64
-local decode_base64 = ngx.decode_base64
+local encode_base64url = b64.encode_base64url
+local decode_base64url = b64.decode_base64url
 
 
 --- Supported algorithms for signing tokens.
@@ -126,8 +127,7 @@ local alg_verify = {
 -- @param input String to base64 encode
 -- @return Base64 encoded string
 local function base64_encode(input)
-  local result = encode_base64(input, true)
-  result = result:gsub("+", "-"):gsub("/", "_")
+  local result = encode_base64url(input)
   return result
 end
 
@@ -143,8 +143,7 @@ local function base64_decode(input)
     input = input .. rep("=", padlen)
   end
 
-  input = input:gsub("-", "+"):gsub("_", "/")
-  return decode_base64(input)
+  return decode_base64url(input)
 end
 
 

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -6,7 +6,7 @@
 -- @see https://github.com/x25/luajwt
 
 local json = require "cjson"
-local b64 = require("ngx.base64")
+local b64 = require "ngx.base64"
 local openssl_digest = require "resty.openssl.digest"
 local openssl_hmac = require "resty.openssl.hmac"
 local openssl_pkey = require "resty.openssl.pkey"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`lua-resty-core` provides two functions `base64.encode_base64url()` and `base64.decode_base64url()`,
Which have the same effect as our Lua functions.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* use `base64.encode_base64url` and `base64.decode_base64url`
* optimize table insert

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
