### PR TITLE
fix(db): pg store connection called without self

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -568,7 +568,7 @@ function _mt:query(sql, operation)
       -- we cannot cleanup the connection
       ngx.log(ngx.ERR, "failed to disconnect: ", err)
     end
-    self.store_connection(nil, operation)
+    self:store_connection(nil, operation)
 
   elseif is_new_conn then
     local keepalive_timeout = self:get_keepalive_timeout(operation)


### PR DESCRIPTION
### Summary

The PR https://github.com/Kong/kong/pull/11480 introduced a bug that calls `store_connection` without passing `self`. This fixes that.