### PR TITLE
fix(vault): resurrect positive results in lru cache for ttl + resurrect ttl

### DIFF
--- a/changelog/unreleased/kong/vault-resurrect.yml
+++ b/changelog/unreleased/kong/vault-resurrect.yml
@@ -1,0 +1,3 @@
+message: Vault resurrect time is respected in case a vault secret is deleted from a vault
+type: bugfix
+scope: Core

--- a/spec/02-integration/13-vaults/07-resurrect_spec.lua
+++ b/spec/02-integration/13-vaults/07-resurrect_spec.lua
@@ -77,6 +77,10 @@ local VAULTS = {
       return test_vault.client.put(secret, value, opts)
     end,
 
+    delete_secret = function(_, secret)
+      return test_vault.client.delete(secret)
+    end,
+
     fixtures = function()
       return {
         http_mock = {
@@ -105,7 +109,8 @@ end
 for _, strategy in helpers.each_strategy() do
 for _, vault in ipairs(VAULTS) do
 
-describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, function()
+
+describe("vault resurrect_ttl and rotation (#" .. strategy .. ") #" .. vault.name, function()
   local client
   local secret = "my-secret"
 
@@ -137,9 +142,9 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
     vault:create_secret(secret, "init")
 
     local bp = helpers.get_db_utils(strategy,
-                                    { "vaults", "routes", "services", "plugins" },
-                                    { "dummy" },
-                                    { vault.name })
+            { "vaults", "routes", "services", "plugins" },
+            { "dummy" },
+            { vault.name })
 
 
     assert(bp.vaults:insert({
@@ -160,8 +165,8 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
     assert(bp.plugins:insert({
       name = "dummy",
       config = {
-        resp_header_value = fmt("{vault://%s/%s?ttl=%s}",
-                                vault.prefix, secret, 10),
+        resp_header_value = fmt("{vault://%s/%s?ttl=%d&resurrect_ttl=%d}",
+                                vault.prefix, secret, 2, 2),
       },
       route = { id = route.id },
     }))
@@ -190,36 +195,46 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
   end)
 
 
-  it("updates plugin config references (backend: #" .. vault.name .. ")", function()
+  it("resurrects plugin config references when secret is deleted (backend: #" .. vault.name .. ")", function()
     local function check_plugin_secret(expect, ttl, leeway)
-      leeway = leeway or 0.25 -- 25%
+    leeway = leeway or 0.25 -- 25%
 
-      local timeout = ttl + (ttl * leeway)
+    local timeout = ttl + (ttl * leeway)
 
-      assert
-        .with_timeout(timeout)
-        .with_step(0.5)
-        .eventually(function()
-          local res = http_get("/")
-          local value = assert.response(res).has.header(DUMMY_HEADER)
+    assert
+            .with_timeout(timeout)
+            .with_step(0.5)
+            .eventually(function()
+      local res = http_get("/")
+      local value
+      if expect == "" then
+        value = res.headers[DUMMY_HEADER] or ""
+        if value == "" then
+          return true
+        end
 
-          if value == expect then
-            return true
-          end
+      else
+        value = assert.response(res).has.header(DUMMY_HEADER)
+        if value == expect then
+          return true
+        end
+      end
 
-          return nil, { expected = expect, got = value }
-        end)
-        .is_truthy("expected plugin secret to be updated to '" .. expect .. "' "
-                .. "' within " .. tostring(timeout) .. "seconds")
-    end
+      return nil, { expected = expect, got = value }
+    end)
+    .is_truthy("expected plugin secret to be updated to '" .. tostring(expect) .. "' "
+            .. "within " .. tostring(timeout) .. " seconds")
+  end
 
-    vault:update_secret(secret, "old", { ttl = 5 })
+    vault:update_secret(secret, "old", { ttl = 2, resurrect_ttl = 2 })
     check_plugin_secret("old", 5)
-
-    vault:update_secret(secret, "new", { ttl = 5 })
-    check_plugin_secret("new", 5)
+    vault:delete_secret(secret)
+    ngx.sleep(2.5)
+    check_plugin_secret("old", 5)
+    check_plugin_secret("", 5)
   end)
 end)
+
 
 end -- each vault backend
 end -- each strategy

--- a/spec/fixtures/custom_vaults/kong/vaults/test/schema.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/test/schema.lua
@@ -1,3 +1,6 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
   name = "test",
   fields = {
@@ -7,6 +10,9 @@ return {
         fields = {
           { default_value     = { type = "string", required = false } },
           { default_value_ttl = { type = "number", required = false } },
+          { ttl                 = typedefs.ttl },
+          { neg_ttl             = typedefs.ttl },
+          { resurrect_ttl       = typedefs.ttl },
         },
       },
     },


### PR DESCRIPTION
### Summary

The vault is rotating secrets on every minute which updates the shared dictionary cache with new values, both negative and positive results. This commit changes the Negative results handling on LRU. Previously the LRU was cleared for negative results, and we just used to cache for config.ttl amount of time. This commit changes it so that LRU values are deleted, and we cache things config.ttl + config.resurrect_ttl amount of time in lru cache too.

It was reported by @Hayk-S on KAG-2833.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE