### PR TITLE
fix(clustering): ensure data plane config hash is never nil

### DIFF
--- a/changelog/unreleased/kong/clustering-empty-data-plane-hash-fix.yml
+++ b/changelog/unreleased/kong/clustering-empty-data-plane-hash-fix.yml
@@ -1,0 +1,3 @@
+message: Fix a bug causing data-plane status updates to fail when an empty PING frame is received from a data-plane
+type: bugfix
+scope: Clustering

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -234,7 +234,9 @@ function _M:handle_cp_websocket()
     local ok
     ok, err = kong.db.clustering_data_planes:upsert({ id = dp_id, }, {
       last_seen = last_seen,
-      config_hash = config_hash ~= "" and config_hash or nil,
+      config_hash = config_hash ~= ""
+                and config_hash
+                 or DECLARATIVE_EMPTY_CONFIG_HASH,
       hostname = dp_hostname,
       ip = dp_ip,
       version = dp_version,
@@ -341,6 +343,10 @@ function _M:handle_cp_websocket()
 
       if not data then
         return nil, "did not receive ping frame from data plane"
+
+      elseif #data ~= 32 then
+        return nil, "received a ping frame from the data plane with an invalid"
+                 .. " hash: '" .. tostring(data) .. "'"
       end
 
       -- dps only send pings

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -91,7 +91,7 @@ local function send_ping(c, log_suffix)
 
   local hash = declarative.get_current_hash()
 
-  if hash == true then
+  if hash == "" or type(hash) ~= "string" then
     hash = DECLARATIVE_EMPTY_CONFIG_HASH
   end
 


### PR DESCRIPTION
### The Bug

The previous logic defaulted the config_hash to nil when it was detected to be an empty string. This can cause update_sync_status() to fail, because config_hash is a required attribute:

    > 2023/11/03 17:13:30 [debug] 4052224#0: *150 [lua] connector.lua:560: execute(): SQL query throw error: ERROR: null value in column "config_hash" of relation "clustering_data_planes" violates not-null constraint
    > Failing row contains (4fb29006-8db1-48bb-b68c-34b582e1d91a, soup, 127.0.0.1, 2023-11-04 00:13:30+00, null, 2023-11-18 00:13:30.799+00, 3.6.0, filter_set_incompatible, 2023-11-04 00:13:30+00, {})., close connection
    > 2023/11/03 17:13:30 [notice] 4052224#0: *150 [lua] init.lua:275: upsert(): ERROR: null value in column "config_hash" of relation "clustering_data_planes" violates not-null constraint

Why was config_hash an empty string? Because we [blindly update this variable from the data received from ping frames from the data plane](https://github.com/Kong/kong/blob/d4ff0e8bc8589e2e0a277f3c3ca20caeae6adb34/kong/clustering/control_plane.lua#L348)

### The Fix

This change addresses the problem from two angles:

1. when empty or invalid, config_hash is set to the default DECLARATIVE_EMPTY_CONFIG_HASH constant instead of nil
2. an additional guard was added to the dp reader thread, which checks the length of ping frame data and returns an error if it is not a proper config hash


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary.
- [x] ~There is a user-facing docs PR~ N/A


### Issue reference

KAG-2967