### PR TITLE
chore(patches): fix incorrect LuaJIT register allocation for IR_*LOAD on ARM64

### DIFF
--- a/CHANGELOG/unreleased/kong/11638.yaml
+++ b/CHANGELOG/unreleased/kong/11638.yaml
@@ -1,0 +1,7 @@
+message: "Fix incorrect LuaJIT register allocation for IR_*LOAD on ARM64"
+type: dependency
+scope: Core
+prs:
+  - 11638
+jiras:
+  - "KAG-2634"

--- a/build/openresty/patches/LuaJIT-2.1-20230410_06_arm64_reg_alloc_fix.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20230410_06_arm64_reg_alloc_fix.patch
@@ -1,0 +1,32 @@
+From 7ff8f26eb852953778736cf244b2884e339d80aa Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Tue, 29 Aug 2023 22:35:10 +0200
+Subject: [PATCH] ARM64: Fix register allocation for IR_*LOAD.
+
+Thanks to Peter Cawley. #1062
+---
+ src/lj_asm_arm64.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/bundle/LuaJIT-2.1-20230410/src/lj_asm_arm64.h b/bundle/LuaJIT-2.1-20230410/src/lj_asm_arm64.h
+index 3889883d..c216fced 100644
+--- a/bundle/LuaJIT-2.1-20230410/src/lj_asm_arm64.h
++++ b/bundle/LuaJIT-2.1-20230410/src/lj_asm_arm64.h
+@@ -1107,6 +1107,8 @@ static void asm_ahuvload(ASMState *as, IRIns *ir)
+   }
+   type = ra_scratch(as, rset_clear(gpr, tmp));
+   idx = asm_fuseahuref(as, ir->op1, &ofs, rset_clear(gpr, type), A64I_LDRx);
++  rset_clear(gpr, idx);
++  if (ofs & FUSE_REG) rset_clear(gpr, ofs & 31);
+   if (ir->o == IR_VLOAD) ofs += 8 * ir->op2;
+   /* Always do the type check, even if the load result is unused. */
+   asm_guardcc(as, irt_isnum(ir->t) ? CC_LS : CC_NE);
+@@ -1114,7 +1116,7 @@ static void asm_ahuvload(ASMState *as, IRIns *ir)
+     lj_assertA(irt_isinteger(ir->t) || irt_isnum(ir->t),
+ 	       "bad load type %d", irt_type(ir->t));
+     emit_nm(as, A64I_CMPx | A64F_SH(A64SH_LSR, 32),
+-	    ra_allock(as, LJ_TISNUM << 15, rset_exclude(gpr, idx)), tmp);
++	    ra_allock(as, LJ_TISNUM << 15, gpr), tmp);
+   } else if (irt_isaddr(ir->t)) {
+     emit_n(as, (A64I_CMNx^A64I_K12) | A64F_U12(-irt_toitype(ir->t)), type);
+     emit_dn(as, A64I_ASRx | A64F_IMMR(47), type, tmp);


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
-  A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-2473]_


[KAG-2473]: https://konghq.atlassian.net/browse/KAG-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ