### PR TITLE
[backport to release/3.4.x] fix(tracing): set parent span correctly (#11786)

### DIFF
--- a/changelog/unreleased/kong/fix-opentelemetry-parent-id.yml
+++ b/changelog/unreleased/kong/fix-opentelemetry-parent-id.yml
@@ -1,0 +1,3 @@
+message: "**Opentelemetry**: fix an issue that resulted in traces with invalid parent IDs when `balancer` instrumentation was enabled"
+type: bugfix
+scope: Plugin

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -115,16 +115,18 @@ function OpenTelemetryHandler:access(conf)
   -- overwrite trace id
   -- as we are in a chain of existing trace
   if trace_id then
+    -- to propagate the correct trace ID we have to set it here
+    -- before passing this span to propagation.set()
     injected_parent_span.trace_id = trace_id
     kong.ctx.plugin.trace_id = trace_id
   end
 
-  -- overwrite parent span's parent_id
+  -- overwrite root span's parent_id
   if span_id then
-    injected_parent_span.parent_id = span_id
+    root_span.parent_id = span_id
 
   elseif parent_id then
-    injected_parent_span.parent_id = parent_id
+    root_span.parent_id = parent_id
   end
 
   propagation_set(conf.header_type, header_type, injected_parent_span, "w3c")

--- a/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
@@ -33,10 +33,10 @@ function _M:access(conf)
   end
 
   if span_id then
-    injected_parent_span.parent_id = span_id
+    root_span.parent_id = span_id
 
   elseif parent_id then
-    injected_parent_span.parent_id = parent_id
+    root_span.parent_id = parent_id
   end
 
   local type = header_type and "preserve" or "w3c"


### PR DESCRIPTION
Backport of https://github.com/Kong/kong/pull/11786

Note: the bug was introduced by https://github.com/Kong/kong/pull/11468 where the parent_id was incorrectly [updated on the balancer span](https://github.com/Kong/kong/pull/11468/files#diff-56740d64d3f92488a0cc8c0a5fd35904c2769d3b0b21770d66520c0c2f049ee3L120-R127) instead of the root span. This PR reverts that part.

### Summary

When the `balancer` instrumentation was enabled, the parent span was set incorrectly on traces, this fix addresses the problem by setting the parent span correctly on the root (`kong`) span when there is an incoming tracing header.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-2811
FTI-5485
