### PR TITLE
tests(azure-functions): temporarily disable tests that use mockbin

### DIFF
--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -6,7 +6,7 @@ local server_tokens = meta._SERVER_TOKENS
 
 
 for _, strategy in helpers.each_strategy() do
-  describe("Plugin: Azure Functions (access) [#" .. strategy .. "]", function()
+  describe("#flaky Plugin: Azure Functions (access) [#" .. strategy .. "]", function()
     local proxy_client
 
     setup(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Temporarily disable the tests that use mockbin.org or mockbin.com as these two websites are shutdown.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
KAG-2912

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
