### PR TITLE
tests(rate-limiting): fix a flaky test

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -762,6 +762,8 @@ if limit_by == "ip" then
     assert
       .with_timeout(15)
       .with_max_tries(10)
+      .with_step(0.5) -- the windows is 1 second, we wait 0.5 seconds between each retry,
+                      -- that can avoid some unlucky case (we are at the end of the window)
       .ignore_exceptions(false)
       .eventually(function()
         local res1 = GET(test_path, { headers = { ["X-Real-IP"] = "127.0.0.3" }})


### PR DESCRIPTION
### Summary

We should not use `with_max_retries` for the `expire counter` tests as the default `step` is `0.05` (too small to across a window).

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-2667]_


[KAG-2667]: https://konghq.atlassian.net/browse/KAG-2667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ