### PR TITLE
fix(request-debugging): fix can't set root properties when enable the phase filter

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -319,9 +319,9 @@ local function execute_global_plugins_iterator(plugins_iterator, phase, ctx)
   end
 
   local old_ws = ctx.workspace
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:plugin_iterator")
   end
 
@@ -333,13 +333,13 @@ local function execute_global_plugins_iterator(plugins_iterator, phase, ctx)
 
     setup_plugin_context(ctx, plugin, configuration)
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "before:plugin", plugin.name, ctx.plugin_id)
     end
 
     plugin.handler[phase](plugin.handler, configuration)
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:plugin")
     end
 
@@ -350,7 +350,7 @@ local function execute_global_plugins_iterator(plugins_iterator, phase, ctx)
     end
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:plugin_iterator")
   end
 end
@@ -369,9 +369,9 @@ local function execute_collecting_plugins_iterator(plugins_iterator, phase, ctx)
   ctx.delay_response = true
 
   local old_ws = ctx.workspace
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:plugin_iterator")
   end
 
@@ -384,14 +384,14 @@ local function execute_collecting_plugins_iterator(plugins_iterator, phase, ctx)
 
       setup_plugin_context(ctx, plugin, configuration)
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "before:plugin", plugin.name, ctx.plugin_id)
       end
 
       local co = coroutine.create(plugin.handler[phase])
       local cok, cerr = coroutine.resume(co, plugin.handler, configuration)
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "after:plugin")
       end
 
@@ -421,7 +421,7 @@ local function execute_collecting_plugins_iterator(plugins_iterator, phase, ctx)
     end
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:plugin_iterator")
   end
 
@@ -440,9 +440,9 @@ local function execute_collected_plugins_iterator(plugins_iterator, phase, ctx)
   end
 
   local old_ws = ctx.workspace
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:plugin_iterator")
   end
 
@@ -454,13 +454,13 @@ local function execute_collected_plugins_iterator(plugins_iterator, phase, ctx)
 
     setup_plugin_context(ctx, plugin, configuration)
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "before:plugin", plugin.name, ctx.plugin_id)
     end
 
     plugin.handler[phase](plugin.handler, configuration)
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:plugin")
     end
 
@@ -471,7 +471,7 @@ local function execute_collected_plugins_iterator(plugins_iterator, phase, ctx)
     end
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:plugin_iterator")
   end
 end
@@ -1082,16 +1082,16 @@ function Kong.rewrite()
   end
 
   ctx.KONG_PHASE = PHASES.rewrite
-  local is_timing_enabled
+  local has_timing
 
   req_dyn_hook_run_hooks(ctx, "timing:auth", "auth")
 
   if req_dyn_hook_is_group_enabled("timing") then
-    ctx.is_timing_enabled = true
-    is_timing_enabled = true
+    ctx.has_timing = true
+    has_timing = true
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:rewrite")
   end
 
@@ -1120,7 +1120,7 @@ function Kong.rewrite()
   ctx.KONG_REWRITE_ENDED_AT = get_updated_now_ms()
   ctx.KONG_REWRITE_TIME = ctx.KONG_REWRITE_ENDED_AT - ctx.KONG_REWRITE_START
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:rewrite")
   end
 end
@@ -1128,9 +1128,9 @@ end
 
 function Kong.access()
   local ctx = ngx.ctx
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:access")
   end
 
@@ -1156,7 +1156,7 @@ function Kong.access()
     ctx.KONG_ACCESS_TIME = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_ACCESS_START
     ctx.KONG_RESPONSE_LATENCY = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_PROCESSING_START
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:access")
     end
 
@@ -1172,7 +1172,7 @@ function Kong.access()
 
     ctx.buffered_proxying = nil
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:access")
     end
 
@@ -1193,7 +1193,7 @@ function Kong.access()
     local version = ngx.req.http_version()
     local upgrade = var.upstream_upgrade or ""
     if version < 2 and upgrade == "" then
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "after:access")
       end
 
@@ -1209,7 +1209,7 @@ function Kong.access()
     ctx.buffered_proxying = nil
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:access")
   end
 end
@@ -1217,9 +1217,9 @@ end
 
 function Kong.balancer()
   local ctx = ngx.ctx
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:balancer")
   end
 
@@ -1301,7 +1301,7 @@ function Kong.balancer()
       ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_BALANCER_START
       ctx.KONG_PROXY_LATENCY = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_PROCESSING_START
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "after:balancer")
       end
 
@@ -1313,7 +1313,7 @@ function Kong.balancer()
       if not ok then
         ngx_log(ngx_ERR, "failed to set balancer Host header: ", err)
 
-        if is_timing_enabled then
+        if has_timing then
           req_dyn_hook_run_hooks(ctx, "timing", "after:balancer")
         end
 
@@ -1368,7 +1368,7 @@ function Kong.balancer()
     ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_BALANCER_START
     ctx.KONG_PROXY_LATENCY = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_PROCESSING_START
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:balancer")
     end
 
@@ -1408,7 +1408,7 @@ function Kong.balancer()
   -- start_time() is kept in seconds with millisecond resolution.
   ctx.KONG_PROXY_LATENCY = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_PROCESSING_START
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:balancer")
   end
 end
@@ -1435,9 +1435,9 @@ do
 
   function Kong.response()
     local ctx = ngx.ctx
-    local is_timing_enabled = ctx.is_timing_enabled
+    local has_timing = ctx.has_timing
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "before:response")
     end
 
@@ -1458,7 +1458,7 @@ do
       ctx.KONG_PHASE = PHASES.error
       ngx.status = res.status or 502
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "after:response")
       end
 
@@ -1512,7 +1512,7 @@ do
     -- buffered response
     ngx.print(body)
 
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:response")
     end
 
@@ -1524,9 +1524,9 @@ end
 
 function Kong.header_filter()
   local ctx = ngx.ctx
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:header_filter")
   end
 
@@ -1598,7 +1598,7 @@ function Kong.header_filter()
   ctx.KONG_HEADER_FILTER_ENDED_AT = get_updated_now_ms()
   ctx.KONG_HEADER_FILTER_TIME = ctx.KONG_HEADER_FILTER_ENDED_AT - ctx.KONG_HEADER_FILTER_START
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:header_filter")
   end
 end
@@ -1606,9 +1606,9 @@ end
 
 function Kong.body_filter()
   local ctx = ngx.ctx
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:body_filter")
   end
 
@@ -1667,7 +1667,7 @@ function Kong.body_filter()
   execute_collected_plugins_iterator(plugins_iterator, "body_filter", ctx)
 
   if not arg[2] then
-    if is_timing_enabled then
+    if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:body_filter")
     end
 
@@ -1689,7 +1689,7 @@ function Kong.body_filter()
                                                              ctx.KONG_ACCESS_ENDED_AT)
   end
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:body_filter")
   end
 end
@@ -1697,9 +1697,9 @@ end
 
 function Kong.log()
   local ctx = ngx.ctx
-  local is_timing_enabled = ctx.is_timing_enabled
+  local has_timing = ctx.has_timing
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "before:log")
   end
 
@@ -1794,7 +1794,7 @@ function Kong.log()
   plugins_iterator.release(ctx)
   runloop.log.after(ctx)
 
-  if is_timing_enabled then
+  if has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "after:log")
   end
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -142,7 +142,7 @@ local cachelookup = function(qname, qtype)
   local cached = dnscache:get(key)
 
   local ctx = ngx.ctx
-  if ctx and ctx.is_timing_enabled then
+  if ctx and ctx.has_timing then
     req_dyn_hook_run_hooks(ctx, "timing", "dns:cache_lookup", cached ~= nil)
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1151,9 +1151,9 @@ return {
       -- to plugins in the access phase for doing headers propagation
       instrumentation.precreate_balancer_span(ctx)
 
-      local is_timing_enabled = ctx.is_timing_enabled
+      local has_timing = ctx.has_timing
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "before:router")
       end
 
@@ -1161,7 +1161,7 @@ return {
       local router = get_updated_router()
       local match_t = router:exec(ctx)
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "after:router")
       end
 
@@ -1182,7 +1182,7 @@ return {
 
       ctx.workspace = match_t.route and match_t.route.ws_id
 
-      if is_timing_enabled then
+      if has_timing then
         req_dyn_hook_run_hooks(ctx, "timing", "workspace_id:got", ctx.workspace)
       end
 

--- a/kong/timing/init.lua
+++ b/kong/timing/init.lua
@@ -142,10 +142,6 @@ end
 
 
 function _M.set_root_context_prop(k, v)
-  if not should_run() then
-    return
-  end
-
   ngx.ctx.req_trace_ctx:set_root_context_prop(k, v)
 end
 


### PR DESCRIPTION
# Please REBASE AND MERGE

### Summary

#### Background

The debugging data for the request is created by combining various contexts through a sequence of push, pop, and set_property operations.

In most cases, certain operations should not be executed within a specific context when employing the phase filter. However, it's important to note that the phase filter should not control the set_property operation for the root context.

The phase filter is currently exclusive to the EE version, but we need to address it in the CE version to maintain synchronization with the EE code.

#### Changes

The `set_root_context_prop `is for setting the `request_id `and `workspace_id`, it should not be affected by the phase filter. The phase filter is a EE only feature, but we should fix it in CE first.

And rename `is_timing_enabled` to `has_timing` to make the var name is the same as EE for reducing merge conflicts.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE