### PR TITLE
chore(helpers): do not display debug log when test errors with status code 500

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2402,9 +2402,17 @@ local function res_status(state, args)
         return false -- no err logs to read in this prefix
       end
 
-      local str_t = pl_stringx.splitlines(str)
+      local lines_t = pl_stringx.splitlines(str)
+      local str_t = {}
+      -- filter out debugs as they are not usually useful in this context
+      for i = 1, #lines_t do
+        if not lines_t[i]:match(" %[debug%] ") then
+          table.insert(str_t, lines_t[i])
+        end
+      end
+
       local first_line = #str_t - math.min(60, #str_t) + 1
-      local msg_t = {"\nError logs (" .. conf.nginx_err_logs .. "):"}
+      local msg_t = {"\nError logs (" .. conf.nginx_err_logs .. "), only last 60 non-debug logs are displayed:"}
       for i = first_line, #str_t do
         msg_t[#msg_t+1] = str_t[i]
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Filter out debug log lines as they are not usually useful for 500 errors.

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
