### PR TITLE
chore(deps): bump lua-resty-healthcheck to 3.0.0

### DIFF
--- a/changelog/unreleased/kong/deps_bump_lua_resty_healthcheck.yml
+++ b/changelog/unreleased/kong/deps_bump_lua_resty_healthcheck.yml
@@ -1,3 +1,3 @@
-message: Bump lua-resty-healthcheck to 3.0.0
+message: Bumped lua-resty-healthcheck from 1.6.3 to 3.0.0
 type: dependency
 scope: Core

--- a/changelog/unreleased/kong/deps_bump_lua_resty_healthcheck.yml
+++ b/changelog/unreleased/kong/deps_bump_lua_resty_healthcheck.yml
@@ -1,0 +1,3 @@
+message: Bump lua-resty-healthcheck to 3.0.0
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.5.0",
-  "lua-resty-healthcheck == 1.6.3",
+  "lua-resty-healthcheck == 3.0.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-aws == 1.3.5",
   "lua-resty-openssl == 0.8.25",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
This bumps lua-resty-healthcheck to 3.0.0

### Checklist

- [x] N/A ~~The Pull Request has tests~~
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Full changelog

* bump lua-resty-healthcheck to 3.0.0

### Issue reference

KAG-2704
