### PR TITLE
Revert "Revert "fix(hybrid): opentelemetry and zipkin header_type

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,6 +23,40 @@ end
 
 
 local compatible_checkers = {
+  { 3004000000, --[[ 3.4.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local has_update
+
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'opentelemetry' or plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.header_type == 'aws' then
+            config.header_type = 'preserve'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' header_type == aws',
+                             'overwritten with default value `preserve`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'zipkin' then
+          local config = plugin.config
+          if config.default_header_type == 'aws' then
+            config.default_header_type = 'b3'
+            log_warn_message('configures ' .. plugin.name .. ' plugin with:' ..
+                             ' default_header_type == aws',
+                             'overwritten with default value `b3`',
+                             dp_version, log_suffix)
+            has_update = true
+          end
+        end
+      end
+
+      return has_update
+    end,
+  },
+
   { 3003000000, --[[ 3.3.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -108,7 +108,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
   end)
 
   describe("plugin config fields", function()
-    local rate_limit
+    local rate_limit, opentelemetry, zipkin
 
     lazy_setup(function()
       rate_limit = admin.plugins:insert {
@@ -178,6 +178,58 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       local plugin = get_plugin(id, "3.4.0", rate_limit.name)
       assert.same(rate_limit.config, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+    end)
+
+    describe("compatibility tests for opentelemetry plugin", function()
+      it("replaces `aws` value of `header_type` property with default `preserve`", function()
+        -- [[ 3.4.x ]] --
+        opentelemetry = admin.plugins:insert {
+          name = "opentelemetry",
+          enabled = true,
+          config = {
+            endpoint = "http://1.1.1.1:12345/v1/trace",
+            -- [[ new value 3.4.0
+            header_type = "aws"
+            -- ]]
+          }
+        }
+
+        local expected_otel_prior_34 = utils.cycle_aware_deep_copy(opentelemetry)
+        expected_otel_prior_34.config.header_type = "preserve"
+        local plugin = get_plugin(utils.uuid(), "3.3.0", expected_otel_prior_34.name)
+        assert.is_not_nil(plugin)
+        assert.same(expected_otel_prior_34.config, plugin.config)
+
+        -- cleanup
+        admin.plugins:remove({ id = opentelemetry.id })
+      end)
+
+    end)
+
+    describe("compatibility tests for zipkin plugin", function()
+      it("replaces `aws` value of `header_type` property with default `preserve`", function()
+        -- [[ 3.4.x ]] --
+        zipkin = admin.plugins:insert {
+          name = "zipkin",
+          enabled = true,
+          config = {
+            http_endpoint = "http://1.1.1.1:12345/v1/trace",
+            -- [[ new value 3.4.0
+            header_type = "aws"
+            -- ]]
+          }
+        }
+
+        local expected_zipkin_prior_34 = utils.cycle_aware_deep_copy(zipkin)
+        expected_zipkin_prior_34.config.header_type = "preserve"
+        expected_zipkin_prior_34.config.default_header_type = "b3"
+        local plugin = get_plugin(utils.uuid(), "3.3.0", expected_zipkin_prior_34.name)
+        assert.is_not_nil(plugin)
+        assert.same(expected_zipkin_prior_34.config, plugin.config)
+
+        -- cleanup
+        admin.plugins:remove({ id = zipkin.id })
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
add back #11687

This reverts commit 0b47e243e0b19ad193b280ae25f349b105c9c74f.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
