### PR TITLE
refactor(pdk): a wrapper function for checking `ngx.headers_sent`

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -952,7 +952,9 @@ local function new(self, major_version)
 
       check_phase(rewrite_access_header)
 
-      check_headers_sent()
+      if ngx.headers_sent then
+        error("headers have already been sent", 2)
+      end
 
       if type(status) ~= "number" then
         error("code must be a number", 2)

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -178,6 +178,12 @@ local function new(self, major_version)
     end
   end
 
+  local function check_headers_sent()
+    if ngx.headers_sent then
+      error("headers have already been sent", 2)
+    end
+  end
+
 
   ---
   -- Returns the HTTP status code currently set for the downstream response (as
@@ -377,9 +383,7 @@ local function new(self, major_version)
   function _RESPONSE.set_status(status)
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     if type(status) ~= "number" then
       error("code must be a number", 2)
@@ -418,9 +422,7 @@ local function new(self, major_version)
   function _RESPONSE.set_header(name, value)
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     validate_header(name, value)
     local lower_name = lower(name)
@@ -455,9 +457,7 @@ local function new(self, major_version)
     -- to show
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     validate_header(name, value)
 
@@ -482,9 +482,7 @@ local function new(self, major_version)
   function _RESPONSE.clear_header(name)
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     if type(name) ~= "string" then
       error("header name must be a string", 2)
@@ -529,9 +527,7 @@ local function new(self, major_version)
   function _RESPONSE.set_headers(headers)
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     validate_headers(headers)
 
@@ -662,9 +658,7 @@ local function new(self, major_version)
   end
 
   local function send(status, body, headers)
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     ngx.status = status
 
@@ -958,9 +952,7 @@ local function new(self, major_version)
 
       check_phase(rewrite_access_header)
 
-      if ngx.headers_sent then
-        error("headers have already been sent", 2)
-      end
+      check_headers_sent()
 
       if type(status) ~= "number" then
         error("code must be a number", 2)
@@ -1113,9 +1105,7 @@ local function new(self, major_version)
 
     check_phase(rewrite_access_header)
 
-    if ngx.headers_sent then
-      error("headers have already been sent", 2)
-    end
+    check_headers_sent()
 
     if type(status) ~= "number" then
       error("code must be a number", 2)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We have too many duplicated code of checking `ngx.headers_sent`,
This PR creates a wrapper function for it.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
