### PR TITLE
perf(clustering): no flattening on data plane 

### DIFF
--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -100,6 +100,8 @@ build = {
     ["kong.resty.mlcache"] = "kong/resty/mlcache/init.lua",
     ["kong.resty.mlcache.ipc"] = "kong/resty/mlcache/ipc.lua",
 
+    ["kong.resty.lmdb.reset-transaction"] = "kong/resty/lmdb/reset-transaction.lua",
+
     ["kong.cmd"] = "kong/cmd/init.lua",
     ["kong.cmd.roar"] = "kong/cmd/roar.lua",
     ["kong.cmd.stop"] = "kong/cmd/stop.lua",

--- a/kong/clustering/config_helper.lua
+++ b/kong/clustering/config_helper.lua
@@ -1,19 +1,28 @@
-local constants = require("kong.constants")
+local txn = require("kong.resty.lmdb.reset-transaction")
 local declarative = require("kong.db.declarative")
 local tablepool = require("tablepool")
-local isempty = require("table.isempty")
 local isarray = require("table.isarray")
 local nkeys = require("table.nkeys")
 local buffer = require("string.buffer")
+local isempty = require("table.isempty")
+local constants = require("kong.constants")
 
 
+local marshall = require("kong.db.declarative.marshaller").marshall
+local pk_string = require("kong.db.schema.others.declarative_config").pk_string
+local get_topologically_sorted_schema_names = require("kong.db.declarative.export").get_topologically_sorted_schema_names
+local declarative_reconfigure_notify = require("kong.runloop.events").declarative_reconfigure_notify
+
+
+local next = next
 local tostring = tostring
+local ipairs = ipairs
 local assert = assert
 local type = type
 local error = error
 local pairs = pairs
-local ipairs = ipairs
 local sort = table.sort
+local insert = table.insert
 local yield = require("kong.tools.utils").yield
 local fetch_table = tablepool.fetch
 local release_table = tablepool.release
@@ -28,11 +37,18 @@ local ngx_md5_bin = ngx.md5_bin
 local ngx_DEBUG = ngx.DEBUG
 
 
+local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+
+
 local _log_prefix = "[clustering] "
 
 
 local _M = {}
+
+
+local UNIQUES = {}
+local FOREIGNS = {}
 
 
 local function to_sorted_string(value, o)
@@ -187,61 +203,256 @@ local function calculate_config_hash(config_table)
   }
 end
 
-local hash_fields = {
-    "config",
-    "routes",
-    "services",
-    "plugins",
-    "upstreams",
-    "targets",
-  }
 
-local function fill_empty_hashes(hashes)
-  for _, field_name in ipairs(hash_fields) do
-    hashes[field_name] = hashes[field_name] or DECLARATIVE_EMPTY_CONFIG_HASH
+local function get_reconfigure_data(hashes, default_ws)
+  local router_hash   = DECLARATIVE_EMPTY_CONFIG_HASH
+  local plugins_hash  = DECLARATIVE_EMPTY_CONFIG_HASH
+  local balancer_hash = DECLARATIVE_EMPTY_CONFIG_HASH
+  if hashes then
+    local routes_hash   = hashes.routes   or DECLARATIVE_EMPTY_CONFIG_HASH
+    local services_hash = hashes.services or DECLARATIVE_EMPTY_CONFIG_HASH
+    if routes_hash ~= DECLARATIVE_EMPTY_CONFIG_HASH then
+      router_hash = ngx_md5(services_hash .. routes_hash)
+    end
+
+    if hashes.plugins then
+      plugins_hash = hashes.plugins
+    end
+
+    local upstreams_hash = hashes.upstreams or DECLARATIVE_EMPTY_CONFIG_HASH
+    local targets_hash   = hashes.targets   or DECLARATIVE_EMPTY_CONFIG_HASH
+    if upstreams_hash ~= DECLARATIVE_EMPTY_CONFIG_HASH
+            or targets_hash   ~= DECLARATIVE_EMPTY_CONFIG_HASH
+    then
+      balancer_hash = ngx_md5(upstreams_hash .. targets_hash)
+    end
+  end
+
+  return {
+    default_ws,
+    router_hash,
+    plugins_hash,
+    balancer_hash,
+  }
+end
+
+
+local function get_uniques(name)
+  if UNIQUES[name] then
+    return UNIQUES[name]
+  end
+
+  local daos = kong.db.daos
+  local dao = assert(daos[name], "unknown entity: " .. name)
+  local schema = dao.schema
+
+  local uniques = {}
+  for fname, fdata in schema:each_field() do
+    if fdata.unique then
+      if fdata.type == "foreign" then
+        if #daos[fdata.reference].schema.primary_key == 1 then
+          insert(uniques, fname)
+        end
+
+      else
+        insert(uniques, fname)
+      end
+    end
+  end
+  UNIQUES[name] = uniques
+  return uniques
+end
+
+
+local function get_foreigns(name)
+  if FOREIGNS[name] then
+    return FOREIGNS[name]
+  end
+
+  local daos = kong.db.daos
+  local dao = assert(daos[name], "unknown entity: " .. name)
+  local schema = dao.schema
+
+  local foreigns = {}
+  for fname, fdata in schema:each_field() do
+    if fdata.type == "foreign" then
+      foreigns[fname] = fdata.reference
+    end
+  end
+  FOREIGNS[name] = foreigns
+  return foreigns
+end
+
+
+local function validate_entity(schema, entity)
+  local ws_id
+  if schema.workspaceable then
+    ws_id = entity.ws_id
+    entity.ws_id = nil
+  end
+  local ok, errors = schema:validate_insert(entity)
+  if not ok then
+    local err_t = kong.db.errors:schema_violation(errors)
+    error(tostring(err_t))
+  end
+  if ws_id and ws_id ~= ngx_null then
+    entity.ws_id = ws_id
   end
 end
 
-function _M.update(declarative_config, config_table, config_hash, hashes)
+
+local function import(config_table, config_hash, default_ws)
+  local daos = kong.db.daos
+  local t = txn.begin()
+
+  local tags = {}
+  local tags_by_name = {}
+
+  for _, name in ipairs(get_topologically_sorted_schema_names(false)) do
+    local entities = config_table[name]
+    if not entities then
+      goto continue
+    end
+
+    local dao = assert(daos[name], "unknown entity: " .. name)
+    local schema = dao.schema
+    local global_key = schema.workspaceable and "*" or ""
+
+    local keys_by_ws = { [global_key] = {} }
+    local page_for = {}
+    local taggings = {}
+
+    for _, entity in ipairs(entities) do
+      validate_entity(schema, entity)
+      local id = pk_string(schema, entity)
+      local ws_id
+      if schema.workspaceable then
+        if not entity.ws_id or entity.ws_id == ngx_null then
+          entity.ws_id = default_ws
+        end
+        ws_id = entity.ws_id
+      end
+      local ws = ws_id or ""
+      local cache_key = dao:cache_key(id, nil, nil, nil, nil, ws_id)
+      local entity_marshalled = assert(marshall(entity))
+      t:set(cache_key, entity_marshalled)
+      t:set(dao:cache_key(id, nil, nil, nil, nil, "*"), entity_marshalled)
+      if schema.cache_key then
+        t:set(dao:cache_key(entity), entity_marshalled)
+      end
+
+      insert(keys_by_ws[global_key], cache_key)
+      if ws_id then
+        keys_by_ws[ws_id] = keys_by_ws[ws_id] or {}
+        insert(keys_by_ws[ws_id], cache_key)
+      end
+
+      for _, unique in ipairs(get_uniques(name)) do
+        local unique_key = entity[unique]
+        if unique_key and unique_key ~= ngx_null then
+          if type(unique_key) == "table" then
+            -- this assumes that foreign keys are not composite
+            _, unique_key = next(unique_key)
+          end
+          t:set(name .. "|" .. (schema.fields[unique].unique_across_ws and "" or ws)
+                  .. "|" .. unique .. ":" .. unique_key, entity_marshalled)
+        end
+      end
+
+      for fname, ref in pairs(get_foreigns(name)) do
+        local entity_fname = entity[fname]
+        if entity_fname and entity_fname ~= ngx_null then
+          local fid = pk_string(daos[ref].schema, entity_fname)
+
+          -- insert paged search entry for global query
+          page_for[ref] = page_for[ref] or {}
+          page_for[ref]["*"] = page_for[ref]["*"] or {}
+          page_for[ref]["*"][fid] = page_for[ref]["*"][fid] or {}
+          insert(page_for[ref]["*"][fid], cache_key)
+
+          -- insert paged search entry for workspaced query
+          page_for[ref][ws] = page_for[ref][ws] or {}
+          page_for[ref][ws][fid] = page_for[ref][ws][fid] or {}
+          insert(page_for[ref][ws][fid], cache_key)
+        end
+      end
+
+      local entity_tags = entity.tags
+      if entity_tags and entity.tags ~= ngx_null then
+        for _, tag in ipairs(entity_tags) do
+          insert(tags, tag .. "|" .. name .. "|" .. id)
+          tags_by_name[tag] = tags_by_name[tag] or {}
+          insert(tags_by_name[tag], tag .. "|" .. name .. "|" .. id)
+          taggings[tag] = taggings[tag] or {}
+          taggings[tag][ws] = taggings[tag][ws] or {}
+          taggings[tag][ws][cache_key] = true
+        end
+      end
+    end
+
+    for ws_id, keys in pairs(keys_by_ws) do
+      local entity_prefix = name .. "|" .. ws_id
+      t:set(entity_prefix .. "|@list", assert(marshall(keys)))
+      for ref, workspaces in pairs(page_for) do
+        if workspaces[ws_id] then
+          for fid, entries in pairs(workspaces[ws_id]) do
+            t:set(entity_prefix .. "|" .. ref .. "|" .. fid .. "|@list", assert(marshall(entries)))
+          end
+        end
+      end
+    end
+
+    for tag_name, workspaces_dict in pairs(taggings) do
+      for ws_id, keys_dict in pairs(workspaces_dict) do
+        local arr, len = {}, 0
+        for id in pairs(keys_dict) do
+          len = len + 1
+          arr[len] = id
+        end
+        sort(arr)
+        t:set("taggings:" .. tag_name .. "|" .. name .. "|" .. ws_id .. "|@list", assert(marshall(arr)))
+      end
+    end
+
+    ::continue::
+  end
+
+  for tag, tags in pairs(tags_by_name) do
+    t:set("tags:" .. tag .. "|@list", assert(marshall(tags)))
+  end
+  t:set("tags||@list", assert(marshall(tags)))
+  t:set(DECLARATIVE_HASH_KEY, config_hash)
+
+  return t:commit()
+end
+
+
+local function find_default_ws(config_table)
+  for _, ws in ipairs(config_table.workspaces) do
+    if ws.name == "default" then
+      return ws.id
+    end
+  end
+end
+
+
+function _M.update(config_table, config_hash, hashes)
   assert(type(config_table) == "table")
-
-  if not config_hash then
-    config_hash, hashes = calculate_config_hash(config_table)
-  end
-
-  if hashes then
-    fill_empty_hashes(hashes)
-  end
 
   local current_hash = declarative.get_current_hash()
   if current_hash == config_hash then
-    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
-      "no need to reload")
+    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, no need to reload")
     return true
   end
 
-  local entities, err, _, meta, new_hash =
-  declarative_config:parse_table(config_table, config_hash)
-  if not entities then
-    return nil, "bad config received from control plane " .. err
-  end
+  local default_ws = assert(find_default_ws(config_table))
 
-  if current_hash == new_hash then
-    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
-      "no need to reload")
-    return true
-  end
-
-  -- NOTE: no worker mutex needed as this code can only be
-  -- executed by worker 0
-
-  local res
-  res, err = declarative.load_into_cache_with_events(entities, meta, new_hash, hashes)
-  if not res then
+  local ok, err = import(config_table, config_hash, default_ws)
+  if not ok then
     return nil, err
   end
 
-  return true
+  return declarative_reconfigure_notify(get_reconfigure_data(hashes, default_ws))
 end
 
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -95,18 +95,13 @@ end
 
 
 function _M:export_deflated_reconfigure_payload()
-  local config_table, err = declarative.export_config()
+  local config_table, err, plugins_configured = declarative.export()
   if not config_table then
     return nil, err
   end
 
   -- update plugins map
-  self.plugins_configured = {}
-  if config_table.plugins then
-    for _, plugin in pairs(config_table.plugins) do
-      self.plugins_configured[plugin.name] = true
-    end
-  end
+  self.plugins_configured = plugins_configured
 
   -- store serialized plugins map for troubleshooting purposes
   local shm_key_name = "clustering:cp_plugins_configured:worker_" .. worker_id()

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -1,5 +1,5 @@
 local lmdb = require("resty.lmdb")
-local txn = require("resty.lmdb.transaction")
+local txn = require("kong.resty.lmdb.reset-transaction")
 local constants = require("kong.constants")
 local workspaces = require("kong.workspaces")
 local utils = require("kong.tools.utils")
@@ -181,8 +181,7 @@ local function load_into_cache(entities, meta, hash)
 
   local db = kong.db
 
-  local t = txn.begin(128)
-  t:db_drop(false)
+  local t = txn.begin()
 
   local phase = get_phase()
   local transform = meta._transform == nil and true or meta._transform

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -244,6 +244,7 @@ end
 _M.to_yaml_string              = declarative_export.to_yaml_string
 _M.to_yaml_file                = declarative_export.to_yaml_file
 _M.export_from_db              = declarative_export.export_from_db
+_M.export                      = declarative_export.export
 _M.export_config               = declarative_export.export_config
 _M.export_config_proto         = declarative_export.export_config_proto
 _M.sanitize_output             = declarative_export.sanitize_output

--- a/kong/resty/lmdb/reset-transaction.lua
+++ b/kong/resty/lmdb/reset-transaction.lua
@@ -1,0 +1,88 @@
+local ffi = require("ffi")
+local base = require("resty.core.base")
+local sha256 = require("kong.tools.utils").sha256_bin
+local get_dbi = require("resty.lmdb.transaction").get_dbi
+
+
+local kong = kong
+local C = ffi.C
+local ffi_new = ffi.new
+local ffi_string = ffi.string
+local ffi_typeof = ffi.typeof
+
+
+local MAX_KEY_SIZE = 511 -- lmdb has 511 bytes limitation for key
+local DEFAULT_DB = "_default"
+local ERROR = ngx.ERROR
+
+
+local OPS_T = ffi_typeof("ngx_lua_resty_lmdb_operation_t[?]")
+local ERR_P = base.get_errmsg_ptr()
+
+
+local function set(self, key, value)
+  if value == nil or key == nil then
+    return
+  end
+
+  local n = self.n + 1
+  self.n = n
+  self.k[n] = key
+  self.v[n] = value
+end
+
+
+local function commit(self, db)
+  local n = self.n
+  local k = self.k
+  local v = self.v
+  local opn = n + 1
+  local ops = ffi_new(OPS_T, opn)
+
+  local dbi, err = get_dbi(true, db or DEFAULT_DB)
+  if err then
+    return nil, "unable to open DB for access: " .. err
+  elseif not dbi then
+    return nil, "DB " .. db .. " does not exist"
+  end
+
+  ops[0].opcode = C.NGX_LMDB_OP_DB_DROP
+  ops[0].dbi = dbi
+  ops[0].flags = 0
+
+  for i = 1, n do
+    local key = k[i]
+    local len = #key
+    if len > MAX_KEY_SIZE then
+      key = sha256(key)
+      len = 32
+    end
+    ops[i].opcode = C.NGX_LMDB_OP_SET
+    ops[i].key.data = key
+    ops[i].key.len = len
+    ops[i].value.data = v[i]
+    ops[i].value.len = #v[i]
+    ops[i].dbi = dbi
+    ops[i].flags = 0
+  end
+
+  local ret = C.ngx_lua_resty_lmdb_ffi_execute(ops, opn, 1, nil, 0, ERR_P)
+  if ret == ERROR then
+    return nil, ffi_string(ERR_P[0])
+  end
+
+  return true
+end
+
+
+return {
+  begin = function(hint)
+    return {
+      k = kong.table.new(hint or 10000, 0),
+      v = kong.table.new(hint or 10000, 0),
+      n = 0,
+      commit = commit,
+      set = set,
+    }
+  end
+}


### PR DESCRIPTION
### Summary

A quick unscientific test shows:

`300.000` routes and services, and adding or deleting a route (around `600.000` entities in total).

#### master:
```
1st sync: declarative import took 27819 ms
2nd sync: declarative import took 32424 ms
```

#### perf/no-flattening:
```
1st sync: declarative import took 18441 ms
2nd sync: declarative import took 21658 ms
```

So it reduces the CPU time in this massive data set by 10 secs, or close to 1/3. Non-yieldable LMDB commit is 2-3 secs on `perf/no-flattening`.

KAG-2676