### PR TITLE
refactor(runloop): use utils.get_updated_monotonic_ms()

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -611,7 +611,6 @@ local reconfigure_handler
 do
   local get_monotonic_ms = utils.get_updated_monotonic_ms
 
-  local update_time = ngx.update_time
   local ngx_worker_id = ngx.worker.id
   local exiting = ngx.worker.exiting
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -609,7 +609,7 @@ end
 
 local reconfigure_handler
 do
-  local cur_msec = require("resty.core.time").monotonic_msec
+  local get_monotonic_ms = utils.get_updated_monotonic_ms
 
   local update_time = ngx.update_time
   local ngx_worker_id = ngx.worker.id
@@ -621,11 +621,6 @@ do
   local CURRENT_ROUTER_HASH   = 0
   local CURRENT_PLUGINS_HASH  = 0
   local CURRENT_BALANCER_HASH = 0
-
-  local function get_monotonic_ms()
-    update_time()
-    return cur_msec()
-  end
 
   reconfigure_handler = function(data)
     local worker_id = ngx_worker_id()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In PR #11627 we introduced a new function `get_updated_monotonic_ms()` in `tools.utils`,
so we can replace the same implementation in `runloop.handler`.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
