### PR TITLE
feat(wasm): combine config and json_config fields

### DIFF
--- a/changelog/unreleased/kong/wasm-filter-json-config.yml
+++ b/changelog/unreleased/kong/wasm-filter-json-config.yml
@@ -1,0 +1,3 @@
+message: Support JSON in Wasm filter configuration
+type: feature
+scope: Core

--- a/kong/db/schema/entities/filter_chains.lua
+++ b/kong/db/schema/entities/filter_chains.lua
@@ -20,8 +20,7 @@ local constants = require "kong.constants"
 ---
 ---@field name        string
 ---@field enabled     boolean
----@field config      string|nil
----@field json_config any|nil
+---@field config      any|nil
 
 
 local filter = {
@@ -29,27 +28,24 @@ local filter = {
   fields = {
     { name       = { type = "string", required = true, one_of = wasm.filter_names,
                      err = "no such filter", }, },
-    { config     = { type = "string", required = false, }, },
     { enabled    = { type = "boolean", default = true, required = true, }, },
 
-    { json_config = {
+    { config = {
         type = "json",
         required = false,
         json_schema = {
           parent_subschema_key = "name",
           namespace = constants.SCHEMA_NAMESPACES.PROXY_WASM_FILTERS,
           optional = true,
+          default = {
+            -- filters with no user-defined JSON schema may accept an optional
+            -- config, but only as a string
+            type = { "string", "null" },
+          },
         },
       },
     },
 
-  },
-  entity_checks = {
-    { mutually_exclusive = {
-        "config",
-        "json_config",
-      },
-    },
   },
 }
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1135,7 +1135,7 @@ validate_fields = function(self, input)
 
         if json_subschema_key then
           local schema_name = json_schema.namespace .. "/" .. json_subschema_key
-          inline_schema = json.get_schema(schema_name)
+          inline_schema = json.get_schema(schema_name) or json_schema.default
 
           if inline_schema then
             _, errors[k] = json_validate(v, inline_schema)

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -128,6 +128,30 @@ local validators = {
 -- means that input validation will fail. When `optional` is `true`, the input
 -- is always accepted.
 --
+-- Schemas which use this dynamic reference format can also optionally supply
+-- a default inline schema, which will be evaluated when the dynamic schema
+-- does not exist:
+--
+-- ```lua
+-- local record = {
+--   type = "record",
+--   fields = {
+--     { name = { type = "string" } },
+--     { config = {
+--         type = "json",
+--         json_schema = {
+--           namespace = "my-record-type",
+--           parent_subschema_key = "name",
+--           default = {
+--             { type = { "string", "null" } },
+--           },
+--         },
+--       },
+--     },
+--   },
+-- }
+-- ```
+--
 local json_metaschema = {
   type = "record",
   fields = {
@@ -135,6 +159,7 @@ local json_metaschema = {
     { parent_subschema_key = { type = "string" }, },
     { optional = { type = "boolean", }, },
     { inline = { type = "any", custom_validator = json_lib.validate_schema, }, },
+    { default = { type = "any", custom_validator = json_lib.validate_schema, }, },
   },
   entity_checks = {
     { at_least_one_of = { "inline", "namespace", "parent_subschema_key" }, },

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -398,10 +398,18 @@ local function rebuild_state(db, version, old_state)
 
       for _, filter in ipairs(chain.filters) do
         if filter.enabled then
-          -- serialize all JSON configurations up front
-          if not filter.config and filter.json_config ~= nil then
-            filter.config = cjson_encode(filter.json_config)
-            filter.json_config = nil
+          -- Serialize all JSON configurations up front
+          --
+          -- NOTE: there is a subtle difference between a raw, non-JSON filter
+          -- configuration which requires no encoding (e.g. `my config bytes`)
+          -- and a JSON filter configuration of type=string, which should be
+          -- JSON-encoded (e.g. `"my config string"`).
+          --
+          -- Properly disambiguating between the two cases requires an
+          -- inspection of the filter metadata, which is not guaranteed to be
+          -- present on data-plane/proxy nodes.
+          if filter.config ~= nil and type(filter.config) ~= "string" then
+            filter.config = cjson_encode(filter.config)
           end
         end
       end

--- a/spec/02-integration/20-wasm/01-admin-api_spec.lua
+++ b/spec/02-integration/20-wasm/01-admin-api_spec.lua
@@ -4,7 +4,6 @@ local utils = require "kong.tools.utils"
 local fmt = string.format
 
 local FILTER_PATH = assert(helpers.test_conf.wasm_filters_path)
-local NULL = ngx.null
 
 local function json(body)
   return {
@@ -207,9 +206,9 @@ describe("wasm admin API [#" .. strategy .. "]", function()
         assert.same({ "foo", "bar" }, patched.tags)
         assert.is_false(patched.enabled)
         assert.equals(2, #patched.filters)
-        assert.same({ name = "tests", config = "123", enabled = true, json_config = NULL },
+        assert.same({ name = "tests", config = "123", enabled = true },
                     patched.filters[1])
-        assert.same({ name = "tests", config = "456", enabled = false, json_config = NULL },
+        assert.same({ name = "tests", config = "456", enabled = false },
                     patched.filters[2])
       end)
     end)
@@ -366,9 +365,9 @@ describe("wasm admin API [#" .. strategy .. "]", function()
         assert.same({ "foo", "bar" }, patched.tags)
         assert.is_false(patched.enabled)
         assert.equals(2, #patched.filters)
-        assert.same({ name = "tests", config = "123", enabled = true, json_config = NULL },
+        assert.same({ name = "tests", config = "123", enabled = true },
                     patched.filters[1])
-        assert.same({ name = "tests", config = "456", enabled = false, json_config = NULL },
+        assert.same({ name = "tests", config = "456", enabled = false },
                     patched.filters[2])
       end)
     end)
@@ -428,7 +427,7 @@ describe("wasm admin API [#" .. strategy .. "]", function()
       fcs = {
         assert(bp.filter_chains:insert({
           filters = {
-            { name = "tests", config = ngx.null, enabled = true },
+            { name = "tests", config = nil, enabled = true },
             { name = "response_transformer", config = "{}", enabled = false },
           },
           service = { id = service.id },

--- a/spec/02-integration/20-wasm/09-filter-meta_spec.lua
+++ b/spec/02-integration/20-wasm/09-filter-meta_spec.lua
@@ -158,7 +158,7 @@ describe("filter metadata [#" .. strategy .. "]", function()
         filters = {
           {
             name = "rt_with_validation",
-            json_config = {}, -- empty
+            config = {}, -- empty
           },
         },
       })
@@ -185,7 +185,7 @@ describe("filter metadata [#" .. strategy .. "]", function()
         assert.same({
           filters = {
             {
-              json_config = "property add is required"
+              config = "property add is required"
             }
           }
         }, body.fields)
@@ -197,7 +197,7 @@ describe("filter metadata [#" .. strategy .. "]", function()
         filters = {
           {
             name = "rt_with_validation",
-            json_config = {
+            config = {
               add = {
                 headers = {
                   "x-foo:123",
@@ -217,7 +217,7 @@ describe("filter metadata [#" .. strategy .. "]", function()
       end).has_no_error()
     end)
 
-    it("filters without config schemas are not validated", function()
+    it("filters without config schemas can only accept a string", function()
       local host = random_name() .. ".test"
 
       local res = create_filter_chain(host, {
@@ -225,11 +225,36 @@ describe("filter metadata [#" .. strategy .. "]", function()
         filters = {
           {
             name = "rt_no_validation",
-            json_config = {
+            config = {
               add = {
                 headers = 1234,
               },
-            },
+            }
+          },
+        },
+      })
+
+      assert.response(res).has.status(400)
+      local body = assert.response(res).has.jsonbody()
+      assert.same({
+        filters = {
+          { config = "wrong type: expected one of string, null, got object" }
+        }
+      }, body.fields)
+    end)
+
+    it("filters without config schemas are not validated", function()
+      local host = random_name() .. ".test"
+      local res = create_filter_chain(host, {
+        name = random_name(),
+        filters = {
+          {
+            name = "rt_no_validation",
+            config = cjson.encode({
+              add = {
+                headers = 123,
+              },
+            }),
           },
         },
       })
@@ -242,7 +267,6 @@ describe("filter metadata [#" .. strategy .. "]", function()
         assert.logfile().has.line("failed parsing filter config", true, 0)
       end).has_no_error()
     end)
-
   end)
 
 end)


### PR DESCRIPTION
### Summary

This change combines the `config` and `json_config` fields for Wasm filters.

Before, JSON configuration lived in the `json_config` attribute, and `config` could only hold strings:

```lua
{
  filters = {
    {
      name = "my-filter-with-string-config",
      config = "a=1 b=2",
    },
    {
      name = "my-filter-with-json-config",
      json_config = {
        a = 1,
        b = 2,
      }
    },
  }
}
```

Now, both string and JSON configurations live in `config`:

```lua
{
  filters = {
    {
      name = "my-filter-with-string-config",
      config = "a=1 b=2",
    },
    {
      name = "my-filter-with-json-config",
      config = {
        a = 1,
        b = 2,
      }
    },
  }
}
```

The `json_config` field/attribute was [introduced recently](https://github.com/Kong/kong/pull/11568) and is unreleased, so this change does not break any existing API. 

Note: filters may _only_ use JSON in `config` if they have supplied a JSON schema in a `{{filter}}.meta.json` file. Filters without a JSON schema may still accept JSON configuration, but it must be serialized, and it will _not_ be validated in any way by the admin API:

```lua
{
  filters = {
    {
      name = "my-filter-with-json-config-and-schema",
      config = {
        a = 1,
        b = 2,
      }
    },
    {
      name = "my-filter-with-json-config-but-no-schema",
      config = [[{
        "a": 1,
        "b": 2
      }]]
    },
  }
}
```

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* implement `json_schema.default` fallback schema for dynamic JSON subschemas
* Remove `filter_chain.filters[].config` and rename `filter_chain.filters[].json_config` to `filter_chain.filters[].config`
* Create a default/fallback schema for `filter_chain.filters[].config` of `{ "type": [ "string", "null" ] }`

### Issue reference
KAG-2707