### PR TITLE
fix(core): print error message correctly when lambda plugin fails.

### DIFF
--- a/changelog/unreleased/kong/fix-error-message-print.yml
+++ b/changelog/unreleased/kong/fix-error-message-print.yml
@@ -1,0 +1,3 @@
+message: print error message correctly when plugin fails
+type: bugfix
+scope: Core

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -181,7 +181,7 @@ function AWSLambdaHandler:access(conf)
 
   local content = res.body
   if res.status >= 400 then
-    return error(content)
+    return error(content.Message)
   end
 
   -- TRACING: set KONG_WAITING_TIME stop


### PR DESCRIPTION
Before the fix, error message is:
[kong] init.lua:405 [aws-lambda] table: 0x04183d70, client:127.0.0.1...

After:
[kong] init.lua:405 [aws-lambda] Function not found: arn:aws:lambda:us-east-1:xxx:function:test-lambda-2, client: 127.0.0.1...

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-2844]_


[KAG-2844]: https://konghq.atlassian.net/browse/KAG-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ