### PR TITLE
chore(deps): pin lua-resty-ljsonschema to 1.1.6-2

### DIFF
--- a/kong-3.5.0-0.rockspec
+++ b/kong-3.5.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.5",
   "lpeg == 1.0.2",
-  "lua-resty-ljsonschema == 1.1.6",
+  "lua-resty-ljsonschema == 1.1.6-2",
 }
 build = {
   type = "builtin",

--- a/scripts/explain_manifest/fixtures/alpine-amd64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-amd64.txt
@@ -31,11 +31,6 @@
   Needed    :
   - libc.so
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/kong/lib/libssl.so.1.1
   Needed    :
   - libcrypto.so.1.1

--- a/scripts/explain_manifest/fixtures/alpine-arm64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-arm64.txt
@@ -37,11 +37,6 @@
   - libc.so
   Rpath     : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -79,11 +79,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
@@ -72,11 +72,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
@@ -57,11 +57,6 @@
   - libc.so.6
   Rpath     : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/debian-10-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-10-amd64.txt
@@ -79,11 +79,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/debian-11-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-11-amd64.txt
@@ -77,11 +77,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -79,11 +79,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -79,11 +79,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el9-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el9-amd64.txt
@@ -72,11 +72,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/el9-arm64.txt
+++ b/scripts/explain_manifest/fixtures/el9-arm64.txt
@@ -57,11 +57,6 @@
   - libc.so.6
   Rpath     : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -77,11 +77,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -70,11 +70,6 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -56,11 +56,6 @@
   - ld-linux-aarch64.so.1
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/lib/lua/5.1/cjson.so
-  Needed    :
-  - libc.so.6
-  Runpath   : /usr/local/kong/lib
-
 - Path      : /usr/local/lib/lua/5.1/lfs.so
   Needed    :
   - libc.so.6


### PR DESCRIPTION
This new package revision removes lua-cjson as a dependency, and therefore the cjson.so entry is also removed from our manifests.

A changelog entry is not needed, as this dependency was first added during the 3.5 release cycle.

KAG-2757