### PR TITLE
chore(deps): bump resty.aws from 1.3.2 to 1.3.5

### DIFF
--- a/CHANGELOG/unreleased/kong/11613.yaml
+++ b/CHANGELOG/unreleased/kong/11613.yaml
@@ -1,0 +1,4 @@
+message: "Bumped lua-resty-aws from 1.3.2 to 1.3.5"
+type: dependency
+prs:
+  - 11613

--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.0",
   "lua-resty-healthcheck == 1.6.3",
   "lua-messagepack == 0.5.2",
-  "lua-resty-aws == 1.3.2",
+  "lua-resty-aws == 1.3.5",
   "lua-resty-openssl == 0.8.25",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
### Summary

#### 1.3.5 (19-Sep-2023)

- fix: lazily initialize structures to avoid c-boundary errors on require [87](https://github.com/Kong/lua-resty-aws/pull/87)

#### 1.3.4 (13-Sep-2023)

- fix: remove more module-level uses of config.global [83](https://github.com/Kong/lua-resty-aws/pull/83)

#### 1.3.3 (13-Sep-2023)

- fix: don't invoke region detection code on the module toplevel and advise against trying to. [81](https://github.com/Kong/lua-resty-aws/pull/81)