### PR TITLE
chore(ci): automatically label community PRs with author/community

### DIFF
--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -13,9 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Label Community PR
+      - name: Label Community PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: "author/community"
         run: |
           set +e
           for id in `gh pr list -S 'draft:false' -s 'open'|awk '{print $1}'`
@@ -23,6 +24,8 @@ jobs:
             name=`gh pr view $id --json author -q '.author.login'`
             gh api orgs/Kong/members --paginate -q '.[].login'|grep -q "^${name}$"
             if [ $? -ne 0 ]; then
-              gh pr edit $id --add-label "author/community"
+              gh pr edit $id --add-label "${{ env.LABEL }}"
+            else
+              gh pr edit $id --remove-label "${{ env.LABEL }}"
             fi
           done

--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -1,0 +1,28 @@
+name: Label community PRs
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_author:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Label Community PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          for id in `gh pr list -S 'draft:false' -s 'open'|awk '{print $1}'`
+          do
+            name=`gh pr view $id --json author -q '.author.login'`
+            gh api orgs/Kong/members --paginate -q '.[].login'|grep -q "^${name}$"
+            if [ $? -ne 0 ]; then
+              gh pr edit $id --add-label "author/community"
+            fi
+          done


### PR DESCRIPTION
**Please do not merge until `secrets.GITHUB_TOKEN` has `read:org` permission.**

Fix step name.
Remove label from prs that created by organization members.

KAG-2562
