### PR TITLE
fix(pdk): response send function should ignore transfer-encoding correctly

### DIFF
--- a/changelog/unreleased/kong/pdk-response-send-remove-transfer-encoding.yml
+++ b/changelog/unreleased/kong/pdk-response-send-remove-transfer-encoding.yml
@@ -1,0 +1,3 @@
+message: Fix an issue that when using kong.response.exit, the Transfer-Encoding header set by user is not removed
+type: bugfix
+scope: PDK

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -660,7 +660,6 @@ local function new(self, major_version)
     local has_content_length
     if headers ~= nil then
       for name, value in pairs(headers) do
-        ngx.header[name] = normalize_multi_header(value)
         local lower_name = lower(name)
         if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
           self.log.warn("manually setting Transfer-Encoding. Ignored.")

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -150,6 +150,12 @@ for _, strategy in helpers.each_strategy() do
         service     = null,
       }
 
+      local route24 = bp.routes:insert {
+        hosts       = { "lambda24.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
       bp.plugins:insert {
         name     = "aws-lambda",
         route    = { id = route1.id },
@@ -459,6 +465,19 @@ for _, strategy in helpers.each_strategy() do
           aws_secret           = "mock-secret",
           aws_region           = "us-east-1",
           function_name        = "functionWithNotBase64EncodedResponse",
+          is_proxy_integration = true,
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route24.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithTransferEncodingHeader",
           is_proxy_integration = true,
         }
       }
@@ -1148,6 +1167,24 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("https", req.vars.scheme)
       end)
 
+      it("#test2 works normally by removing transfer encoding header when proxy integration mode", function ()
+        proxy_client:set_timeout(3000)
+        assert.eventually(function ()
+          local res = assert(proxy_client:send({
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              ["Host"] = "lambda24.com"
+            }
+          }))
+
+          assert.res_status(200, res)
+          assert.is_nil(res.headers["Transfer-Encoding"])
+          assert.is_nil(res.headers["transfer-encoding"])
+
+          return true
+        end).with_timeout(3).is_truthy()
+      end)
     end)
 
     describe("AWS_REGION environment is set", function()

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -57,6 +57,9 @@ local fixtures = {
                     elseif string.match(ngx.var.uri, "functionEcho") then
                       require("spec.fixtures.mock_upstream").send_default_json_response()
 
+                    elseif string.match(ngx.var.uri, "functionWithTransferEncodingHeader") then
+                      ngx.say("{\"statusCode\": 200, \"headers\": { \"Transfer-Encoding\": \"chunked\", \"transfer-encoding\": \"chunked\"}}")
+
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -1148,6 +1148,7 @@ GET /t
 --- response_body
 test
 --- response_headers
+! Transfer-Encoding
 Content-Length: 5
 X-test: test
 --- error_log

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
 do "./t/Util.pm";
 
-plan tests => repeat_each() * (blocks() * 4) + 11;
+plan tests => repeat_each() * (blocks() * 4) + 12;
 
 run_tests();
 
@@ -1128,7 +1128,7 @@ finalize stream session: 200
 
 
 
-=== TEST 18: response.exit() does not set transfer-encoding from headers
+=== TEST 44: response.exit() does not set transfer-encoding from headers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR is a follow-up fix for https://github.com/Kong/kong/pull/8698 to ignore the transfer encoding header set by the user.

The line removed in this PR seems to be conflict with the original fix and makes the original fix meaningless, so removed this line to get the expected behavior.

We have related bug reports that when using the AWS-Lambda plugin in proxy_integration mode if the lamdba function returns an arbitrary transfer-encoding header, the response sent by Kong will both contain content-length and transfer-encoding, which is an unexpected result.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

Fix FTI-5028
