### PR TITLE
fix(template): fix failure of starting if `proxy_access_log` is `off`

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -239,6 +239,7 @@ local function compile_conf(kong_config, conf_template, template_env_inject)
   -- computed config properties for templating
   local compile_env = {
     _escape = ">",
+    proxy_access_log_enabled = kong_config.proxy_access_log ~= "off",
     pairs = pairs,
     ipairs = ipairs,
     tostring = tostring,

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -85,7 +85,12 @@ server {
     # https://github.com/Kong/lua-kong-nginx-module#lua_kong_error_log_request_id
     lua_kong_error_log_request_id $request_id;
 
+> if proxy_access_log_enabled then
     access_log ${{PROXY_ACCESS_LOG}} kong_log_format;
+> else
+    access_log off;
+> end
+
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if proxy_ssl_enabled then

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -497,6 +497,16 @@ describe("NGINX conf compiler", function()
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
+          proxy_access_log = "off",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%soff;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
           proxy_stream_access_log = "/dev/stdout custom",
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",


### PR DESCRIPTION
### Summary

Kong can't start once we set `proxy_access_log` to `off` as `access_log off kong_log_format` is invalid in Nginx.

### Checklist

- [X] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-2730]_


[KAG-2730]: https://konghq.atlassian.net/browse/KAG-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ