### PR TITLE
Fix/rl-unique-sync-timer

### DIFF
--- a/changelog/unreleased/kong/rate-limiting-share-sync-timer.yml
+++ b/changelog/unreleased/kong/rate-limiting-share-sync-timer.yml
@@ -1,0 +1,3 @@
+message: "**Rate Limiting**: fixed a bug where instances share 1 timer and only 1 instance sync to the datebase"
+type: bugfix
+scope: Plugin

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -190,7 +190,7 @@ local function periodical_sync(conf, sync_func)
   if not auto_sync_timer then
     local err
     -- timer may be initialized after the module's loaded so we need to update the reference
-    auto_sync_timer, err = kong.timer:named_every("rate-limiting-auto-sync", conf.sync_rate, sync_func, conf)
+    auto_sync_timer, err = kong.timer:named_every("rate-limiting-auto-sync" .. conf.__plugin_id , conf.sync_rate, sync_func, conf)
 
     if not auto_sync_timer then
       kong.log.err("failed to create timer: ", err)

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -1482,8 +1482,8 @@ describe("#regression #" .. strategy, function ()
       url = UPSTREAM_URL,
     })
 
-    -- we have another bug that caches for counters of different route mix up
-    -- so we try to avoid that by using different redis database
+    -- the bug causes all the counters to be synced to the same redis database
+    -- so we set up multiple routes with different redis database
     for i = 1, INSTANCES do
       local route_sync_rate = assert(bp.routes:insert {
         service = { id = service.id },


### PR DESCRIPTION
## BLOCKED

We need to make a design decision before writing the fix.

### Summary

**Rate Limiting**: fixed a bug where instances share 1 timer and only 1 instance sync to the datebase

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Full changelog

* Timers are created with plugin_id as name;
* Timers are purged when plugin is modified

### Issue reference

Fix KAG-2904
