### PR TITLE
chore(deps): bump lpeg from 1.0.2 to 1.1.0

### DIFF
--- a/changelog/unreleased/kong/bump-lpeg-1.1.0.yml
+++ b/changelog/unreleased/kong/bump-lpeg-1.1.0.yml
@@ -1,0 +1,3 @@
+message: "Bumped LPEG from 1.0.2 to 1.1.0"
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-acme == 0.12.0",
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.5",
-  "lpeg == 1.0.2",
+  "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
 }
 build = {


### PR DESCRIPTION
### Summary

+ accumulator capture
+ UTF-8 ranges
+ Larger limit for number of rules in a grammar
+ Larger limit for number of captures in a match
+ bug fixes
+ other small improvements
### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)