### PR TITLE
fix(acl-plugin): Move schema descriptions into the right field

### DIFF
--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -9,8 +9,12 @@ return {
     { config = {
         type = "record",
         fields = {
-          { allow = { type = "array", elements = { type = "string", description = "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified." }, }, },
-          { deny = { type = "array", elements = { type = "string", description = "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified." }, }, },
+          { allow = { description = "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
+              type = "array",
+              elements = { type = "string" }, }, },
+          { deny = { description = "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
+              type = "array",
+              elements = { type = "string" }, }, },
           { hide_groups_header = { type = "boolean", required = true, default = false, description = "If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service." }, },
         },
       }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Accidentally added schema descriptions to the nested `elements` field instead of the field itself, so the description is being applied to the wrong thing. Fixing that.

### Checklist

- [ N/A ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
