### PR TITLE
tests(ci): integrate upgrade tests into `build_and_test.yml`

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -23,6 +23,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+env:
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   upgrade-test:
@@ -30,25 +32,38 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Install Docker
+      - name: Install Prerequisites
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install ca-certificates curl gnupg lsb-release
+          sudo apt-get -y install ca-certificates curl gnupg lsb-release jq libyaml-dev net-tools
           sudo mkdir -p /etc/apt/keyrings
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-      - name: Install prerequisites
-        run: |
-          sudo apt-get -y install jq
-
-      - name: Clone Kong source code
+      - name: Clone Source Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
 
-      - name: Run upgrade tests
+      - name: Build Debian Package
         run: |
-          bash ./scripts/upgrade-tests/test-upgrade-path.sh
+          make package/deb
+          mv bazel-bin/pkg/kong.amd64.deb .
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          file: build/dockerfiles/deb.Dockerfile
+          context: .
+          push: false
+          tags: "kong-local/kong:latest"
+          build-args: |
+            KONG_BASE_IMAGE=ubuntu:22.04
+            KONG_ARTIFACT_PATH=./
+
+      - name: Run Upgrade Tests
+        run: |
+          bash ./scripts/upgrade-tests/test-upgrade-path.sh -i kong-local/kong:latest


### PR DESCRIPTION
### Summary

Previously, the upgrade tests were in a standalone workflow and used an incorrect container image as the upgrade target version. With this PR, the tests are integrated into the main build/test workflow and make use of the same container image as pongo, which is built from the PR's branch.

Adapted from https://github.com/Kong/kong-ee/pull/6853 - In EE, we already build a docker image for testing with Pongo, so it made sense to piggy-back the upgrade testing onto that.  In CE, we don't have that, so the image is built specifically for the upgrade test.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2804