### PR TITLE
fix(build):add openresty/lualib into rpath

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -53,10 +53,15 @@ genrule(
     """.format(luajit_version = LUAJIT_VERSION),
 )
 
+rpath_flags = "-Wl,-rpath,%s/kong/lib -Wl,-rpath,%s/openresty/lualib" % (
+    KONG_VAR["INSTALL_DESTDIR"],
+    KONG_VAR["INSTALL_DESTDIR"],
+)
+
 make(
     name = "luajit",
     args = [
-        "LDFLAGS=\"-Wl,-rpath,%s/kong/lib\"" % KONG_VAR["INSTALL_DESTDIR"],  # make ffi.load happy, even when it's invoked without nginx
+        "LDFLAGS=\"%s\"" % rpath_flags,  # make ffi.load happy, even when it's invoked without nginx
         "XCFLAGS=\"$(cat $$EXT_BUILD_ROOT$$/$(execpath :luajit_xcflags))\"",
         "LUA_ROOT=%s/openresty/luajit" % KONG_VAR["INSTALL_DESTDIR"].rstrip("/"),
         "MACOSX_DEPLOYMENT_TARGET=" + KONG_VAR["MACOSX_DEPLOYMENT_TARGET"],
@@ -140,12 +145,12 @@ CONFIGURE_OPTIONS = [
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/pcre/lib\"",
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/openssl/lib\"",
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/luajit/lib\"",
-    # here let's try not having --disable-new-dtags; --disable-new-dtags creates runpath instead of rpath
-    # note runpath can't handle indirect dependency (nginx -> luajit -> dlopen("other")), so each indirect
+    # Here let's try not having --disable-new-dtags; --disable-new-dtags creates rpath instead of runpath
+    # note rpath can't handle indirect dependency (nginx -> luajit -> dlopen("other")), so each indirect
     # dependency should have its rpath set (luajit, libxslt etc); on the other side, rpath is not
-    # overridable by LD_LIBRARY_PATH and it may cause trouble debugging, so we _should_ prefer runpath.
-    # if it doesn't work, then add --disable-new-dtags back
-    "--with-ld-opt=\"-Wl,-rpath,%s/kong/lib\"" % KONG_VAR["INSTALL_DESTDIR"],
+    # overridable by LD_LIBRARY_PATH and it may cause trouble debugging, so we _should_ prefer runpath
+    # whenever available.
+    "--with-ld-opt=\"%s\"" % rpath_flags,
     "-j%s" % KONG_VAR["NPROC"],
 
     # options from our customed patch

--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -23,7 +23,7 @@ def transform(f: FileInfo):
         # otherwise remain unmodified
 
     if f.path.endswith("/modules/ngx_wasm_module.so"):
-        expected_rpath = "/usr/local/openresty/luajit/lib:/usr/local/kong/lib"
+        expected_rpath = "/usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib"
         if f.rpath and expected_rpath in f.rpath:
             f.rpath = expected_rpath
         elif f.runpath and expected_rpath in f.runpath:

--- a/scripts/explain_manifest/fixtures/alpine-amd64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-amd64.txt
@@ -133,7 +133,7 @@
   - libcrypto.so.1.1
   - libz.so.1
   - libc.so
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/alpine-arm64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-arm64.txt
@@ -133,7 +133,7 @@
   - libcrypto.so.1.1
   - libz.so.1
   - libc.so
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -182,7 +182,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -195,7 +195,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
@@ -170,7 +170,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -181,7 +181,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
@@ -152,7 +152,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-aarch64.so.1
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -163,7 +163,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/debian-10-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-10-amd64.txt
@@ -182,7 +182,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -195,7 +195,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/debian-11-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-11-amd64.txt
@@ -171,7 +171,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -183,7 +183,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -182,7 +182,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -195,7 +195,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -181,7 +181,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -194,7 +194,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/el9-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el9-amd64.txt
@@ -170,7 +170,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -181,7 +181,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/el9-arm64.txt
+++ b/scripts/explain_manifest/fixtures/el9-arm64.txt
@@ -152,7 +152,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-aarch64.so.1
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -163,7 +163,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Rpath     : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -175,7 +175,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -187,7 +187,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -164,7 +164,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-x86-64.so.2
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -174,7 +174,7 @@
   - libcrypto.so.3
   - libz.so.1
   - libc.so.6
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -161,7 +161,7 @@
   - libgcc_s.so.1
   - libc.so.6
   - ld-linux-aarch64.so.1
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
 
 - Path      : /usr/local/openresty/nginx/sbin/nginx
   Needed    :
@@ -172,7 +172,7 @@
   - libz.so.1
   - libc.so.6
   - ld-linux-aarch64.so.1
-  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
   Modules   :
   - lua-kong-nginx-module
   - lua-kong-nginx-module/stream

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -23,7 +23,7 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False):
 
     # binary correctness
     expect("/usr/local/openresty/nginx/sbin/nginx", "nginx rpath should contain kong lib") \
-        .rpath.equals("/usr/local/openresty/luajit/lib:/usr/local/kong/lib")
+        .rpath.equals("/usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib")
 
     expect("/usr/local/openresty/nginx/sbin/nginx", "nginx binary should contain dwarf info for dynatrace") \
         .has_dwarf_info.equals(True) \


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix an issue that resty.signal fails to find librestysignal.so and fails to parse certain LUA_CPATH.

### Checklist

- [x] The Pull Request has tests
- [na] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

fix(build):add openresty/lualib into rpath

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
From https://github.com/Kong/kong/pull/11382
