### PR TITLE
chore(ci): automatically label community PRs with author/community

### DIFF
--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -19,14 +19,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.COMMUNITY_PRS_TOKEN }}
           LABEL: "author/community"
-          BOTS: "team-gateway-bot dependabot"
+          BOTS: "team-gateway-bot app/dependabot"
         run: |
           set +e
           for id in `gh pr list -S 'draft:false' -s 'open'|awk '{print $1}'`
           do
             name=`gh pr view $id --json author -q '.author.login'`
-            gh api orgs/Kong/members --paginate -q '.[].login'|grep -q "^${name}$"
-            if [[ $? -ne 0 && ! "${BOTS[@]}" =~ $name ]]; then
+            ret=`gh api orgs/Kong/members --paginate -q '.[].login'|grep "^${name}$"`
+            if [[ -z $ret && ! "${BOTS[@]}" =~ $name ]]; then
               gh pr edit $id --add-label "${{ env.LABEL }}"
             else
               gh pr edit $id --remove-label "${{ env.LABEL }}"


### PR DESCRIPTION
Remove label from PRs that created by organization members and bots

[KAG-2562](https://konghq.atlassian.net/browse/KAG-2562)

[KAG-2562]: https://konghq.atlassian.net/browse/KAG-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ