### PR TITLE
fix(patches): apply Nginx patch for detecting HTTP/2 stream reset attacks early (CVE-2023-44487)

### DIFF
--- a/build/openresty/patches/nginx-1.21.4_09-http2-rapid-reset-ddos-attack-cve-2023-44487.patch
+++ b/build/openresty/patches/nginx-1.21.4_09-http2-rapid-reset-ddos-attack-cve-2023-44487.patch
@@ -1,0 +1,53 @@
+diff --git a/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.c b/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.c
+index 3afa8b6..228b060 100644
+--- a/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.c
++++ b/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.c
+@@ -361,6 +361,7 @@ ngx_http_v2_read_handler(ngx_event_t *rev)
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http2 read handler");
+ 
+     h2c->blocked = 1;
++    h2c->new_streams = 0;
+ 
+     if (c->close) {
+         c->close = 0;
+@@ -1321,6 +1322,14 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
+         goto rst_stream;
+     }
+ 
++    if (h2c->new_streams++ >= 2 * h2scf->concurrent_streams) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many streams at once");
++
++        status = NGX_HTTP_V2_REFUSED_STREAM;
++        goto rst_stream;
++    }
++
+     if (!h2c->settings_ack
+         && !(h2c->state.flags & NGX_HTTP_V2_END_STREAM_FLAG)
+         && h2scf->preread_size < NGX_HTTP_V2_DEFAULT_WINDOW)
+@@ -1386,6 +1395,12 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
+ 
+ rst_stream:
+ 
++    if (h2c->refused_streams++ > ngx_max(h2scf->concurrent_streams, 100)) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many refused streams");
++        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_NO_ERROR);
++    }
++
+     if (ngx_http_v2_send_rst_stream(h2c, h2c->state.sid, status) != NGX_OK) {
+         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+     }
+diff --git a/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.h b/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.h
+index 0eceae3..aef40bb 100644
+--- a/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.h
++++ b/bundle/nginx-1.21.4/src/http/v2/ngx_http_v2.h
+@@ -124,6 +124,8 @@ struct ngx_http_v2_connection_s {
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
+     ngx_uint_t                       idle;
++    ngx_uint_t                       new_streams;
++    ngx_uint_t                       refused_streams;
+     ngx_uint_t                       priority_limit;
+ 
+     ngx_uint_t                       pushing;

--- a/changelog/unreleased/kong/fix-cve-2023-44487.yml
+++ b/changelog/unreleased/kong/fix-cve-2023-44487.yml
@@ -1,0 +1,3 @@
+message: Apply Nginx patch for detecting HTTP/2 stream reset attacks early (CVE-2023-44487)
+type: bugfix
+scope: Core


### PR DESCRIPTION
fix(patches): apply Nginx patch for detecting HTTP/2 stream reset attacks early (CVE-2023-44487)

From nginx/nginx@6ceef19
---------

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Patch was acquired from here:
https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html

It was slightly modified to apply cleanly on our nginx-1.21.4 (just small offset differences),

See: https://www.cve.org/CVERecord?id=CVE-2023-44487

SIR-435

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
