### PR TITLE
fix(acl): Add missing descriptions to plugin schema

### DIFF
--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -9,9 +9,9 @@ return {
     { config = {
         type = "record",
         fields = {
-          { allow = { type = "array", elements = { type = "string" }, }, },
-          { deny = { type = "array", elements = { type = "string" }, }, },
-          { hide_groups_header = { type = "boolean", required = true, default = false }, },
+          { allow = { type = "array", elements = { type = "string", description = "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified." }, }, },
+          { deny = { type = "array", elements = { type = "string", description = "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified." }, }, },
+          { hide_groups_header = { type = "boolean", required = true, default = false, description = "If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service." }, },
         },
       }
     }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The ACL plugin is missing descriptions for its configuration parameters, resulting in empty doc fields: https://docs.konghq.com/hub/kong-inc/acl/configuration/#config

Adding descriptions from the [previous version](https://docs.konghq.com/hub/kong-inc/acl/3.3.x/configuration/#config), when they were written manually.

### Checklist

- [ N/A ] The Pull Request has tests
- [ N/A ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ N/A ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - can't do this until we update the schema.

### Full changelog

Not applicable.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
