### PR TITLE
fix(build): fix the building failure when applying patches

### DIFF
--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -54,10 +54,10 @@ def _load_vars(ctx):
 
     # convert them into a list of labels relative to the workspace root
     # TODO: this may not change after a bazel clean if cache exists
-    patches = [
+    patches = sorted([
         '"@kong//:%s"' % str(p).replace(workspace_path, "").lstrip("/")
         for p in ctx.path(workspace_path + "/build/openresty/patches").readdir()
-    ]
+    ])
 
     content += '"OPENRESTY_PATCHES": [%s],' % (", ".join(patches))
 

--- a/changelog/unreleased/kong/fix_patch_order.yml
+++ b/changelog/unreleased/kong/fix_patch_order.yml
@@ -1,0 +1,7 @@
+message: fix the building failure when applying patches
+type: bugfix
+scope: Core
+prs:
+  - 11696
+jiras:
+  - KAG-2712


### PR DESCRIPTION
When openresty patch applying order matters, some patch applying fails. Fix it by sorting.

There are 2 patches in the Openresty LuaJIT patches directory that have dependency:
1. LuaJIT-2.1-20230410_03_arm64_sigill.patch
2. LuaJIT-2.1-20230410_07_ldp_stp_unaligned.patch

2 depends on 1. And the current bazel build applying the patch in a non-deterministic order and sometime, it can run to build error if 2 is applied first. Fix it by sorting the patch.


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-2712]_


[KAG-2712]: https://konghq.atlassian.net/browse/KAG-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ