### PR TITLE
chore(conf): gui #admin_listen > 0 -> #admin_listeners > 0

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -453,7 +453,7 @@ server {
 }
 > end
 
-> if (role == "control_plane" or role == "traditional") and #admin_listen > 0 and #admin_gui_listeners > 0 then
+> if (role == "control_plane" or role == "traditional") and #admin_listeners > 0 and #admin_gui_listeners > 0 then
 server {
     server_name kong_gui;
 > for i = 1, #admin_gui_listeners do
@@ -496,7 +496,7 @@ server {
 
     include nginx-kong-gui-include.conf;
 }
-> end -- of the (role == "control_plane" or role == "traditional") and #admin_listen > 0 and #admin_gui_listeners > 0
+> end -- of the (role == "control_plane" or role == "traditional") and #admin_listeners > 0 and #admin_gui_listeners > 0
 
 > if role == "control_plane" then
 server {


### PR DESCRIPTION
### Summary

Just uses more correct `#admin_listeners > 0` in templates. I think `admin_listen` may be `"off"` which is kinda against of the reason why this statement is there in template in a first place.