### PR TITLE
perf(router): use `resty.core.utils.str_replace_char()` for dashes

### DIFF
--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -164,6 +164,7 @@ build = {
     ["kong.tools.protobuf"] = "kong/tools/protobuf.lua",
     ["kong.tools.mime_type"] = "kong/tools/mime_type.lua",
     ["kong.tools.request_aware_table"] = "kong/tools/request_aware_table.lua",
+    ["kong.tools.string"] = "kong/tools/string.lua",
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",
     ["kong.runloop.events"] = "kong/runloop/events.lua",

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -41,9 +41,6 @@ local get_body_file = req.get_body_file
 local decode_args = ngx.decode_args
 
 
-local is_http_subsystem = ngx and ngx.config.subsystem == "http"
-
-
 local PHASES = phase_checker.phases
 
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -85,11 +85,7 @@ local function new(self)
     end
   end
 
-  local replace_dashes do
-    if is_http_subsystem then
-      replace_dashes = require("kong.tools.utils").replace_dashes
-    end
-  end
+  local replace_dashes = require("kong.tools.utils").replace_dashes
 
 
   ---

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -82,7 +82,7 @@ local function new(self)
     end
   end
 
-  local replace_dashes = require("kong.tools.utils").replace_dashes
+  local replace_dashes = require("kong.tools.string").replace_dashes
 
 
   ---

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -86,16 +86,8 @@ local function new(self)
   end
 
   local replace_dashes do
-    -- 1.000.000 iterations with input of "my-header":
-    -- string.gsub:        81ms
-    -- ngx.re.gsub:        74ms
-    -- loop/string.buffer: 28ms
-    -- str_replace_char:   14ms
     if is_http_subsystem then
-      local str_replace_char = require("resty.core.utils").str_replace_char
-      replace_dashes = function(str)
-        return str_replace_char(str, "-", "_")
-      end
+      replace_dashes = require("kong.tools.utils").replace_dashes
     end
   end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -562,6 +562,7 @@ local get_queries_key
 do
   local tb_sort = table.sort
   local tb_concat = table.concat
+  local replace_dashes = require("kong.tools.utils").replace_dashes
 
   local str_buf = buffer.new(64)
 
@@ -570,7 +571,7 @@ do
 
     -- NOTE: DO NOT yield until str_buf:get()
     for name, value in pairs(headers) do
-      local name = name:gsub("-", "_"):lower()
+      local name = replace_dashes():lower()
 
       if type(value) == "table" then
         for i, v in ipairs(value) do

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -562,7 +562,7 @@ local get_queries_key
 do
   local tb_sort = table.sort
   local tb_concat = table.concat
-  local replace_dashes = require("kong.tools.utils").replace_dashes
+  local replace_dashes = require("kong.tools.string").replace_dashes
 
   local str_buf = buffer.new(64)
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -562,7 +562,7 @@ local get_queries_key
 do
   local tb_sort = table.sort
   local tb_concat = table.concat
-  local replace_dashes = require("kong.tools.string").replace_dashes
+  local replace_dashes_lower = require("kong.tools.string").replace_dashes_lower
 
   local str_buf = buffer.new(64)
 
@@ -571,7 +571,7 @@ do
 
     -- NOTE: DO NOT yield until str_buf:get()
     for name, value in pairs(headers) do
-      local name = replace_dashes(name):lower()
+      local name = replace_dashes_lower(name)
 
       if type(value) == "table" then
         for i, v in ipairs(value) do

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -571,7 +571,7 @@ do
 
     -- NOTE: DO NOT yield until str_buf:get()
     for name, value in pairs(headers) do
-      local name = replace_dashes():lower()
+      local name = replace_dashes(name):lower()
 
       if type(value) == "table" then
         for i, v in ipairs(value) do

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -10,8 +10,8 @@ local tb_nkeys = require("table.nkeys")
 local uuid = require("resty.jit-uuid")
 
 
-local shallow_copy    = require("kong.tools.utils").shallow_copy
-local replace_dashes  = require("kong.tools.string").replace_dashes
+local shallow_copy          = require("kong.tools.utils").shallow_copy
+local replace_dashes_lower  = require("kong.tools.string").replace_dashes_lower
 
 
 local is_regex_magic  = utils.is_regex_magic
@@ -252,7 +252,7 @@ local function get_expression(route)
       single_header_buf:reset():put("(")
 
       for i, value in ipairs(v) do
-        local name = "any(http.headers." .. replace_dashes(h):lower() .. ")"
+        local name = "any(http.headers." .. replace_dashes_lower(h) .. ")"
         local op = OP_EQUAL
 
         -- value starts with "~*"

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -11,6 +11,7 @@ local uuid = require("resty.jit-uuid")
 
 
 local shallow_copy    = require("kong.tools.utils").shallow_copy
+local replace_dashes  = require("kong.tools.string").replace_dashes
 
 
 local is_regex_magic  = utils.is_regex_magic
@@ -251,7 +252,7 @@ local function get_expression(route)
       single_header_buf:reset():put("(")
 
       for i, value in ipairs(v) do
-        local name = "any(http.headers." .. h:gsub("-", "_"):lower() .. ")"
+        local name = "any(http.headers." .. replace_dashes(h):lower() .. ")"
         local op = OP_EQUAL
 
         -- value starts with "~*"

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -6,6 +6,7 @@ local _M = {}
 
 
 local replace_dashes
+local replace_dashes_lower
 do
   local str_replace_char
 
@@ -31,8 +32,13 @@ do
   replace_dashes = function(str)
     return str_replace_char(str, "-", "_")
   end
+
+  replace_dashes_lower = function(str)
+    return str_replace_char(str:lower(), "-", "_")
+  end
 end
 _M.replace_dashes = replace_dashes
+_M.replace_dashes_lower = replace_dashes_lower
 
 
 return _M

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -29,7 +29,7 @@ do
   end
 
   replace_dashes = function(str)
-    return str_replace_char(str or "", "-", "_")
+    return str_replace_char(str, "-", "_")
   end
 end
 _M.replace_dashes = replace_dashes

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -1,8 +1,14 @@
+local find          = string.find
+local gsub          = string.gsub
+
+
 local _M = {}
 
 
 local replace_dashes
 do
+  local str_replace_char
+
   if ngx and ngx.config.subsystem == "http" then
 
     -- 1,000,000 iterations with input of "my-header":
@@ -10,20 +16,20 @@ do
     -- ngx.re.gsub:        74ms
     -- loop/string.buffer: 28ms
     -- str_replace_char:   14ms
-    local str_replace_char = require("resty.core.utils").str_replace_char
-
-    replace_dashes = function(str)
-      return str_replace_char(str or "", "-", "_")
-    end
+    str_replace_char = require("resty.core.utils").str_replace_char
 
   else    -- stream subsystem
-    replace_dashes = function(str)
-      if not find(str or "", "-", nil, true) then
+    str_replace_char = function(str, f, replace)
+      if not find(str, f, nil, true) then
         return str
       end
 
-      return gsub(str, "-", "_")
+      return gsub(str, f, replace)
     end
+  end
+
+  replace_dashes = function(str)
+    return str_replace_char(str or "", "-", "_")
   end
 end
 _M.replace_dashes = replace_dashes

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -1,0 +1,33 @@
+local _M = {}
+
+
+local replace_dashes
+do
+  if ngx and ngx.config.subsystem == "http" then
+
+    -- 1,000,000 iterations with input of "my-header":
+    -- string.gsub:        81ms
+    -- ngx.re.gsub:        74ms
+    -- loop/string.buffer: 28ms
+    -- str_replace_char:   14ms
+    local str_replace_char = require("resty.core.utils").str_replace_char
+
+    replace_dashes = function(str)
+      return str_replace_char(str or "", "-", "_")
+    end
+
+  else    -- stream subsystem
+    replace_dashes = function(str)
+      if not find(str or "", "-", nil, true) then
+        return str
+      end
+
+      return gsub(str, "-", "_")
+    end
+  end
+end
+_M.replace_dashes = replace_dashes
+
+
+return _M
+

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -19,12 +19,12 @@ do
     str_replace_char = require("resty.core.utils").str_replace_char
 
   else    -- stream subsystem
-    str_replace_char = function(str, f, replace)
-      if not find(str, f, nil, true) then
+    str_replace_char = function(str, ch, replace)
+      if not find(str, ch, nil, true) then
         return str
       end
 
-      return gsub(str, f, replace)
+      return gsub(str, ch, replace)
     end
   end
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1859,7 +1859,7 @@ do
   -- str_replace_char:   14ms
   local str_replace_char = require("resty.core.utils").str_replace_char
   replace_dashes = function(str)
-    return str_replace_char(str, "-", "_")
+    return str_replace_char(str or "", "-", "_")
   end
 end
 _M.replace_dashes = replace_dashes

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1849,17 +1849,29 @@ _M.get_start_time_ms  = get_start_time_ms
 _M.get_updated_monotonic_ms = get_updated_monotonic_ms
 
 
--- only available in http subsystem
 local replace_dashes
 do
-  -- 1,000,000 iterations with input of "my-header":
-  -- string.gsub:        81ms
-  -- ngx.re.gsub:        74ms
-  -- loop/string.buffer: 28ms
-  -- str_replace_char:   14ms
-  local str_replace_char = require("resty.core.utils").str_replace_char
-  replace_dashes = function(str)
-    return str_replace_char(str or "", "-", "_")
+  if ngx and ngx.config.subsystem == "http" then
+
+    -- 1,000,000 iterations with input of "my-header":
+    -- string.gsub:        81ms
+    -- ngx.re.gsub:        74ms
+    -- loop/string.buffer: 28ms
+    -- str_replace_char:   14ms
+    local str_replace_char = require("resty.core.utils").str_replace_char
+
+    replace_dashes = function(str)
+      return str_replace_char(str or "", "-", "_")
+    end
+
+  else    -- stream subsystem
+    replace_dashes = function(str)
+      if not find(str or "", "-", nil, true) then
+        return str
+      end
+
+      return gsub(str, "-", "_")
+    end
   end
 end
 _M.replace_dashes = replace_dashes

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1849,12 +1849,4 @@ _M.get_start_time_ms  = get_start_time_ms
 _M.get_updated_monotonic_ms = get_updated_monotonic_ms
 
 
-do
-  local str = require "kong.tools.string"
-  for name, func in pairs(str) do
-    _M[name] = func
-  end
-end
-
-
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1849,4 +1849,20 @@ _M.get_start_time_ms  = get_start_time_ms
 _M.get_updated_monotonic_ms = get_updated_monotonic_ms
 
 
+-- only available in http subsystem
+local replace_dashes
+do
+  -- 1,000,000 iterations with input of "my-header":
+  -- string.gsub:        81ms
+  -- ngx.re.gsub:        74ms
+  -- loop/string.buffer: 28ms
+  -- str_replace_char:   14ms
+  local str_replace_char = require("resty.core.utils").str_replace_char
+  replace_dashes = function(str)
+    return str_replace_char(str, "-", "_")
+  end
+end
+_M.replace_dashes = replace_dashes
+
+
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1849,32 +1849,12 @@ _M.get_start_time_ms  = get_start_time_ms
 _M.get_updated_monotonic_ms = get_updated_monotonic_ms
 
 
-local replace_dashes
 do
-  if ngx and ngx.config.subsystem == "http" then
-
-    -- 1,000,000 iterations with input of "my-header":
-    -- string.gsub:        81ms
-    -- ngx.re.gsub:        74ms
-    -- loop/string.buffer: 28ms
-    -- str_replace_char:   14ms
-    local str_replace_char = require("resty.core.utils").str_replace_char
-
-    replace_dashes = function(str)
-      return str_replace_char(str or "", "-", "_")
-    end
-
-  else    -- stream subsystem
-    replace_dashes = function(str)
-      if not find(str or "", "-", nil, true) then
-        return str
-      end
-
-      return gsub(str, "-", "_")
-    end
+  local str = require "kong.tools.string"
+  for name, func in pairs(str) do
+    _M[name] = func
   end
 end
-_M.replace_dashes = replace_dashes
 
 
 return _M


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`resty.core.utils.str_replace_char()`  is a better way to replace `-` to `_`.
In the future `string.lua` will gather more functions to simplify `tools.utils.lua`.

See: #10443

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
