### PR TITLE
fix(test): don't expect specific status code in queue shutdown test

### DIFF
--- a/spec/02-integration/16-queues/01-shutdown_spec.lua
+++ b/spec/02-integration/16-queues/01-shutdown_spec.lua
@@ -122,7 +122,7 @@ for _, strategy in helpers.each_strategy() do
       local res, err = helpers.stop_kong(nil, true, nil, "QUIT")
       assert(res, err)
 
-      assert.logfile().has.line("handler could not process entries: request to konghq.com:80 returned status code 301")
+      assert.logfile().has.line("handler could not process entries: request to konghq.com:80 returned status code")
     end)
   end)
 end


### PR DESCRIPTION
### Summary

konghq.com:80 no longer responds with 301 to POST requests, but as we're not interested in the specific status code anyway, remove it from the expected string.  We only need to make sure that an attempt was made to contact the log server (konghq.com).

(EE PR: https://github.com/Kong/kong-ee/pull/6579)

### Checklist

- [X] The Pull Request has tests
- [X] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2612
