### PR TITLE
refactor(tools): cache lower(unit) for `bytes_to_str()`

### DIFF
--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -75,7 +75,9 @@ end
 -- bytes_to_str(5497558, "G", 3) -- "5.120 GiB"
 --
 function _M.bytes_to_str(bytes, unit, scale)
-  if not unit or unit == "" or lower(unit) == "b" then
+  local u = lower(unit or "")
+
+  if u == "" or u == "b" then
     return fmt("%d", bytes)
   end
 
@@ -87,15 +89,15 @@ function _M.bytes_to_str(bytes, unit, scale)
 
   local fspec = fmt("%%.%df", scale)
 
-  if lower(unit) == "k" then
+  if u == "k" then
     return fmt(fspec .. " KiB", bytes / 2^10)
   end
 
-  if lower(unit) == "m" then
+  if u == "m" then
     return fmt(fspec .. " MiB", bytes / 2^20)
   end
 
-  if lower(unit) == "g" then
+  if u == "g" then
     return fmt(fspec .. " GiB", bytes / 2^30)
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Cache the result of lower(unit) in `bytes_to_str()`, avoiding duplicated calcuation.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
