### PR TITLE
chore(ci): automatically label community PRs with author/community

### DIFF
--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -1,0 +1,28 @@
+name: Label community PRs
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_author:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Label Community PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          for id in `gh pr list -S 'draft:false' -s 'open'|awk '{print $1}'`
+          do
+            name=`gh pr view $id --json author -q '.author.login'`
+            gh api orgs/Kong/members --paginate -q '.[].login'|grep -q "^${name}$"
+            if [ $? -ne 0 ]; then
+              gh pr edit $id --add-label "author/community"
+            fi
+          done


### PR DESCRIPTION
When a pull request against the Kong/kong repository is opened, it should be automatically labeled with `author/community` if the account opening the PR is not a member of the Kong organization.
But because of the author's permissions, it is not allowed to add labels to the PR. So try to use `schedule` instead of `pull_request` to implement this requirement.

KAG-2562