### PR TITLE
refactor(api): export yaml with `string.buffer`

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -1,3 +1,4 @@
+local buffer = require("string.buffer")
 local declarative = require("kong.db.declarative")
 local reports = require("kong.reports")
 local errors = require("kong.db.errors")
@@ -93,9 +94,9 @@ return {
       end
 
       local file = {
-        buffer = {},
+        buf = buffer.new(),
         write = function(self, str)
-          self.buffer[#self.buffer + 1] = str
+          self.buf:put(str)
         end,
       }
 
@@ -105,7 +106,7 @@ return {
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 
-      return kong.response.exit(200, { config = table.concat(file.buffer) })
+      return kong.response.exit(200, { config = file.buf:get() })
     end,
     POST = function(self, db)
       if kong.db.strategy ~= "off" then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`string.buffer` has better performance than `table.concat`, we have already used it in other places.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
