### PR TITLE
chore(release): bump version numbers to 3.4.2

### DIFF
--- a/kong-3.4.2-0.rockspec
+++ b/kong-3.4.2-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong"
-version = "3.4.1-0"
+version = "3.4.2-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git+https://github.com/Kong/kong.git",
-  tag = "3.4.1"
+  tag = "3.4.2"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 3,
   minor = 4,
-  patch = 1,
+  patch = 2,
   --suffix = "-alpha.13"
 }, {
   -- our Makefile during certain releases adjusts this line. Any changes to

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -164,8 +164,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/debian-10-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-10-amd64.txt
@@ -164,8 +164,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/debian-11-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-11-amd64.txt
@@ -155,8 +155,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -164,8 +164,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -163,8 +163,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -159,8 +159,8 @@
 
 - Path      : /usr/local/openresty/nginx/modules/ngx_wasm_module.so
   Needed    :
-  - libm.so.6
   - libdl.so.2
+  - libm.so.6
   - libpthread.so.0
   - libgcc_s.so.1
   - libc.so.6


### PR DESCRIPTION
Two noticeable changes:
* Bumps the version numbers of rockspec and meta after release of 3.4.1
* Backports https://github.com/Kong/kong/pull/11465 (with modifications) to the 3.4.x branch in order to avoid errors in the manifest checks - example  https://github.com/Kong/kong/actions/runs/6391958890/job/17349006720 
