### PR TITLE
fix(ci): trigger upgrade tests when changing kong/templates files

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -10,6 +10,7 @@ on:
     - '.github/workflows/upgrade-tests.yml'
     - 'kong/plugins/*/migrations/**'
     - 'plugins-ee/**/migrations/**'
+    - 'kong/templates/**'
   push:
     paths-ignore:
     # ignore markdown files (CHANGELOG.md, README.md, etc.)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Originally changes to the kong/templates files didn't trigger the upgrade test in the PR build, however, this leads an issue that it may cause the master failure after the PR is merged. This change is to trigger the upgrade test workflow in the PR's CI so that we could identify any potential migration issue earlier during the development.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
