### PR TITLE
chore: disable `dedicated_config_processing by default

### DIFF
--- a/changelog/unreleased/kong/dedicated_config_processing.yml
+++ b/changelog/unreleased/kong/dedicated_config_processing.yml
@@ -1,4 +1,4 @@
 message: |
-    rename `privileged_agent` to `dedicated_config_processing. Enable `dedicated_config_processing` by default
+    rename `privileged_agent` to `dedicated_config_processing.
 type: feature
 scope: Core

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -182,7 +182,7 @@
                                  # cache (i.e. when the configured
                                  # `mem_cache_size`) is full.
 
-#dedicated_config_processing = on  # Enables or disables a special worker
+#dedicated_config_processing = off # Enables or disables a special worker
                                    # process for configuration processing. This process
                                    # increases memory usage a little bit while
                                    # allowing to reduce latencies by moving some
@@ -2127,7 +2127,7 @@
 # information such as domain name tried during these processes.
 #
 #request_debug = on              # When enabled, Kong will provide detailed timing information
-                                 # for its components to the client and the error log 
+                                 # for its components to the client and the error log
                                  # if the following headers are present in the proxy request:
                                  # - `X-Kong-Request-Debug`:
                                  #   If the value is set to `*`,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -161,7 +161,7 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
-dedicated_config_processing = on
+dedicated_config_processing = off
 worker_consistency = eventual
 worker_state_update_frequency = 5
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -65,7 +65,7 @@ describe("Configuration loader", function()
     assert.same({}, conf.status_ssl_cert)
     assert.same({}, conf.status_ssl_cert_key)
     assert.same(nil, conf.privileged_agent)
-    assert.same(true, conf.dedicated_config_processing)
+    assert.same(false, conf.dedicated_config_processing)
     assert.same(false, conf.allow_debug_header)
     assert.is_nil(getmetatable(conf))
   end)
@@ -2020,7 +2020,7 @@ describe("Configuration loader", function()
         privileged_agent = "on",
       }))
       assert.same(nil, conf.privileged_agent)
-      assert.same(true, conf.dedicated_config_processing)
+      assert.same(false, conf.dedicated_config_processing)
       assert.equal(nil, err)
 
       -- no clobber
@@ -2419,6 +2419,7 @@ describe("Configuration loader", function()
         assert.matches(label.err, err)
       end
     end)
+
   end)
 
 end)

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -25,7 +25,7 @@ anonymous_reports = off
 
 worker_consistency = strict
 
-dedicated_config_processing = on
+dedicated_config_processing = off
 
 dns_hostsfile = spec/fixtures/hosts
 


### PR DESCRIPTION
This patch exists only to simplify the switch-back to the old default

EDIT: Decided to change the default value to OFF on the 26 Oct Block and Tackle meeting.
