### PR TITLE
fix(router): http headers sensitive for expressions and insensitive for traditional_compatible

### DIFF
--- a/changelog/unreleased/kong/expression_http_headers_sensitive.yml
+++ b/changelog/unreleased/kong/expression_http_headers_sensitive.yml
@@ -1,5 +1,5 @@
 message: |
-    Header value matching in `expressions` router flavor are now case sensitive.
+    Header value matching (`http.headers.*`) in `expressions` router flavor are now case sensitive.
     This change does not affect on `traditional_compatible` mode
     where header value match are always performed ignoring the case.
 type: bugfix

--- a/changelog/unreleased/kong/expression_http_headers_sensitive.yml
+++ b/changelog/unreleased/kong/expression_http_headers_sensitive.yml
@@ -1,6 +1,6 @@
 message: |
-    Enable case sensitive in `expressions` router flavor,
-    and make the `traditional_compatible` flavor more compatible
-    with the `traditional` flavor's behavior.
+    Header value matching in `expressions` router flavor are now case sensitive.
+    This change does not have effect on `traditional_compatible` mode
+    where header value match are always performed ignoring the case.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/expression_http_headers_sensitive.yml
+++ b/changelog/unreleased/kong/expression_http_headers_sensitive.yml
@@ -1,6 +1,6 @@
 message: |
     Enable case sensitive in `expressions` router flavor,
-    and make `traditional_compatible` flavor more compatible
+    and make the `traditional_compatible` flavor more compatible
     with the `traditional` flavor's behavior.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/expression_http_headers_sensitive.yml
+++ b/changelog/unreleased/kong/expression_http_headers_sensitive.yml
@@ -1,6 +1,6 @@
 message: |
     Header value matching in `expressions` router flavor are now case sensitive.
-    This change does not have effect on `traditional_compatible` mode
+    This change does not affect on `traditional_compatible` mode
     where header value match are always performed ignoring the case.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/expression_http_headers_sensitive.yml
+++ b/changelog/unreleased/kong/expression_http_headers_sensitive.yml
@@ -1,0 +1,6 @@
+message: |
+    Enable case sensitive in `expressions` router flavor,
+    and make `traditional_compatible` flavor more compatible
+    with the `traditional` flavor's behavior.
+type: bugfix
+scope: Core

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -596,13 +596,13 @@ do
 
       if type(value) == "table" then
         for i, v in ipairs(value) do
-          value[i] = v:lower()
+          value[i] = tuning_header(v)
         end
         tb_sort(value)
         value = tb_concat(value, ", ")
 
       else
-        value = value:lower()
+        value = tuning_header(value)
       end
 
       str_buf:putf("|%s=%s", name, value)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -482,14 +482,14 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       local v = req_headers[h]
 
       if type(v) == "string" then
-        local res, err = c:add_value(field, tuning_header(v))
+        local res, err = c:add_value(field, v)
         if not res then
           return nil, err
         end
 
       elseif type(v) == "table" then
         for _, v in ipairs(v) do
-          local res, err = c:add_value(field, tuning_header(v))
+          local res, err = c:add_value(field, v)
           if not res then
             return nil, err
           end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -412,6 +412,11 @@ local add_debug_headers    = utils.add_debug_headers
 local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
+local is_expressions_flavor = kong and
+                              kong.configuration and
+                              kong.configuration.router_flavor == "expressions"
+
+
 function _M:select(req_method, req_uri, req_host, req_scheme,
                    _, _,
                    _, _,
@@ -467,14 +472,16 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       local v = req_headers[h]
 
       if type(v) == "string" then
-        local res, err = c:add_value(field, v:lower())
+        local res, err = c:add_value(field,
+                                     is_expressions_flavor and v or v:lower())
         if not res then
           return nil, err
         end
 
       elseif type(v) == "table" then
         for _, v in ipairs(v) do
-          local res, err = c:add_value(field, v:lower())
+          local res, err = c:add_value(field,
+                                       is_expressions_flavor and v or v:lower())
           if not res then
             return nil, err
           end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -412,21 +412,6 @@ local add_debug_headers    = utils.add_debug_headers
 local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
--- traditional_compatible is case insensitive
-local tuning_header = string.lower
-
-
--- expressions is case sensitive
-if kong and
-   kong.configuration and
-   kong.configuration.router_flavor == "expressions"
-then
-  tuning_header = function(str)
-    return str
-  end
-end
-
-
 function _M:select(req_method, req_uri, req_host, req_scheme,
                    _, _,
                    _, _,
@@ -584,6 +569,19 @@ do
   local tb_sort = table.sort
   local tb_concat = table.concat
   local replace_dashes_lower = require("kong.tools.string").replace_dashes_lower
+
+  -- traditional_compatible is case insensitive
+  local tuning_header = string.lower
+
+  -- expressions is case sensitive
+  if kong and
+     kong.configuration and
+     kong.configuration.router_flavor == "expressions"
+  then
+    tuning_header = function(str)
+      return str
+    end
+  end
 
   local str_buf = buffer.new(64)
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -570,19 +570,6 @@ do
   local tb_concat = table.concat
   local replace_dashes_lower = require("kong.tools.string").replace_dashes_lower
 
-  -- traditional_compatible is case insensitive
-  local tuning_header = string.lower
-
-  -- expressions is case sensitive
-  if kong and
-     kong.configuration and
-     kong.configuration.router_flavor == "expressions"
-  then
-    tuning_header = function(str)
-      return str
-    end
-  end
-
   local str_buf = buffer.new(64)
 
   get_headers_key = function(headers)
@@ -593,14 +580,8 @@ do
       local name = replace_dashes_lower(name)
 
       if type(value) == "table" then
-        for i, v in ipairs(value) do
-          value[i] = tuning_header(v)
-        end
         tb_sort(value)
         value = tb_concat(value, ", ")
-
-      else
-        value = tuning_header(value)
       end
 
       str_buf:putf("|%s=%s", name, value)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -252,7 +252,7 @@ local function get_expression(route)
       single_header_buf:reset():put("(")
 
       for i, value in ipairs(v) do
-        local name = "any(http.headers." .. replace_dashes_lower(h) .. ")"
+        local name = "any(lower(http.headers." .. replace_dashes_lower(h) .. "))"
         local op = OP_EQUAL
 
         -- value starts with "~*"

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4940,7 +4940,7 @@ do
       }
     end)
 
-    it("[#only cache hit should be case insensitive]", function()
+    it("[cache hit should be case insensitive]", function()
       router = assert(new_router(use_case))
 
       local ctx = {}

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5105,11 +5105,11 @@ do
           },
         },
       }
-
-      router = assert(new_router(use_case))
     end)
 
     it("select() should match with case sensitive", function()
+      router = assert(new_router(use_case))
+
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, {test = "quote"})
       assert.falsy(match_t)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5174,7 +5174,7 @@ do
       }
     end)
 
-    it("select() should match with case sensitive", function()
+    it("select() should match with case sensitivity", function()
       router = assert(new_router(use_case))
 
       local match_t = router:select("GET", "/foo/bar", nil, nil, nil, nil, nil, nil, nil, {test1 = "quote"})

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2289,7 +2289,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end)
 
           it("should always add lower()", function()
-            use_case[1].route.headers = { test = { "~*quote" }, }
+            use_case[1].route.headers = { test = { "~*Quote" }, }
 
             assert.equal([[(http.method == "GET") && (any(lower(http.headers.test)) ~ "quote")]],
                          get_expression(use_case[1].route))

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2269,7 +2269,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("should always add lower()", function()
             use_case[1].route.headers = { test = { "~*Quote" }, }
 
-            assert.equal([[(http.method == "GET") && (any(lower(http.headers.test)) ~ "quote")]],
+            assert.equal([[(http.method == r#"GET"#) && (any(lower(http.headers.test)) ~ r#"quote"#)]],
                          get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4970,7 +4970,7 @@ do
       assert.same(ctx.route_match_cached, "pos")
     end)
   end)
-end
+end   -- local flavor = "traditional_compatible"
 
 do
   local flavor = "expressions"
@@ -5211,7 +5211,7 @@ do
       assert.same(use_case[1].route, match_t.route)
       assert.falsy(ctx.route_match_cached)
 
-      -- cache hit
+      -- cache hit pos
       local match_t = router:exec(ctx)
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
@@ -5226,7 +5226,7 @@ do
       assert.falsy(match_t)
       assert.falsy(ctx.route_match_cached)
 
-      -- cache miss
+      -- cache hit neg
       local match_t = router:exec(ctx)
       assert.falsy(match_t)
       assert.same(ctx.route_match_cached, "neg")

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4940,7 +4940,7 @@ do
       }
     end)
 
-    it("[cache hit should be case insensitive]", function()
+    it("[cache hit should be case sensitive]", function()
       router = assert(new_router(use_case))
 
       local ctx = {}
@@ -4953,7 +4953,7 @@ do
       assert.same(use_case[1].route, match_t.route)
       assert.falsy(ctx.route_match_cached)
 
-      -- cache hit, case insensitive
+      -- cache hit
       local match_t = router:exec(ctx)
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
@@ -4967,7 +4967,9 @@ do
       local match_t = router:exec(ctx)
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
-      assert.same(ctx.route_match_cached, "pos")
+
+      -- cache miss, case sensitive
+      assert.falsy(ctx.route_match_cached)
     end)
   end)
 end   -- local flavor = "traditional_compatible"

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -586,7 +586,10 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         -- expressions is case sensitive for headers
         if flavor == "expressions" then
           assert.falsy(match_t)
-          return
+          -- Linux => linux
+          match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+            user_agent = "Mozilla/5.0 (X11; linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
+          })
         end
 
         assert.truthy(match_t)
@@ -1728,7 +1731,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           -- expressions is case sensitive for headers
           if flavor == "expressions" then
             assert.falsy(match_t)
-            return
+            -- FOO => foo
+            match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
+                                    {
+                                      user_agent = "foo",
+                                    })
           end
 
           assert.truthy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -582,6 +582,13 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
           user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         })
+
+        -- expressions is case sensitive for headers
+        if flavor == "expressions" then
+          assert.falsy(match_t)
+          return
+        end
+
         assert.truthy(match_t)
         assert.same(use_case[15].route, match_t.route)
         assert.same(nil, match_t.matches.method)
@@ -1717,7 +1724,15 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
                                         {
                                           user_agent = "FOO",
                                         })
+
+          -- expressions is case sensitive for headers
+          if flavor == "expressions" then
+            assert.falsy(match_t)
+            return
+          end
+
           assert.truthy(match_t)
+
           assert.same(use_case[1].route, match_t.route)
           if flavor == "traditional" then
             assert.same({ user_agent = "foo" }, match_t.matches.headers)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1717,7 +1717,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
                                         {
                                           user_agent = "FOO",
                                         })
-
           assert.truthy(match_t)
           assert.same(use_case[1].route, match_t.route)
           if flavor == "traditional" then

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -583,15 +583,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
         })
 
-        -- expressions is case sensitive for headers
-        if flavor == "expressions" then
-          assert.falsy(match_t)
-          -- Linux => linux
-          match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
-            user_agent = "Mozilla/5.0 (X11; linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
-          })
-        end
-
         assert.truthy(match_t)
         assert.same(use_case[15].route, match_t.route)
         assert.same(nil, match_t.matches.method)
@@ -1728,18 +1719,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
                                           user_agent = "FOO",
                                         })
 
-          -- expressions is case sensitive for headers
-          if flavor == "expressions" then
-            assert.falsy(match_t)
-            -- FOO => foo
-            match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
-                                    {
-                                      user_agent = "foo",
-                                    })
-          end
-
           assert.truthy(match_t)
-
           assert.same(use_case[1].route, match_t.route)
           if flavor == "traditional" then
             assert.same({ user_agent = "foo" }, match_t.matches.headers)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2271,7 +2271,32 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             assert(new_router(use_case))
           end)
         end)
-      end
+
+        describe("match http.headers.*", function()
+          local use_case
+          local get_expression = atc_compat.get_expression
+
+          before_each(function()
+            use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  methods = { "GET" },
+                },
+              },
+            }
+          end)
+
+          it("should always add lower()", function()
+            use_case[1].route.headers = { test = { "~*quote" }, }
+
+            assert.equal([[(http.method == "GET") && (any(lower(http.headers.test)) ~ "quote")]],
+                         get_expression(use_case[1].route))
+            assert(new_router(use_case))
+          end)
+        end)
+      end   -- if flavor ~= "traditional"
 
       describe("normalization stopgap measurements", function()
         local use_case, router


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-2905


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
