### PR TITLE
refactor(router): use rust style raw string in expression

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -96,7 +96,21 @@ end
 
 
 local function escape_str(str)
-  return "r#\"" .. str .. "\"#"
+  -- rust style raw string
+  if not str:find([["#]], 1, true) then
+    return "r#\"" .. str .. "\"#"
+  end
+
+  -- normal escape string
+  if str:find([[\]], 1, true) then
+    str = str:gsub([[\]], [[\\]])
+  end
+
+  if str:find([["]], 1, true) then
+    str = str:gsub([["]], [[\"]])
+  end
+
+  return "\"" .. str .. "\""
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -96,13 +96,7 @@ end
 
 
 local function escape_str(str)
-  if str:find([[\]], 1, true) or
-     str:find([["]], 1, true)
-  then
-    return "r#\"" .. str .. "\"#"
-  end
-
-  return "\"" .. str .. "\""
+  return "r#\"" .. str .. "\"#"
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -96,7 +96,13 @@ end
 
 
 local function escape_str(str)
-  return "r#\"" .. str .. "\"#"
+  if str:find([[\]], 1, true) or
+     str:find([["]], 1, true)
+  then
+    return "r#\"" .. str .. "\"#"
+  end
+
+  return "\"" .. str .. "\""
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -96,15 +96,7 @@ end
 
 
 local function escape_str(str)
-  if str:find([[\]], 1, true) then
-    str = str:gsub([[\]], [[\\]])
-  end
-
-  if str:find([["]], 1, true) then
-    str = str:gsub([["]], [[\"]])
-  end
-
-  return "\"" .. str .. "\""
+  return "r#\"" .. str .. "\"#"
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -96,12 +96,12 @@ end
 
 
 local function escape_str(str)
-  -- rust style raw string
+  -- raw string
   if not str:find([["#]], 1, true) then
     return "r#\"" .. str .. "\"#"
   end
 
-  -- normal escape string
+  -- standard string escaping (unlikely case)
   if str:find([[\]], 1, true) then
     str = str:gsub([[\]], [[\\]])
   end

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -165,9 +165,9 @@ local function get_expression(route)
     -- See #6425, if `net.protocol` is not `https`
     -- then SNI matching should simply not be considered
     if srcs or dsts then
-      gen = "(net.protocol != \"tls\""   .. LOGICAL_OR .. gen .. ")"
+      gen = "(net.protocol != r#\"tls\"#"   .. LOGICAL_OR .. gen .. ")"
     else
-      gen = "(net.protocol != \"https\"" .. LOGICAL_OR .. gen .. ")"
+      gen = "(net.protocol != r#\"https\"#" .. LOGICAL_OR .. gen .. ")"
     end
 
     expression_append(expr_buf, LOGICAL_AND, gen)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2150,35 +2150,35 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             it("empty methods", function()
               use_case[1].route.methods = v
 
-              assert.equal(get_expression(use_case[1].route), [[(http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.path ^= r#"/foo"#)]])
               assert(new_router(use_case))
             end)
 
             it("empty hosts", function()
               use_case[1].route.hosts = v
 
-              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == r#"GET"#) && (http.path ^= r#"/foo"#)]])
               assert(new_router(use_case))
             end)
 
             it("empty headers", function()
               use_case[1].route.headers = v
 
-              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == r#"GET"#) && (http.path ^= r#"/foo"#)]])
               assert(new_router(use_case))
             end)
 
             it("empty paths", function()
               use_case[1].route.paths = v
 
-              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == r#"GET"#)]])
               assert(new_router(use_case))
             end)
 
             it("empty snis", function()
               use_case[1].route.snis = v
 
-              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == r#"GET"#) && (http.path ^= r#"/foo"#)]])
               assert(new_router(use_case))
             end)
           end
@@ -2203,7 +2203,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("regex path has double '\\'", function()
             use_case[1].route.paths = { [[~/\\/*$]], }
 
-            assert.equal([[(http.method == "GET") && (http.path ~ r#"^/\\/*$"#)]],
+            assert.equal([[(http.method == r#"GET"#) && (http.path ~ r#"^/\\/*$"#)]],
                          get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
@@ -2211,7 +2211,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("regex path has '\\d'", function()
             use_case[1].route.paths = { [[~/\d+]], }
 
-            assert.equal([[(http.method == "GET") && (http.path ~ r#"^/\d+"#)]],
+            assert.equal([[(http.method == r#"GET"#) && (http.path ~ r#"^/\d+"#)]],
                          get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
@@ -4659,7 +4659,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
               use_case[1].route.destinations = {{ ip = "192.168.0.1/16" },}
 
               assert.equal(get_expression(use_case[1].route),
-                [[(net.protocol != "tls" || (tls.sni == "www.example.org")) && (net.dst.ip in 192.168.0.0/16)]])
+                [[(net.protocol != r#"tls"# || (tls.sni == r#"www.example.org"#)) && (net.dst.ip in 192.168.0.0/16)]])
               assert(new_router(use_case))
             end)
 
@@ -4667,7 +4667,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
               use_case[1].route.destinations = v
 
               assert.equal(get_expression(use_case[1].route),
-                [[(net.protocol != "tls" || (tls.sni == "www.example.org")) && (net.src.ip == 127.0.0.1)]])
+                [[(net.protocol != r#"tls"# || (tls.sni == r#"www.example.org"#)) && (net.src.ip == 127.0.0.1)]])
               assert(new_router(use_case))
             end)
           end

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2203,7 +2203,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("regex path has double '\\'", function()
             use_case[1].route.paths = { [[~/\\/*$]], }
 
-            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]],
+            assert.equal([[(http.method == "GET") && (http.path ~ r#"^/\\/*$"#)]],
                          get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
@@ -2211,7 +2211,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("regex path has '\\d'", function()
             use_case[1].route.paths = { [[~/\d+]], }
 
-            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\d+")]],
+            assert.equal([[(http.method == "GET") && (http.path ~ r#"^/\d+"#)]],
                          get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2184,7 +2184,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
         end)
 
-        describe("rust style raw string", function()
+        describe("raw string", function()
           local use_case
           local get_expression = atc_compat.get_expression
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2184,6 +2184,39 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
         end)
 
+        describe("rust style raw string", function()
+          local use_case
+          local get_expression = atc_compat.get_expression
+
+          before_each(function()
+            use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  methods = { "GET" },
+                },
+              },
+            }
+          end)
+
+          it("path has '\"'", function()
+            use_case[1].route.paths = { [[~/\"/*$]], }
+
+            assert.equal([[(http.method == r#"GET"#) && (http.path ~ r#"^/\"/*$"#)]],
+                         get_expression(use_case[1].route))
+            assert(new_router(use_case))
+          end)
+
+          it("path has '\"#'", function()
+            use_case[1].route.paths = { [[~/\"#/*$]], }
+
+            assert.equal([[(http.method == r#"GET"#) && (http.path ~ "^/\\\"#/*$")]],
+                         get_expression(use_case[1].route))
+            assert(new_router(use_case))
+          end)
+        end)
+
         describe("check regex with '\\'", function()
           local use_case
           local get_expression = atc_compat.get_expression


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In latest atc-router library we introduced raw string feature, now we need not to escape string.
See: https://github.com/Kong/atc-router/pull/22

KAG-2952

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
