### PR TITLE
perf(request-debugging): improve performance

### DIFF
--- a/kong/dynamic_hook/init.lua
+++ b/kong/dynamic_hook/init.lua
@@ -74,17 +74,28 @@ function _M.hook(group_name, hook_name, handler)
 end
 
 
-function _M.run_hooks(ctx, group_name, hook_name, ...)
-  if not always_enabled_groups[group_name] then
-    local dynamic_hook = ctx.dynamic_hook
-    if not dynamic_hook then
-      return
-    end
+function _M.is_group_enabled(group_name)
+  if always_enabled_groups[group_name] then
+    return true
+  end
 
-    local enabled_groups = dynamic_hook.enabled_groups
-    if not enabled_groups[group_name] then
-      return
-    end
+  local dynamic_hook = ngx.ctx.dynamic_hook
+  if not dynamic_hook then
+    return false
+  end
+
+  local enabled_groups = dynamic_hook.enabled_groups
+  if not enabled_groups[group_name] then
+    return false
+  end
+
+  return true
+end
+
+
+function _M.run_hooks(ctx, group_name, hook_name, ...)
+  if not _M.is_group_enabled(group_name) then
+    return
   end
 
   local hooks = non_function_hooks[group_name]

--- a/kong/dynamic_hook/init.lua
+++ b/kong/dynamic_hook/init.lua
@@ -74,9 +74,9 @@ function _M.hook(group_name, hook_name, handler)
 end
 
 
-function _M.run_hooks(group_name, hook_name, ...)
+function _M.run_hooks(ctx, group_name, hook_name, ...)
   if not always_enabled_groups[group_name] then
-    local dynamic_hook = ngx.ctx.dynamic_hook
+    local dynamic_hook = ctx.dynamic_hook
     if not dynamic_hook then
       return
     end

--- a/kong/dynamic_hook/wrap_function_gen.lua
+++ b/kong/dynamic_hook/wrap_function_gen.lua
@@ -3,6 +3,7 @@ local ngx_get_phase = ngx.get_phase
 local TEMPLATE = [[
   return function(always_enabled_groups, group_name, original_func, handlers)
     -- we cannot access upvalue here as this function is generated
+    local ngx = ngx
     local ngx_get_phase = ngx.get_phase
 
     return function(%s)

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -49,6 +49,9 @@ local table_concat = table.concat
 local string_lower = string.lower
 local string_byte  = string.byte
 
+local req_dyn_hook_run_hooks = req_dyn_hook.run_hooks
+
+
 local DOT   = string_byte(".")
 local COLON = string_byte(":")
 
@@ -138,7 +141,7 @@ local cachelookup = function(qname, qtype)
   local key = qtype..":"..qname
   local cached = dnscache:get(key)
 
-  req_dyn_hook.run_hooks("timing", "dns:cache_lookup", cached ~= nil)
+  req_dyn_hook_run_hooks(ngx.ctx, "timing", "dns:cache_lookup", cached ~= nil)
 
   if cached then
     cached.touch = now

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -141,7 +141,10 @@ local cachelookup = function(qname, qtype)
   local key = qtype..":"..qname
   local cached = dnscache:get(key)
 
-  req_dyn_hook_run_hooks(ngx.ctx, "timing", "dns:cache_lookup", cached ~= nil)
+  local ctx = ngx.ctx
+  if ctx and ctx.is_timing_enabled then
+    req_dyn_hook_run_hooks(ctx, "timing", "dns:cache_lookup", cached ~= nil)
+  end
 
   if cached then
     cached.touch = now

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -53,6 +53,7 @@ local request_id_get    = request_id.get
 local escape            = require("kong.tools.uri").escape
 local encode            = require("string.buffer").encode
 
+local req_dyn_hook_run_hooks = req_dyn_hook.run_hooks
 
 local is_http_module   = subsystem == "http"
 local is_stream_module = subsystem == "stream"
@@ -1138,10 +1139,10 @@ return {
       instrumentation.precreate_balancer_span(ctx)
 
       -- routing request
-      req_dyn_hook.run_hooks("timing", "before:router")
+      req_dyn_hook_run_hooks(ctx, "timing", "before:router")
       local router = get_updated_router()
       local match_t = router:exec(ctx)
-      req_dyn_hook.run_hooks("timing", "after:router")
+      req_dyn_hook_run_hooks(ctx, "timing", "after:router")
       if not match_t then
         -- tracing
         if span then
@@ -1159,7 +1160,7 @@ return {
 
       ctx.workspace = match_t.route and match_t.route.ws_id
 
-      req_dyn_hook.run_hooks("timing", "workspace_id:got", ctx.workspace)
+      req_dyn_hook_run_hooks(ctx, "timing", "workspace_id:got", ctx.workspace)
 
       local host           = var.host
       local port           = tonumber(ctx.host_port, 10)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1138,11 +1138,20 @@ return {
       -- to plugins in the access phase for doing headers propagation
       instrumentation.precreate_balancer_span(ctx)
 
+      local is_timing_enabled = ctx.is_timing_enabled
+
+      if is_timing_enabled then
+        req_dyn_hook_run_hooks(ctx, "timing", "before:router")
+      end
+
       -- routing request
-      req_dyn_hook_run_hooks(ctx, "timing", "before:router")
       local router = get_updated_router()
       local match_t = router:exec(ctx)
-      req_dyn_hook_run_hooks(ctx, "timing", "after:router")
+
+      if is_timing_enabled then
+        req_dyn_hook_run_hooks(ctx, "timing", "after:router")
+      end
+
       if not match_t then
         -- tracing
         if span then
@@ -1160,7 +1169,9 @@ return {
 
       ctx.workspace = match_t.route and match_t.route.ws_id
 
-      req_dyn_hook_run_hooks(ctx, "timing", "workspace_id:got", ctx.workspace)
+      if is_timing_enabled then
+        req_dyn_hook_run_hooks(ctx, "timing", "workspace_id:got", ctx.workspace)
+      end
 
       local host           = var.host
       local port           = tonumber(ctx.host_port, 10)

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -59,6 +59,9 @@ log_format kong_log_format '$remote_addr - $remote_user [$time_local] '
 # Load variable indexes
 lua_kong_load_var_index default;
 lua_kong_load_var_index $request_id;
+lua_kong_load_var_index $http_x_kong_request_debug;
+lua_kong_load_var_index $http_x_kong_request_debug_token;
+lua_kong_load_var_index $http_x_kong_request_debug_log;
 
 upstream kong_upstream {
     server 0.0.0.1;

--- a/kong/timing/init.lua
+++ b/kong/timing/init.lua
@@ -1,14 +1,15 @@
-local context         = require("kong.timing.context")
-local cjson           = require("cjson.safe")
-local req_dyn_hook    = require("kong.dynamic_hook")
-local constants       = require("kong.constants")
+local context             = require("kong.timing.context")
+local cjson               = require("cjson.safe")
+local req_dyn_hook        = require("kong.dynamic_hook")
+local constants           = require("kong.constants")
 
-local ngx             = ngx
-local ngx_var         = ngx.var
+local ngx                 = ngx
+local ngx_var             = ngx.var
+local ngx_req_set_header  = ngx.req.set_header
 
-local string_format   = string.format
+local string_format       = string.format
 
-local request_id_get  = require("kong.tracing.request_id").get
+local request_id_get      = require("kong.tracing.request_id").get
 
 local FILTER_ALL_PHASES = {
   ssl_cert      = nil,    -- NYI
@@ -67,9 +68,17 @@ function _M.auth()
   local http_x_kong_request_debug_token = ngx_var.http_x_kong_request_debug_token
   local http_x_kong_request_debug_log = ngx_var.http_x_kong_request_debug_log
 
-  ngx.req.set_header("X-Kong-Request-Debug", nil)
-  ngx.req.set_header("X-Kong-Request-Debug-Token", nil)
-  ngx.req.set_header("X-Kong-Request-Debug-Log", nil)
+  if http_x_kong_request_debug then
+    ngx_req_set_header("X-Kong-Request-Debug", nil)
+  end
+
+  if http_x_kong_request_debug_token then
+    ngx_req_set_header("X-Kong-Request-Debug-Token", nil)
+  end
+
+  if http_x_kong_request_debug_log then
+    ngx_req_set_header("X-Kong-Request-Debug-Log", nil)
+  end
 
   if http_x_kong_request_debug == nil or
      http_x_kong_request_debug ~= "*"


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Improve the performance of the request debugging feature.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* reduce the number of calls of `ngx.ctx`
* cache some functions at the module level
* delete debug request headers only when debug headers exist.
* reduce the number of calls of `req_dyn_hook.runhooks()`.

### Issue reference

_[KAG-2738]_


[KAG-2738]: https://konghq.atlassian.net/browse/KAG-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ