### PR TITLE
[KAG-911] fix(bazel): don't rm lapis/luarocks-admin bins

### DIFF
--- a/CHANGELOG/unreleased/kong/11578.yaml
+++ b/CHANGELOG/unreleased/kong/11578.yaml
@@ -1,0 +1,4 @@
+message: "Restore lapis & luarocks-admin bins"
+type: bugfix
+prs:
+  - 11578

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -141,7 +141,6 @@ kong_directory_genrule(
 
         LUAROCKS=${WORKSPACE_PATH}/$(dirname '$(location @luarocks//:luarocks_make)')/luarocks_tree
         cp -r ${LUAROCKS}/. ${BUILD_DESTDIR}/.
-        rm ${BUILD_DESTDIR}/bin/lapis ${BUILD_DESTDIR}/bin/luarocks-admin
 
         ATC_ROUTER=${WORKSPACE_PATH}/$(location @atc_router)
         cp $ATC_ROUTER ${BUILD_DESTDIR}/openresty/lualib/.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

> luarocks-admin and lapis are removed from the docker images by the bazel build system, but they are needed by the container smoke tests, so they need to be brought back.

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Restore lapis & luarocks-admin bins]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-911]_


[KAG-911]: https://konghq.atlassian.net/browse/KAG-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ