### PR TITLE
refactor(tools): simplify the logic of request_aware_table

### DIFF
--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -3,7 +3,8 @@
 
 local table_new = require("table.new")
 local table_clear = require("table.clear")
-local get_request_id = require("kong.tracing.request_id").get
+local request_id = require("kong.tracing.request_id")
+
 
 local is_not_debug_mode = (kong.configuration.log_level ~= "debug")
 
@@ -14,22 +15,16 @@ local setmetatable = setmetatable
 local get_phase    = ngx.get_phase
 
 
-local NGX_VAR_PHASES = {
-  set           = true,
-  rewrite       = true,
-  access        = true,
-  content       = true,
-  header_filter = true,
-  body_filter   = true,
-  log           = true,
-  balancer      = true,
-}
+local get_request_id = request_id.get
+local var_available = request_id.var_available
+
+
 local ALLOWED_REQUEST_ID_K = "__allowed_request_id"
 
 
 -- Check if access is allowed for table, based on the request ID
 local function enforce_sequential_access(table)
-  if not NGX_VAR_PHASES[get_phase()] then
+  if not var_available(get_phase()) then
     -- allow access and reset allowed request ID
     rawset(table, ALLOWED_REQUEST_ID_K, nil)
     return

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -3,7 +3,7 @@
 
 local table_new = require("table.new")
 local table_clear = require("table.clear")
-local request_id = require("kong.tracing.request_id")
+local get_request_id = require("kong.tracing.request_id").get
 
 
 local is_not_debug_mode = (kong.configuration.log_level ~= "debug")
@@ -12,9 +12,6 @@ local is_not_debug_mode = (kong.configuration.log_level ~= "debug")
 local error        = error
 local rawset       = rawset
 local setmetatable = setmetatable
-
-
-local get_request_id = request_id.get
 
 
 local ALLOWED_REQUEST_ID_K = "__allowed_request_id"

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -15,7 +15,6 @@ local setmetatable = setmetatable
 
 
 local get_request_id = request_id.get
-local var_available = request_id.var_available
 
 
 local ALLOWED_REQUEST_ID_K = "__allowed_request_id"
@@ -23,13 +22,14 @@ local ALLOWED_REQUEST_ID_K = "__allowed_request_id"
 
 -- Check if access is allowed for table, based on the request ID
 local function enforce_sequential_access(table)
-  if not var_available() then
+  local curr_request_id = get_request_id()
+
+  if not curr_request_id then
     -- allow access and reset allowed request ID
     rawset(table, ALLOWED_REQUEST_ID_K, nil)
     return
   end
 
-  local curr_request_id = get_request_id()
   local allowed_request_id = rawget(table, ALLOWED_REQUEST_ID_K)
   if not allowed_request_id then
     -- first access. Set allowed request ID and allow access

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -12,7 +12,6 @@ local is_not_debug_mode = (kong.configuration.log_level ~= "debug")
 local error        = error
 local rawset       = rawset
 local setmetatable = setmetatable
-local get_phase    = ngx.get_phase
 
 
 local get_request_id = request_id.get
@@ -24,7 +23,7 @@ local ALLOWED_REQUEST_ID_K = "__allowed_request_id"
 
 -- Check if access is allowed for table, based on the request ID
 local function enforce_sequential_access(table)
-  if not var_available(get_phase()) then
+  if not var_available() then
     -- allow access and reset allowed request ID
     rawset(table, ALLOWED_REQUEST_ID_K, nil)
     return

--- a/kong/tracing/request_id.lua
+++ b/kong/tracing/request_id.lua
@@ -20,17 +20,12 @@ local function get_ctx_request_id()
 end
 
 
-local function var_available(phase)
-  return NGX_VAR_PHASES[phase or get_phase()]
-end
-
-
 local function get()
   local rid = get_ctx_request_id()
 
   if not rid then
     local phase = get_phase()
-    if not var_available(phase) then
+    if not NGX_VAR_PHASES[phase] then
       return nil, "cannot access ngx.var in " .. phase .. " phase"
     end
 

--- a/kong/tracing/request_id.lua
+++ b/kong/tracing/request_id.lua
@@ -47,8 +47,6 @@ end
 return {
   get = get,
 
-  var_available = var_available,
-
   -- for unit testing
   _get_ctx_request_id = get_ctx_request_id,
 }

--- a/kong/tracing/request_id.lua
+++ b/kong/tracing/request_id.lua
@@ -20,8 +20,8 @@ local function get_ctx_request_id()
 end
 
 
-local function var_available()
-  return NGX_VAR_PHASES[get_phase()]
+local function var_available(phase)
+  return NGX_VAR_PHASES[phase or get_phase()]
 end
 
 
@@ -29,8 +29,9 @@ local function get()
   local rid = get_ctx_request_id()
 
   if not rid then
-    if not var_available() then
-      return nil, "cannot access ngx.var in " .. get_phase() .. " phase"
+    local phase = get_phase()
+    if not var_available(phase) then
+      return nil, "cannot access ngx.var in " .. phase .. " phase"
     end
 
     -- first access to the request id for this request:

--- a/kong/tracing/request_id.lua
+++ b/kong/tracing/request_id.lua
@@ -2,6 +2,7 @@ local ngx = ngx
 local var = ngx.var
 local get_phase = ngx.get_phase
 
+
 local NGX_VAR_PHASES = {
   set           = true,
   rewrite       = true,
@@ -19,12 +20,17 @@ local function get_ctx_request_id()
 end
 
 
+local function var_available(phase)
+  return NGX_VAR_PHASES[phase]
+end
+
+
 local function get()
   local rid = get_ctx_request_id()
 
   if not rid then
     local phase = get_phase()
-    if not NGX_VAR_PHASES[phase] then
+    if not var_available(phase) then
       return nil, "cannot access ngx.var in " .. phase .. " phase"
     end
 
@@ -40,6 +46,8 @@ end
 
 return {
   get = get,
+
+  var_available = var_available,
 
   -- for unit testing
   _get_ctx_request_id = get_ctx_request_id,

--- a/kong/tracing/request_id.lua
+++ b/kong/tracing/request_id.lua
@@ -20,8 +20,8 @@ local function get_ctx_request_id()
 end
 
 
-local function var_available(phase)
-  return NGX_VAR_PHASES[phase]
+local function var_available()
+  return NGX_VAR_PHASES[get_phase()]
 end
 
 
@@ -29,9 +29,8 @@ local function get()
   local rid = get_ctx_request_id()
 
   if not rid then
-    local phase = get_phase()
-    if not var_available(phase) then
-      return nil, "cannot access ngx.var in " .. phase .. " phase"
+    if not var_available() then
+      return nil, "cannot access ngx.var in " .. get_phase() .. " phase"
     end
 
     -- first access to the request id for this request:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

There are some duplicated code in `tracing.request_id` and `request_aware_table`,
use `request_id.get()` to get clean code.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
