### PR TITLE
docs(kong.conf): Add names of referenced caches to mem_cache_size parameter

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -721,7 +721,9 @@
 
 #mem_cache_size = 128m           # Size of each of the two shared memory caches
                                  # for traditional mode database entities
-                                 # and runtime data.
+                                 # and runtime data, `kong_core_cache` and 
+                                 # `kong_cache`.
+                                 #
                                  # The accepted units are `k` and `m`, with a minimum
                                  # recommended value of a few MBs.
                                  #


### PR DESCRIPTION
### Summary

The `mem_cache_size` parameter in kong.conf mentions that it controls the size of two caches, but doesn't say what the names of the caches are.
According to our [changelog](https://github.com/Kong/kong/blob/master/CHANGELOG-OLD.md#core-32), these two in-memory caches are `kong_core_cache` and `kong_cache`.

Resolves doc ticket https://konghq.atlassian.net/browse/DOCU-1878.

### Checklist

- [ N/A ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com: https://github.com/Kong/docs.konghq.com/pull/6206

### Full changelog

N/A

### Issue reference
N/A
