### PR TITLE
fix(plugin/azure-function): clear upstream uri and request uri inject plugin logic

### DIFF
--- a/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
+++ b/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
@@ -1,3 +1,3 @@
-message: "**azure-functions**: clear upstream uri and request uri inject plugin logic"
+message: "**azure-functions**: azure-functions plugin now eliminates upstream/request URI and only use `routeprefix` configuration field to construct request path when requesting Azure API"
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
+++ b/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
@@ -1,3 +1,3 @@
 message: "**azure-functions**: azure-functions plugin now eliminates upstream/request URI and only use `routeprefix` configuration field to construct request path when requesting Azure API"
-type: bugfix
+type: breaking_change
 scope: Plugin

--- a/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
+++ b/changelog/unreleased/kong/fix-upstream-uri-azure-function-plugin.yml
@@ -1,0 +1,3 @@
+message: "**azure-functions**: clear upstream uri and request uri inject plugin logic"
+type: bugfix
+scope: Plugin

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -6,8 +6,6 @@ local kong_meta     = require "kong.meta"
 
 local kong          = kong
 local fmt           = string.format
-local sub           = string.sub
-local find          = string.find
 local byte          = string.byte
 local match         = string.match
 local var           = ngx.var

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -26,10 +26,6 @@ local azure = {
 
 function azure:access(conf)
   local path do
-    -- strip any query args
-    local upstream_uri = var.upstream_uri or var.request_uri
-    local s = find(upstream_uri, "?", 1, true)
-    upstream_uri = s and sub(upstream_uri, 1, s - 1) or upstream_uri
 
     -- strip pre-/postfix slashes
     path = match(conf.routeprefix or "", STRIP_SLASHES_PATTERN)
@@ -39,24 +35,11 @@ function azure:access(conf)
       path = "/" .. path
     end
 
-    path = path .. "/" .. func
-
-    -- concatenate path with upstream uri
-    local upstream_uri_first_byte = byte(upstream_uri, 1)
-    local path_last_byte = byte(path, -1)
-    if path_last_byte == SLASH then
-      if upstream_uri_first_byte == SLASH then
-        path = path .. sub(upstream_uri, 2, -1)
-      else
-        path = path .. upstream_uri
-      end
-
+    local functionname_first_byte = byte(func, 1)
+    if functionname_first_byte == SLASH then
+      path = path .. func
     else
-      if upstream_uri_first_byte == SLASH then
-        path = path .. upstream_uri
-      elseif upstream_uri ~= "" then
-        path = path .. "/" .. upstream_uri
-      end
+      path = path .. "/" .. func
     end
   end
 

--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -98,22 +98,19 @@ for _, strategy in helpers.each_strategy() do
         dns_mock = helpers.dns_mock.new()
       }
 
-      fixtures.dns_mock:A({
-        name = "azure.example.com",
-        address = "127.0.0.1",
       local route3 = db.routes:insert {
         hosts      = { "azure3.com" },
         protocols  = { "http", "https" },
         service   = db.services:insert(
           {
             name = "azure3",
-            host = "mockbin.org",
+            host = "azure.example.com", -- just mock service, it will not be requested
             port = 80,
             path = "/request",
           }
         ),
       }
-
+      
       -- this plugin definition results in an upstream url to
       -- http://mockbin.org/request
       -- which will echo the request for inspection
@@ -121,9 +118,9 @@ for _, strategy in helpers.each_strategy() do
         name     = "azure-functions",
         route    = { id = route3.id },
         config   = {
-          https           = true,
-          appname         = "mockbin",
-          hostdomain      = "org",
+          https           = false,
+          appname         = "azure",
+          hostdomain      = "example.com",
           routeprefix     = "request",
           functionname    = "test-func-name",
           apikey          = "anything_but_an_API_key",
@@ -131,9 +128,9 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
-      assert(helpers.start_kong{
-        database = strategy,
-        plugins  = "azure-functions",
+      fixtures.dns_mock:A({
+        name = "azure.example.com",
+        address = "127.0.0.1",
       })
 
       assert(helpers.start_kong({


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
KAG-2841

