### PR TITLE
chore(deps): bump kong-lapis from 1.14.0.2 to 1.14.0.3

### DIFF
--- a/changelog/unreleased/kong/lapis_version_bump.yml
+++ b/changelog/unreleased/kong/lapis_version_bump.yml
@@ -1,0 +1,2 @@
+message: "Bumped kong-lapis from 1.14.0.2 to 1.14.0.3"
+type: dependency

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "lua-ffi-zlib == 0.6",
   "multipart == 0.5.9",
   "version == 1.0.1",
-  "kong-lapis == 1.14.0.2",
+  "kong-lapis == 1.14.0.3",
   "kong-pgmoon == 1.16.2",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Bump kong-lapis from 1.14.0.2 to 1.14.0.3, to remove duplicate dependency of pgmoon

[kong-lapis v1.14.0.3](https://github.com/Kong/lapis/releases/tag/v1.14.0.3) changelog:
- Change pgmoon dependency to kong-pgmoon


### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


### Issue reference

KAG-1695
