### PR TITLE
feat(db): allow primary key passed as full entity to DAOs

### DIFF
--- a/changelog/unreleased/kong/dao-pk-as-entity.yml
+++ b/changelog/unreleased/kong/dao-pk-as-entity.yml
@@ -1,0 +1,3 @@
+message: Allow primary key passed as a full entity to DAO functions.
+type: feature
+scope: Core

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -227,7 +227,7 @@ function _M:handle_cp_websocket()
   local purge_delay = self.conf.cluster_data_plane_purge_delay
   local update_sync_status = function()
     local ok
-    ok, err = kong.db.clustering_data_planes:upsert({ id = dp_id, }, {
+    ok, err = kong.db.clustering_data_planes:upsert({ id = dp_id }, {
       last_seen = last_seen,
       config_hash = config_hash ~= ""
                 and config_hash

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -69,7 +69,7 @@ function _Certificates:insert(cert, options)
   cert.snis = name_list or cjson.empty_array
 
   if name_list then
-    local ok, err, err_t = self.db.snis:insert_list({ id = cert.id }, name_list, options)
+    local ok, err, err_t = self.db.snis:insert_list(cert, name_list, options)
     if not ok then
       return nil, err, err_t
     end
@@ -196,7 +196,7 @@ function _Certificates:page(size, offset, options)
 
   for i=1, #certs do
     local cert = certs[i]
-    local snis, err, err_t = self.db.snis:list_for_certificate({ id = cert.id })
+    local snis, err, err_t = self.db.snis:list_for_certificate(cert)
     if not snis then
       return nil, err, err_t
     end

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -973,13 +973,14 @@ function DAO:truncate()
 end
 
 
-function DAO:select(primary_key, options)
-  validate_primary_key_type(primary_key)
+function DAO:select(pk_or_entity, options)
+  validate_primary_key_type(pk_or_entity)
 
   if options ~= nil then
     validate_options_type(options)
   end
 
+  local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
   if not ok then
     local err_t = self.errors:invalid_primary_key(errors)
@@ -1163,14 +1164,15 @@ function DAO:insert(entity, options)
 end
 
 
-function DAO:update(primary_key, entity, options)
-  validate_primary_key_type(primary_key)
+function DAO:update(pk_or_entity, entity, options)
+  validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
 
   if options ~= nil then
     validate_options_type(options)
   end
 
+  local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
   if not ok then
     local err_t = self.errors:invalid_primary_key(errors)
@@ -1215,14 +1217,15 @@ function DAO:update(primary_key, entity, options)
 end
 
 
-function DAO:upsert(primary_key, entity, options)
-  validate_primary_key_type(primary_key)
+function DAO:upsert(pk_or_entity, entity, options)
+  validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
 
   if options ~= nil then
     validate_options_type(options)
   end
 
+  local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
   if not ok then
     local err_t = self.errors:invalid_primary_key(errors)
@@ -1272,13 +1275,14 @@ function DAO:upsert(primary_key, entity, options)
 end
 
 
-function DAO:delete(primary_key, options)
-  validate_primary_key_type(primary_key)
+function DAO:delete(pk_or_entity, options)
+  validate_primary_key_type(pk_or_entity)
 
   if options ~= nil then
     validate_options_type(options)
   end
 
+  local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
   if not ok then
     local err_t = self.errors:invalid_primary_key(errors)

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -47,6 +47,7 @@ end
 -- Creates one instance of SNI for each name in name_list
 -- All created instances will be associated to the given certificate
 function _SNIs:insert_list(cert_pk, name_list)
+  cert_pk = self.db.certificates.schema:extract_pk_values(cert_pk)
   for _, name in ipairs(name_list) do
     local _, err, err_t = self:insert({
       name         = name,

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -70,7 +70,7 @@ function _TARGETS:upsert(pk, entity, options)
     if existent.target == entity.target then
       -- if the upserting entity is newer, update
       if entity.created_at > existent.created_at then
-        local ok, err, err_t = self.super.delete(self, { id = existent.id }, opts)
+        local ok, err, err_t = self.super.delete(self, existent, opts)
         if ok then
           return self.super.insert(self, entity, options)
         end

--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -192,7 +192,7 @@ local function new(self)
     end
 
     if utils.is_valid_uuid(consumer_id) then
-      local result, err = kong.db.consumers:select { id = consumer_id }
+      local result, err = kong.db.consumers:select({ id = consumer_id })
 
       if result then
         return result

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -193,9 +193,7 @@ local function save_dao(host, key, cert)
   })
 
   if err then
-    local ok, err_2 = kong.db.certificates:delete({
-      id = cert_entity.id,
-    })
+    local ok, err_2 = kong.db.certificates:delete(cert_entity)
     if not ok then
       kong.log.warn("error cleaning up certificate entity ", cert_entity.id, ": ", err_2)
     end
@@ -203,12 +201,9 @@ local function save_dao(host, key, cert)
   end
 
   if old_sni_entity and old_sni_entity.certificate then
-    local id = old_sni_entity.certificate.id
-    local ok, err = kong.db.certificates:delete({
-      id = id,
-    })
+    local ok, err = kong.db.certificates:delete(old_sni_entity.certificate)
     if not ok then
-      kong.log.warn("error deleting expired certificate entity ", id, ": ", err)
+      kong.log.warn("error deleting expired certificate entity ", old_sni_entity.certificate.id, ": ", err)
     end
   end
 end
@@ -228,7 +223,7 @@ end
 
 local function get_account_key(conf)
   local kid = conf.key_id
-  local lookup = {kid = kid}
+  local lookup = { kid = kid }
 
   if conf.key_set then
     local key_set, key_set_err = kong.db.key_sets:select_by_name(conf.key_set)
@@ -237,7 +232,7 @@ local function get_account_key(conf)
       return nil, "could not load keyset: " .. key_set_err
     end
 
-    lookup.set = {id = key_set.id}
+    lookup.set = { id = key_set.id }
   end
 
   local cache_key = kong.db.keys:cache_key(lookup)
@@ -393,7 +388,7 @@ local function load_certkey(conf, host)
     return nil, "DAO returns empty SNI entity or Certificte entity"
   end
 
-  local cert_entity, err = kong.db.certificates:select({ id = sni_entity.certificate.id })
+  local cert_entity, err = kong.db.certificates:select(sni_entity.certificate)
   if err then
     kong.log.info("can't read certificate ", sni_entity.certificate.id, " from db",
                   ", deleting renew config")

--- a/kong/plugins/acme/storage/kong.lua
+++ b/kong/plugins/acme/storage/kong.lua
@@ -55,9 +55,7 @@ function _M:delete(k)
     return
   end
 
-  local _, err = self.dao:delete({
-    id = v.id
-  })
+  local _, err = self.dao:delete(v)
   return err
 end
 

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -107,9 +107,7 @@ local function generate_token(conf, service, credential, authenticated_userid,
   local refresh_token
   local token, err
   if existing_token and conf.reuse_refresh_token then
-    token, err = kong.db.oauth2_tokens:update({
-      id = existing_token.id
-    }, {
+    token, err = kong.db.oauth2_tokens:update(existing_token, {
       access_token = random_string(),
       expires_in = token_expiration,
       created_at = timestamp.get_utc() / 1000
@@ -676,7 +674,7 @@ local function issue_token(conf)
               auth_code.scope, state)
 
             -- Delete authorization code so it cannot be reused
-            kong.db.oauth2_authorization_codes:delete({ id = auth_code.id })
+            kong.db.oauth2_authorization_codes:delete(auth_code)
           end
         end
 
@@ -785,7 +783,7 @@ local function issue_token(conf)
                                              token.scope, state, false, token)
             -- Delete old token if refresh token not persisted
             if not conf.reuse_refresh_token then
-              kong.db.oauth2_tokens:delete({ id = token.id })
+              kong.db.oauth2_tokens:delete(token)
             end
           end
         end
@@ -894,7 +892,7 @@ end
 
 
 local function load_oauth2_credential_into_memory(credential_id)
-  local result, err = kong.db.oauth2_credentials:select { id = credential_id }
+  local result, err = kong.db.oauth2_credentials:select({ id = credential_id })
   if err then
     return nil, err
   end

--- a/kong/plugins/proxy-cache/api.lua
+++ b/kong/plugins/proxy-cache/api.lua
@@ -129,9 +129,7 @@ return {
     resource = "proxy-cache",
 
     GET = function(self)
-      local plugin, err = kong.db.plugins:select {
-        id   = self.params.plugin_id,
-      }
+      local plugin, err = kong.db.plugins:select({ id = self.params.plugin_id })
       if err then
         return kong.response.exit(500, err)
       end
@@ -156,9 +154,7 @@ return {
       return kong.response.exit(200, cache_val)
     end,
     DELETE = function(self)
-      local plugin, err = kong.db.plugins:select {
-        id   = self.params.plugin_id,
-      }
+      local plugin, err = kong.db.plugins:select({ id = self.params.plugin_id })
       if err then
         return kong.response.exit(500, err)
       end

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -261,9 +261,7 @@ function ProxyCacheHandler:init_worker()
     kong.log.err("handling purge of '", data, "'")
 
     local plugin_id, cache_key = unpack(utils.split(data, ":"))
-    local plugin, err = kong.db.plugins:select({
-      id = plugin_id,
-    })
+    local plugin, err = kong.db.plugins:select({ id = plugin_id })
     if err then
       kong.log.err("error in retrieving plugins: ", err)
       return

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -62,7 +62,7 @@ end
 -- @param upstream_id string
 -- @return the upstream table, or nil+error
 local function load_upstream_into_memory(upstream_id)
-  local upstream, err = kong.db.upstreams:select({id = upstream_id}, GLOBAL_QUERY_OPTS)
+  local upstream, err = kong.db.upstreams:select({ id = upstream_id }, GLOBAL_QUERY_OPTS)
   if not upstream then
     return nil, err
   end

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -809,7 +809,7 @@ for _, strategy in helpers.each_strategy() do
             service = bp.services:insert(),
           }))
 
-          local route_in_db = assert(db.routes:select({ id = route.id }))
+          local route_in_db = assert(db.routes:select(route))
           assert.truthy(now - route_in_db.created_at < 0.1)
           assert.truthy(now - route_in_db.updated_at < 0.1)
         end)
@@ -995,7 +995,7 @@ for _, strategy in helpers.each_strategy() do
           local route_inserted = bp.routes:insert({
             hosts = { "example.com" },
           })
-          local route, err, err_t = db.routes:select({ id = route_inserted.id })
+          local route, err, err_t = db.routes:select(route_inserted)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.same(route_inserted, route)
@@ -1017,9 +1017,7 @@ for _, strategy in helpers.each_strategy() do
               service = bp.services:insert(),
             })
             assert.is_nil(err)
-            local route, err, err_t = db.routes:select({
-              id = route_inserted.id
-            })
+            local route, err, err_t = db.routes:select(route_inserted)
             assert.is_nil(err_t)
             assert.is_nil(err)
 
@@ -1043,8 +1041,7 @@ for _, strategy in helpers.each_strategy() do
 
         it("errors on invalid values", function()
           local route = bp.routes:insert({ hosts = { "example.com" } })
-          local pk = { id = route.id }
-          local new_route, err, err_t = db.routes:update(pk, {
+          local new_route, err, err_t = db.routes:update(route, {
             protocols = { "http", 123 },
           })
           assert.is_nil(new_route)
@@ -1092,7 +1089,7 @@ for _, strategy in helpers.each_strategy() do
 
           -- ngx.sleep(1)
 
-          local new_route, err, err_t = db.routes:update({ id = route.id }, {
+          local new_route, err, err_t = db.routes:update(route, {
             protocols = { "https" },
             hosts = { "example.com" },
             regex_priority = 5,
@@ -1132,7 +1129,7 @@ for _, strategy in helpers.each_strategy() do
               path_handling = "v0",
             })
 
-            local new_route, err, err_t = db.routes:update({ id = route.id }, {
+            local new_route, err, err_t = db.routes:update(route, {
               methods = ngx.null
             })
             assert.is_nil(err_t)
@@ -1161,7 +1158,7 @@ for _, strategy in helpers.each_strategy() do
               methods = { "GET" },
             })
 
-            local new_route, _, err_t = db.routes:update({ id = route.id }, {
+            local new_route, _, err_t = db.routes:update(route, {
               hosts   = ngx.null,
               methods = ngx.null,
             })
@@ -1189,7 +1186,7 @@ for _, strategy in helpers.each_strategy() do
               snis    = { "example.org" },
             })
 
-            local new_route, _, err_t = db.routes:update({ id = route.id }, {
+            local new_route, _, err_t = db.routes:update(route, {
               protocols = { "http" },
               hosts   = ngx.null,
               methods = ngx.null,
@@ -1222,7 +1219,7 @@ for _, strategy in helpers.each_strategy() do
               paths   = ngx.null,
             }, { nulls = true })
 
-            local new_route, err, err_t = db.routes:update({ id = route.id }, {
+            local new_route, err, err_t = db.routes:update(route, {
               hosts   = { "example2.com" },
             }, { nulls = true })
             assert.is_nil(err_t)
@@ -1244,7 +1241,7 @@ for _, strategy in helpers.each_strategy() do
               methods = { "GET" },
             })
 
-            local new_route, _, err_t = db.routes:update({ id = route.id }, {
+            local new_route, _, err_t = db.routes:update(route, {
               hosts   = ngx.null,
               methods = ngx.null,
             })
@@ -1291,16 +1288,12 @@ for _, strategy in helpers.each_strategy() do
             hosts = { "example.com" },
           })
 
-          local ok, err, err_t = db.routes:delete({
-            id = route.id
-          })
+          local ok, err, err_t = db.routes:delete(route)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_true(ok)
 
-          local route_in_db, err, err_t = db.routes:select({
-            id = route.id
-          })
+          local route_in_db, err, err_t = db.routes:select(route)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_nil(route_in_db)
@@ -1620,9 +1613,7 @@ for _, strategy in helpers.each_strategy() do
             host = "example.com"
           }))
 
-          local service_in_db, err, err_t = db.services:select({
-            id = service.id
-          })
+          local service_in_db, err, err_t = db.services:select(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("example.com", service_in_db.host)
@@ -1674,8 +1665,7 @@ for _, strategy in helpers.each_strategy() do
 
         it("errors on invalid values", function()
           local service = assert(db.services:insert({ host = "service.test" }))
-          local pk = { id = service.id }
-          local new_service, err, err_t = db.services:update(pk, { protocol = 123 })
+          local new_service, err, err_t = db.services:update(service, { protocol = 123 })
           assert.is_nil(new_service)
           local message = "schema violation (protocol: expected a string)"
           assert.equal(fmt("[%s] %s", strategy, message), err)
@@ -1708,16 +1698,12 @@ for _, strategy in helpers.each_strategy() do
             host = "service.com"
           }))
 
-          local updated_service, err, err_t = db.services:update({
-            id = service.id
-          }, { protocol = "https" })
+          local updated_service, err, err_t = db.services:update(service, { protocol = "https" })
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("https", updated_service.protocol)
 
-          local service_in_db, err, err_t = db.services:select({
-            id = service.id
-          })
+          local service_in_db, err, err_t = db.services:select(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("https", service_in_db.protocol)
@@ -1741,9 +1727,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(err_t)
 
           -- update insert 2 with insert 1 name
-          local updated_service, _, err_t = db.services:update({
-            id = service.id,
-          }, { name = "service" })
+          local updated_service, _, err_t = db.services:update(service, { name = "service" })
           assert.is_nil(updated_service)
           assert.same({
             code     = Errors.codes.UNIQUE_VIOLATION,
@@ -1761,11 +1745,11 @@ for _, strategy in helpers.each_strategy() do
         local s1, s2
         before_each(function()
           if s1 then
-            local ok, err = db.services:delete({ id = s1.id })
+            local ok, err = db.services:delete(s1)
             assert(ok, tostring(err))
           end
           if s2 then
-            local ok, err = db.services:delete({ id = s2.id })
+            local ok, err = db.services:delete(s2)
             assert(ok, tostring(err))
           end
 
@@ -1820,16 +1804,12 @@ for _, strategy in helpers.each_strategy() do
             host = "service.com"
           }))
 
-          local updated_service, err, err_t = db.services:update({
-            id = service.id
-          }, { protocol = "https" })
+          local updated_service, err, err_t = db.services:update(service, { protocol = "https" })
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("https", updated_service.protocol)
 
-          local service_in_db, err, err_t = db.services:select({
-            id = service.id
-          })
+          local service_in_db, err, err_t = db.services:select(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("https", service_in_db.protocol)
@@ -1843,9 +1823,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(err)
           assert.equal("https", updated_service.protocol)
 
-          local service_in_db, err, err_t = db.services:select({
-            id = updated_service.id
-          })
+          local service_in_db, err, err_t = db.services:select(updated_service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("https", service_in_db.protocol)
@@ -1899,16 +1877,12 @@ for _, strategy in helpers.each_strategy() do
             host = "example.com"
           }))
 
-          local ok, err, err_t = db.services:delete({
-            id = service.id
-          })
+          local ok, err, err_t = db.services:delete(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_true(ok)
 
-          local service_in_db, err, err_t = db.services:select({
-            id = service.id
-          })
+          local service_in_db, err, err_t = db.services:select(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_nil(service_in_db)
@@ -1946,9 +1920,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(err)
           assert.is_true(ok)
 
-          local service_in_db, err, err_t = db.services:select({
-            id = service.id
-          })
+          local service_in_db, err, err_t = db.services:select(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_nil(service_in_db)
@@ -2002,7 +1974,7 @@ for _, strategy in helpers.each_strategy() do
           response_buffering = true,
         }, route)
 
-        local route_in_db, err, err_t = db.routes:select({ id = route.id }, { nulls = true })
+        local route_in_db, err, err_t = db.routes:select(route, { nulls = true })
         assert.is_nil(err_t)
         assert.is_nil(err)
         assert.same(route, route_in_db)
@@ -2014,7 +1986,7 @@ for _, strategy in helpers.each_strategy() do
 
         local route = bp.routes:insert({ service = service1, methods = { "GET" } })
 
-        local new_route, err, err_t = db.routes:update({ id = route.id }, {
+        local new_route, err, err_t = db.routes:update(route, {
           service = service2
         })
         assert.is_nil(err_t)
@@ -2025,7 +1997,7 @@ for _, strategy in helpers.each_strategy() do
       it(":update() detaches a Route from an existing Service", function()
         local service1 = bp.services:insert({ host = "service1.com" })
         local route = bp.routes:insert({ service = service1, methods = { "GET" } })
-        local new_route, err, err_t = db.routes:update({ id = route.id }, {
+        local new_route, err, err_t = db.routes:update(route, {
           service = ngx.null
         })
         assert.is_nil(err_t)
@@ -2045,7 +2017,7 @@ for _, strategy in helpers.each_strategy() do
           hosts = { "example.com" },
         })
 
-        local new_route, err, err_t = db.routes:update({ id = route.id }, {
+        local new_route, err, err_t = db.routes:update(route, {
           service = service
         })
         assert.is_nil(new_route)
@@ -2075,7 +2047,7 @@ for _, strategy in helpers.each_strategy() do
 
         bp.routes:insert({ service = service, methods = { "GET" } })
 
-        local ok, err, err_t = db.services:delete({ id = service.id })
+        local ok, err, err_t = db.services:delete(service)
         assert.is_nil(ok)
         local message  = "an existing 'routes' entity references this 'services' entity"
         assert.equal(fmt("[%s] %s", strategy, message), err)
@@ -2097,14 +2069,12 @@ for _, strategy in helpers.each_strategy() do
 
         local route = bp.routes:insert({ service = service, methods = { "GET" } })
 
-        local ok, err, err_t = db.routes:delete({ id = route.id })
+        local ok, err, err_t = db.routes:delete(route)
         assert.is_nil(err_t)
         assert.is_nil(err)
         assert.is_true(ok)
 
-        local service_in_db, err, err_t = db.services:select({
-          id = service.id
-        })
+        local service_in_db, err, err_t = db.services:select(service)
         assert.is_nil(err_t)
         assert.is_nil(err)
         assert.same(service, service_in_db)
@@ -2163,9 +2133,7 @@ for _, strategy in helpers.each_strategy() do
             -- different service
           }
 
-          local rows, err, err_t = db.routes:page_for_service {
-            id = service.id,
-          }
+          local rows, err, err_t = db.routes:page_for_service(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.same({ route1 }, rows)
@@ -2181,9 +2149,7 @@ for _, strategy in helpers.each_strategy() do
             methods = { "GET" },
           }
 
-          local rows, err, err_t = db.routes:page_for_service {
-            id = service.id,
-          }
+          local rows, err, err_t = db.routes:page_for_service(service)
           assert.is_nil(err_t)
           assert.is_nil(err)
 
@@ -2221,18 +2187,14 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("= 100", function()
-              local rows, err, err_t = db.routes:page_for_service {
-                id = service.id,
-              }
+              local rows, err, err_t = db.routes:page_for_service(service)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.equal(100, #rows)
             end)
 
             it("max page_size = 1000", function()
-              local _, _, err_t = db.routes:page_for_service({
-                id = service.id,
-              }, 1002)
+              local _, _, err_t = db.routes:page_for_service(service, 1002)
               assert.same({
                 code = Errors.codes.INVALID_SIZE,
                 message = "size must be an integer between 1 and 1000",
@@ -2256,9 +2218,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("fetches all rows in one page", function()
-              local rows, err, err_t, offset = db.routes:page_for_service {
-                id = service.id,
-              }
+              local rows, err, err_t, offset = db.routes:page_for_service(service)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_nil(offset)
@@ -2283,17 +2243,15 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("fetches rows always in same order", function()
-              local rows1 = db.routes:page_for_service { id = service.id }
-              local rows2 = db.routes:page_for_service { id = service.id }
+              local rows1 = db.routes:page_for_service(service)
+              local rows2 = db.routes:page_for_service(service)
               assert.is_table(rows1)
               assert.is_table(rows2)
               assert.same(rows1, rows2)
             end)
 
             it("returns offset when page_size < total", function()
-              local rows, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, 5)
+              local rows, err, err_t, offset = db.routes:page_for_service(service, 5)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_table(rows)
@@ -2302,9 +2260,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("fetches subsequent pages with offset", function()
-              local rows_1, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, 5)
+              local rows_1, err, err_t, offset = db.routes:page_for_service(service, 5)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_table(rows_1)
@@ -2313,9 +2269,7 @@ for _, strategy in helpers.each_strategy() do
 
               local page_size = 5
 
-              local rows_2, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, page_size, offset)
+              local rows_2, err, err_t, offset = db.routes:page_for_service(service, page_size, offset)
 
               assert.is_nil(err_t)
               assert.is_nil(err)
@@ -2333,24 +2287,18 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("fetches same page with same offset", function()
-              local _, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, 3)
+              local _, err, err_t, offset = db.routes:page_for_service(service, 3)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_string(offset)
 
-              local rows_a, err, err_t = db.routes:page_for_service({
-                id = service.id,
-              }, 3, offset)
+              local rows_a, err, err_t = db.routes:page_for_service(service, 3, offset)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_table(rows_a)
               assert.equal(3, #rows_a)
 
-              local rows_b, err, err_t = db.routes:page_for_service({
-                id = service.id,
-              }, 3, offset)
+              local rows_b, err, err_t = db.routes:page_for_service(service, 3, offset)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.is_table(rows_b)
@@ -2367,9 +2315,7 @@ for _, strategy in helpers.each_strategy() do
               repeat
                 local err, err_t
 
-                rows, err, err_t, offset = db.routes:page_for_service({
-                  id = service.id,
-                }, 3, offset)
+                rows, err, err_t, offset = db.routes:page_for_service(service, 3, offset)
                 assert.is_nil(err_t)
                 assert.is_nil(err)
 
@@ -2382,9 +2328,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("fetches first page with invalid offset", function()
-              local rows, err, err_t = db.routes:page_for_service({
-                id = service.id,
-              }, 3, "hello")
+              local rows, err, err_t = db.routes:page_for_service(service, 3, "hello")
               assert.is_nil(rows)
               local message  = "'hello' is not a valid offset: " ..
                                "bad base64 encoding"
@@ -2412,9 +2356,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             it("overrides the defaults", function()
-              local rows, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, nil, nil, {
+              local rows, err, err_t, offset = db.routes:page_for_service(service, nil, nil, {
                 pagination = {
                   page_size     = 5,
                   max_page_size = 5,
@@ -2425,9 +2367,7 @@ for _, strategy in helpers.each_strategy() do
               assert.is_not_nil(offset)
               assert.equal(5, #rows)
 
-              rows, err, err_t, offset = db.routes:page_for_service({
-                id = service.id,
-              }, nil, offset, {
+              rows, err, err_t, offset = db.routes:page_for_service(service, nil, offset, {
                 pagination = {
                   page_size     = 6,
                   max_page_size = 6,
@@ -2465,17 +2405,13 @@ for _, strategy in helpers.each_strategy() do
 
       describe(":page_for_upstream()", function()
         it("return value 'offset' is a string", function()
-          local page, _, _, offset = db.targets:page_for_upstream({
-            id = upstream.id,
-          }, 1)
+          local page, _, _, offset = db.targets:page_for_upstream(upstream, 1)
           assert.not_nil(page)
           assert.is_string(offset)
         end)
 
         it("respects nulls=true on targets too", function()
-          local page = db.targets:page_for_upstream({
-            id = upstream.id,
-          }, 1, nil, { nulls = true })
+          local page = db.targets:page_for_upstream(upstream, 1, nil, { nulls = true })
           assert.not_nil(page)
           assert.equal(cjson.null, page[1].tags)
         end)

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -160,13 +160,13 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("returns an error when updating mismatched plugins", function()
-        local p, _, err_t = db.plugins:update({ id = global_plugin.id },
+        local p, _, err_t = db.plugins:update(global_plugin,
                                               { route = { id = route.id } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
 
 
-        local p, _, err_t = db.plugins:update({ id = global_plugin.id },
+        local p, _, err_t = db.plugins:update(global_plugin,
                                               { service = { id = service.id } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols,
@@ -176,13 +176,13 @@ for _, strategy in helpers.each_strategy() do
 
     describe(":upsert()", function()
       it("returns an error when upserting mismatched plugins", function()
-        local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
+        local p, _, err_t = db.plugins:upsert(global_plugin,
                                               { route = { id = route.id }, protocols = { "http" } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
 
 
-        local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
+        local p, _, err_t = db.plugins:upsert(global_plugin,
                                               { service = { id = service.id }, protocols = { "http" } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols,

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -208,16 +208,16 @@ for _, strategy in helpers.each_strategy() do
       assert(declarative.load_into_db({
         snis = { [sni_def.id] = sni_def },
         certificates = { [certificate_def.id] = certificate_def },
-        routes = { 
+        routes = {
           [route_def.id] = route_def,
           [disabled_route_def.id] = disabled_route_def,
         },
-        services = { 
+        services = {
           [service_def.id] = service_def,
           [disabled_service_def.id] = disabled_service_def,
        },
         consumers = { [consumer_def.id] = consumer_def },
-        plugins = { 
+        plugins = {
           [plugin_def.id] = plugin_def,
           [disabled_service_plugin_def.id] = disabled_service_plugin_def,
           [disabled_plugin_def.id] = disabled_plugin_def,
@@ -239,7 +239,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals(sni_def.id, sni.id)
         assert.equals(certificate_def.id, sni.certificate.id)
 
-        local cert = assert(db.certificates:select({ id = certificate_def.id }))
+        local cert = assert(db.certificates:select(certificate_def))
         assert.equals(certificate_def.id, cert.id)
         assert.same(ssl_fixtures.key, cert.key)
         assert.same(ssl_fixtures.cert, cert.cert)
@@ -260,23 +260,23 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("andru", consumer_def.username)
         assert.equals("donalds", consumer_def.custom_id)
 
-        local plugin = assert(db.plugins:select({ id = plugin_def.id }, { nulls = true }))
+        local plugin = assert(db.plugins:select(plugin_def, { nulls = true }))
         assert.equals(plugin_def.id, plugin.id)
         assert.equals(service.id, plugin.service.id)
         assert.equals("acl", plugin.name)
         assert.same(plugin_def.config, plugin.config)
 
-        local acl = assert(db.acls:select({ id = acl_def.id }))
+        local acl = assert(db.acls:select(acl_def))
         assert.equals(consumer_def.id, acl.consumer.id)
         assert.equals("The A Team", acl.group)
 
-        local basicauth_credential = assert(db.basicauth_credentials:select({ id = basicauth_credential_def.id }))
+        local basicauth_credential = assert(db.basicauth_credentials:select(basicauth_credential_def))
         assert.equals(basicauth_credential_def.id, basicauth_credential.id)
         assert.equals(consumer.id, basicauth_credential.consumer.id)
         assert.equals("james", basicauth_credential.username)
         assert.equals(crypto.hash(consumer.id, "secret"), basicauth_credential.password)
 
-        local basicauth_hashed_credential = assert(db.basicauth_credentials:select({ id = basicauth_hashed_credential_def.id }))
+        local basicauth_hashed_credential = assert(db.basicauth_credentials:select(basicauth_hashed_credential_def))
         assert.equals(basicauth_hashed_credential_def.id, basicauth_hashed_credential.id)
         assert.equals(consumer.id, basicauth_hashed_credential.consumer.id)
         assert.equals("bond", basicauth_hashed_credential.username)
@@ -392,7 +392,7 @@ for _, strategy in helpers.each_strategy() do
         assert.same(plugin_def.config, plugin.config)
 
         --[[ FIXME this case is known to cause an issue
-        local plugin_with_null = assert(db.plugins:select({ id = plugin_with_null_def.id }, { nulls = true }))
+        local plugin_with_null = assert(db.plugins:select(plugin_with_null_def, { nulls = true }))
         assert.equals(plugin_with_null_def.id, plugin_with_null.id)
         assert.equals(service.id, plugin_with_null.service.id)
         assert.equals("correlation-id", plugin_with_null.name)
@@ -503,7 +503,7 @@ for _, strategy in helpers.each_strategy() do
         assert.same(plugin_def.config, plugin.config)
 
         --[[ FIXME this case is known to cause an issue
-        local plugin_with_null = assert(db.plugins:select({ id = plugin_with_null_def.id }, { nulls = true }))
+        local plugin_with_null = assert(db.plugins:select(plugin_with_null_def, { nulls = true }))
         assert.equals(plugin_with_null_def.id, plugin_with_null.id)
         assert.equals(service.id, plugin_with_null.service.id)
         assert.equals("correlation-id", plugin_with_null.name)
@@ -533,5 +533,3 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 end
-
-

--- a/spec/02-integration/03-db/10-db_unique_foreign_spec.lua
+++ b/spec/02-integration/03-db/10-db_unique_foreign_spec.lua
@@ -66,9 +66,7 @@ for _, strategy in helpers.each_strategy() do
         -- I/O
         it("returns existing Unique Foreign", function()
           for i = 1, 5 do
-            local unique_reference, err, err_t = db.unique_references:select_by_unique_foreign({
-              id = unique_foreigns[i].id,
-            })
+            local unique_reference, err, err_t = db.unique_references:select_by_unique_foreign(unique_foreigns[i])
 
             assert.is_nil(err)
             assert.is_nil(err_t)
@@ -99,9 +97,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("errors on invalid values", function()
-          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign({
-            id = unique_foreigns[1].id,
-          }, {
+          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign(unique_foreigns[1], {
             note = 123,
           })
           assert.is_nil(unique_reference)
@@ -135,27 +131,21 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("updates an existing Unique Reference", function()
-          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign({
-              id = unique_foreigns[1].id,
-            }, {
+          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign(unique_foreigns[1], {
             note = "note updated",
           })
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("note updated", unique_reference.note)
 
-          local unique_reference_in_db, err, err_t = db.unique_references:select({
-            id = unique_reference.id
-          })
+          local unique_reference_in_db, err, err_t = db.unique_references:select(unique_reference)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("note updated", unique_reference_in_db.note)
         end)
 
         it("cannot update a Unique Reference to be an already existing Unique Foreign", function()
-          local updated_service, _, err_t = db.unique_references:update_by_unique_foreign({
-            id = unique_foreigns[1].id,
-          }, {
+          local updated_service, _, err_t = db.unique_references:update_by_unique_foreign(unique_foreigns[1], {
             unique_foreign = {
               id = unique_foreigns[2].id,
             }
@@ -184,9 +174,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("errors on invalid values", function()
-          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
-            id = unique_foreigns[1].id,
-          }, {
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign(unique_foreigns[1], {
             note = 123,
           })
           assert.is_nil(unique_reference)
@@ -220,18 +208,14 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("upserts an existing Unique Reference", function()
-          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
-            id = unique_foreigns[1].id,
-          }, {
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign(unique_foreigns[1], {
             note = "note updated",
           })
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("note updated", unique_reference.note)
 
-          local unique_reference_in_db, err, err_t = db.unique_references:select({
-            id = unique_reference.id
-          })
+          local unique_reference_in_db, err, err_t = db.unique_references:select(unique_reference)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.equal("note updated", unique_reference_in_db.note)
@@ -241,9 +225,7 @@ for _, strategy in helpers.each_strategy() do
           -- TODO: this is slightly unexpected, but it has its uses when thinking about idempotency
           --       of `PUT`. This has been like that with other DAO methods do, but perhaps we want
           --       to revisit this later.
-          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
-            id = unique_foreigns[1].id,
-          }, {
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign(unique_foreigns[1], {
             unique_foreign = {
               id = unique_foreigns[2].id,
             }
@@ -257,9 +239,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe(":update()", function()
         it("cannot update a Unique Reference to be an already existing Unique Foreign", function()
-          local updated_unique_reference, _, err_t = db.unique_references:update({
-            id = unique_references[1].id,
-          }, {
+          local updated_unique_reference, _, err_t = db.unique_references:update(unique_references[1], {
             unique_foreign = {
               id = unique_foreigns[2].id,
             }
@@ -284,9 +264,7 @@ for _, strategy in helpers.each_strategy() do
             name = "new unique foreign",
           }))
 
-          local updated_unique_reference, err, err_t = db.unique_references:update({
-            id = unique_references[1].id,
-          }, {
+          local updated_unique_reference, err, err_t = db.unique_references:update(unique_references[1], {
             note = "updated note",
             unique_foreign = {
               id = unique_foreign.id,
@@ -335,16 +313,12 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("deletes an existing Unique Reference", function()
-          local ok, err, err_t = db.unique_references:delete_by_unique_foreign({
-            id = unique_foreign.id,
-          })
+          local ok, err, err_t = db.unique_references:delete_by_unique_foreign(unique_foreign)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_true(ok)
 
-          local unique_reference, err, err_t = db.unique_references:select({
-            id = unique_reference.id
-          })
+          local unique_reference, err, err_t = db.unique_references:select(unique_reference)
           assert.is_nil(err_t)
           assert.is_nil(err)
           assert.is_nil(unique_reference)

--- a/spec/02-integration/03-db/11-db_transformations_spec.lua
+++ b/spec/02-integration/03-db/11-db_transformations_spec.lua
@@ -40,14 +40,14 @@ for _, strategy in helpers.each_strategy() do
             name = "test"
           }))
 
-          local newdao, err = db.transformations:update({ id = dao.id }, {
+          local newdao, err = db.transformations:update(dao, {
             secret = "dog",
           })
 
           assert.equal(nil, newdao)
           assert.equal(errmsg, err)
 
-          assert(db.transformations:delete({ id = dao.id }))
+          assert(db.transformations:delete(dao))
         end)
 
         it("updating hash_secret requires secret", function()
@@ -55,14 +55,14 @@ for _, strategy in helpers.each_strategy() do
             name = "test"
           }))
 
-          local newdao, err = db.transformations:update({ id = dao.id }, {
+          local newdao, err = db.transformations:update(dao, {
             hash_secret = true,
           })
 
           assert.equal(nil, newdao)
           assert.equal(errmsg, err)
 
-          assert(db.transformations:delete({ id = dao.id }))
+          assert(db.transformations:delete(dao))
         end)
       end)
 
@@ -74,12 +74,12 @@ for _, strategy in helpers.each_strategy() do
 
         assert.equal("abc", dao.case)
 
-        local newdao = assert(db.transformations:update({ id = dao.id }, {
+        local newdao = assert(db.transformations:update(dao, {
           case = "aBc",
         }))
 
         assert.equal("abc", newdao.case)
-        assert(db.transformations:delete({ id = dao.id }))
+        assert(db.transformations:delete(dao))
       end)
 
       it("vault references are resolved after transformations", function()
@@ -94,7 +94,7 @@ for _, strategy in helpers.each_strategy() do
           name = "test",
         }))
 
-        local newdao = assert(db.transformations:update({ id = dao.id }, {
+        local newdao = assert(db.transformations:update(dao, {
           meta = "{vault://env/meta-value}",
         }))
 
@@ -102,7 +102,7 @@ for _, strategy in helpers.each_strategy() do
         assert.same({
           meta = "{vault://env/meta-value}",
         }, newdao["$refs"])
-        assert(db.transformations:delete({ id = dao.id }))
+        assert(db.transformations:delete(dao))
       end)
     end)
 

--- a/spec/02-integration/03-db/12-dao_hooks_spec.lua
+++ b/spec/02-integration/03-db/12-dao_hooks_spec.lua
@@ -183,7 +183,7 @@ for _, strategy in helpers.each_strategy() do
           hooks.clear_hooks()
         end)
 
-        assert(db.routes:select( {id = r1.id} ))
+        assert(db.routes:select(r1))
         assert.spy(pre_hook).was_called(1)
         assert.spy(post_hook).was_called(1)
       end)
@@ -266,7 +266,7 @@ for _, strategy in helpers.each_strategy() do
           hooks.clear_hooks()
         end)
 
-        assert(db.routes:update({ id = r1.id }, {
+        assert(db.routes:update(r1, {
           protocols = { "http" },
           hosts = { "host1" },
           service = s1,

--- a/spec/02-integration/03-db/13-cluster_status_spec.lua
+++ b/spec/02-integration/03-db/13-cluster_status_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("can update the row", function()
-        local p, err = db.clustering_data_planes:update({ id = cs.id, }, { config_hash = "a9a166c59873245db8f1a747ba9a80a7", })
+        local p, err = db.clustering_data_planes:update(cs, { config_hash = "a9a166c59873245db8f1a747ba9a80a7", })
         assert.is_truthy(p)
         assert.is_nil(err)
       end)

--- a/spec/02-integration/03-db/18-keys_spec.lua
+++ b/spec/02-integration/03-db/18-keys_spec.lua
@@ -45,7 +45,7 @@ for _, strategy in helpers.all_strategies() do
       })
       assert(key)
       assert.is_nil(err)
-      local key_o, s_err = db.keys:select({ id = key.id })
+      local key_o, s_err = db.keys:select(key)
       assert.is_nil(s_err)
       assert.same("string", type(key_o.jwk))
     end)
@@ -60,7 +60,7 @@ for _, strategy in helpers.all_strategies() do
           private_key = pem_priv
         }
       })
-      local key_o, err = db.keys:select({ id = init_pem_key.id })
+      local key_o, err = db.keys:select(init_pem_key)
       assert.is_nil(err)
       assert.same('456', key_o.kid)
       assert.same(pem_priv, key_o.pem.private_key)

--- a/spec/02-integration/03-db/19-key-sets_spec.lua
+++ b/spec/02-integration/03-db/19-key-sets_spec.lua
@@ -27,7 +27,7 @@ for _, strategy in helpers.all_strategies() do
     end)
 
     it(":select returns an item", function()
-      local key_set, err = kong.db.key_sets:select({ id = keyset.id })
+      local key_set, err = kong.db.key_sets:select(keyset)
       assert.is_nil(err)
       assert(key_set.name == keyset.name)
     end)
@@ -46,15 +46,13 @@ for _, strategy in helpers.all_strategies() do
       }
       assert.is_nil(err)
       assert(key_set.name == "that")
-      local ok, d_err = kong.db.key_sets:delete {
-        id = key_set.id
-      }
+      local ok, d_err = kong.db.key_sets:delete(key_set)
       assert.is_nil(d_err)
       assert.is_truthy(ok)
     end)
 
     it(":update updates a keyset's fields", function()
-      local key_set, err = kong.db.key_sets:update({ id = keyset.id }, {
+      local key_set, err = kong.db.key_sets:update(keyset, {
         name = "changed"
       })
       assert.is_nil(err)
@@ -75,17 +73,15 @@ for _, strategy in helpers.all_strategies() do
       }
       assert.is_nil(ins_err)
       -- verify creation
-      local key_select, select_err = kong.db.keys:select({ id = key.id })
+      local key_select, select_err = kong.db.keys:select(key)
       assert.is_nil(select_err)
       assert.is_not_nil(key_select)
       -- delete the set
-      local ok, d_err = kong.db.key_sets:delete {
-        id = key_set.id
-      }
+      local ok, d_err = kong.db.key_sets:delete(key_set)
       assert.is_true(ok)
       assert.is_nil(d_err)
       -- verify if key is gone
-      local key_select_deleted, select_deleted_err = kong.db.keys:select({ id = key.id })
+      local key_select_deleted, select_deleted_err = kong.db.keys:select(key)
       assert.is_nil(select_deleted_err)
       assert.is_nil(key_select_deleted)
     end)
@@ -119,7 +115,7 @@ for _, strategy in helpers.all_strategies() do
 
       local rows = {}
       local i = 1
-      for row, err_t in kong.db.keys:each_for_set({id = key_set.id}) do
+      for row, err_t in kong.db.keys:each_for_set(key_set) do
         assert.is_nil(err_t)
         rows[i] = row
         i = i + 1

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -373,7 +373,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
             assert.equal(consumer.id, json.id)
             assert.truthy(consumer.updated_at < json.updated_at)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
+            local in_db = assert(db.consumers:select(consumer, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -394,7 +394,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
             assert.equal(new_username, json.username)
             assert.equal(consumer.id, json.id)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
+            local in_db = assert(db.consumers:select(consumer, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -416,7 +416,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
             assert.equal(consumer.custom_id, json.custom_id)
             assert.equal(consumer.id, json.id)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
+            local in_db = assert(db.consumers:select(consumer, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -511,7 +511,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
             local json = cjson.decode(body)
             assert.equal(new_username, json.username)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
+            local in_db = assert(db.consumers:select(consumer, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -834,7 +834,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
           assert.equal("updated", json.config.value)
           assert.equal(plugin.id, json.id)
 
-          local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+          local in_db = assert(db.plugins:select(plugin, { nulls = true }))
           assert.same(json, in_db)
         end)
 
@@ -844,8 +844,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
           local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }})
 
           local err
-          plugin, err = db.plugins:update(
-            { id = plugin.id },
+          plugin, err = db.plugins:update(plugin,
             {
               name = "rewriter",
               route = plugin.route,
@@ -896,7 +895,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
           local json = cjson.decode(body)
           assert.False(json.enabled)
 
-          plugin = assert(db.plugins:select{ id = plugin.id })
+          plugin = assert(db.plugins:select(plugin))
           assert.False(plugin.enabled)
         end
       end)
@@ -989,9 +988,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
           assert.equal("updated", json.config.value)
           assert.equal(plugin.id, json.id)
 
-          local in_db = assert(db.plugins:select({
-            id = plugin.id,
-          }, { nulls = true }))
+          local in_db = assert(db.plugins:select(plugin, { nulls = true }))
           assert.same(json, in_db)
         end)
       end

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -276,7 +276,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.False(json.enabled)
 
-            local in_db = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugins[1], { nulls = true }))
             assert.same(json, in_db)
           end)
           it("updates a plugin by instance_name", function()
@@ -290,11 +290,11 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.False(json.enabled)
 
-            local in_db = assert(db.plugins:select({ id = plugins[2].id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugins[2], { nulls = true }))
             assert.same(json, in_db)
           end)
           it("updates a plugin bis", function()
-            local plugin = assert(db.plugins:select({ id = plugins[2].id }, { nulls = true }))
+            local plugin = assert(db.plugins:select(plugins[2], { nulls = true }))
 
             plugin.enabled = not plugin.enabled
             plugin.created_at = nil
@@ -325,7 +325,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.same(ngx.null, json.service)
 
-            local in_db = assert(db.plugins:select({ id = plugins[2].id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugins[2], { nulls = true }))
             assert.same(json, in_db)
           end)
           it("does not infer json input", function()
@@ -341,7 +341,7 @@ for _, strategy in helpers.each_strategy() do
           end)
           describe("errors", function()
             it("handles invalid input", function()
-              local before = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))
+              local before = assert(db.plugins:select(plugins[1], { nulls = true }))
               local res = assert(client:send {
                 method = "PATCH",
                 path = "/plugins/" .. plugins[1].id,
@@ -358,12 +358,12 @@ for _, strategy in helpers.each_strategy() do
                 code = 2,
               }, body)
 
-              local after = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))
+              local after = assert(db.plugins:select(plugins[1], { nulls = true }))
               assert.same(before, after)
               assert.same({"testkey"}, after.config.key_names)
             end)
             it("handles invalid config, see #9224", function()
-              local before = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))
+              local before = assert(db.plugins:select(plugins[1], { nulls = true }))
               local res = assert(client:send {
                 method = "PATCH",
                 path = "/plugins/" .. plugins[1].id,
@@ -380,7 +380,7 @@ for _, strategy in helpers.each_strategy() do
                 code = 2,
               }, body)
 
-              local after = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))
+              local after = assert(db.plugins:select(plugins[1], { nulls = true }))
               assert.same(before, after)
               assert.same({"testkey"}, after.config.key_names)
             end)

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -397,7 +397,7 @@ describe("Admin API: #" .. strategy, function()
         assert.same({ n1, n2 }, json.snis)
         json.snis = nil
 
-        local in_db = assert(db.certificates:select({ id = json.id }, { nulls = true }))
+        local in_db = assert(db.certificates:select(json, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -422,7 +422,7 @@ describe("Admin API: #" .. strategy, function()
         assert.same({ n1, n2 }, json.snis)
         json.snis = nil
 
-        local in_db = assert(db.certificates:select({ id = json.id }, { nulls = true }))
+        local in_db = assert(db.certificates:select(json, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -446,7 +446,7 @@ describe("Admin API: #" .. strategy, function()
 
         json.snis = nil
 
-        local in_db = assert(db.certificates:select({ id = certificate.id }, { nulls = true }))
+        local in_db = assert(db.certificates:select(certificate, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -472,7 +472,7 @@ describe("Admin API: #" .. strategy, function()
 
         json.snis = nil
 
-        local in_db = assert(db.certificates:select({ id = certificate.id }, { nulls = true }))
+        local in_db = assert(db.certificates:select(certificate, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -1244,7 +1244,7 @@ describe("Admin API: #" .. strategy, function()
         local json = cjson.decode(body)
         assert.same(n2, json.name)
 
-        local in_db = assert(db.snis:select({ id = sni.id }, { nulls = true }))
+        local in_db = assert(db.snis:select(sni, { nulls = true }))
         assert.same(json, in_db)
         assert.truthy(sni.updated_at < json.updated_at)
       end)

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -814,7 +814,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -850,7 +850,7 @@ for _, strategy in helpers.each_strategy() do
               local in_db = assert(db.routes:select_by_name(route.name, { nulls = true }))
               assert.same(json, in_db)
 
-              db.routes:delete({ id = route.id })
+              db.routes:delete(route)
             end
           end)
 
@@ -1058,7 +1058,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -1091,10 +1091,10 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
 
-              db.routes:delete({ id = route.id })
+              db.routes:delete(route)
             end
           end)
 
@@ -1114,7 +1114,7 @@ for _, strategy in helpers.each_strategy() do
               assert.True(json.strip_path)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -1144,7 +1144,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -1168,7 +1168,7 @@ for _, strategy in helpers.each_strategy() do
             assert.same(cjson.null, json.methods)
             assert.equal(route.id, json.id)
 
-            local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
+            local in_db = assert(db.routes:select(route, { nulls = true }))
             assert.same(json, in_db)
           end)
 
@@ -1227,10 +1227,10 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.service)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
+              local in_db = assert(db.routes:select(route, { nulls = true }))
               assert.same(json, in_db)
 
-              db.routes:delete({ id = route.id })
+              db.routes:delete(route)
             end
           end)
 
@@ -1288,7 +1288,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.routes:select({id = route.id}, { nulls = true })
+            local in_db, err = db.routes:select(route, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -1302,7 +1302,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.routes:select({id = route.id}, { nulls = true })
+            local in_db, err = db.routes:select(route, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -1393,7 +1393,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null,   json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -1426,11 +1426,11 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null,   json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
 
-              db.routes:delete({ id = route.id })
-              db.services:delete({ id = service.id })
+              db.routes:delete(route)
+              db.services:delete(service)
             end
           end)
 
@@ -1453,7 +1453,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("/foo",        json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -1544,7 +1544,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.same("konghq.com", json.host)
 
-            local in_db = assert(db.services:select({ id = json.id }, { nulls = true }))
+            local in_db = assert(db.services:select(json, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -1577,7 +1577,7 @@ for _, strategy in helpers.each_strategy() do
             assert.same(cjson.null,   json.path)
 
 
-            local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+            local in_db = assert(db.services:select(service, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -1610,11 +1610,11 @@ for _, strategy in helpers.each_strategy() do
             assert.same(cjson.null,   json.path)
 
 
-            local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+            local in_db = assert(db.services:select(service, { nulls = true }))
             assert.same(json, in_db)
 
-            db.routes:delete({ id = route.id })
-            db.services:delete({ id = service.id })
+            db.routes:delete(route)
+            db.services:delete(service)
           end
         end)
 
@@ -1637,7 +1637,7 @@ for _, strategy in helpers.each_strategy() do
             assert.equal("/foo",        json.path)
 
 
-            local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+            local in_db = assert(db.services:select(service, { nulls = true }))
             assert.same(json, in_db)
           end
         end)
@@ -1835,7 +1835,7 @@ for _, strategy in helpers.each_strategy() do
             local route = bp.routes:insert({ paths = { "/my-route" } })
             assert(db.plugins:insert {
               name = "key-auth",
-              route = { id = route.id },
+              route = route,
             })
             local res = assert(client:send {
               method = "GET",
@@ -1850,7 +1850,7 @@ for _, strategy in helpers.each_strategy() do
             local route = bp.routes:insert({ name = "my-plugins-route", paths = { "/my-route" } })
             assert(db.plugins:insert {
               name = "key-auth",
-              route = { id = route.id },
+              route = route,
             })
             local res = assert(client:send {
               method = "GET",
@@ -1860,7 +1860,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.equal(1, #json.data)
 
-            db.routes:delete({ id = route.id })
+            db.routes:delete(route)
           end)
 
           it("ignores an invalid body", function()
@@ -1892,7 +1892,7 @@ for _, strategy in helpers.each_strategy() do
             local res = client:get("/routes/" .. route.id .. "/plugins/" .. plugin.id)
             local body = assert.res_status(200, res)
             local json = cjson.decode(body)
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
           it("retrieves a plugin by instance_name", function()
@@ -1908,7 +1908,7 @@ for _, strategy in helpers.each_strategy() do
             local res = client:get("/routes/" .. route.id .. "/plugins/" .. plugin.instance_name)
             local body = assert.res_status(200, res)
             local json = cjson.decode(body)
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
         end)
@@ -1922,7 +1922,7 @@ for _, strategy in helpers.each_strategy() do
             local res = assert(client:delete("/routes/" .. route.id .. "/plugins/" .. plugin.id))
             assert.res_status(204, res)
 
-            local in_db, err = db.plugins:select({id = plugin.id}, { nulls = true })
+            local in_db, err = db.plugins:select(plugin, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -1935,7 +1935,7 @@ for _, strategy in helpers.each_strategy() do
             local res = assert(client:delete("/routes/" .. route.id .. "/plugins/" .. plugin.instance_name))
             assert.res_status(204, res)
 
-            local in_db, err = db.plugins:select({id = plugin.id}, { nulls = true })
+            local in_db, err = db.plugins:select(plugin, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -328,7 +328,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("https",    json.protocol)
               assert.equal(service.id, json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -381,7 +381,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(cjson.null,     json.path)
               assert.equal(service.id,     json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
 
 
@@ -402,7 +402,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("/",             json.path)
               assert.equal(service.id,      json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
 
               local res = client:patch("/services/" .. service.id, {
@@ -422,7 +422,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(cjson.null,      json.path)
               assert.equal(service.id,      json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
+              local in_db = assert(db.services:select(service, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -436,7 +436,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.services:select({ id = service.id }, { nulls = true })
+            local in_db, err = db.services:select(service, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -677,7 +677,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.False(json.enabled)
 
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
           it("updates a plugin bis", function()
@@ -718,7 +718,7 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.same(ngx.null, json.service)
 
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
 
@@ -734,7 +734,7 @@ for _, strategy in helpers.each_strategy() do
                 config = { key_names = { "testkey" } },
               })
 
-              local before = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+              local before = assert(db.plugins:select(plugin, { nulls = true }))
               local res = assert(client:send {
                 method = "PATCH",
                 path = "/services/" .. service.id .. "/plugins/" .. plugin.id,
@@ -750,7 +750,7 @@ for _, strategy in helpers.each_strategy() do
                 },
                 code = 2,
               }, body)
-              local after = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+              local after = assert(db.plugins:select(plugin, { nulls = true }))
               assert.same(before, after)
               assert.same({"testkey"}, after.config.key_names)
             end)
@@ -808,7 +808,7 @@ for _, strategy in helpers.each_strategy() do
             local res = client:get("/services/" .. service.id .. "/plugins/" .. plugin.id)
             local body = assert.res_status(200, res)
             local json = cjson.decode(body)
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
           it("retrieves a plugin by instance_name", function()
@@ -820,7 +820,7 @@ for _, strategy in helpers.each_strategy() do
             local res = client:get("/services/" .. service.id .. "/plugins/" .. plugin.instance_name)
             local body = assert.res_status(200, res)
             local json = cjson.decode(body)
-            local in_db = assert(db.plugins:select({ id = plugin.id }, { nulls = true }))
+            local in_db = assert(db.plugins:select(plugin, { nulls = true }))
             assert.same(json, in_db)
           end)
         end)
@@ -834,7 +834,7 @@ for _, strategy in helpers.each_strategy() do
             local res = assert(client:delete("/services/" .. service.id .. "/plugins/" .. plugin.id))
             assert.res_status(204, res)
 
-            local in_db, err = db.plugins:select({id = plugin.id}, { nulls = true })
+            local in_db, err = db.plugins:select(plugin, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -847,7 +847,7 @@ for _, strategy in helpers.each_strategy() do
             local res = assert(client:delete("/services/" .. service.id .. "/plugins/" .. plugin.instance_name))
             assert.res_status(204, res)
 
-            local in_db, err = db.plugins:select({id = plugin.id}, { nulls = true })
+            local in_db, err = db.plugins:select(plugin, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)

--- a/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
+++ b/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
@@ -76,8 +76,8 @@ for _, strategy in helpers.each_strategy() do
           local json = cjson.decode(body)
           assert.same(foreign_entity, json)
 
-          assert(db.foreign_references:delete({ id = foreign_reference.id }))
-          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          assert(db.foreign_references:delete(foreign_reference))
+          assert(db.foreign_entities:delete(foreign_entity))
         end)
 
         it("retrieves by name", function()
@@ -90,8 +90,8 @@ for _, strategy in helpers.each_strategy() do
           local json = cjson.decode(body)
           assert.same(foreign_entity, json)
 
-          assert(db.foreign_references:delete({ id = foreign_reference.id }))
-          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          assert(db.foreign_references:delete(foreign_reference))
+          assert(db.foreign_entities:delete(foreign_entity))
         end)
 
         it("returns 404 if not found", function()
@@ -116,8 +116,8 @@ for _, strategy in helpers.each_strategy() do
           })
           assert.res_status(200, res)
 
-          assert(db.foreign_references:delete({ id = foreign_reference.id }))
-          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          assert(db.foreign_references:delete(foreign_reference))
+          assert(db.foreign_entities:delete(foreign_entity))
         end)
       end)
 
@@ -145,11 +145,11 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.equal(edited_name, json.name)
 
-            local in_db = assert(db.foreign_entities:select({ id = foreign_entity.id }, { nulls = true }))
+            local in_db = assert(db.foreign_entities:select(foreign_entity, { nulls = true }))
             assert.same(json, in_db)
 
-            assert(db.foreign_references:delete({ id = foreign_reference.id }))
-            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+            assert(db.foreign_references:delete(foreign_reference))
+            assert(db.foreign_entities:delete(foreign_entity))
           end
         end)
 
@@ -175,11 +175,11 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.equal(edited_name, json.name)
 
-            local in_db = assert(db.foreign_entities:select({ id = foreign_entity.id }, { nulls = true }))
+            local in_db = assert(db.foreign_entities:select(foreign_entity, { nulls = true }))
             assert.same(json, in_db)
 
-            assert(db.foreign_references:delete({ id = foreign_reference.id }))
-            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+            assert(db.foreign_references:delete(foreign_reference))
+            assert(db.foreign_entities:delete(foreign_entity))
           end
         end)
 
@@ -220,8 +220,8 @@ for _, strategy in helpers.each_strategy() do
                 },
               }, cjson.decode(body))
 
-              assert(db.foreign_references:delete({ id = foreign_reference.id }))
-              assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+              assert(db.foreign_references:delete(foreign_reference))
+              assert(db.foreign_entities:delete(foreign_entity))
             end
           end)
         end)
@@ -236,8 +236,8 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(405, res)
             assert.same({ message = 'Method not allowed' }, cjson.decode(body))
 
-            assert(db.foreign_references:delete({ id = foreign_reference.id }))
-            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+            assert(db.foreign_references:delete(foreign_reference))
+            assert(db.foreign_entities:delete(foreign_entity))
           end)
 
           it("returns HTTP 404 with non-existing foreign entity ", function()

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -85,7 +85,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
       assert.is_nil(certificate["$refs"])
 
-      certificate, err = db.certificates:select({ id = certificate.id })
+      certificate, err = db.certificates:select(certificate)
       assert.is_nil(err)
       assert.equal(ssl_fixtures.cert, certificate.cert)
       assert.equal(ssl_fixtures.key, certificate.key)
@@ -103,7 +103,7 @@ for _, strategy in helpers.each_strategy() do
       -- TODO: this is unexpected but schema.process_auto_fields uses currently
       -- the `nulls` parameter to detect if the call comes from Admin API
       -- for performance reasons
-      certificate, err = db.certificates:select({ id = certificate.id }, { nulls = true })
+      certificate, err = db.certificates:select(certificate, { nulls = true })
       assert.is_nil(err)
       assert.equal("{vault://test-vault/cert}", certificate.cert)
       assert.equal("{vault://test-vault/key}", certificate.key)
@@ -142,7 +142,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
       assert.is_nil(certificate["$refs"])
 
-      certificate, err = db.certificates:select({ id = certificate.id })
+      certificate, err = db.certificates:select(certificate)
       assert.is_nil(err)
       assert.equal(ssl_fixtures.cert, certificate.cert)
       assert.equal(ssl_fixtures.key, certificate.key)
@@ -156,7 +156,7 @@ for _, strategy in helpers.each_strategy() do
       -- TODO: this is unexpected but schema.process_auto_fields uses currently
       -- the `nulls` parameter to detect if the call comes from Admin API
       -- for performance reasons
-      certificate, err = db.certificates:select({ id = certificate.id }, { nulls = true })
+      certificate, err = db.certificates:select(certificate, { nulls = true })
       assert.is_nil(err)
       assert.equal("{vault://mock-vault/cert}", certificate.cert)
       assert.equal("{vault://mock-vault/key}", certificate.key)

--- a/spec/02-integration/20-wasm/02-db_spec.lua
+++ b/spec/02-integration/20-wasm/02-db_spec.lua
@@ -264,7 +264,7 @@ describe("wasm DB entities [#" .. strategy .. "]", function()
 
         assert.is_nil(chain.tags)
 
-        chain = assert(dao:update({ id = chain.id }, { tags = { "foo" } }))
+        chain = assert(dao:update(chain, { tags = { "foo" } }))
         assert.same({ "foo" }, chain.tags)
       end)
     end)

--- a/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
+++ b/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
@@ -127,19 +127,19 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("andru", consumer_def.username)
         assert.equals("donalds", consumer_def.custom_id)
 
-        local plugin = assert(db.plugins:select({ id = plugin_def.id }))
+        local plugin = assert(db.plugins:select(plugin_def))
         assert.equals(plugin_def.id, plugin.id)
         assert.equals(service.id, plugin.service.id)
         assert.equals("basic-auth", plugin.name)
         assert.same(plugin_def.config, plugin.config)
 
-        local basicauth_credential = assert(db.basicauth_credentials:select({ id = basicauth_credential_def.id }))
+        local basicauth_credential = assert(db.basicauth_credentials:select(basicauth_credential_def))
         assert.equals(basicauth_credential_def.id, basicauth_credential.id)
         assert.equals(consumer.id, basicauth_credential.consumer.id)
         assert.equals("james", basicauth_credential.username)
         assert.equals(crypto.hash(consumer.id, "secret"), basicauth_credential.password)
 
-        local basicauth_hashed_credential = assert(db.basicauth_credentials:select({ id = basicauth_hashed_credential_def.id }))
+        local basicauth_hashed_credential = assert(db.basicauth_credentials:select(basicauth_hashed_credential_def))
         assert.equals(basicauth_hashed_credential_def.id, basicauth_hashed_credential.id)
         assert.equals(consumer.id, basicauth_hashed_credential.consumer.id)
         assert.equals("bond", basicauth_hashed_credential.username)
@@ -224,5 +224,3 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 end
-
-

--- a/spec/03-plugins/16-jwt/02-api_spec.lua
+++ b/spec/03-plugins/16-jwt/02-api_spec.lua
@@ -248,7 +248,7 @@ for _, strategy in helpers.each_strategy() do
             path = "/consumers/bob/jwt/",
           })
           local body = cjson.decode(assert.res_status(200, res))
-          assert.equal(7, #(body.data))
+          assert.equal(6, #(body.data))
         end)
       end)
     end)

--- a/spec/03-plugins/25-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/25-oauth2/01-schema_spec.lua
@@ -189,31 +189,31 @@ for _, strategy in helpers.each_strategy() do
           service = { id = service.id },
         })
 
-        token, err = db.oauth2_tokens:select({ id = token.id })
+        token, err = db.oauth2_tokens:select(token)
         assert.falsy(err)
         assert.truthy(token)
 
-        code, err = db.oauth2_authorization_codes:select({ id = code.id })
+        code, err = db.oauth2_authorization_codes:select(code)
         assert.falsy(err)
         assert.truthy(code)
 
-        ok, err, err_t = db.services:delete({ id = service.id })
+        ok, err, err_t = db.services:delete(service)
         assert.truthy(ok)
         assert.is_falsy(err_t)
         assert.is_falsy(err)
 
         -- no more service
-        service, err = db.services:select({ id = service.id })
+        service, err = db.services:select(service)
         assert.falsy(err)
         assert.falsy(service)
 
         -- no more token
-        token, err = db.oauth2_tokens:select({ id = token.id })
+        token, err = db.oauth2_tokens:select(token)
         assert.falsy(err)
         assert.falsy(token)
 
         -- no more code
-        code, err = db.oauth2_authorization_codes:select({ id = code.id })
+        code, err = db.oauth2_authorization_codes:select(code)
         assert.falsy(err)
         assert.falsy(code)
       end)

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -2883,7 +2883,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local db_code, err = db.oauth2_authorization_codes:select_by_code(code)
         assert.is_nil(err)
         db_code.plugin = ngx.null
-        local _, _, err = db.oauth2_authorization_codes:update({ id = db_code.id }, db_code)
+        local _, _, err = db.oauth2_authorization_codes:update(db_code, db_code)
         assert.is_nil(err)
         local res = assert(proxy_ssl_client:send {
           method  = "POST",
@@ -3732,9 +3732,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
 
 
         -- check refreshing sets created_at so access token doesn't expire
-        db.oauth2_tokens:update({
-          id = new_refresh_token.id
-        }, {
+        db.oauth2_tokens:update(new_refresh_token, {
           created_at = 123, -- set time as expired
         })
 

--- a/spec/03-plugins/29-acme/01-client_spec.lua
+++ b/spec/03-plugins/29-acme/01-client_spec.lua
@@ -299,7 +299,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("create new certificate", function()
-        new_cert, err = db.certificates:select({ id = new_sni.certificate.id })
+        new_cert, err = db.certificates:select(new_sni.certificate)
         assert.is_nil(err)
         assert.same(new_cert.key, key)
         assert.same(new_cert.cert, crt)
@@ -324,14 +324,14 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("creates new certificate", function()
-        new_cert, err = db.certificates:select({ id = new_sni.certificate.id })
+        new_cert, err = db.certificates:select(new_sni.certificate)
         assert.is_nil(err)
         assert.same(new_cert.key, key)
         assert.same(new_cert.cert, crt)
       end)
 
       it("deletes old certificate", function()
-        new_cert, err = db.certificates:select({ id = cert.id })
+        new_cert, err = db.certificates:select(cert)
         assert.is_nil(err)
         assert.is_nil(new_cert)
       end)


### PR DESCRIPTION
### Summary

Previously you needed to write code like this:
```lua
local route = kong.db.routes:select_by_name("my-route")
kong.db.routes:update({ id = route.id }, {
  paths = { "/test" },
})
kong.db.routes:delete({ id = route.id })
```

with this change you can write it like this:

```lua
local route = kong.db.routes:select_by_name("my-route")
kong.db.routes:update(route, {
  paths = { "/test" },
})
kong.db.routes:delete(route)
```
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE