### PR TITLE
fix(dns): set default `dns_no_sync` to `on`

### DIFF
--- a/changelog/unreleased/kong/fix_dns_enable_dns_no_sync.yml
+++ b/changelog/unreleased/kong/fix_dns_enable_dns_no_sync.yml
@@ -1,3 +1,3 @@
-message: change the default `dns_no_sync` option to `on`
+message: The default value of `dns_no_sync` option has been changed to `on`
 type: bugfix
 scope: Configuration

--- a/changelog/unreleased/kong/fix_dns_enable_dns_no_sync.yml
+++ b/changelog/unreleased/kong/fix_dns_enable_dns_no_sync.yml
@@ -1,0 +1,3 @@
+message: change the default `dns_no_sync` option to `on`
+type: bugfix
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1543,7 +1543,7 @@
 
 #dns_error_ttl = 1               # TTL in seconds for error responses.
 
-#dns_no_sync = off               # If enabled, then upon a cache-miss every
+#dns_no_sync = on                # If enabled, then upon a cache-miss every
                                  # request will trigger its own dns query.
                                  # When disabled multiple requests for the
                                  # same name/type will be synchronised to a

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -159,7 +159,7 @@ dns_stale_ttl = 4
 dns_cache_size = 10000
 dns_not_found_ttl = 30
 dns_error_ttl = 1
-dns_no_sync = off
+dns_no_sync = on
 
 dedicated_config_processing = off
 worker_consistency = eventual


### PR DESCRIPTION
### Summary

This is a temporary fix for the DNS resolution blocking issue. If the issue is resolved, remember to revert this option to `off`.



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->



<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests (reuse the original test case)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-5348
