### PR TITLE
fix(aws-lambda): lazily initialize aws library

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -355,29 +355,5 @@ function Plugins:get_handlers()
   return list
 end
 
-function Plugins:execute_plugin_init()
-  local handlers, err = self:get_handlers()
-  if not handlers then
-    return nil, err
-  end
-
-  local errors
-
-  for _, handler in ipairs(handlers) do
-    if implements(handler.handler, "init") then
-      local ok, err = pcall(handler.handler.init, handler.handler)
-      if not ok then
-        errors = errors or {}
-        errors[#errors + 1] = "on plugin '" .. handler.name .. "': " .. tostring(err)
-      end
-    end
-  end
-
-  if errors then
-    return nil, "error executing plugin init: " .. table.concat(errors, "; ")
-  end
-
-  return true
-end
 
 return Plugins

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -629,8 +629,6 @@ function Kong.init()
   -- Load plugins as late as possible so that everything is set up
   assert(db.plugins:load_plugin_schemas(config.loaded_plugins))
 
-  assert(db.plugins:execute_plugin_init())
-
   if is_stream_module then
     stream_api.load_handlers()
   end


### PR DESCRIPTION
### Summary

Lazily initializes AWS library on a first use, to remove startup delay caused by AWS metadata discovery.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

^ this PR does not need any of those, this is on top of unreleased feature.