### PR TITLE
style(runloop): fix incorrect error log message

### DIFF
--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -517,7 +517,7 @@ do
 
     local reconfigure_data, err = buffer.decode(data)
     if not reconfigure_data then
-      ngx.log(ngx.ERR, "failed to json decode reconfigure data: ", err)
+      ngx.log(ngx.ERR, "failed to decode reconfigure data: ", err)
       return
     end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We are using `string.buffer` now, no json any more.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
