### PR TITLE
fix(key-auth): add missing www-authenticate headers

### DIFF
--- a/changelog/unreleased/kong/key_auth_www_authenticate.yml
+++ b/changelog/unreleased/kong/key_auth_www_authenticate.yml
@@ -1,0 +1,3 @@
+message: Add WWW-Authenticate headers to all 401 response in key auth plugin.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -20,6 +20,7 @@ return {
           { key_in_query = { description = "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.", type = "boolean", required = true, default = true }, },
           { key_in_body = { description = "If enabled, the plugin reads the request body. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.", type = "boolean", required = true, default = false }, },
           { run_on_preflight = { description = "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.", type = "boolean", required = true, default = true }, },
+          { realm = { description = "When authentication fails the plugin sends `WWW-Authenticate` header with `realm` attribute value.", type = "string", required = false }, },
         },
     }, },
   },

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -121,6 +121,7 @@ describe("plugins", function()
       key_names = { "apikey" },
       hide_credentials = false,
       anonymous = ngx.null,
+      realm = ngx.null,
       key_in_header = true,
       key_in_query = true,
       key_in_body = false,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -320,6 +320,7 @@ describe("declarative config: flatten", function()
               config = {
                 anonymous = null,
                 hide_credentials = false,
+                realm = null,
                 key_in_header = true,
                 key_in_query = true,
                 key_in_body = false,
@@ -430,6 +431,7 @@ describe("declarative config: flatten", function()
               config = {
                 anonymous = null,
                 hide_credentials = false,
+                realm = null,
                 key_in_header = true,
                 key_in_query = true,
                 key_in_body = false,
@@ -628,6 +630,7 @@ describe("declarative config: flatten", function()
                 config = {
                   anonymous = null,
                   hide_credentials = false,
+                  realm = null,
                   key_in_header = true,
                   key_in_query = true,
                   key_in_body = false,
@@ -1144,6 +1147,7 @@ describe("declarative config: flatten", function()
                 config = {
                   anonymous = null,
                   hide_credentials = false,
+                  realm = null,
                   key_in_header = true,
                   key_in_query = true,
                   key_in_body = false,

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require "spec.helpers"
 local cjson   = require "cjson"
-local meta    = require "kong.meta"
 local utils   = require "kong.tools.utils"
 
 
@@ -578,7 +577,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.response(res).has.status(401)
-        assert.equal('Key realm="' .. meta._NAME .. '"', res.headers["WWW-Authenticate"])
+        assert.equal('Key', res.headers["WWW-Authenticate"])
       end)
 
       it("fails 401, with no credential provided", function()
@@ -590,7 +589,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.response(res).has.status(401)
-        assert.equal('Key realm="' .. meta._NAME .. '"', res.headers["WWW-Authenticate"])
+        assert.equal('Key', res.headers["WWW-Authenticate"])
       end)
 
     end)


### PR DESCRIPTION
### Summary

When kong returns `401 Unauthorized` response it should return `WWW-Authenticate` header with proper challenge. Key auth was missing this header on some responses. This PR also adds a possibility to configure an optional parameter - realm (defaults to `null`).

### Related PRs:
- https://github.com/Kong/kong/pull/11791
- https://github.com/Kong/kong/pull/11792
- https://github.com/Kong/kong/pull/11795
- https://github.com/Kong/kong/pull/11820
- https://github.com/Kong/kong/pull/11833

### RFCs & Materials

- https://httpwg.org/specs/rfc7235.html#status.401
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

- add `WWW-Authenticate` header to all key-auth 401 response

### Issue reference

- Fix #7772
- KAG-321
