### PR TITLE
fix(core): definition of cookie name validate

### DIFF
--- a/changelog/unreleased/kong/cookie-name-validator.yml
+++ b/changelog/unreleased/kong/cookie-name-validator.yml
@@ -1,0 +1,3 @@
+message: Now cookie names are validated against RFC 6265, which allows more characters than the previous validation.
+type: bugfix
+scope: Core

--- a/kong/db/schema/entities/upstreams.lua
+++ b/kong/db/schema/entities/upstreams.lua
@@ -189,7 +189,7 @@ local r =  {
     { hash_fallback = hash_on },
     { hash_on_header = typedefs.header_name, },
     { hash_fallback_header = typedefs.header_name, },
-    { hash_on_cookie = { description = "The cookie name to take the value from as hash input.", type = "string",  custom_validator = utils.validate_cookie_name }, },
+    { hash_on_cookie = typedefs.cookie_name{ description = "The cookie name to take the value from as hash input."}, },
     { hash_on_cookie_path = typedefs.path{ default = "/", }, },
     { hash_on_query_arg = simple_param },
     { hash_fallback_query_arg = simple_param },

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -331,6 +331,14 @@ typedefs.url = Schema.define {
   description = "A string representing a URL, such as https://example.com/path/to/resource?q=search."
 }
 
+
+typedefs.cookie_name = Schema.define {
+  type = "string",
+  custom_validator = utils.validate_cookie_name,
+  description = "A string representing an HTTP token defined by RFC 2616."
+}
+
+-- should we also allow all http token for this?
 typedefs.header_name = Schema.define {
   type = "string",
   custom_validator = utils.validate_header_name,

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -656,12 +656,12 @@ describe("Utils", function()
     end
   end)
   it("validate_cookie_name() validates cookie names", function()
-    local header_chars = [[_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
+    local cookie_chars = [[~`|!#$%&'*+-._-^0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
 
     for i = 1, 255 do
       local c = string.char(i)
 
-      if string.find(header_chars, c, nil, true) then
+      if string.find(cookie_chars, c, nil, true) then
         assert(utils.validate_cookie_name(c) == c,
           "ascii character '" .. c .. "' (" .. i .. ") should have been allowed")
       else

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -404,7 +404,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.equals([[must not contain invalid characters: ASCII control characters (0-31;127), space, tab and the following characters: ()<>@,;:"/?={}[]. Please refer to RFC 2616]],
+            assert.equals([[contains one or more invalid characters. ASCII control characters (0-31;127), space, tab and the characters ()<>@,;:\"/?={}[] are not allowed.]],
                           json.fields.hash_on_cookie)
 
             -- Invalid cookie path
@@ -437,7 +437,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.equals([[must not contain invalid characters: ASCII control characters (0-31;127), space, tab and the following characters: ()<>@,;:"/?={}[]. Please refer to RFC 2616]],
+            assert.equals([[contains one or more invalid characters. ASCII control characters (0-31;127), space, tab and the characters ()<>@,;:\"/?={}[] are not allowed.]],
                           json.fields.hash_on_cookie)
 
             -- Invalid cookie path in hash fallback

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -404,7 +404,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.equals("bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
+            assert.equals([[must not contain invalid characters: ASCII control characters (0-31;127), space, tab and the following characters: ()<>@,;:"/?={}[]. Please refer to RFC 2616]],
                           json.fields.hash_on_cookie)
 
             -- Invalid cookie path
@@ -437,7 +437,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.equals("bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
+            assert.equals([[must not contain invalid characters: ASCII control characters (0-31;127), space, tab and the following characters: ()<>@,;:"/?={}[]. Please refer to RFC 2616]],
                           json.fields.hash_on_cookie)
 
             -- Invalid cookie path in hash fallback


### PR DESCRIPTION
### Summary

We have a too strong limitation on the character used in cookie names. For example "." should be allowed.

We choose not to do the same to the header because we rely on Nginx's API to handle headers, which has more strict restrictions on the characters.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Full changelog

* [Implement ...]

### Issue reference

Fix #11860
