### PR TITLE
fix(ci): disable -x flag when running upgrade tests

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -18,6 +18,7 @@ on:
     - master
     - release/*
     - test-please/*
+  workflow_dispatch:
 # cancel previous runs if new commits are pushed to the PR, but run for each commit on master
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -50,4 +51,4 @@ jobs:
 
       - name: Run upgrade tests
         run: |
-          bash -x ./scripts/upgrade-tests/test-upgrade-path.sh
+          bash ./scripts/upgrade-tests/test-upgrade-path.sh


### PR DESCRIPTION
### Summary

It seems that the -x flag triggered an issue in the upgrade test script, but it is not entirely clear how only the release/3.3.x branch was affected.  Disable -x for now to make sure that we're not seeing the problem in other branches

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
