### PR TITLE
tests(dns): add a test case to cover dns resolution in stream subsystem

### DIFF
--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -207,7 +207,7 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
-    describe("run in stream subsystem #tag", function()
+    describe("run in stream subsystem", function()
       local domain_name = "www.example.test"
       local address = "127.0.0.1"
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

just make sure dns resolve can run normally in the stream subsystem
 
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #11896
