### PR TITLE
fix(vault): properly warmups the cache on init

### DIFF
--- a/changelog/unreleased/kong/vault-init-warmup.yml
+++ b/changelog/unreleased/kong/vault-init-warmup.yml
@@ -1,0 +1,3 @@
+message: Properly warmup Vault caches on init
+type: bugfix
+scope: Core

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -141,6 +141,8 @@ describe("kong start/stop #" .. strategy, function()
     }))
 
     assert.not_matches("failed to dereference {vault://env/pg_password}", stderr, nil, true)
+    assert.logfile().has.no.line("[warn]", true)
+    assert.logfile().has.no.line("env/pg_password", true)
     assert.matches("Kong started", stdout, nil, true)
     assert(kong_exec("stop", {
       prefix = PREFIX,


### PR DESCRIPTION
### Summary

Fixes issue where this was logged to logs:
```
2023/10/18 13:53:33 [warn] 8714#0: [kong] vault.lua:861 error updating secret reference {vault://env/PG_USER}: could not find cached value
```

That happened for example when starting Kong with this command:
```
KONG_LOG_LEVEL=warn PG_USER=kong KONG_PG_USER={vault://env/PG_USER} ./bin/kong start
```

It auto-corrected itself, which was good in this case. This commit makes it more robust, and does not warn anymore as caches are properly warmed.