### PR TITLE
chore(tests): remove unwanted license headers

### DIFF
--- a/spec/02-integration/03-db/18-keys_spec.lua
+++ b/spec/02-integration/03-db/18-keys_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local merge = kong.table.merge

--- a/spec/02-integration/03-db/19-key-sets_spec.lua
+++ b/spec/02-integration/03-db/19-key-sets_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local merge = kong.table.merge
 local cjson = require "cjson"

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local merge = kong.table.merge

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local typedefs = require "kong.db.schema.typedefs"
 
 return {


### PR DESCRIPTION
Summary
Removes license headers as they must not be in kong-oss.

Closes: https://github.com/Kong/kong/issues/11661
Fix: https://konghq.atlassian.net/browse/KAG-2666