### PR TITLE
chore(patches): apply the LuaJIT ARM64 LDP/STP fix for unaligned accesses.

### DIFF
--- a/CHANGELOG/unreleased/kong/11639.yaml
+++ b/CHANGELOG/unreleased/kong/11639.yaml
@@ -1,0 +1,7 @@
+message: "Fix LDP/STP fusing for unaligned accesses on ARM64"
+type: dependency
+scope: Core
+prs:
+  - 11639
+jiras:
+  - "KAG-2634"

--- a/build/openresty/patches/LuaJIT-2.1-20230410_07_ldp_stp_unaligned.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20230410_07_ldp_stp_unaligned.patch
@@ -1,0 +1,23 @@
+From 0fa2f1cbcf023ad0549f1428809e506fa2c78552 Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Mon, 28 Aug 2023 22:33:54 +0200
+Subject: [PATCH] ARM64: Fix LDP/STP fusing for unaligned accesses.
+
+Thanks to Peter Cawley. #1056
+---
+ src/lj_emit_arm64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h b/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h
+index 52d010b8..6926c71a 100644
+--- a/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h
++++ b/bundle/LuaJIT-2.1-20230410/src/lj_emit_arm64.h
+@@ -151,7 +151,7 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
+     } else {
+       goto nopair;
+     }
+-    if (ofsm >= (int)((unsigned int)-64<<sc) && ofsm <= (63<<sc)) {
++    if (lj_ror((unsigned int)ofsm + (64u<<sc), sc) <= 127u) {
+       *as->mcp = aip | A64F_N(rn) | (((ofsm >> sc)&0x7f) << 15) |
+ 	(ai ^ ((ai == A64I_LDRx || ai == A64I_STRx) ? 0x50000000 : 0x90000000));
+       return;


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
