### PR TITLE
feat(core): add `/schemas/vaults/:name` endpoint

### DIFF
--- a/changelog/unreleased/kong/11727.yml
+++ b/changelog/unreleased/kong/11727.yml
@@ -1,0 +1,3 @@
+message: "Add a new endpoint `/schemas/vaults/:name` to retrieve the schema of a vault."
+type: feature
+scope: Core

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -183,6 +183,19 @@ return {
       return validate_schema(db_entity_name, self.params)
     end
   },
+
+  ["/schemas/vaults/:name"] = {
+    GET = function(self, db, helpers)
+      local subschema = kong.db.vaults.schema.subschemas[self.params.name]
+      if not subschema then
+        return kong.response.exit(404, { message = "No vault named '"
+                                  .. self.params.name .. "'" })
+      end
+      local copy = api_helpers.schema_to_jsonable(subschema)
+      strip_foreign_schemas(copy.fields)
+      return kong.response.exit(200, copy)
+    end
+  },
   ["/schemas/plugins/:name"] = {
     GET = function(self, db, helpers)
       local subschema = kong.db.plugins.schema.subschemas[self.params.name]

--- a/kong/vaults/env/schema.lua
+++ b/kong/vaults/env/schema.lua
@@ -5,7 +5,7 @@ return {
       config = {
         type = "record",
         fields = {
-          { prefix = { type = "string", match = [[^[%a_-][%a%d_-]*$]] } },
+          { prefix = { type = "string", match = [[^[%a_-][%a%d_-]*$]], description = "The prefix for the environment variable that the value will be stored in." } },
         },
       },
     },

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -462,6 +462,30 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
     end)
   end)
 
+  describe("/schemas/vaults/:name", function()
+    it("returns schema of all vaults", function()
+      for _, vault in ipairs({"env"}) do
+        local res = assert(client:send {
+          method = "GET",
+          path = "/schemas/vaults/" .. vault,
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.fields)
+      end
+    end)
+
+    it("returns 404 on a non-existent plugin", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/schemas/vaults/not-present",
+      })
+      local body = assert.res_status(404, res)
+      local json = cjson.decode(body)
+      assert.same({ message = "No vault named 'not-present'" }, json)
+    end)
+  end)
+
   describe("/schemas/:entity", function()
     it("returns schema of all plugins", function()
       for plugin, _ in pairs(helpers.test_conf.loaded_plugins) do

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -475,7 +475,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       end
     end)
 
-    it("returns 404 on a non-existent plugin", function()
+    it("returns 404 on a non-existent vault", function()
       local res = assert(client:send {
         method = "GET",
         path = "/schemas/vaults/not-present",


### PR DESCRIPTION
### Summary

Adding a new endpoint for named vaults. 

`/schemas/vaults/:name`

Vaults are very similar to plugins in terms of internal structure and we do provide such an endpoint for plugins already (`/schemas/plugins/:name`). This endpoint allows us to query a schema of a specific vault, which wasn't possible before.

@Guaris @fabianrbz  This might be of interest to you.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)


### Issue reference

Fix https://konghq.atlassian.net/browse/KAG-2535
