### PR TITLE
refactor(pdk): remove duplicated code in set_status()

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -388,10 +388,6 @@ local function new(self, major_version)
       error(fmt("code must be a number between %u and %u", MIN_STATUS_CODE, MAX_STATUS_CODE), 2)
     end
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
-
     ngx.status = status
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The check of `ngx.headers_sent` appears two times, I think that it is unnecessary.

I also think that we could create a new wrapper function for the checking of `ngx.headers_sent` ( will do it in another PR).

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
