### PR TITLE
fix(build): correctly set manifest for multiarch images

### DIFF
--- a/build/dockerfiles/apk.Dockerfile
+++ b/build/dockerfiles/apk.Dockerfile
@@ -1,5 +1,5 @@
 ARG KONG_BASE_IMAGE=alpine:3.16
-FROM $KONG_BASE_IMAGE
+FROM --platform=$TARGETPLATFORM $KONG_BASE_IMAGE
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 

--- a/build/dockerfiles/deb.Dockerfile
+++ b/build/dockerfiles/deb.Dockerfile
@@ -1,5 +1,5 @@
 ARG KONG_BASE_IMAGE=debian:bullseye-slim
-FROM $KONG_BASE_IMAGE
+FROM --platform=$TARGETPLATFORM $KONG_BASE_IMAGE
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 

--- a/build/dockerfiles/rpm.Dockerfile
+++ b/build/dockerfiles/rpm.Dockerfile
@@ -1,5 +1,5 @@
 ARG KONG_BASE_IMAGE=redhat/ubi8
-FROM $KONG_BASE_IMAGE
+FROM --platform=$TARGETPLATFORM $KONG_BASE_IMAGE
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 


### PR DESCRIPTION
Behaviour change from https://github.com/Kong/kong/pull/11594

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-2855
Fix #11776
