### PR TITLE
fix(pdk): # and ipairs on response.get_headers()

### DIFF
--- a/changelog/unreleased/kong/pdk-response-header-mt.yaml
+++ b/changelog/unreleased/kong/pdk-response-header-mt.yaml
@@ -1,0 +1,8 @@
+message: "Fix behavior of kong.service.response.get_headers() when using # and pairs()"
+type: bugfix
+scope: Core
+prs:
+  - 11708
+jiras:
+  - "#11546"
+  - "KAG-2602"


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

Fix #11546, KAG-2602
