### PR TITLE
fix(wasm): permit json-typed filter configuration on data plane nodes

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -58,7 +58,8 @@ if [ "$TEST_SUITE" == "dbless" ]; then
                      spec/02-integration/04-admin_api/15-off_spec.lua \
                      spec/02-integration/08-status_api/01-core_routes_spec.lua \
                      spec/02-integration/08-status_api/03-readiness_endpoint_spec.lua \
-                     spec/02-integration/11-dbless
+                     spec/02-integration/11-dbless \
+                     spec/02-integration/20-wasm
 fi
 if [ "$TEST_SUITE" == "plugins" ]; then
     set +ex

--- a/spec/02-integration/20-wasm/01-admin-api_spec.lua
+++ b/spec/02-integration/20-wasm/01-admin-api_spec.lua
@@ -61,7 +61,7 @@ describe("wasm admin API [#" .. strategy .. "]", function()
 
   lazy_teardown(function()
     if admin then admin:close() end
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 
@@ -568,7 +568,7 @@ describe("wasm admin API - wasm = off [#" .. strategy .. "]", function()
 
   lazy_teardown(function()
     if admin then admin:close() end
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("/filter-chains", function()

--- a/spec/02-integration/20-wasm/03-runtime_spec.lua
+++ b/spec/02-integration/20-wasm/03-runtime_spec.lua
@@ -34,7 +34,7 @@ describe("#wasm filter execution (#" .. strategy .. ")", function()
       },
     })
 
-    local bp = helpers.get_db_utils("postgres", {
+    local bp = helpers.get_db_utils(strategy, {
       "routes",
       "services",
       "filter_chains",
@@ -358,19 +358,14 @@ describe("#wasm filter execution (#" .. strategy .. ")", function()
 
     assert(helpers.start_kong({
       database = strategy,
-      declarative_config = strategy == "off"
-                       and helpers.make_yaml_file()
-                        or nil,
-
       nginx_conf = "spec/fixtures/custom_nginx.template",
-
       wasm = true,
     }))
   end)
 
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
+++ b/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
@@ -22,98 +22,19 @@ local function make_config(src)
 end
 
 
-local function update_yaml_config()
-  local fname = helpers.make_yaml_file()
-  local yaml = assert(helpers.file.read(fname))
-
-  local client = helpers.admin_client()
-
-  local res = client:post("/config", {
-    headers = { ["Content-Type"] = "text/yaml" },
-    body = yaml,
-  })
-
-  assert.response(res).has.status(201)
-
-  client:close()
-end
-
-
-local function declarative_api_functions(db)
-  local dao = db.filter_chains
-
-  local insert = function(entity)
-    local res = assert(dao:insert(entity))
-    update_yaml_config()
-    return res
-  end
-
-  local update = function(id, updates)
-    if type(id) == "string" then
-      id = { id = id }
-    end
-    local res = assert(dao:update(id, updates))
-    update_yaml_config()
-    return res
-  end
-
-  local delete = function(id)
-    if type(id) == "string" then
-      id = { id = id }
-    end
-    local res = assert(dao:delete(id))
-    update_yaml_config()
-    return res
-  end
-
-  return insert, update, delete
-end
-
-
-local function db_api_functions()
-  local api = require("spec.fixtures.admin_api").filter_chains
-
-  local insert = function(entity)
-    return assert(api:insert(entity))
-  end
-
-  local update = function(id, updates)
-    return assert(api:update(id, updates))
-  end
-
-  local delete = function(id)
-    local _, err = api:remove(id)
-    assert(not err, err)
-  end
-
-  return insert, update, delete
-end
-
-
-local function make_api(strategy, db)
-  if strategy == "off" then
-    return declarative_api_functions(db)
-  end
-
-  return db_api_functions()
-end
-
-
 -- we must use more than one worker to ensure adequate test coverage
 local WORKER_COUNT = 4
 local WORKER_ID_HEADER = "X-Worker-Id"
 
-for _, strategy in ipairs({ "postgres", "off"}) do
+for _, strategy in helpers.each_strategy({ "postgres", "off" }) do
 
 for _, consistency in ipairs({ "eventual", "strict" }) do
 
 local mode_suffix = fmt("(strategy: #%s) (#%s consistency)",
-                   strategy, consistency)
+                        strategy, consistency)
 
 describe("#wasm filter chain cache " .. mode_suffix, function()
-  local db
-
-  local insert, update, delete
+  local bp
 
   local hosts = {
     filter     = "filter.test",
@@ -206,12 +127,36 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
       },
     })
 
-    local bp
-    bp, db = helpers.get_db_utils("postgres", {
+    helpers.get_db_utils(strategy, {
       "services",
       "routes",
       "filter_chains",
     })
+
+    assert(helpers.start_kong({
+      database = strategy,
+      declarative_config_string = strategy == "off"
+                                  and cjson.encode({ _format_version = "3.0" })
+                                  or nil,
+
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      wasm = true,
+
+      nginx_main_worker_processes = WORKER_COUNT,
+
+      worker_consistency = consistency,
+      worker_state_update_frequency = 0.25,
+
+      proxy_listen = fmt("%s:%s reuseport",
+                         helpers.get_proxy_ip(),
+                         helpers.get_proxy_port()),
+    }))
+
+    if strategy == "off" then
+      bp = require("spec.fixtures.dc_blueprints").admin_api(helpers.db)
+    else
+      bp = require("spec.fixtures.admin_api")
+    end
 
     services.filter = bp.services:insert({ name = hosts.filter })
     services.no_filter = bp.services:insert({ name = hosts.no_filter })
@@ -250,38 +195,18 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     }))
 
 
-    insert, update, delete = make_api(strategy, db)
 
-
-    assert(helpers.start_kong({
-      database = strategy,
-      declarative_config = strategy == "off"
-                       and helpers.make_yaml_file()
-                        or nil,
-
-      nginx_conf = "spec/fixtures/custom_nginx.template",
-      wasm = true,
-
-      nginx_main_worker_processes = WORKER_COUNT,
-
-      worker_consistency = consistency,
-      worker_state_update_frequency = 0.25,
-
-      proxy_listen = fmt("%s:%s reuseport",
-                         helpers.get_proxy_ip(),
-                         helpers.get_proxy_port()),
-    }))
   end)
 
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 
   before_each(function()
     helpers.clean_logfile()
-    db.filter_chains:truncate()
+    assert(bp.filter_chains:truncate())
 
     -- sanity
     assert_no_filter(hosts.no_filter, "(test setup)")
@@ -291,7 +216,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
   it("is invalidated on filter creation and removal", function()
     assert_no_filter(hosts.filter, "(initial test)")
 
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       service = services.filter,
       filters = {
         { name = "response_transformer",
@@ -303,7 +228,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     assert_filters(hosts.filter, { "service" },
                    "after adding a service filter chain")
 
-    local route_chain = insert({
+    local route_chain = bp.filter_chains:insert({
       route = routes.filter,
       filters = {
         { name = "response_transformer",
@@ -315,11 +240,11 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     assert_filters(hosts.filter, { "service", "route" },
                    "after adding a route filter chain")
 
-    delete({ id = route_chain.id })
+    bp.filter_chains:remove({ id = route_chain.id })
     assert_filters(hosts.filter, { "service" },
                    "after removing the route filter chain")
 
-    delete({ id = service_chain.id })
+    bp.filter_chains:remove({ id = service_chain.id })
 
     assert_no_filter(hosts.filter,
                      "after removing all relevant filter chains")
@@ -328,7 +253,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
   it("is invalidated on update when a filter chain is enabled/disabled", function()
     assert_no_filter(hosts.filter, "(initial test)")
 
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       enabled = false,
       service = services.filter,
       filters = {
@@ -338,7 +263,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
       }
     })
 
-    local route_chain = insert({
+    local route_chain = bp.filter_chains:insert({
       enabled = false,
       route = routes.filter,
       filters = {
@@ -351,31 +276,31 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     -- sanity
     assert_no_filter(hosts.filter, "after adding disabled filter chains")
 
-    assert(update(service_chain.id, { enabled = true }))
+    assert(bp.filter_chains:update(service_chain.id, { enabled = true }))
 
     assert_filters(hosts.filter, { "service" },
                    "after enabling the service filter chain")
 
 
-    assert(update(route_chain.id, { enabled = true }))
+    assert(bp.filter_chains:update(route_chain.id, { enabled = true }))
 
     assert_filters(hosts.filter, { "service", "route" },
                    "after enabling the route filter chain")
 
 
-    assert(update(route_chain.id, { enabled = false }))
+    assert(bp.filter_chains:update(route_chain.id, { enabled = false }))
 
     assert_filters(hosts.filter, { "service" },
                    "after disabling the route filter chain")
 
 
-    assert(update(service_chain.id, { enabled = false }))
+    assert(bp.filter_chains:update(service_chain.id, { enabled = false }))
 
     assert_no_filter(hosts.filter, "after disabling all filter chains")
   end)
 
   it("is invalidated on update when filters are added/removed", function()
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       service = services.filter,
       filters = {
         { name = "response_transformer",
@@ -387,7 +312,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     assert_filters(hosts.filter, { "service" },
                    "after enabling a service filter chain")
 
-    assert(update(service_chain.id, {
+    assert(bp.filter_chains:update(service_chain.id, {
       filters = {
         { name = "response_transformer",
           config = make_config("service")
@@ -402,7 +327,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     assert_filters(hosts.filter, { "service", "new" },
                    "after adding a filter to the service filter chain")
 
-    assert(update(service_chain.id, {
+    assert(bp.filter_chains:update(service_chain.id, {
       filters = {
         { name = "response_transformer",
           config = make_config("new")
@@ -415,7 +340,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
   end)
 
   it("is invalidated when filters are enabled/disabled", function()
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       service = services.filter,
       filters = {
         { name = "response_transformer",
@@ -434,26 +359,26 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
                    "after enabling a service filter chain")
 
     service_chain.filters[1].enabled = false
-    assert(update(service_chain.id, service_chain))
+    assert(bp.filter_chains:update(service_chain.id, service_chain))
 
     assert_filters(hosts.filter, { "other" },
                    "after disabling a filter in the chain")
 
     service_chain.filters[1].enabled = true
     service_chain.filters[2].enabled = false
-    assert(update(service_chain.id, service_chain))
+    assert(bp.filter_chains:update(service_chain.id, service_chain))
     assert_filters(hosts.filter, { "service" },
                    "after changing the enabled filters in the chain")
 
     service_chain.filters[1].enabled = false
     service_chain.filters[2].enabled = false
-    assert(update(service_chain.id, service_chain))
+    assert(bp.filter_chains:update(service_chain.id, service_chain))
 
     assert_no_filter(hosts.filter, "after disabling all filters in the chain")
   end)
 
   it("is invalidated when filters are re-ordered", function()
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       service = services.filter,
       filters = {
         { name = "response_transformer",
@@ -479,7 +404,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
     service_chain.filters[1], service_chain.filters[3]
       = service_chain.filters[3], service_chain.filters[1]
 
-    assert(update(service_chain.id, service_chain))
+    assert(bp.filter_chains:update(service_chain.id, service_chain))
 
     assert_filters(hosts.filter, { "last", "middle", "first" },
                    "after re-ordering the filter chain items")
@@ -487,7 +412,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
 
 
   it("is invalidated when filter configuration is changed", function()
-    local service_chain = insert({
+    local service_chain = bp.filter_chains:insert({
       service = services.filter,
       filters = {
         { name = "response_transformer",
@@ -501,7 +426,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
                    "after enabling a service filter chain")
 
     service_chain.filters[1].config = make_config("after")
-    assert(update(service_chain.id, service_chain))
+    assert(bp.filter_chains:update(service_chain.id, service_chain))
 
     assert_filters(hosts.filter, { "after" },
                    "after enabling a service filter chain")

--- a/spec/02-integration/20-wasm/07-reports_spec.lua
+++ b/spec/02-integration/20-wasm/07-reports_spec.lua
@@ -3,14 +3,6 @@ local constants = require "kong.constants"
 local cjson = require "cjson"
 
 
-local function json(body)
-  return {
-    headers = { ["Content-Type"] = "application/json" },
-    body = body,
-  }
-end
-
-
 for _, strategy in helpers.each_strategy() do
   local dns_hostsfile
   local reports_server
@@ -30,10 +22,17 @@ for _, strategy in helpers.each_strategy() do
       assert(fd:write("127.0.0.1 " .. constants.REPORTS.ADDRESS))
       assert(fd:close())
 
+      require("kong.runloop.wasm").enable({
+        { name = "tests",
+          path = helpers.test_conf.wasm_filters_path .. "/tests.wasm",
+        },
+      })
+
       local bp = assert(helpers.get_db_utils(strategy, {
         "services",
         "routes",
         "plugins",
+        "filter_chains",
       }, { "reports-api" }))
 
       local http_srv = assert(bp.services:insert {
@@ -51,10 +50,9 @@ for _, strategy in helpers.each_strategy() do
         config = {}
       })
 
-      require("kong.runloop.wasm").enable({
-        { name = "tests",
-          path = helpers.test_conf.wasm_filters_path .. "/tests.wasm",
-        },
+      bp.filter_chains:insert({
+        filters = { { name = "tests" } },
+        service = { id = http_srv.id },
       })
 
       assert(helpers.start_kong({
@@ -65,15 +63,6 @@ for _, strategy in helpers.each_strategy() do
         wasm = true,
         anonymous_reports = true,
       }))
-
-      local admin = assert(helpers.admin_client())
-      local res = admin:post("/filter-chains", json({
-          filters = { { name = "tests" } },
-          service = { id = http_srv.id },
-        })
-      )
-      assert.res_status(201, res)
-      admin:close()
     end)
 
     lazy_teardown(function()

--- a/spec/02-integration/20-wasm/09-filter-meta_spec.lua
+++ b/spec/02-integration/20-wasm/09-filter-meta_spec.lua
@@ -236,11 +236,30 @@ describe("filter metadata [#" .. strategy .. "]", function()
 
       assert.response(res).has.status(400)
       local body = assert.response(res).has.jsonbody()
-      assert.same({
-        filters = {
-          { config = "wrong type: expected one of string, null, got object" }
-        }
-      }, body.fields)
+
+      if strategy == "off" then
+        assert.is_table(body.flattened_errors)
+        assert.same(1, #body.flattened_errors)
+
+        local err = body.flattened_errors[1]
+        assert.is_table(err)
+        assert.same("filter_chain", err.entity_type)
+        assert.same({
+          {
+            field = "filters.1.config",
+            message = "wrong type: expected one of string, null, got object",
+            type = "field"
+          }
+        }, err.errors)
+
+      else
+        assert.same({
+          filters = {
+            { config = "wrong type: expected one of string, null, got object" }
+          }
+        }, body.fields)
+      end
+
     end)
 
     it("filters without config schemas are not validated", function()
@@ -250,11 +269,7 @@ describe("filter metadata [#" .. strategy .. "]", function()
         filters = {
           {
             name = "rt_no_validation",
-            config = cjson.encode({
-              add = {
-                headers = 123,
-              },
-            }),
+            config = [[{ "add": { "headers": 1234 } }]],
           },
         },
       })
@@ -403,3 +418,85 @@ describe("filter metadata [#" .. strategy .. "] startup errors -", function()
 end)
 
 end -- each strategy
+
+
+describe("filter metadata [#off] yaml config", function()
+  local tmp_dir
+  local kong_yaml
+  local client
+
+  lazy_setup(function()
+    tmp_dir = helpers.make_temp_dir()
+    assert(file.copy(TEST_FILTER_SRC, tmp_dir .. "/response_transformer.wasm"))
+    assert(file.copy(TEST_FILTER_SRC, tmp_dir .. "/response_transformer_with_schema.wasm"))
+    assert(file.write(tmp_dir .. "/response_transformer_with_schema.meta.json", cjson.encode({
+      config_schema = {
+        type = "object",
+      },
+    })))
+
+    kong_yaml = helpers.make_yaml_file(([[
+      _format_version: "3.0"
+      services:
+      - url: http://127.0.0.1:%s
+        routes:
+        - hosts:
+          - wasm.test
+          filter_chains:
+          - filters:
+            - name: response_transformer
+              config: '{
+                  "append": {
+                    "headers": [
+                      "x-response-transformer-1:TEST"
+                    ]
+                  }
+                }'
+            - name: response_transformer_with_schema
+              config:
+                append:
+                  headers:
+                  - x-response-transformer-2:TEST
+                rename: ~
+                remove: null
+    ]]):format(helpers.mock_upstream_port))
+
+    assert(helpers.start_kong({
+      database = "off",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "off",
+      wasm = true,
+      wasm_filters_path = tmp_dir,
+      nginx_main_worker_processes = 1,
+      declarative_config = kong_yaml,
+    }))
+
+    client = helpers.proxy_client()
+  end)
+
+  lazy_teardown(function()
+    if client then client:close() end
+    helpers.stop_kong()
+    if tmp_dir then helpers.dir.rmtree(tmp_dir) end
+  end)
+
+  it("accepts filters with JSON and string configs", function()
+    assert.eventually(function()
+      local res = client:get("/", { headers = { host = "wasm.test" } })
+
+      assert.response(res).has.status(200)
+
+      if res.headers["x-response-transformer-1"] == "TEST"
+        and res.headers["x-response-transformer-2"] == "TEST"
+      then
+        return true
+      end
+
+      return nil, {
+        message = "missing or incorrect x-response-transformer-{1,2} headers",
+        headers = res.headers,
+      }
+
+    end).is_truthy()
+  end)
+end)

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -47,6 +47,20 @@ for name, dao in pairs(helpers.db.daos) do
     update = function(_, id, tbl)
       return api_send("PATCH", "/" .. admin_api_name .. "/" .. id, tbl)
     end,
+    truncate = function()
+      repeat
+        local res = api_send("GET", "/" .. admin_api_name)
+        assert(type(res) == "table" and type(res.data) == "table")
+        for _, entity in ipairs(res.data) do
+          local _, err = admin_api_as_db[name]:remove(entity)
+          if err then
+            return nil, err
+          end
+        end
+      until #res.data == 0
+
+      return true
+    end,
   }
 end
 

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -60,6 +60,13 @@ function Blueprint:insert_n(n, overrides, options)
   return res
 end
 
+function Blueprint:truncate()
+  local _, err = self.dao:truncate()
+  if err then
+    error(err, 2)
+  end
+  return true
+end
 
 local function new_blueprint(dao, build_function)
   return setmetatable({

--- a/spec/fixtures/dc_blueprints.lua
+++ b/spec/fixtures/dc_blueprints.lua
@@ -1,5 +1,6 @@
 local blueprints = require "spec.fixtures.blueprints"
 local utils = require "kong.tools.utils"
+local assert = require "luassert"
 
 
 local dc_blueprints = {}
@@ -8,7 +9,7 @@ local dc_blueprints = {}
 local null = ngx.null
 
 
-local function reset()
+local function new_config()
   return {
     _format_version = "3.0"
   }
@@ -27,18 +28,17 @@ local function remove_nulls(tbl)
 end
 
 
-function dc_blueprints.new(db)
+local function wrap_db(db)
   local dc_as_db = {}
 
-  local save_dc
-  local dc = reset()
+  local config = new_config()
 
   for name, _ in pairs(db.daos) do
     dc_as_db[name] = {
       insert = function(_, tbl)
         tbl = utils.cycle_aware_deep_copy(tbl)
-        if not dc[name] then
-          dc[name] = {}
+        if not config[name] then
+          config[name] = {}
         end
         local schema = db.daos[name].schema
         tbl = schema:process_auto_fields(tbl, "insert")
@@ -49,16 +49,16 @@ function dc_blueprints.new(db)
                          or nil
           end
         end
-        table.insert(dc[name], remove_nulls(tbl))
+        table.insert(config[name], remove_nulls(tbl))
         return utils.cycle_aware_deep_copy(tbl)
       end,
       update = function(_, id, tbl)
-        if not dc[name] then
+        if not config[name] then
           return nil, "not found"
         end
         tbl = utils.cycle_aware_deep_copy(tbl)
         local element
-        for _, e in ipairs(dc[name]) do
+        for _, e in ipairs(config[name]) do
           if e.id == id then
             element = e
             break
@@ -71,25 +71,142 @@ function dc_blueprints.new(db)
           element[k] = v
         end
         return element
-      end
+      end,
+      remove = function(_, id)
+        assert(id, "id is required")
+        if type(id) == "table" then
+          id = assert(type(id.id) == "string" and id.id)
+        end
+
+        if not config[name] then
+          return nil, "not found"
+        end
+
+        for idx, entity in ipairs(config[name]) do
+          if entity.id == id then
+            table.remove(config[name], idx)
+            return entity
+          end
+        end
+
+        return nil, "not found"
+      end,
     }
   end
+
+  dc_as_db.export = function()
+    return utils.cycle_aware_deep_copy(config)
+  end
+
+  dc_as_db.import = function(input)
+    config = utils.cycle_aware_deep_copy(input)
+  end
+
+  dc_as_db.reset = function()
+    config = new_config()
+  end
+
+  return dc_as_db
+end
+
+
+function dc_blueprints.new(db)
+  local dc_as_db = wrap_db(db)
+
+  local save_dc = new_config()
 
   local bp = blueprints.new(dc_as_db)
 
   bp.done = function()
-    local ret = dc
-    save_dc = dc
-    dc = reset()
+    local ret = dc_as_db.export()
+    save_dc = ret
+    dc_as_db.reset()
     return ret
   end
 
   bp.reset_back = function()
-    dc = save_dc
+    dc_as_db.import(save_dc)
   end
 
   return bp
 end
 
+
+function dc_blueprints.admin_api(db, forced_port)
+  -- lazy import to avoid cyclical dependency
+  local helpers = require "spec.helpers"
+
+  db = db or helpers.db
+
+  local dc_as_db = wrap_db(db)
+  local api = {}
+
+  local function update_config()
+    local client = helpers.admin_client(nil, forced_port)
+
+    local res = client:post("/config", {
+      headers = {
+        ["Content-Type"] = "application/json",
+      },
+      body = dc_as_db.export(),
+    })
+
+    assert.response(res).has.status(201)
+    client:close()
+    return assert.response(res).has.jsonbody()
+  end
+
+  for name in pairs(db.daos) do
+    local dao = dc_as_db[name]
+
+    api[name] = {
+      insert = function(_, entity)
+        local res, err = dao:insert(entity)
+
+        if not res then
+          return nil, err
+        end
+
+        update_config()
+
+        return res
+      end,
+
+      update = function(_, id, updates)
+        local res, err = dao:update(id, updates)
+        if not res then
+          return nil, err
+        end
+
+        update_config()
+
+        return res
+      end,
+
+      remove = function(_, id)
+        local res, err = dao:remove(id)
+        if not res then
+          return nil, err
+        end
+
+        update_config()
+
+        return res
+      end,
+
+      truncate = function()
+        local config = dc_as_db.export()
+        config[name] = {}
+
+        dc_as_db.import(config)
+        update_config()
+
+        return true
+      end,
+    }
+  end
+
+  return blueprints.new(api)
+end
 
 return dc_blueprints


### PR DESCRIPTION
### Summary

This PR started as an effort to add more test coverage and culminated in a bugfix with filter chain validation in hybrid mode.

Filters that have an associated JSON schema may accept typed configuration, whereas filters with no schema must have their configuration JSON-encoded:

```json
{
  "name": "my-filter-chain",
  "filters": [
    {
      "name": "my-typed-filter",
      "config": {
        "a": 1,
        "b": 2
      }
    },
    {
      "name": "my-non-typed-filter",
      "config": "{ \"a\": 1, \"b\": 2 }"
    }
  ]
}
```

Filter JSON schemas are defined in `{{filter}}.meta.json` files. These files are not currently required to be present on data-plane nodes, which means the data-plane won't always know which filters have JSON configurations and which ones have string configurations.

This can result in an error when a typed/JSON filter config is sent over the wire to a data-plane, causing it to fail validation.

Now, in my opinion, the proper long term fix for this is simply _don't revalidate data sent by the control-plane._ In the mean time we're going to work around the problem by using a permissive, "anything goes" inline JSON schema for filter chains on data-plane nodes.

Beyond this one fix, this PR includes a bunch more test coverage and also ensures that the Wasm tests are executed in DBLess mode.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary.
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - N/A

### Issue reference

KAG-2768