### PR TITLE
fix(basic-auth): add missing www-authenticate headers

### DIFF
--- a/changelog/unreleased/kong/basic_www_authenticate.yml
+++ b/changelog/unreleased/kong/basic_www_authenticate.yml
@@ -1,0 +1,3 @@
+message: Add missing WWW-Authenticate headers to 401 response in basic auth plugin.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -17,9 +17,6 @@ local HEADERS_CREDENTIAL_IDENTIFIER = constants.HEADERS.CREDENTIAL_IDENTIFIER
 local HEADERS_ANONYMOUS             = constants.HEADERS.ANONYMOUS
 
 
-local realm = 'Basic realm="' .. _KONG._NAME .. '"'
-
-
 local _M = {}
 
 
@@ -154,21 +151,17 @@ local function set_consumer(consumer, credential)
 end
 
 
-local function fail_authentication()
-  return false, { status = 401, message = "Invalid authentication credentials" }
+local function unauthorized(message, www_auth_content)
+  return { status = 401, message = message, headers = { ["WWW-Authenticate"] = www_auth_content } }
 end
 
 
 local function do_authentication(conf)
+  local www_authenticate = "Basic realm=\"" .. conf.realm .. "\""
+
   -- If both headers are missing, return 401
   if not (kong.request.get_header("authorization") or kong.request.get_header("proxy-authorization")) then
-    return false, {
-      status = 401,
-      message = "Unauthorized",
-      headers = {
-        ["WWW-Authenticate"] = realm
-      }
-    }
+    return false, unauthorized("Unauthorized", www_authenticate)
   end
 
   local credential
@@ -183,12 +176,12 @@ local function do_authentication(conf)
     if given_username and given_password then
       credential = load_credential_from_db(given_username)
     else
-      return fail_authentication()
+      return false, unauthorized("Invalid authentication credentials", www_authenticate)
     end
   end
 
   if not credential or not validate_credentials(credential, given_password) then
-    return fail_authentication()
+    return false, unauthorized("Invalid authentication credentials", www_authenticate)
   end
 
   -- Retrieve consumer

--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -11,6 +11,7 @@ return {
         fields = {
           { anonymous = { description = "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.", type = "string" }, },
           { hide_credentials = { description = "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.", type = "boolean", required = true, default = false }, },
+          { realm = { description = "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value.", type = "string", required = true, default = "service" }, },
     }, }, },
   },
 }

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -375,6 +375,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "grpc", "grpcs", "http", "https" },
                     config = {
                       hide_credentials = false,
+                      realm = "service",
                     }
                   },
                   {
@@ -709,6 +710,7 @@ describe("declarative config: process_auto_fields", function()
                         protocols = { "grpc", "grpcs", "http", "https" },
                         config = {
                           hide_credentials = false,
+                          realm = "service",
                         }
                       },
                       {

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -573,7 +573,8 @@ describe("declarative config: flatten", function()
             plugins = { {
                 config = {
                   anonymous = null,
-                  hide_credentials = false
+                  hide_credentials = false,
+                  realm = "service"
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -1088,7 +1089,8 @@ describe("declarative config: flatten", function()
             plugins = { {
                 config = {
                   anonymous = null,
-                  hide_credentials = false
+                  hide_credentials = false,
+                  realm = "service"
                 },
                 consumer = null,
                 created_at = 1234567890,

--- a/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
+++ b/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
@@ -86,6 +86,7 @@ for _, strategy in helpers.each_strategy() do
       name = "basic-auth",
       config = {
         hide_credentials = true,
+        realm = "service",
       }
     }
 


### PR DESCRIPTION
### Summary

When kong returns `401 Unauthorized` response it should return `WWW-Authenticate` header with proper challenge. Basic auth was missing this header on some responses. Previously it only returned this header when `Authorization` or `Proxy-Authorization` was missing but the RFC states that it should return it for every 401 response. This PR also adds a possibility to configure a parameter - realm (defaults to `service`).

### Related PRs:
- https://github.com/Kong/kong/pull/11791
- https://github.com/Kong/kong/pull/11792
- https://github.com/Kong/kong/pull/11794
- https://github.com/Kong/kong/pull/11820
- https://github.com/Kong/kong/pull/11833

### RFCs & Materials

- https://httpwg.org/specs/rfc7235.html#status.401
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

- add `WWW-Authenticate` header to all basic-auth 401 response

### Issue reference

- Fix #7772
- KAG-321
