### PR TITLE
refactor(router): http/stream subsystem does not share schema

### DIFF
--- a/changelog/unreleased/kong/subsystems_do_not_share_router_schemas.yml
+++ b/changelog/unreleased/kong/subsystems_do_not_share_router_schemas.yml
@@ -1,0 +1,6 @@
+message: |
+  Now route expressions in `http` and `stream` subsystem have more strict validation,
+  `http.*` fields will not be allowed in `stream` subsystem.
+type: bugfix
+scope: Core
+

--- a/changelog/unreleased/kong/subsystems_do_not_share_router_schemas.yml
+++ b/changelog/unreleased/kong/subsystems_do_not_share_router_schemas.yml
@@ -1,6 +1,6 @@
 message: |
-  Now route expressions in `http` and `stream` subsystem have more strict validation,
-  `http.*` fields will not be allowed in `stream` subsystem.
+  Expressions route in `http` and `stream` subsystem now have stricter validation.
+  Previously they share the same validation schema which means admin can configure expressions
+  route using fields like `http.path` even for stream routes. This is no longer allowed.
 type: bugfix
 scope: Core
-

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -3,7 +3,6 @@ local router = require("resty.router.router")
 local deprecation = require("kong.deprecation")
 
 local validate_route
-local has_paths
 do
   local isempty        = require("table.isempty")
   local get_schema     = require("kong.router.atc").schema
@@ -21,11 +20,6 @@ do
     end
 
     return true
-  end
-
-  has_paths = function(entity)
-    local paths = entity.paths
-    return type(paths) == "table" and not isempty(paths)
   end
 end
 
@@ -128,12 +122,10 @@ else
         run_with_missing_fields = true,
         --field_sources = { "id", "paths", "protocols", },
         fn = function(entity)
-          --if has_paths(entity) then
-            local ok, err = validate_route(entity)
-            if not ok then
-              return nil, err
-            end
-          --end
+          local ok, err = validate_route(entity)
+          if not ok then
+            return nil, err
+          end
 
           return true
         end,

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -13,8 +13,9 @@ do
   -- works with both `traditional_compatiable` and `expressions` routes`
   validate_route = function(entity)
     local exp = entity.expression or get_expression(entity)
+    local schema = get_schema(entity.protocols)
 
-    local ok, err = router.validate(get_schema(entity.protocols), exp)
+    local ok, err = router.validate(schema, exp)
     if not ok then
       return nil, "Router Expression failed validation: " .. err
     end
@@ -120,7 +121,6 @@ else
     table.insert(entity_checks,
       { custom_entity_check = {
         run_with_missing_fields = true,
-        --field_sources = { "id", "paths", "protocols", },
         fn = function(entity)
           local ok, err = validate_route(entity)
           if not ok then

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -4,11 +4,8 @@ local deprecation = require("kong.deprecation")
 
 local validate_route
 do
-  local isempty        = require("table.isempty")
   local get_schema     = require("kong.router.atc").schema
   local get_expression = require("kong.router.compat").get_expression
-
-  local type = type
 
   -- works with both `traditional_compatiable` and `expressions` routes`
   validate_route = function(entity)

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -9,8 +9,8 @@ do
 
   -- works with both `traditional_compatiable` and `expressions` routes`
   validate_route = function(entity)
-    local exp = entity.expression or get_expression(entity)
     local schema = get_schema(entity.protocols)
+    local exp = entity.expression or get_expression(entity)
 
     local ok, err = router.validate(schema, exp)
     if not ok then

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -66,14 +66,7 @@ if kong_router_flavor == "expressions" then
     entity_checks = {
       { custom_entity_check = {
         field_sources = { "expression", "id", "protocols", },
-        fn = function(entity)
-          local ok, err = validate_route(entity)
-          if not ok then
-            return nil, err
-          end
-
-          return true
-        end,
+        fn = validate_route,
       } },
     },
   }
@@ -118,14 +111,7 @@ else
     table.insert(entity_checks,
       { custom_entity_check = {
         run_with_missing_fields = true,
-        fn = function(entity)
-          local ok, err = validate_route(entity)
-          if not ok then
-            return nil, err
-          end
-
-          return true
-        end,
+        fn = validate_route,
       }}
     )
   end

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -126,14 +126,14 @@ else
     table.insert(entity_checks,
       { custom_entity_check = {
         run_with_missing_fields = true,
-        field_sources = { "id", "paths", "protocols", },
+        --field_sources = { "id", "paths", "protocols", },
         fn = function(entity)
-          if has_paths(entity) then
+          --if has_paths(entity) then
             local ok, err = validate_route(entity)
             if not ok then
               return nil, err
             end
-          end
+          --end
 
           return true
         end,

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -6,7 +6,7 @@ local validate_route
 local has_paths
 do
   local isempty        = require("table.isempty")
-  local CACHED_SCHEMA  = require("kong.router.atc").schema
+  local get_schema     = require("kong.router.atc").schema
   local get_expression = require("kong.router.compat").get_expression
 
   local type = type
@@ -15,7 +15,7 @@ do
   validate_route = function(entity)
     local exp = entity.expression or get_expression(entity)
 
-    local ok, err = router.validate(CACHED_SCHEMA, exp)
+    local ok, err = router.validate(get_schema(entity.protocols), exp)
     if not ok then
       return nil, "Router Expression failed validation: " .. err
     end
@@ -73,7 +73,7 @@ if kong_router_flavor == "expressions" then
 
     entity_checks = {
       { custom_entity_check = {
-        field_sources = { "expression", "id", },
+        field_sources = { "expression", "id", "protocols", },
         fn = function(entity)
           local ok, err = validate_route(entity)
           if not ok then
@@ -126,7 +126,7 @@ else
     table.insert(entity_checks,
       { custom_entity_check = {
         run_with_missing_fields = true,
-        field_sources = { "id", "paths", },
+        field_sources = { "id", "paths", "protocols", },
         fn = function(entity)
           if has_paths(entity) then
             local ok, err = validate_route(entity)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -55,8 +55,10 @@ local values_buf = buffer.new(64)
 
 
 local CACHED_SCHEMA
+local HTTP_SCHEMA
+local STREAM_SCHEMA
 do
-  local FIELDS = {
+  local HTTP_FIELDS = {
 
     ["String"] = {"net.protocol", "tls.sni",
                   "http.method", "http.host",
@@ -73,14 +75,36 @@ do
                  },
   }
 
-  CACHED_SCHEMA = schema.new()
+  local STREAM_FIELDS = {
 
-  for typ, fields in pairs(FIELDS) do
+    ["String"] = {"net.protocol", "tls.sni",
+                 },
+
+    ["Int"]    = {"net.src.port", "net.dst.port",
+                 },
+
+    ["IpAddr"] = {"net.src.ip", "net.dst.ip",
+                 },
+  }
+
+  -- http only
+  HTTP_SCHEMA   = schema.new()
+  for typ, fields in pairs(HTTP_FIELDS) do
     for _, v in ipairs(fields) do
-      assert(CACHED_SCHEMA:add_field(v, typ))
+      assert(HTTP_SCHEMA:add_field(v, typ))
     end
   end
 
+  -- stream only
+  STREAM_SCHEMA = schema.new()
+  for typ, fields in pairs(STREAM_FIELDS) do
+    for _, v in ipairs(fields) do
+      assert(STREAM_SCHEMA:add_field(v, typ))
+    end
+  end
+
+  -- used by router running
+  CACHED_SCHEMA = is_http and HTTP_SCHEMA or STREAM_SCHEMA
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -87,23 +87,23 @@ do
                  },
   }
 
-  -- http only
-  HTTP_SCHEMA = schema.new()
-  for typ, fields in pairs(HTTP_FIELDS) do
-    for _, v in ipairs(fields) do
-      assert(HTTP_SCHEMA:add_field(v, typ))
+  local function generate_schema(fields)
+    local s = schema.new()
+
+    for t, f in pairs(fields) do
+      for _, v in ipairs(f) do
+        assert(s:add_field(v, t))
+      end
     end
+
+    return s
   end
 
-  -- stream only
-  STREAM_SCHEMA = schema.new()
-  for typ, fields in pairs(STREAM_FIELDS) do
-    for _, v in ipairs(fields) do
-      assert(STREAM_SCHEMA:add_field(v, typ))
-    end
-  end
+  -- used by validation
+  HTTP_SCHEMA   = generate_schema(HTTP_FIELDS)
+  STREAM_SCHEMA = generate_schema(STREAM_FIELDS)
 
-  -- used by router running
+  -- used by running router
   CACHED_SCHEMA = is_http and HTTP_SCHEMA or STREAM_SCHEMA
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -892,7 +892,7 @@ end
 
 
 do
-  local protocol_to_shcema = {
+  local protocol_to_schema = {
     http  = HTTP_SCHEMA,
     https = HTTP_SCHEMA,
     grpc  = HTTP_SCHEMA,
@@ -907,7 +907,7 @@ do
 
   -- for db schema validation
   function _M.schema(protocols)
-    return assert(protocol_to_shcema[protocols[1]])
+    return assert(protocol_to_schema[protocols[1]])
   end
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -68,10 +68,6 @@ do
                  },
 
     ["Int"]    = {"net.port",
-                  "net.src.port", "net.dst.port",
-                 },
-
-    ["IpAddr"] = {"net.src.ip", "net.dst.ip",
                  },
   }
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -895,7 +895,17 @@ function _M._set_ngx(mock_ngx)
 end
 
 
-_M.schema          = CACHED_SCHEMA
+-- for db schema validation
+function _M.schema(protocols)
+  local p = assert(protocols[1]:sub(1, 4))
+
+  if p == "http" or p == "grpc" then
+    return HTTP_SCHEMA
+  else
+    return STREAM_SCHEMA
+  end
+end
+
 
 _M.LOGICAL_OR      = LOGICAL_OR
 _M.LOGICAL_AND     = LOGICAL_AND

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -891,14 +891,23 @@ function _M._set_ngx(mock_ngx)
 end
 
 
--- for db schema validation
-function _M.schema(protocols)
-  local p = assert(protocols[1]:sub(1, 4))
+do
+  local protocol_to_shcema = {
+    http  = HTTP_SCHEMA,
+    https = HTTP_SCHEMA,
+    grpc  = HTTP_SCHEMA,
+    grpcs = HTTP_SCHEMA,
 
-  if p == "http" or p == "grpc" then
-    return HTTP_SCHEMA
-  else
-    return STREAM_SCHEMA
+    tcp   = STREAM_SCHEMA,
+    udp   = STREAM_SCHEMA,
+    tls   = STREAM_SCHEMA,
+
+    tls_passthrough = STREAM_SCHEMA,
+  }
+
+  -- for db schema validation
+  function _M.schema(protocols)
+    return assert(protocol_to_shcema[protocols[1]])
   end
 end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -88,7 +88,7 @@ do
   }
 
   -- http only
-  HTTP_SCHEMA   = schema.new()
+  HTTP_SCHEMA = schema.new()
   for typ, fields in pairs(HTTP_FIELDS) do
     for _, v in ipairs(fields) do
       assert(HTTP_SCHEMA:add_field(v, typ))

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1494,7 +1494,7 @@ describe("routes schema (flavor = expressions)", function()
     assert.truthy(errs["@entity"])
   end)
 
-  it("fails if invalid field appears", function()
+  it("fails if http route's field appears in stream route", function()
     local route = {
       id             = a_valid_uuid,
       name           = "my_route",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We do not need the function `has_paths()`, which is only useful for http subsystem, and now we support expressions in both http and stream subsystem.

KAG-2961

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
