### PR TITLE
refactor(router): simplify the functions of cache calculation

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -572,12 +572,14 @@ do
 
   local str_buf = buffer.new(64)
 
-  get_headers_key = function(headers)
+  local function get_headers_or_queries_key(values, lower_func)
     str_buf:reset()
 
     -- NOTE: DO NOT yield until str_buf:get()
-    for name, value in pairs(headers) do
-      local name = replace_dashes_lower(name)
+    for name, value in pairs(values) do
+      if lower_func then
+        name = lower_func(name)
+      end
 
       if type(value) == "table" then
         tb_sort(value)
@@ -590,20 +592,12 @@ do
     return str_buf:get()
   end
 
+  get_headers_key = function(headers)
+    return get_headers_or_queries_key(headers, replace_dashes_lower)
+  end
+
   get_queries_key = function(queries)
-    str_buf:reset()
-
-    -- NOTE: DO NOT yield until str_buf:get()
-    for name, value in pairs(queries) do
-      if type(value) == "table" then
-        tb_sort(value)
-        value = tb_concat(value, ", ")
-      end
-
-      str_buf:putf("|%s=%s", name, value)
-    end
-
-    return str_buf:get()
+    return get_headers_or_queries_key(queries)
   end
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`get_headers_key()` and `get_queries_key` have almost the same implementation,
this PR introduce a new function `get_headers_or_queries_key()` and simplify these two functions.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
