### PR TITLE
fix(vault): vault try should avoid using semaphore in non-yieldable phases

### DIFF
--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -1,6 +1,6 @@
 local resty_lock = require "resty.lock"
 local ngx_semaphore = require "ngx.semaphore"
-local check_phase_yieldable = require("kong.tools.utils").check_phase_yieldable
+local in_yieldable_phase = require("kong.tools.utils").in_yieldable_phase
 
 
 local type  = type
@@ -89,7 +89,7 @@ function concurrency.with_coroutine_mutex(opts, fn)
     error("invalid value for opts.on_timeout", 2)
   end
 
-  if not check_phase_yieldable() then
+  if not in_yieldable_phase() then
     return fn()
   end
 

--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -1,13 +1,11 @@
 local resty_lock = require "resty.lock"
 local ngx_semaphore = require "ngx.semaphore"
+local check_phase_yieldable = require("kong.tools.utils").check_phase_yieldable
 
 
 local type  = type
 local error = error
 local pcall = pcall
-
-
-local get_phase = ngx.get_phase
 
 
 local concurrency = {}
@@ -91,7 +89,7 @@ function concurrency.with_coroutine_mutex(opts, fn)
     error("invalid value for opts.on_timeout", 2)
   end
 
-  if get_phase() == "init_worker" then
+  if not check_phase_yieldable() then
     return fn()
   end
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1653,7 +1653,7 @@ end
 -- @tparam string phase the phase to check, if not specified then
 -- the default value will be the current phase
 -- @treturn boolean true if the phase is yieldable, false otherwise
-local check_phase_yieldable do
+local in_yieldable_phase do
   local get_phase = ngx.get_phase
 
   -- https://github.com/openresty/lua-nginx-module/blob/c89469e920713d17d703a5f3736c9335edac22bf/src/ngx_http_lua_util.h#L35C10-L35C10
@@ -1669,7 +1669,7 @@ local check_phase_yieldable do
     preread = true,
   }
 
-  check_phase_yieldable = function(phase)
+  in_yieldable_phase = function(phase)
     if LUA_CONTEXT_YIELDABLE_PHASE[phase or get_phase()] == nil then
       return false
     end
@@ -1677,7 +1677,7 @@ local check_phase_yieldable do
   end
 end
 
-_M.check_phase_yieldable = check_phase_yieldable
+_M.in_yieldable_phase = in_yieldable_phase
 
 do
   local ngx_sleep = _G.native_ngx_sleep or ngx.sleep
@@ -1686,7 +1686,7 @@ do
   local counter = YIELD_ITERATIONS
 
   function _M.yield(in_loop, phase)
-    if ngx.IS_CLI or not check_phase_yieldable(phase) then
+    if ngx.IS_CLI or not in_yieldable_phase(phase) then
       return
     end
     if in_loop then

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1648,26 +1648,45 @@ function _M.sort_by_handler_priority(a, b)
   return prio_a > prio_b
 end
 
-do
+---
+-- Check if the phase is yieldable.
+-- @tparam string phase the phase to check, if not specified then
+-- the default value will be the current phase
+-- @treturn boolean true if the phase is yieldable, false otherwise
+local check_phase_yieldable do
   local get_phase = ngx.get_phase
-  local ngx_sleep = _G.native_ngx_sleep or ngx.sleep
 
-  local SLEEP_PHASES = {
+  -- https://github.com/openresty/lua-nginx-module/blob/c89469e920713d17d703a5f3736c9335edac22bf/src/ngx_http_lua_util.h#L35C10-L35C10
+  local LUA_CONTEXT_YIELDABLE_PHASE = {
     rewrite = true,
+    server_rewrite = true,
     access = true,
     content = true,
     timer = true,
+    ssl_client_hello = true,
     ssl_certificate = true,
     ssl_session_fetch = true,
-    ssl_client_hello = true,
     preread = true,
   }
+
+  check_phase_yieldable = function(phase)
+    if LUA_CONTEXT_YIELDABLE_PHASE[phase or get_phase()] == nil then
+      return false
+    end
+    return true
+  end
+end
+
+_M.check_phase_yieldable = check_phase_yieldable
+
+do
+  local ngx_sleep = _G.native_ngx_sleep or ngx.sleep
 
   local YIELD_ITERATIONS = 1000
   local counter = YIELD_ITERATIONS
 
   function _M.yield(in_loop, phase)
-    if ngx.IS_CLI or SLEEP_PHASES[phase or get_phase()] == nil then
+    if ngx.IS_CLI or not check_phase_yieldable(phase) then
       return
     end
     if in_loop then

--- a/spec/02-integration/13-vaults/03-mock_spec.lua
+++ b/spec/02-integration/13-vaults/03-mock_spec.lua
@@ -145,4 +145,26 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
   end)
+
+  if strategy == "postgres" then
+    describe("ENV Vault #" .. strategy, function ()
+      describe("Kong Start", function ()
+        it("can resolve reference in init_phase", function ()
+          helpers.setenv("TEST_ENV_VAULT_LOGLEVEL", "debug")
+
+          assert(helpers.start_kong {
+            database = strategy,
+            prefix = helpers.test_conf.prefix,
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+            vaults = "env",
+            log_level = "{vault://env/TEST_ENV_VAULT_LOGLEVEL}"
+          })
+
+          finally(function ()
+            assert(helpers.stop_kong())
+          end)
+        end)
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Vault's `try` function now uses `with_coroutine_mutex` concurrency control, but it may be triggered in phases(for example, init phase during config dereference)that does not support `semaphore:wait`, so problem occurs.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
