### PR TITLE
perf(request-id): use proxy_set_header instead of lua api set_header

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -44,7 +44,6 @@ local log               = ngx.log
 local exit              = ngx.exit
 local exec              = ngx.exec
 local header            = ngx.header
-local set_header        = ngx.req.set_header
 local timer_at          = ngx.timer.at
 local get_phase         = ngx.get_phase
 local subsystem         = ngx.config.subsystem
@@ -1355,9 +1354,6 @@ return {
     end,
     -- Only executed if the `router` module found a route and allows nginx to proxy it.
     after = function(ctx)
-      local enabled_headers_upstream = kong.configuration.enabled_headers_upstream
-      local headers = constants.HEADERS
-
       -- Nginx's behavior when proxying a request with an empty querystring
       -- `/foo?` is to keep `$is_args` an empty string, hence effectively
       -- stripping the empty querystring.
@@ -1449,16 +1445,6 @@ return {
 
       if var.http_proxy_connection then
         clear_header("Proxy-Connection")
-      end
-
-      -- X-Kong-Request-Id upstream header
-      local rid, rid_get_err = request_id_get()
-      if not rid then
-        log(WARN, "failed to get Request ID: ", rid_get_err)
-      end
-
-      if enabled_headers_upstream[headers.REQUEST_ID] and rid then
-        set_header(headers.REQUEST_ID, rid)
       end
     end
   },

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -168,6 +168,12 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        proxy_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -199,6 +205,12 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        proxy_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -230,6 +242,12 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        proxy_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -261,6 +279,12 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        proxy_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -285,6 +309,12 @@ server {
         grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        grpc_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         grpc_pass_header     Server;
         grpc_pass_header     Date;
         grpc_ssl_name        $upstream_host;
@@ -328,6 +358,12 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
+> for _, name in ipairs(headers_upstream) do
+>   if name:lower() == "x-kong-request-id" then
+        proxy_set_header      X-Kong-Request-Id  $kong_request_id;
+>     break
+>   end
+> end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -168,11 +168,8 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         proxy_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
@@ -205,11 +202,8 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         proxy_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
@@ -242,11 +236,8 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         proxy_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
@@ -279,11 +270,8 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         proxy_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         proxy_pass_header     Server;
         proxy_pass_header     Date;
@@ -309,11 +297,8 @@ server {
         grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         grpc_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         grpc_pass_header     Server;
         grpc_pass_header     Date;
@@ -358,11 +343,8 @@ server {
         proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
-> for _, name in ipairs(headers_upstream) do
->   if name:lower() == "x-kong-request-id" then
+> if enabled_headers_upstream["X-Kong-Request-Id"] then
         proxy_set_header      X-Kong-Request-Id  $kong_request_id;
->     break
->   end
 > end
         proxy_pass_header     Server;
         proxy_pass_header     Date;


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
If we utilize the nginx original directive `proxy_set_header X-Kong-Request-Id $kong_request_id` instead of lua source code `set_header(Kong-Request-Id ,request_id)`, we can enhance the QPS by ~2% in the testing scenario where no plugins are used and pure http proxying is deployed.

And there are no `set_header` calls within the core path. All the headers that are added to the upstream are currently configured using the proxy_set_header directive.


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
  * Reuse old test cases. The functionality hasn't been modified
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* This PR replaces the lua api call of `set_header` with `proxy_set_header`.

### Issue reference
KAG-2814

