### PR TITLE
tests(request-debugging): fix flaky tests

### DIFF
--- a/spec/02-integration/21-request-debug/01-request-debug_spec.lua
+++ b/spec/02-integration/21-request-debug/01-request-debug_spec.lua
@@ -144,8 +144,7 @@ local function get_output_header(_deployment, path, filter, fake_ip, token)
       ["X-Real-IP"] = fake_ip or "127.0.0.1",
     }
   })
-  assert.not_same(500, res.status)
-  res:read_body() -- discard body
+  assert.not_same(500, res.status, res:read_body())
   proxy_client:close()
 
   if not res.headers["X-Kong-Request-Debug-Output"] then
@@ -512,7 +511,7 @@ describe(desc, function()
     local total_log = assert(tonumber(log_output.child.upstream.total_time))
     local tfb_log = assert(tonumber(log_output.child.upstream.child.time_to_first_byte.total_time))
     local streaming = assert(tonumber(log_output.child.upstream.child.streaming.total_time))
-    assert.near(tfb_header, tfb_log, 10)
+    assert.near(tfb_header, tfb_log, 50)
     assert.same(total_log, tfb_log + streaming)
 
     assert.near(TIME_TO_FIRST_BYTE, tfb_log, 50)
@@ -656,7 +655,7 @@ describe(desc, function()
 
   it("truncate/split too large debug output", function()
     local route_id = setup_route("/large_debug_output", upstream)
-    local plugin_id = setup_plugin(route_id, "muti-external-http-calls", { calls = 50 })
+    local plugin_id = setup_plugin(route_id, "muti-external-http-calls", { calls = 10 })
 
     finally(function()
       if plugin_id then

--- a/spec/fixtures/custom_plugins/kong/plugins/muti-external-http-calls/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/muti-external-http-calls/handler.lua
@@ -12,7 +12,9 @@ function EnableBuffering:access(conf)
 
   for suffix = 0, conf.calls - 1 do
     local uri = "http://really.really.really.really.really.really.not.exists." .. suffix
-    httpc:request_uri(uri)
+    pcall(function()
+      httpc:request_uri(uri)
+    end)
   end
 end
 


### PR DESCRIPTION
### Summary

1. Increase the tolerance for upstream latency in the `upstream_span` tests, given that the timing on CI can be more variable.
2. Use `pcall` when calling `resty.http.request_uri` to prevent potential HTTP 500 errors.


### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

_[KAG-3279]_


[KAG-3279]: https://konghq.atlassian.net/browse/KAG-3279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ