### PR TITLE
fix(hybrid): opentelemetry and zipkin header_type

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,6 +23,74 @@ end
 
 
 local compatible_checkers = {
+  { 3005000000, --[[ 3.5.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local has_update
+
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'opentelemetry' or plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.header_type == 'gcp' then
+            config.header_type = 'preserve'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' header_type == gcp',
+                             'overwritten with default value `preserve`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.default_header_type == 'gcp' then
+            config.default_header_type = 'b3'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' default_header_type == gcp',
+                             'overwritten with default value `b3`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+      end
+
+      return has_update
+    end,
+  },
+
+  { 3004000000, --[[ 3.4.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local has_update
+
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'opentelemetry' or plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.header_type == 'aws' then
+            config.header_type = 'preserve'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' header_type == aws',
+                             'overwritten with default value `preserve`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.default_header_type == 'aws' then
+            config.default_header_type = 'b3'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' default_header_type == aws',
+                             'overwritten with default value `b3`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+      end
+
+      return has_update
+    end,
+  },
+
   { 3003000000, --[[ 3.3.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update


### PR DESCRIPTION
### Summary

Address compatibility for older DPs for the opentelemetry and zipkin configuration option: `header_type` and for zipkin's `default_heder_type`

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-2705
