### PR TITLE
fix(rate-limiting): revert request-aware-table usage

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -2,7 +2,7 @@ local policy_cluster = require "kong.plugins.rate-limiting.policies.cluster"
 local timestamp = require "kong.tools.timestamp"
 local reports = require "kong.reports"
 local redis = require "resty.redis"
-local request_aware_table = require "kong.tools.request_aware_table"
+local table_clear = require "table.clear"
 
 local kong = kong
 local pairs = pairs
@@ -18,26 +18,23 @@ local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
 -- for `conf.sync_rate > 0`
 local auto_sync_timer
 
-local cur_usage = request_aware_table.new()
--- {
---     [[
---     [cache_key] = <integer>
---     ]]
--- }
+local cur_usage = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
 
-local cur_usage_expire_at = request_aware_table.new()
--- {
---     [[
---     [cache_key] = <integer>
---     ]]
--- }
+local cur_usage_expire_at = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
 
-local cur_delta = request_aware_table.new()
--- {
---     [[
---     [cache_key] = <integer>
---     ]]
--- }
+local cur_delta = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
 
 
 local function is_present(str)
@@ -141,9 +138,9 @@ local function get_redis_connection(conf)
 end
 
 local function clear_local_counter()
-  cur_usage:clear()
-  cur_usage_expire_at:clear()
-  cur_delta:clear()
+  table_clear(cur_usage)
+  table_clear(cur_usage_expire_at)
+  table_clear(cur_delta)
 end
 
 local function sync_to_redis(premature, conf)


### PR DESCRIPTION
### Summary

The [request-aware-table](https://github.com/Kong/kong/pull/11017/) was incorrectly used in this plugin, these tables are expected to be shared across requests and should not be limited to a single request.

This PR just reverts the usage of the request-aware-table from the rate-limiting plugin.

### Checklist

- [x] (no) The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
