### PR TITLE
perf(prometheus): remove `o` option in `ngx.re.gsub`

### DIFF
--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -205,11 +205,11 @@ local function full_metric_name(name, label_names, label_values)
       end
 
       if string.find(label_value, slash, 1, true) then
-        label_value = ngx_re_gsub(label_value, reg_slash, double_slash, "jo")
+        label_value = ngx_re_gsub(label_value, reg_slash, double_slash, "j")
       end
 
       if string.find(label_value, quote, 1, true) then
-        label_value = ngx_re_gsub(label_value, reg_quote, slash_quote, "jo")
+        label_value = ngx_re_gsub(label_value, reg_quote, slash_quote, "j")
       end
     end
 
@@ -316,7 +316,7 @@ local function construct_bucket_format(buckets)
     assert(type(bucket) == "number", "bucket boundaries should be numeric")
 
     -- floating point number with all trailing zeros removed
-    local as_string = ngx_re_gsub(string.format("%f", bucket), "0*$", "", "jo")
+    local as_string = ngx_re_gsub(string.format("%f", bucket), "0*$", "", "j")
 
     local dot_idx = as_string:find(".", 1, true)
     max_order = math.max(max_order, dot_idx - 1)
@@ -820,13 +820,13 @@ local function register(self, name, help, label_names, buckets, typ, local_stora
   local name_maybe_historgram = name
 
   if string.find(name_maybe_historgram, "_bucket", 1, true) then
-    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_bucket$", "", "jo")
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_bucket$", "", "j")
   end
   if string.find(name_maybe_historgram, "_count", 1, true) then
-    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_count$", "", "jo")
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_count$", "", "j")
   end
   if string.find(name_maybe_historgram, "_sum", 1, true) then
-    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_sum$", "", "jo")
+    name_maybe_historgram = ngx_re_gsub(name_maybe_historgram, "_sum$", "", "j")
   end
 
   if (typ ~= TYPE_HISTOGRAM and (


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

According to https://github.com/openresty/lua-nginx-module#lua_regex_cache_max_entries,
we should not use `o` for `ngx.re.gsub`.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
