### PR TITLE
chore(*): add changlog for Kong Manager 3.5

### DIFF
--- a/changelog/3.5.0/kong-manager/config_card_format.yml
+++ b/changelog/3.5.0/kong-manager/config_card_format.yml
@@ -1,2 +1,3 @@
 message: Add `JSON` and `YAML` formats in entity config cards.
 type: feature
+githubs: [111]

--- a/changelog/3.5.0/kong-manager/config_card_format.yml
+++ b/changelog/3.5.0/kong-manager/config_card_format.yml
@@ -1,0 +1,2 @@
+message: Add `JSON` and `YAML` formats in entity config cards.
+type: feature

--- a/changelog/3.5.0/kong-manager/fix_port_info.yml
+++ b/changelog/3.5.0/kong-manager/fix_port_info.yml
@@ -1,2 +1,3 @@
 message: Fix incorrect port number in Port Details.
 type: bugfix
+githubs: [103]

--- a/changelog/3.5.0/kong-manager/fix_port_info.yml
+++ b/changelog/3.5.0/kong-manager/fix_port_info.yml
@@ -1,0 +1,2 @@
+message: Fix incorrect port number in Port Details.
+type: bugfix

--- a/changelog/3.5.0/kong-manager/fix_proxdy_cache.yml
+++ b/changelog/3.5.0/kong-manager/fix_proxdy_cache.yml
@@ -1,0 +1,2 @@
+message: Fix a bug where the `proxy-cache` plugin cannot be installed.
+type: bugfix

--- a/changelog/3.5.0/kong-manager/fix_proxy_cache.yml
+++ b/changelog/3.5.0/kong-manager/fix_proxy_cache.yml
@@ -1,2 +1,3 @@
 message: Fix a bug where the `proxy-cache` plugin cannot be installed.
 type: bugfix
+githubs: [104]

--- a/changelog/3.5.0/kong-manager/plugin_field_descriptions.yml
+++ b/changelog/3.5.0/kong-manager/plugin_field_descriptions.yml
@@ -1,0 +1,2 @@
+message: Plugin form fields now display descriptions from backend schema.
+type: feature

--- a/changelog/3.5.0/kong-manager/plugin_field_descriptions.yml
+++ b/changelog/3.5.0/kong-manager/plugin_field_descriptions.yml
@@ -1,2 +1,3 @@
 message: Plugin form fields now display descriptions from backend schema.
 type: feature
+githubs: [66]

--- a/changelog/3.5.0/kong-manager/plugin_protocol.yml
+++ b/changelog/3.5.0/kong-manager/plugin_protocol.yml
@@ -1,2 +1,3 @@
 message: Add the `protocols` field in plugin form.
 type: feature
+githubs: [93]

--- a/changelog/3.5.0/kong-manager/plugin_protocol.yml
+++ b/changelog/3.5.0/kong-manager/plugin_protocol.yml
@@ -1,0 +1,2 @@
+message: Add the `protocols` field in plugin form.
+type: feature

--- a/changelog/3.5.0/kong-manager/target_list_actions.yml
+++ b/changelog/3.5.0/kong-manager/target_list_actions.yml
@@ -1,2 +1,3 @@
 message: The upstream target list shows the `Mark Healthy` and `Mark Unhealthy` action items when certain conditions are met.
 type: feature
+githubs: [86]

--- a/changelog/3.5.0/kong-manager/target_list_actions.yml
+++ b/changelog/3.5.0/kong-manager/target_list_actions.yml
@@ -1,0 +1,2 @@
+message: The upstream target list shows the `Mark Healthy` and `Mark Unhealthy` action items when certain conditions are met.
+type: feature


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds Kong Manager Open Source 3.5 changelog.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
