### PR TITLE
tests(request-debug): improve integration tests

### DIFF
--- a/spec/02-integration/21-request-debug/01-request-debug_spec.lua
+++ b/spec/02-integration/21-request-debug/01-request-debug_spec.lua
@@ -146,6 +146,7 @@ local function get_output_header(_deployment, path, filter, fake_ip, token)
   })
   assert.not_same(500, res.status)
   res:read_body() -- discard body
+  proxy_client:close()
 
   if not res.headers["X-Kong-Request-Debug-Output"] then
     return nil
@@ -153,7 +154,6 @@ local function get_output_header(_deployment, path, filter, fake_ip, token)
 
   local json = assert(cjson.decode(res.headers["X-Kong-Request-Debug-Output"]))
   assert.falsy(json.dangling)
-  proxy_client:close()
   return json
 end
 
@@ -184,6 +184,7 @@ local function get_output_log(deployment, path, filter, fake_ip, token)
   })
   assert.not_same(500, res.status)
   res:read_body() -- discard body
+  proxy_client:close()
 
   if not res.headers["X-Kong-Request-Debug-Output"] then
     return nil
@@ -254,8 +255,6 @@ local function get_output_log(deployment, path, filter, fake_ip, token)
   end
 
   assert.falsy(json.dangling)
-  proxy_client:close()
-
   assert.same(debug_id, json.debug_id)
 
   return json, truncated

--- a/spec/02-integration/21-request-debug/01-request-debug_spec.lua
+++ b/spec/02-integration/21-request-debug/01-request-debug_spec.lua
@@ -11,6 +11,7 @@ local TOKEN_FILE          = ".request_debug_token"
 local PLGUINS_ENABLED     = "bundled,enable-buffering-response,muti-external-http-calls"
 local TIME_TO_FIRST_BYTE  = 250  -- milliseconds
 local STREAMING           = 400  -- seconds
+local DB_INIT             = {}
 
 
 
@@ -262,10 +263,13 @@ local function start_kong(strategy, deployment, disable_req_dbg, token)
     request_debug = "off"
   end
 
-  helpers.get_db_utils(strategy, nil, {
-    "enable-buffering-response",
-    "muti-external-http-calls",
-  })
+  if not DB_INIT[strategy] then
+    helpers.get_db_utils(strategy, nil, {
+      "enable-buffering-response",
+      "muti-external-http-calls",
+    })
+    DB_INIT[strategy] = true
+  end
 
   if deployment == "traditional" then
     assert(helpers.start_kong({

--- a/spec/02-integration/21-request-debug/01-request-debug_spec.lua
+++ b/spec/02-integration/21-request-debug/01-request-debug_spec.lua
@@ -157,6 +157,18 @@ end
 
 
 local function get_output_log(deployment, path, filter, fake_ip, token)
+  local errlog
+
+  if deployment == "traditional" then
+    errlog = pl_path.join(helpers.test_conf.prefix, "logs/error.log")
+
+  else
+    assert(deployment == "hybrid", "unknown deploy mode")
+    errlog = pl_path.join(DP_PREFIX, "logs/error.log")
+  end
+
+  helpers.clean_logfile(errlog)
+
   local proxy_client = helpers.proxy_client()
   local res = assert(proxy_client:send {
     method = "GET",
@@ -194,7 +206,7 @@ local function get_output_log(deployment, path, filter, fake_ip, token)
   pcall(function()
     helpers.pwait_until(function()
       json = ""
-      local content = assert(pl_file.read(path))
+      local content = assert(pl_file.read(errlog))
       local start_idx = assert(content:find(keyword, nil, true))
       start_idx = assert(content:find("output: ", start_idx, true))
       local end_idx


### PR DESCRIPTION
### Summary

This includes several changes designed to make the request-debug test suite faster and less memory-intensive.

This test suite is occasionally triggering the OOMKiller in our Enterprise CI runs, and this changeset aims to stop the bleeding.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~

### Full changelog

* de-dupe DB initialization calls (`helpers.get_db_utils()`)
* truncate `error.log` before running tests
* search `error.log` line-by-line instead of all at once
* ensure proxy client connections are closed in all branches

### Issue reference

KAG-2710
