### PR TITLE
chore(*): add a cherry-pick warning entry to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
 
 - [ ] The Pull Request has tests
 - [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
+- [ ] A CE2EE cherry-pick PR is required and created - PUT cherry-pick PR HERE
 - [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
 
 ### Full changelog

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
 
 - [ ] The Pull Request has tests
 - [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
-- [ ] A CE2EE cherry-pick PR is required and created - PUT cherry-pick PR HERE
+- [ ] A CE2EE cherry-pick PR is required and created (Kong employees only) - PUT cherry-pick PR HERE
 - [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
 
 ### Full changelog


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Some PRs may be required by customer as well. So, Kong employees can individually and selectively cherry-pick some commits to customer releases.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* add a cherry-pick warning entry to PR template

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5499]_


[FTI-5499]: https://konghq.atlassian.net/browse/FTI-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ