### PR TITLE
fix(rate-limiting): counters accuracy with redis policy & sync_rate

### DIFF
--- a/changelog/unreleased/kong/rate-limiting-fix-redis-sync-rate.yml
+++ b/changelog/unreleased/kong/rate-limiting-fix-redis-sync-rate.yml
@@ -1,0 +1,3 @@
+message: "**Rate Limiting**: fix to provide better accuracy in counters when sync_rate is used with the redis policy."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -206,14 +206,9 @@ local function update_local_counters(conf, periods, limits, identifier, value)
     if limits[period] then
       local cache_key = get_local_key(conf, identifier, period, period_date)
 
-      if cur_delta[cache_key] then
-        cur_delta[cache_key] = cur_delta[cache_key] + value
-      else
-        cur_delta[cache_key] = value
-      end
+      cur_delta[cache_key] = (cur_delta[cache_key] or 0) + value
     end
   end
-  
 end
 
 return {
@@ -346,7 +341,9 @@ return {
       if conf.sync_rate ~= SYNC_RATE_REALTIME then
         cur_usage[cache_key] = current_metric or 0
         cur_usage_expire_at[cache_key] = periods[period] + EXPIRATION[period]
-        cur_delta[cache_key] = 0
+        -- The key was just read from Redis using `incr`, which incremented it
+        -- by 1. Adjust the value to account for the prior increment.
+        cur_delta[cache_key] = -1
       end
 
       return current_metric or 0

--- a/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
@@ -176,42 +176,41 @@ describe("Plugin: rate-limiting (policies)", function()
     end)
   end
 
-  for _, sync_rate in ipairs{1, SYNC_RATE_REALTIME} do
-    describe("redis with sync rate: " .. sync_rate, function()
-      local identifier = uuid()
-      local conf       = {
-        route_id = uuid(),
-        service_id = uuid(),
-        redis_host = helpers.redis_host,
-        redis_port = helpers.redis_port,
-        redis_database = 0,
-        sync_rate = sync_rate,
-      }
+  for _, sync_rate in ipairs{0.5, SYNC_RATE_REALTIME} do
+    local current_timestamp = 1424217600
+    local periods = timestamp.get_timestamps(current_timestamp)
 
-      before_each(function()
-        local red = require "resty.redis"
-        local redis = assert(red:new())
-        redis:set_timeout(1000)
-        assert(redis:connect(conf.redis_host, conf.redis_port))
-        redis:flushall()
-        redis:close()
-      end)
+    for period in pairs(periods) do
+      describe("redis with sync rate: " .. sync_rate .. " period: " .. period, function()
+        local identifier = uuid()
+        local conf       = {
+          route_id = uuid(),
+          service_id = uuid(),
+          redis_host = helpers.redis_host,
+          redis_port = helpers.redis_port,
+          redis_database = 0,
+          sync_rate = sync_rate,
+        }
 
-      it("increase & usage", function()
-        --[[
-          Just a simple test:
-          - increase 1
-          - check usage == 1
-          - increase 1
-          - check usage == 2
-          - increase 1 (beyond the limit)
-          - check usage == 3
-        --]]
+        before_each(function()
+          local red = require "resty.redis"
+          local redis = assert(red:new())
+          redis:set_timeout(1000)
+          assert(redis:connect(conf.redis_host, conf.redis_port))
+          redis:flushall()
+          redis:close()
+        end)
 
-        local current_timestamp = 1424217600
-        local periods = timestamp.get_timestamps(current_timestamp)
-
-        for period in pairs(periods) do
+        it("increase & usage", function()
+          --[[
+            Just a simple test:
+            - increase 1
+            - check usage == 1
+            - increase 1
+            - check usage == 2
+            - increase 1 (beyond the limit)
+            - check usage == 3
+          --]]
 
           local metric = assert(policies.redis.usage(conf, identifier, period, current_timestamp))
           assert.equal(0, metric)
@@ -232,8 +231,8 @@ describe("Plugin: rate-limiting (policies)", function()
               assert.equal(i, metric)
             end
           end
-        end
+        end)
       end)
-    end)
+    end
   end
 end)


### PR DESCRIPTION
### Summary

When the periodic sync to redis feature is turned on, using the `sync_rate` configuration option, keys are incremented by 2 instead of 1 for requests that arrive after the `sync_rate` interval has expired.

This happens because after each sync, the key is loaded from redis using `incr` (see: https://github.com/Kong/kong/pull/10559) however the next call to `increment` also adds 1 to the counter, so the key is incremented twice every time it's loaded from redis. In other words there can be 2 increments for the same request: [here](https://github.com/Kong/kong/blob/f59e36b554b6071a9213deea6947eb804dd7a6f6/kong/plugins/rate-limiting/policies/init.lua#L325) and then [here](https://github.com/Kong/kong/blob/f59e36b554b6071a9213deea6947eb804dd7a6f6/kong/plugins/rate-limiting/policies/init.lua#L293).

This fix sets a negative delta for the key when
`conf.sync_rate ~= SYNC_RATE_REALTIME` and the key was loaded from redis to account for the prior increment.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

KAG-2906