### PR TITLE
chore(conf): enable `dedicated_config_processing` by default

### DIFF
--- a/changelog/unreleased/kong/dedicated_config_processing.yml
+++ b/changelog/unreleased/kong/dedicated_config_processing.yml
@@ -1,4 +1,4 @@
 message: |
-    rename `privileged_agent` to `dedicated_config_processing.
+    rename `privileged_agent` to `dedicated_config_processing. Enable `dedicated_config_processing` by default
 type: feature
 scope: Core

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2127,7 +2127,7 @@
 # information such as domain name tried during these processes.
 #
 #request_debug = on              # When enabled, Kong will provide detailed timing information
-                                 # for its components to the client and the error log 
+                                 # for its components to the client and the error log
                                  # if the following headers are present in the proxy request:
                                  # - `X-Kong-Request-Debug`:
                                  #   If the value is set to `*`,

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -182,7 +182,7 @@
                                  # cache (i.e. when the configured
                                  # `mem_cache_size`) is full.
 
-#dedicated_config_processing = off # Enables or disables a special worker
+#dedicated_config_processing = on  # Enables or disables a special worker
                                    # process for configuration processing. This process
                                    # increases memory usage a little bit while
                                    # allowing to reduce latencies by moving some
@@ -2127,7 +2127,7 @@
 # information such as domain name tried during these processes.
 #
 #request_debug = on              # When enabled, Kong will provide detailed timing information
-                                 # for its components to the client and the error log
+                                 # for its components to the client and the error log 
                                  # if the following headers are present in the proxy request:
                                  # - `X-Kong-Request-Debug`:
                                  #   If the value is set to `*`,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -161,7 +161,7 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = on
 
-dedicated_config_processing = off
+dedicated_config_processing = on
 worker_consistency = eventual
 worker_state_update_frequency = 5
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -65,7 +65,7 @@ describe("Configuration loader", function()
     assert.same({}, conf.status_ssl_cert)
     assert.same({}, conf.status_ssl_cert_key)
     assert.same(nil, conf.privileged_agent)
-    assert.same(false, conf.dedicated_config_processing)
+    assert.same(true, conf.dedicated_config_processing)
     assert.same(false, conf.allow_debug_header)
     assert.is_nil(getmetatable(conf))
   end)
@@ -2020,7 +2020,7 @@ describe("Configuration loader", function()
         privileged_agent = "on",
       }))
       assert.same(nil, conf.privileged_agent)
-      assert.same(false, conf.dedicated_config_processing)
+      assert.same(true, conf.dedicated_config_processing)
       assert.equal(nil, err)
 
       -- no clobber
@@ -2419,7 +2419,6 @@ describe("Configuration loader", function()
         assert.matches(label.err, err)
       end
     end)
-
   end)
 
 end)

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -25,7 +25,7 @@ anonymous_reports = off
 
 worker_consistency = strict
 
-dedicated_config_processing = off
+dedicated_config_processing = on
 
 dns_hostsfile = spec/fixtures/hosts
 


### PR DESCRIPTION
This reverts commit 6bccc872cbb3a8bb52389a4e7b18a06b59e05ac0.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Based on the performance benchmark results, we decided to enable `dedicated_config_processing` by default.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
