### PR TITLE
chore(patches): make luajit patches apply cleanly

### DIFF
--- a/build/openresty/patches/LuaJIT-2.1-20230410_05_ldp_stp_fusion.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20230410_05_ldp_stp_fusion.patch
@@ -12,7 +12,7 @@ diff --git a/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h b/bundle/LuaJIT-2.1-
 index d4c542557..9161c9582 100644
 --- a/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h
 +++ b/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h
-@@ -113,6 +113,17 @@ static int emit_checkofs(A64Ins ai, int64_t ofs)
+@@ -121,6 +121,17 @@ static int emit_checkofs(A64Ins ai, int64_t ofs)
    }
  }
  
@@ -30,7 +30,7 @@ index d4c542557..9161c9582 100644
  static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
  {
    int ot = emit_checkofs(ai, ofs), sc = (ai >> 30) & 3;
-@@ -124,11 +135,9 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
+@@ -132,11 +143,9 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
      uint32_t prev = *as->mcp & ~A64F_D(31);
      int ofsm = ofs - (1<<sc), ofsp = ofs + (1<<sc);
      A64Ins aip;


### PR DESCRIPTION
### Summary

Without this I get:
```
Hunk #1 succeeded at 121 (offset 8 lines).
Hunk #2 succeeded at 143 (offset 8 lines).
```

When applying the `ldp_stp_fusion` patch.