### PR TITLE
[backport #11686 to release/3.4.x] fix(hybrid): opentelemetry and zipkin header_type

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,6 +23,40 @@ end
 
 
 local compatible_checkers = {
+  { 3004000000, --[[ 3.4.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local has_update
+
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'opentelemetry' or plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.header_type == 'aws' then
+            config.header_type = 'preserve'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' header_type == aws',
+                             'overwritten with default value `preserve`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.default_header_type == 'aws' then
+            config.default_header_type = 'b3'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' default_header_type == aws',
+                             'overwritten with default value `b3`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+      end
+
+      return has_update
+    end,
+  },
+
   { 3003000000, --[[ 3.3.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -108,7 +108,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
   end)
 
   describe("plugin config fields", function()
-    local rate_limit
+    local rate_limit, opentelemetry, zipkin
 
     lazy_setup(function()
       rate_limit = admin.plugins:insert {
@@ -178,6 +178,58 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       local plugin = get_plugin(id, "3.4.0", rate_limit.name)
       assert.same(rate_limit.config, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+    end)
+
+    describe("compatibility tests for opentelemetry plugin", function()
+      it("replaces `aws` value of `header_type` property with default `preserve`", function()
+        -- [[ 3.4.x ]] --
+        opentelemetry = admin.plugins:insert {
+          name = "opentelemetry",
+          enabled = true,
+          config = {
+            endpoint = "http://1.1.1.1:12345/v1/trace",
+            -- [[ new value 3.4.0
+            header_type = "aws"
+            -- ]]
+          }
+        }
+
+        local expected_otel_prior_34 = utils.cycle_aware_deep_copy(opentelemetry)
+        expected_otel_prior_34.config.header_type = "preserve"
+        local plugin = get_plugin(utils.uuid(), "3.3.0", expected_otel_prior_34.name)
+        assert.is_not_nil(plugin)
+        assert.same(expected_otel_prior_34.config, plugin.config)
+
+        -- cleanup
+        admin.plugins:remove({ id = opentelemetry.id })
+      end)
+
+    end)
+
+    describe("compatibility tests for zipkin plugin", function()
+      it("replaces `aws` value of `header_type` property with default `preserve`", function()
+        -- [[ 3.4.x ]] --
+        zipkin = admin.plugins:insert {
+          name = "zipkin",
+          enabled = true,
+          config = {
+            http_endpoint = "http://1.1.1.1:12345/v1/trace",
+            -- [[ new value 3.4.0
+            header_type = "aws"
+            -- ]]
+          }
+        }
+
+        local expected_zipkin_prior_34 = utils.cycle_aware_deep_copy(zipkin)
+        expected_zipkin_prior_34.config.header_type = "preserve"
+        expected_zipkin_prior_34.config.default_header_type = "b3"
+        local plugin = get_plugin(utils.uuid(), "3.3.0", expected_zipkin_prior_34.name)
+        assert.is_not_nil(plugin)
+        assert.same(expected_zipkin_prior_34.config, plugin.config)
+
+        -- cleanup
+        admin.plugins:remove({ id = zipkin.id })
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
backport of https://github.com/Kong/kong/pull/11686

### Summary

address compatibility for older DPs for the opentelemetry and zipkin configuration option: `header_type` and for zipkin's `default_heder_type`

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [] The Pull Request has backports to all the versions it needs to cover
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-2705
