### PR TITLE
feat(conf): inject nginx directives into kong's proxy location block

### DIFF
--- a/changelog/unreleased/kong/inject-nginx-directives-location.yml
+++ b/changelog/unreleased/kong/inject-nginx-directives-location.yml
@@ -1,0 +1,3 @@
+message: Allow to inject Nginx directives into Kong's proxy location block
+type: feature
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1069,6 +1069,8 @@
 # - `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.
 # - `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy
 #   `server {}` block.
+# - `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`
+#    location block (nested under Kong's proxy server {} block).
 # - `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy
 #   `upstream {}` block.
 # - `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -198,6 +198,11 @@ local DYNAMIC_KEY_NAMESPACES = {
     ignore = EMPTY,
   },
   {
+    injected_conf_name = "nginx_location_directives",
+    prefix = "nginx_location_",
+    ignore = EMPTY,
+  },
+  {
     injected_conf_name = "nginx_status_directives",
     prefix = "nginx_status_",
     ignore = EMPTY,

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -157,6 +157,11 @@ server {
         proxy_buffering          on;
         proxy_request_buffering  on;
 
+        # injected nginx_location_* directives
+> for _, el in ipairs(nginx_location_directives) do
+        $(el.name) $(el.value);
+> end
+
         proxy_set_header      TE                 $upstream_te;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -611,6 +611,14 @@ describe("NGINX conf compiler", function()
         assert.matches("large_client_header_buffers%s+16 24k;", nginx_conf)
       end)
 
+      it("injects nginx_location_* directives", function()
+        local conf = assert(conf_loader(nil, {
+          nginx_location_proxy_ignore_headers = "X-Accel-Redirect",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("proxy_ignore_headers%sX%-Accel%-Redirect;", nginx_conf)
+      end)
+
       it("injects nginx_admin_* directives", function()
         local conf = assert(conf_loader(nil, {
           nginx_admin_large_client_header_buffers = "4 24k",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The injection of Nginx directives [is currently supported](https://docs.konghq.com/gateway/latest/reference/nginx-directives/#injecting-individual-nginx-directives) in the `http` and `server` contexts, but not in the `location` context.

To inject Nginx directives into the `location` context, it is required to create and maintain a custom Nginx template, as detailed in [this document](https://docs.konghq.com/gateway/latest/reference/nginx-directives/#custom-nginx-templates).

The goal is to enable injection of Nginx location directives into the Kong Gateway’s proxy block, following the same pattern used for `http` and `server` contexts, without the need of a custom Nginx template.

This would streamline the process and maintain consistency across different Kong Gateway’s proxy contexts.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add `nginx_location_*`. The new prefix allows for the dynamic injection of Nginx directives into the `/` location block within Kong's proxy `server {}` block.



### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
