### PR TITLE
chore(ci): automatically stale and close issue/pr

### DIFF
--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -17,9 +17,20 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is marked as stale because it has been open for 14 days with no activity."
           close-issue-message: |
-            **This issue is being closed automatically because of lack of activity for 21 days(3 weeks).**
-            We're sorry if your issue is not solved. We apperciate your contribution to the community. Please referer to [our pledge to community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md).
-            Feel free to reopen the issue if you still want to update/get updated.
+            Dear contributor,
+            
+            We are automatically closing this issue because it has not seen any activity for three weeks.
+            We're sorry that your issue could not be resolved.  If any new information comes up that could
+            help resolving it, please feel free to reopen it.
+            
+            Your contribution is greatly appreciated!
+            
+            Please have a look
+            [our pledge to the community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md)
+            for more information.
+            
+            Sincerely,
+            Your Kong Gateway team
           stale-pr-message: "This PR is marked as stale because it has been open for 14 days with no activity."
           close-pr-message: |
             **This PR is being closed automatically because of lack of activity for 21 days(3 weeks).**

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -33,7 +33,18 @@ jobs:
             Your Kong Gateway team
           stale-pr-message: "This PR is marked as stale because it has been open for 14 days with no activity."
           close-pr-message: |
-            **This PR is being closed automatically because of lack of activity for 21 days(3 weeks).**
-            We're sorry for we can not merge your PR. We apperciate your contribution to the community. Please referer to [our pledge to community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md).
-            Feel free to reopen the PR if you still want to maintain the PR.
+            Dear contributor,
+            
+            We are automatically closing this pull request because it has not seen any activity for three weeks.
+            We're sorry that we could not merge it.  If you still want to pursure your patch, please feel free to 
+            reopen it and address any remaining issues.
+            
+            Your contribution is greatly appreciated!
+            
+            Please have a look
+            [our pledge to the community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md)
+            for more information.
+            
+            Sincerely,
+            Your Kong Gateway team
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -1,0 +1,28 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is marked as stale because it has been open for 14 days with no activity."
+          close-issue-message: |
+            **This issue is being closed automatically because of lack of activity for 21 days(3 weeks).**
+            We're sorry if your issue is not solved. We apperciate your contribution to the community. Please referer to [our pledge to community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md).
+            Feel free to reopen the issue if you still want to update/get updated.
+          stale-pr-message: "This PR is marked as stale because it has been open for 14 days with no activity."
+          close-pr-message: |
+            **This PR is being closed automatically because of lack of activity for 21 days(3 weeks).**
+            We're sorry for we can not merge your PR. We apperciate your contribution to the community. Please referer to [our pledge to community](https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md).
+            Feel free to reopen the PR if you still want to maintain the PR.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

We decided to close old tickets for the repo. This workflow will automatically label PRs/issues as stale for 14 days of inactivity, and close after another 7 days.
