### PR TITLE
chore(deps): bump resty-openssl from 0.8.25 to 1.0.1

### DIFF
--- a/changelog/unreleased/kong/bump-resty-openssl-1.0.1.yml
+++ b/changelog/unreleased/kong/bump-resty-openssl-1.0.1.yml
@@ -1,0 +1,3 @@
+message: Bump resty-openssl from 0.8.25 to 1.0.1
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.0.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-aws == 1.3.5",
-  "lua-resty-openssl == 0.8.25",
+  "lua-resty-openssl == 1.0.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.12.0",


### PR DESCRIPTION
### Summary

<a name="1.0.1"></a>
#### [1.0.1] - 2023-11-07
##### bug fixes
- **jwk:** return error if exporting private key from public key ([#128](https://github.com/fffonion/lua-resty-openssl/issues/128)) [3a1bc27](https://github.com/fffonion/lua-resty-openssl/commit/3a1bc273e2a3f41faa7eb68f2939fd1fc25cdecb)

<a name="1.0.0"></a>
#### [1.0.0] - 2023-11-03
##### code refactoring
- **\*:** remove unused cdefs [84abc0a](https://github.com/fffonion/lua-resty-openssl/commit/84abc0ab99b3d649c7fe4575cf13867cf96a94ef)
- **\*:** BREAKING: drop OpenSSL 1.0.2, 1.1.0 and BoringSSL support [99b493e](https://github.com/fffonion/lua-resty-openssl/commit/99b493e671886e68c07b1b9c9472075c22ce38e9)

##### features
- **fips:** add get_fips_version_text [935227b](https://github.com/fffonion/lua-resty-openssl/commit/935227b348ba4416f2f4d671dd94f7910cbf9e61)

<a name="0.8.26"></a>
#### [0.8.26] - 2023-10-30
##### bug fixes
- **version:** add support for all 3.x versions [1516b4d](https://github.com/fffonion/lua-resty-openssl/commit/1516b4d94ac4621a1b243c14b5133ded81515d28)
- **x509.csr:** remove extension before adding it [d6ed964](https://github.com/fffonion/lua-resty-openssl/commit/d6ed9648e39f46f7519413489baf021092ccbc49)

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

