### PR TITLE
fix(test): change test to not depend on server to be present

### DIFF
--- a/spec/02-integration/16-queues/01-shutdown_spec.lua
+++ b/spec/02-integration/16-queues/01-shutdown_spec.lua
@@ -55,7 +55,7 @@ for _, strategy in helpers.each_strategy() do
         route = { id = route2.id },
         name     = "http-log",
         config   = {
-          http_endpoint = "http://konghq.com:80",
+          http_endpoint = "http://this-does-not-exist.example.com:80/this-does-not-exist",
           queue = {
             max_batch_size = 10,
             max_coalescing_delay = 10,
@@ -122,7 +122,7 @@ for _, strategy in helpers.each_strategy() do
       local res, err = helpers.stop_kong(nil, true, nil, "QUIT")
       assert(res, err)
 
-      assert.logfile().has.line("handler could not process entries: request to konghq.com:80 returned status code")
+      assert.logfile().has.line("DNS resolution failed: dns server error: 3 name error.")
     end)
   end)
 end


### PR DESCRIPTION
### Summary

Instead of testing whether a certain server responded, test whether the provided name could not be resolved by the DNS client.  This is closer to what the test actually tries to verify anyway

### Checklist

- [X] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2615