### PR TITLE
refactor(tools): merge the implementation of `is_lapis_array`

### DIFF
--- a/kong/tools/table.lua
+++ b/kong/tools/table.lua
@@ -118,19 +118,7 @@ end
 -- *** NOTE *** string-keys containing integers are considered valid array entries!
 -- @param t The table to check
 -- @return Returns `true` if the table is an array, `false` otherwise
-function _M.is_lapis_array(t)
-  if type(t) ~= "table" then
-    return false
-  end
-  local i = 0
-  for _ in pairs(t) do
-    i = i + 1
-    if t[i] == nil and t[tostring(i)] == nil then
-      return false
-    end
-  end
-  return true
-end
+_M.is_lapis_array = is_array_lapis
 
 
 --- Deep copies a table into a new table.

--- a/kong/tools/table.lua
+++ b/kong/tools/table.lua
@@ -111,14 +111,14 @@ do
 
     return is_array_strict(t)
   end
+
+
+  --- Checks if a table is an array and not an associative array.
+  -- *** NOTE *** string-keys containing integers are considered valid array entries!
+  -- @param t The table to check
+  -- @return Returns `true` if the table is an array, `false` otherwise
+  _M.is_lapis_array = is_array_lapis
 end
-
-
---- Checks if a table is an array and not an associative array.
--- *** NOTE *** string-keys containing integers are considered valid array entries!
--- @param t The table to check
--- @return Returns `true` if the table is an array, `false` otherwise
-_M.is_lapis_array = is_array_lapis
 
 
 --- Deep copies a table into a new table.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`is_lapis_array()` and `is_array_lapis()` have the same implementation code,
this PR removed the duplicated code.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
