### PR TITLE
fix(tracing): error when DNS query fails

### DIFF
--- a/changelog/unreleased/kong/fix_dns_instrument_error_handling.yml
+++ b/changelog/unreleased/kong/fix_dns_instrument_error_handling.yml
@@ -1,3 +1,3 @@
-message: "**tracing:** Fixed an issue where the DNS query failure would cause tracing failure."
+message: "**tracing:** Fixed an issue where a DNS query failure would cause a tracing failure."
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix_dns_instrument_error_handling.yml
+++ b/changelog/unreleased/kong/fix_dns_instrument_error_handling.yml
@@ -1,0 +1,3 @@
+message: "**tracing:** Fixed an issue where the DNS query failure would cause tracing failure."
+type: bugfix
+scope: Core

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -287,7 +287,12 @@ do
     if span then
       span:set_attribute("dns.record.domain", host)
       span:set_attribute("dns.record.port", port)
-      span:set_attribute("dns.record.ip", ip_addr)
+      if ip_addr then
+        span:set_attribute("dns.record.ip", ip_addr)
+      else
+        span:record_error(res_port)
+        span:set_status(2)
+      end
       span:finish()
     end
 

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -48,7 +48,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("tracing instrumentations spec #" .. strategy, function()
 
-    local function setup_instrumentations(types, custom_spans)
+    local function setup_instrumentations(types, custom_spans, post_func)
       local bp, _ = assert(helpers.get_db_utils(strategy, {
         "services",
         "routes",
@@ -95,6 +95,10 @@ for _, strategy in helpers.each_strategy() do
           message = "No coffee for you. I'm a teapot.",
         }
       })
+
+      if post_func then
+        post_func(bp)
+      end
 
       assert(helpers.start_kong {
         database = strategy,
@@ -510,6 +514,52 @@ for _, strategy in helpers.each_strategy() do
 
         local spans = cjson.decode(res)
         assert_has_spans("kong", spans, 1)
+      end)
+    end)
+
+    describe("#regression", function ()
+      describe("nil attribute for dns_query when fail to query", function ()
+        lazy_setup(function()
+          setup_instrumentations("dns_query", true, function(bp)
+            -- intentionally trigger a DNS query error
+            -- TODO: find a way to trigger a DNS query error
+            -- There's a bug that the balancer's DNS query is not instrumented
+            local service = bp.services:insert({
+              name = "inexist-host-service",
+              host = "really-inexist-host",
+              port = 80,
+            })
+
+            bp.routes:insert({
+              service = service,
+              protocols = { "http" },
+              paths = { "/test" },
+            })
+          end)
+        end)
+  
+        lazy_teardown(function()
+          helpers.stop_kong()
+        end)
+  
+        it("contains the expected kong.dns span", function ()
+          local thread = helpers.tcp_server(TCP_PORT)
+          local r = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/test",
+          })
+          assert.res_status(503, r)
+  
+          -- Getting back the TCP server input
+          local ok, res = thread:join()
+          assert.True(ok)
+          assert.is_string(res)
+  
+          local spans = cjson.decode(res)
+          assert_has_span("kong", spans)
+          assert_has_span("kong.dns", spans)
+          print(require"inspect"(spans))
+        end)
       end)
     end)
   end)


### PR DESCRIPTION
**PLEASE MERGE AFTER** https://github.com/Kong/kong/pull/11996

### Summary

The patching function assumes the query never fails and that's not true.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Issue reference

Fix FTI-5544
