### PR TITLE
chore(update-copyright): pass EXPAT_DIR to luarocks

### DIFF
--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -61,5 +61,7 @@ export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lua
 export KONG_PREFIX="$KONG_VENV/kong/servroot"
 export LIBRARY_PREFIX="$KONG_VENV/kong" # let "make dev" happy
 export OPENSSL_DIR="$KONG_VENV/kong" # let "make dev" happy
+export CRYPTO_DIR="$KONG_VENV/kong" # let "update-copyright" happy
+export EXPAT_DIR="$KONG_VENV/kong" # let "update-copyright" happy
 
 EOF

--- a/scripts/update-copyright
+++ b/scripts/update-copyright
@@ -20,11 +20,10 @@ including installing rocks inside said folder.
 
 Requires internet connection in order to download luarocks and license files.
 
-On Macs, you might need to set up OPENSSL_DIR and CRYPTO_DIR.
+You might need to set up OPENSSL_DIR, CRYPTO_DIR, and EXPAT_DIR.
 
-The default for mac is:
+You'd better source the bazel-bin/build/kong-dev-venv.sh to setup these environments.
 
-OPENSSL_DIR=/usr/local/opt/openssl/ CRYPTO_DIR=/usr/local/opt/openssl/ ./scripts/update-copyright
 ]]
 
 setmetatable(_G, nil)
@@ -38,6 +37,9 @@ assert(OPENSSL_DIR, "please set the OPENSSL_DIR env variable (needed for install
 
 local CRYPTO_DIR = os.getenv("CRYPTO_DIR")
 assert(CRYPTO_DIR, "please set the CRYPTO_DIR env variable (needed for installing luaOSSL)")
+
+local EXPAT_DIR = os.getenv("EXPAT_DIR")
+assert(EXPAT_DIR, "please set the EXPAT_DIR env variable (needed for installing lua-resty-aws)")
 
 local work_folder = os.tmpname() .. "-update-copyright"
 
@@ -383,8 +385,8 @@ print("")
 print(fmt("Installing rocks in work folder. (Install log: %s/luarocks.log) ...", work_folder))
 
 assert(os.execute(fmt("cp kong*.rockspec %s", work_folder)))
-assert(os.execute(fmt("luarocks --lua-version=5.1 --tree %s make %s/kong*.rockspec OPENSSL_DIR=%s CRYPTO_DIR=%s 2>&1 > %s/luarocks.log",
-                      work_folder, work_folder, OPENSSL_DIR, CRYPTO_DIR, work_folder)))
+assert(os.execute(fmt("luarocks --lua-version=5.1 --tree %s make %s/kong*.rockspec OPENSSL_DIR=%s CRYPTO_DIR=%s EXPAT_DIR=%s 2>&1 > %s/luarocks.log",
+                      work_folder, work_folder, OPENSSL_DIR, CRYPTO_DIR, EXPAT_DIR, work_folder)))
 
 local rocklist_path = fmt("%s/rocklist.txt", work_folder)
 assert(os.execute(fmt("find %s/lib | grep rockspec > %s", work_folder, rocklist_path)))


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
The newly added lua-resty-aws requires expat.h thus we need to pass the EXPAT_DIR to the luarocks command to install the dependency. Expose the EXPAT_DIR and CRYPTO_DIR in the venv script to make it easier to execute the update_copyright command.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference
KAG-3030

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
