### PR TITLE
fix(jwt): add missing www-authenticate headers

### DIFF
--- a/changelog/unreleased/kong/jwt_www_authenticate.yml
+++ b/changelog/unreleased/kong/jwt_www_authenticate.yml
@@ -1,0 +1,3 @@
+message: Add WWW-Authenticate headers to 401 response in jwt auth plugin.
+type: bugfix
+scope: Plugin


### PR DESCRIPTION
### Summary

When kong returns `401 Unauthorized` response it should return `WWW-Authenticate` header with proper challenge. JWT auth was missing this header.

### Related PRs:
- https://github.com/Kong/kong/pull/11791

### RFCs & Materials

- https://httpwg.org/specs/rfc7235.html#status.401
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

- add `WWW-Authenticate` headxer to jwt 401 response

### Issue reference

- Fix #7772
- KAG-321
