### PR TITLE
refactor(pdk): get_raw_body with string.buffer

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -568,21 +568,17 @@ local function new(self, major_version)
   function _RESPONSE.get_raw_body()
     check_phase(PHASES.body_filter)
 
-    local body_buffer
+    local body_buffer = ngx.ctx.KONG_BODY_BUFFER
     local chunk = arg[1]
     local eof = arg[2]
+
     if eof then
-      body_buffer = ngx.ctx.KONG_BODY_BUFFER
       if not body_buffer then
         return chunk
       end
     end
 
     if type(chunk) == "string" and chunk ~= "" then
-      if not eof then
-        body_buffer = ngx.ctx.KONG_BODY_BUFFER
-      end
-
       if not body_buffer then
         body_buffer = buffer.new()
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -572,10 +572,8 @@ local function new(self, major_version)
     local chunk = arg[1]
     local eof = arg[2]
 
-    if eof then
-      if not body_buffer then
-        return chunk
-      end
+    if eof and not body_buffer then
+      return chunk
     end
 
     if type(chunk) == "string" and chunk ~= "" then

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -12,6 +12,7 @@
 -- @module kong.response
 
 
+local buffer = require "string.buffer"
 local cjson = require "cjson.safe"
 local checks = require "kong.pdk.private.checks"
 local phase_checker = require "kong.pdk.private.phases"
@@ -27,7 +28,6 @@ local find = string.find
 local lower = string.lower
 local error = error
 local pairs = pairs
-local concat = table.concat
 local coroutine = coroutine
 local cjson_encode = cjson.encode
 local normalize_header = checks.normalize_header
@@ -583,24 +583,18 @@ local function new(self, major_version)
         body_buffer = ngx.ctx.KONG_BODY_BUFFER
       end
 
-      if body_buffer then
-        local n = body_buffer.n + 1
-        body_buffer.n = n
-        body_buffer[n] = chunk
-
-      else
-        body_buffer = {
-          chunk,
-          n = 1,
-        }
+      if not body_buffer then
+        body_buffer = buffer.new()
 
         ngx.ctx.KONG_BODY_BUFFER = body_buffer
       end
+
+      body_buffer:put(chunk)
     end
 
     if eof then
       if body_buffer then
-        body_buffer = concat(body_buffer, "", 1, body_buffer.n)
+        body_buffer = body_buffer:get()
       else
         body_buffer = ""
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

As we did in other PRs, `string.buffer` is better than `table.concat`.

I also change the logic of `ngx.ctx.KONG_BODY_BUFFER`, Please verify it is correct.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
