### PR TITLE
fix(upgrade-tests): redirect stdout of docker pull in upgrade tests

### DIFF
--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -26,7 +26,7 @@ trap "echo exiting because of error" 0
 function get_current_version() {
     local image_tag=$1
     local version_from_rockspec=$(perl -ne 'print "$1\n" if (/^\s*tag = "(.*)"/)' kong*.rockspec)
-    if docker pull $image_tag:$version_from_rockspec 2>/dev/null
+    if docker pull $image_tag:$version_from_rockspec >/dev/null 2>/dev/null
     then
         echo $version_from_rockspec-ubuntu
     else


### PR DESCRIPTION
### Summary

It seems that `docker pull` started to print to stdout in a recent base image upgrade.  This PR redirects its stdout to `/dev/null` so that the migration tests pass again.

### Checklist

- [X] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

