### PR TITLE
feat(pdk): kong.node.is_data_plane|control_plane|traditional|etc. helpers

### DIFF
--- a/kong/api/routes/clustering.lua
+++ b/kong/api/routes/clustering.lua
@@ -12,7 +12,7 @@ return {
     schema = kong.db.clustering_data_planes.schema,
     methods = {
       GET = function(self, dao, helpers)
-        if kong.configuration.role ~= "control_plane" then
+        if kong.node.is_not_control_plane() then
           return kong.response.exit(400, {
             message = "this endpoint is only available when Kong is " ..
                       "configured to run as Control Plane for the cluster"
@@ -28,7 +28,7 @@ return {
     schema = kong.db.clustering_data_planes.schema,
     methods = {
       GET = function(self, db, helpers)
-        if kong.configuration.role ~= "control_plane" then
+        if kong.node.is_not_control_plane() then
           return kong.response.exit(400, {
             message = "this endpoint is only available when Kong is " ..
                       "configured to run as Control Plane for the cluster"

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -86,7 +86,7 @@ end
 return {
   ["/config"] = {
     GET = function(self, db)
-      if kong.db.strategy ~= "off" then
+      if kong.node.is_not_dbless() then
         return kong.response.exit(400, {
           message = "this endpoint is only available when Kong is " ..
                     "configured to not use a database"
@@ -109,7 +109,7 @@ return {
       return kong.response.exit(200, { config = file.buf:get() })
     end,
     POST = function(self, db)
-      if kong.db.strategy ~= "off" then
+      if kong.node.is_not_dbless() then
         return kong.response.exit(400, {
           message = "this endpoint is only available when Kong is " ..
                     "configured to not use a database"

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -7,10 +7,6 @@ local knode  = (kong and kong.node) and kong.node or
                require "kong.pdk.node".new()
 
 
-local dbless = kong.configuration.database == "off"
-local data_plane_role = kong.configuration.role == "data_plane"
-
-
 return {
   ["/status"] = {
     GET = function(self, dao, helpers)
@@ -49,7 +45,7 @@ return {
       -- to make decisions when something changes in the data-plane (e.g.
       -- if the gateway gets unexpectedly restarted and its configuration
       -- has been reset to empty).
-      if dbless or data_plane_role then
+      if kong.node.is_dbless() then
         status_response.configuration_hash = declarative.get_current_hash()
         -- remove the meanless database entry when in dbless mode or data plane
         status_response.database = nil

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -223,7 +223,7 @@ local api_routes = {
 }
 
 -- upstream targets' healthcheck management is not available in the hybrid mode
-if kong.configuration.role ~= "control_plane" then
+if kong.node.is_not_control_plane() then
   api_routes["/upstreams/:upstreams/targets/:targets/healthy"] = {
     PUT = function(self, db)
       return set_target_health(self, db, true)

--- a/kong/cluster_events/init.lua
+++ b/kong/cluster_events/init.lua
@@ -85,18 +85,9 @@ function _M.new(opts)
   local poll_delay    = max(opts.poll_delay    or 0, 0)
 
   do
-    local db_strategy
-
-    if opts.db.strategy == "postgres" then
-      db_strategy = require "kong.cluster_events.strategies.postgres"
-
-    elseif opts.db.strategy == "off" then
-      db_strategy = require "kong.cluster_events.strategies.off"
-
-    else
-      return error("no cluster_events strategy for " ..
-                   opts.db.strategy)
-    end
+    local db_strategy = kong.node.is_dbless()
+                    and require("kong.cluster_events.strategies.off")
+                     or require("kong.cluster_events.strategies.postgres")
 
     local event_ttl_in_db = max(poll_offset * 10, MIN_EVENT_TTL_IN_DB)
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -114,14 +114,12 @@ function _M:init_worker()
     filters = filters,
   }
 
-  local role = self.conf.role
-
-  if role == "control_plane" then
+  if kong.node.is_control_plane() then
     self:init_cp_worker(basic_info)
     return
   end
 
-  if role == "data_plane" then
+  if kong.node.is_data_plane() then
     self:init_dp_worker(basic_info)
   end
 end

--- a/kong/db/dao/workspaces.lua
+++ b/kong/db/dao/workspaces.lua
@@ -3,7 +3,7 @@ local Workspaces = {}
 
 function Workspaces:truncate()
   self.super.truncate(self)
-  if kong.configuration.database == "off" then
+  if kong.node.is_dbless() then
     return true
   end
 

--- a/kong/db/declarative/export.lua
+++ b/kong/db/declarative/export.lua
@@ -69,7 +69,7 @@ end
 
 
 local function begin_transaction(db)
-  if db.strategy == "postgres" then
+  if kong.node.is_not_dbless() then
     local ok, err = db.connector:connect("read")
     if not ok then
       return nil, err
@@ -86,7 +86,7 @@ end
 
 
 local function end_transaction(db)
-  if db.strategy == "postgres" then
+  if kong.node.is_not_dbless() then
     -- just finish up the read-only transaction,
     -- either COMMIT or ROLLBACK is fine.
     db.connector:query("ROLLBACK;", "read")

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1692,7 +1692,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   local resolve_references
   if is_select and not nulls then
     if kong and kong.configuration then
-      resolve_references = kong.configuration.role ~= "control_plane"
+      resolve_references = kong.node.is_not_control_plane()
     else
       resolve_references = true
     end

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -313,7 +313,7 @@ end
 
 
 function _mt:init_worker(strategies)
-  if ngx.worker.id() == 0 and #kong.configuration.admin_listeners > 0 then
+  if ngx.worker.id() == 0 and kong.node.is_serving_admin_apis() then
     local table_names = get_names_of_tables_with_ttl(strategies)
     local ttl_escaped = self:escape_identifier("ttl")
     local expire_at_escaped = self:escape_identifier("expire_at")

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -257,6 +257,344 @@ local function new(self)
     return gsub(hostname, "\n$", "")
   end
 
+  ---
+  -- Returns `true` if a node is a data plane node.
+  --
+  -- @function kong.node.is_data_plane
+  -- @treturn boolean `true` if a node is a data plane node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_data_plane() then
+  --   ...
+  -- end
+  local function is_data_plane()
+    return self.configuration.role == "data_plane"
+  end
+  _NODE.is_data_plane = is_data_plane
+
+
+  ---
+  -- Returns `true` if a node is not a data plane node.
+  --
+  -- @function kong.node.is_not_data_plane
+  -- @treturn boolean `true` if a node is not a data plane node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_data_plane() then
+  --   ...
+  -- end
+  local function is_not_data_plane()
+    return not is_data_plane()
+  end
+  _NODE.is_not_data_plane = is_not_data_plane
+
+
+  ---
+  -- Returns `true` if a node is a control plane node.
+  --
+  -- @function kong.node.is_control_plane
+  -- @treturn boolean `true` if a node is a control plane node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_control_plane() then
+  --   ...
+  -- end
+  local function is_control_plane()
+    return self.configuration.role == "control_plane"
+  end
+  _NODE.is_control_plane = is_control_plane
+
+
+  ---
+  -- Returns `true` if a node is not a control plane node.
+  --
+  -- @function kong.node.is_not_control_plane
+  -- @treturn boolean `true` if a node is not a control plane node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_control_plane() then
+  --   ...
+  -- end
+  local function is_not_control_plane()
+    return not is_control_plane()
+  end
+  _NODE.is_not_control_plane = is_not_control_plane
+
+
+  ---
+  -- Returns `true` if a node is a traditional node.
+  --
+  -- @function kong.node.is_traditional
+  -- @treturn boolean `true` if a node is a traditional node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_traditional() then
+  --   ...
+  -- end
+  local function is_traditional()
+    return self.configuration.role == "traditional"
+  end
+  _NODE.is_traditional = is_traditional
+
+
+  -- Returns `true` if a node is not a traditional node.
+  --
+  -- @function kong.node.is_not_traditional
+  -- @treturn boolean `true` if a node is not a traditional node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_traditional() then
+  --   ...
+  -- end
+  local function is_not_traditional()
+    return not is_traditional()
+  end
+  _NODE.is_not_traditional = is_not_traditional
+
+
+  ---
+  -- Returns `true` if a node is a dbless node.
+  --
+  -- *Note:* both data plane and non-hybrid dbless nodes are considered as dbless.
+  --
+  -- @function kong.node.is_dbless
+  -- @treturn boolean `true` if a node is a dbless node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_dbless() then
+  --   ...
+  -- end
+  local function is_dbless()
+    return self.configuration.database == "off"
+  end
+  _NODE.is_dbless = is_dbless
+
+
+  ---
+  -- Returns `true` if a node is not a dbless node.
+  --
+  -- *Note:* both data plane and non-hybrid dbless nodes are considered as dbless.
+  --
+  -- @function kong.node.is_not_dbless
+  -- @treturn boolean `true` if a node is not a dbless node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_dbless() then
+  --   ...
+  -- end
+  local function is_not_dbless()
+    return not is_dbless()
+  end
+  _NODE.is_not_dbless = is_not_dbless
+
+
+  ---
+  -- Returns `true` if a node is either a control plane node or a data plane node.
+  --
+  -- @function kong.node.is_hybrid
+  -- @treturn boolean `true` if a node is a hybrid node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_hybrid() then
+  --   ...
+  -- end
+  local function is_hybrid()
+    return is_data_plane() or is_control_plane()
+  end
+  _NODE.is_hybrid = is_hybrid
+
+
+  ---
+  -- Returns `true` if a node is neither a control plane node or a data plane node.
+  --
+  -- @function kong.node.is_not_hybrid
+  -- @treturn boolean `true` if a node is not a hybrid node, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_hybrid() then
+  --   ...
+  -- end
+  local function is_not_hybrid()
+    return not is_hybrid()
+  end
+  _NODE.is_not_hybrid = is_not_hybrid
+
+
+  ---
+  -- Returns `true` if a node is serving (or proxying) http traffic.
+  --
+  -- @function kong.node.is_serving_http_traffic
+  -- @treturn boolean `true` if a node is serving http traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_http_traffic() then
+  --   ...
+  -- end
+  local function is_serving_http_traffic()
+    return (is_data_plane() or is_traditional()) and #self.configuration.proxy_listeners > 0
+  end
+  _NODE.is_serving_http_traffic = is_serving_http_traffic
+
+
+  ---
+  -- Returns `true` if a node is not serving (or proxying) http traffic.
+  --
+  -- @function kong.node.is_not_serving_http_traffic
+  -- @treturn boolean `true` if a node is not serving http traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_http_traffic() then
+  --   ...
+  -- end
+  local function is_not_serving_http_traffic()
+    return not is_serving_http_traffic()
+  end
+  _NODE.is_not_serving_http_traffic = is_not_serving_http_traffic
+
+
+  ---
+  -- Returns `true` if a node is serving (or proxying) stream (tcp/udp) traffic.
+  --
+  -- @function kong.node.is_serving_stream_traffic
+  -- @treturn boolean `true` if a node is serving stream (tcp/udp) traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_stream_traffic() then
+  --   ...
+  -- end
+  local function is_serving_stream_traffic()
+    return (is_data_plane() or is_traditional()) and #self.configuration.stream_listeners > 0
+  end
+  _NODE.is_serving_stream_traffic = is_serving_stream_traffic
+
+
+  ---
+  -- Returns `true` if a node is not serving (or proxying) stream (tcp/udp) traffic.
+  --
+  -- @function kong.node.is_not_serving_stream_traffic
+  -- @treturn boolean `true` if a node is not able to proxy stream (tcp/udp) traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_stream_traffic() then
+  --   ...
+  -- end
+  local function is_not_serving_stream_traffic()
+    return not is_serving_stream_traffic()
+  end
+  _NODE.is_not_serving_stream_traffic = is_not_serving_stream_traffic
+
+
+  ---
+  -- Returns `true` if a node is serving (or proxying) http and/or stream (tcp/udp) traffic.
+  --
+  -- @function kong.node.is_serving_proxy_traffic
+  -- @treturn boolean `true` if a node is serving (or proxying) http and/or stream (tcp/udp) traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_proxy_traffic() then
+  --   ...
+  -- end
+  local function is_serving_proxy_traffic()
+    return is_serving_http_traffic() or is_serving_stream_traffic()
+  end
+  _NODE.is_serving_proxy_traffic = is_serving_proxy_traffic
+
+
+  ---
+  -- Returns `true` if a node is not serving (or proxying) http or stream (tcp/udp) traffic.
+  --
+  -- @function kong.node.is_not_serving_proxy_traffic
+  -- @treturn boolean `true` if a node is not serving (or proxying) http or stream (tcp/udp) traffic, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_proxy_traffic() then
+  --   ...
+  -- end
+  local function is_not_serving_proxy_traffic()
+    return not is_serving_proxy_traffic()
+  end
+  _NODE.is_not_serving_proxy_traffic = is_not_serving_proxy_traffic
+
+
+  ---
+  -- Returns `true` if a node is serving admin APIs.
+  --
+  -- *Note:* Non-hybrid dbless nodes can also serve (mostly read-only) admin APIs
+  -- in addition to control plane and traditional admin nodes.
+  --
+  -- @function kong.node.is_serving_admin_apis
+  -- @treturn boolean `true` if a node is serving admin APIs, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_admin_apis() then
+  --   ...
+  -- end
+  local function is_serving_admin_apis()
+    return (is_control_plane() or is_traditional()) and #self.configuration.admin_listeners > 0
+  end
+  _NODE.is_serving_admin_apis = is_serving_admin_apis
+
+
+  ---
+  -- Returns `true` if a node is not serving admin APIs.
+  --
+  -- *Note:* Non-hybrid dbless nodes can also serve (mostly read-only) admin APIs
+  -- in addition to control plane and traditional admin nodes.
+  --
+  -- @function kong.node.is_not_serving_admin_apis
+  -- @treturn boolean `true` if a node is not serving admin APIs, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_admin_apis() then
+  --   ...
+  -- end
+  local function is_not_serving_admin_apis()
+    return not is_serving_admin_apis()
+  end
+  _NODE.is_not_serving_admin_apis = is_not_serving_admin_apis
+
+
+  ---
+  -- Returns `true` if a node is serving admin GUI.
+  --
+  -- @function kong.node.is_serving_admin_gui
+  -- @treturn boolean `true` if a node is serving admin GUI, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_admin_gui() then
+  --   ...
+  -- end
+  local function is_serving_admin_gui()
+    return is_serving_admin_apis() and #self.configuration.admin_gui_listeners > 0
+  end
+  _NODE.is_serving_admin_gui = is_serving_admin_gui
+
+
+  ---
+  -- Returns `true` if a node is not serving admin GUI.
+  --
+  -- @function kong.node.is_not_serving_admin_gui
+  -- @treturn boolean `true` if a node is not serving admin GUI, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_admin_gui() then
+  --   ...
+  -- end
+  local function is_not_serving_admin_gui()
+    return not is_serving_admin_gui()
+  end
+  _NODE.is_not_serving_admin_gui = is_not_serving_admin_gui
+
+
+  ---
+  -- Returns `true` if a node is serving status APIs.
+  --
+  -- @function kong.node.is_serving_status_apis
+  -- @treturn boolean `true` if a node is serving admin APIs, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_serving_status_apis() then
+  --   ...
+  -- end
+  local function is_serving_status_apis()
+    return #self.configuration.status_listeners > 0
+  end
+  _NODE.is_serving_status_apis = is_serving_status_apis
+
+
+  ---
+  -- Returns `true` if a node is not serving status APIs.
+  --
+  -- @function kong.node.is_not_serving_status_apis
+  -- @treturn boolean `true` if a node is not serving admin APIs, otherwise `false`.
+  -- @usage
+  -- if kong.node.is_not_serving_status_apis() then
+  --   ...
+  -- end
+  local function is_not_serving_status_apis()
+    return not is_serving_status_apis()
+  end
+  _NODE.is_not_serving_status_apis = is_not_serving_status_apis
+
 
   -- the PDK can be even when there is no configuration (for docs/tests)
   -- so execute below block only when running under correct context

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -183,7 +183,7 @@ end
 local function new(self)
   -- Don't put this onto the top level of the file unless you're prepared for a surprise
   local Schema = require "kong.db.schema"
-  
+
   local ROTATION_MUTEX_OPTS = {
     name = "vault-rotation",
     exptime = ROTATION_INTERVAL * 1.5, -- just in case the lock is not properly released
@@ -1105,7 +1105,7 @@ local function new(self)
       -- We cannot retry, so let's just call the callback and return
       return callback(options)
     end
-    
+
     local name = "vault.try:" .. calculate_hash(concat(references, "."))
     local old_updated_at = RETRY_LRU:get(name) or 0
 
@@ -1296,11 +1296,11 @@ local function new(self)
 
     initialized = true
 
-    if self.configuration.role == "control_plane" then
+    if self.node.is_control_plane() then
       return
     end
 
-    if self.configuration.database ~= "off" then
+    if self.node.is_not_dbless() then
       self.worker_events.register(handle_vault_crud_event, "crud", "vaults")
     end
 

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -158,7 +158,7 @@ function ACMEHandler:certificate(conf)
 
   -- cert not found, get a new one and serve default cert for now
   if not certkey then
-    if kong.configuration.role == "data_plane" and conf.storage == "kong" then
+    if kong.node.is_data_plane() and conf.storage == "kong" then
       kong.log.err("creating new certificate through proxy side with ",
                     "\"kong\" storage in Hybrid mode is not supported; ",
                     "consider create certificate using Admin API or ",

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -237,11 +237,10 @@ local schema = {
         field_sources = { "config.storage", },
         fn = function(entity)
           local field = entity.config.storage
-          if _G.kong and kong.configuration.database == "off" and
-              kong.configuration.role ~= "data_plane" and field == "kong" then
+          if field == "kong" and kong and kong.node.is_dbless() and kong.node.is_not_data_plane()  then
             return nil, "\"kong\" storage can't be used with dbless mode"
           end
-          if _G.kong and kong.configuration.role == "control_plane" and field == "shm" then
+          if field == "shm" and kong and kong.node.is_control_plane() then
             return nil, "\"shm\" storage can't be used in Hybrid mode"
           end
           return true

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -407,10 +407,10 @@ local function configure_ping(kong_conf)
   add_immutable_value("database", kong_conf.database)
   add_immutable_value("role", kong_conf.role)
   add_immutable_value("kic", kong_conf.kic)
-  add_immutable_value("_admin", #kong_conf.admin_listeners > 0 and 1 or 0)
-  add_immutable_value("_admin_gui", #kong_conf.admin_gui_listeners > 0 and 1 or 0)
-  add_immutable_value("_proxy", #kong_conf.proxy_listeners > 0 and 1 or 0)
-  add_immutable_value("_stream", #kong_conf.stream_listeners > 0 and 1 or 0)
+  add_immutable_value("_admin", kong.node.is_serving_admin_apis() and 1 or 0)
+  add_immutable_value("_admin_gui", kong.node.is_serving_admin_gui() and 1 or 0)
+  add_immutable_value("_proxy", kong.node.is_serving_http_traffic() and 1 or 0)
+  add_immutable_value("_stream", kong.node.is_serving_stream_traffic() and 1 or 0)
 end
 
 

--- a/kong/status/init.lua
+++ b/kong/status/init.lua
@@ -29,7 +29,7 @@ api_helpers.attach_routes(app, require "kong.api.routes.health")
 api_helpers.attach_routes(app, require "kong.status.ready")
 
 
-if kong.configuration.database == "off" then
+if kong.node.is_dbless() then
   -- Load core upstream readonly routes
   -- Customized routes in upstreams doesn't call `parent`, otherwise we will need
   -- api/init.lua:customize_routes to pass `parent`.

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -453,7 +453,7 @@ server {
 }
 > end
 
-> if (role == "control_plane" or role == "traditional") and #admin_listen > 0 and #admin_gui_listeners > 0 then
+> if (role == "control_plane" or role == "traditional") and #admin_listeners > 0 and #admin_gui_listeners > 0 then
 server {
     server_name kong_gui;
 > for i = 1, #admin_gui_listeners do
@@ -496,7 +496,7 @@ server {
 
     include nginx-kong-gui-include.conf;
 }
-> end -- of the (role == "control_plane" or role == "traditional") and #admin_listen > 0 and #admin_gui_listeners > 0
+> end -- of the (role == "control_plane" or role == "traditional") and #admin_listeners > 0 and #admin_gui_listeners > 0
 
 > if role == "control_plane" then
 server {


### PR DESCRIPTION
### Summary

Adds following PDK functions:

- `kong.node.is_data_plane()`
- `kong.node.is_control_plane()`
- `kong.node.is_traditional()`
- `kong.node.is_dbless()` (includes data planes)
- `kong.node.is_hybrid()`
- `kong.node.is_serving_http_traffic()`
- `kong.node.is_serving_stream_traffic()`
- `kong.node.is_serving_proxy_traffic()`
- `kong.node.is_serving_admin_apis()` (includes non-data plane dbless nodes if they listen admin, which they do by default)
- `kong.node.is_serving_admin_gui()`
- `kong.node.is_serving_status_apis()`
- `kong.node.is_not_data_plane()`
- `kong.node.is_not_control_plane()`
- `kong.node.is_not_traditional()`
- `kong.node.is_not_hybrid()`
- `kong.node.is_not_serving_http_traffic()`
- `kong.node.is_not_serving_stream_traffic()`
- `kong.node.is_not_serving_proxy_traffic()`
- `kong.node.is_not_serving_admin_apis()`
- `kong.node.is_not_serving_admin_gui()`
- `kong.node.is_not_serving_status_apis()`


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE