### PR TITLE
fix(tracing): set attribute `http.status_code` when no route entry matched

### DIFF
--- a/changelog/unreleased/kong/11711.yml
+++ b/changelog/unreleased/kong/11711.yml
@@ -1,0 +1,3 @@
+message: "set attribute `http.status_code` to 404 in tracing span when no route is matched"
+type: bugfix
+scope: Core

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1145,6 +1145,7 @@ return {
       if not match_t then
         -- tracing
         if span then
+          span:set_attribute("http.status_code", 404)
           span:set_status(2)
           span:finish()
         end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1145,7 +1145,8 @@ return {
       if not match_t then
         -- tracing
         if span then
-          span:set_attribute("http.status_code", 404)
+          local root_span = ctx.KONG_SPANS and ctx.KONG_SPANS[1]
+          root_span:set_attribute("http.status_code", 404)
           span:set_status(2)
           span:finish()
         end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1144,9 +1144,12 @@ return {
       req_dyn_hook.run_hooks("timing", "after:router")
       if not match_t then
         -- tracing
-        if span then
-          local root_span = ctx.KONG_SPANS and ctx.KONG_SPANS[1]
+        local root_span = ctx.KONG_SPANS and ctx.KONG_SPANS[1]
+        if root_span then
           root_span:set_attribute("http.status_code", 404)
+        end
+
+        if span then
           span:set_status(2)
           span:finish()
         end

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -210,7 +210,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_string(res)
 
         local spans = cjson.decode(res)
-        local span = assert_has_span("kong.router", spans)
+        local span = assert_has_span("kong", spans)
         assert_has_attributes(span, {
           ["http.status_code"] = "404",}
         )

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -57,7 +57,7 @@ for _, strategy in helpers.each_strategy() do
 
       bp.routes:insert({ service = http_srv,
                          protocols = { "http" },
-                         paths = { "/" }})
+                         paths = { "/proxy" }})
 
       bp.routes:insert({ service = http_srv,
                          protocols = { "http" },
@@ -114,7 +114,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -142,7 +142,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -176,7 +176,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -195,6 +195,26 @@ for _, strategy in helpers.each_strategy() do
         assert_has_no_span("kong.rewrite.plugin." .. tcp_trace_plugin_name, spans)
         assert_has_no_span("kong.header_filter.plugin." .. tcp_trace_plugin_name, spans)
       end)
+
+      it("http.status_code 404 when no route matched", function()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/404",
+        })
+        assert.res_status(404, r)
+
+        -- Getting back the TCP server input
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        local spans = cjson.decode(res)
+        local span = assert_has_span("kong.router", spans)
+        assert_has_attributes(span, {
+          ["http.status_code"] = "404",}
+        )
+      end)
     end)
 
     describe("http_client", function ()
@@ -210,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -244,7 +264,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -278,7 +298,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -312,7 +332,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -380,7 +400,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 
@@ -489,7 +509,7 @@ for _, strategy in helpers.each_strategy() do
         local thread = helpers.tcp_server(TCP_PORT)
         local r = assert(proxy_client:send {
           method  = "GET",
-          path    = "/",
+          path    = "/proxy",
         })
         assert.res_status(200, r)
 


### PR DESCRIPTION
### Summary

set attribute `http.status_code` in span when no route entry matched

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-5407
