### PR TITLE
chore(deps): bump lua-messagepack from 0.5.2 to 0.5.3

### DIFF
--- a/changelog/unreleased/kong/bump-lua-messagepack-0.5.3.yml
+++ b/changelog/unreleased/kong/bump-lua-messagepack-0.5.3.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-messagepack from 0.5.2 to 0.5.3"
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -32,7 +32,7 @@ dependencies = {
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.5.0",
   "lua-resty-healthcheck == 3.0.0",
-  "lua-messagepack == 0.5.2",
+  "lua-messagepack == 0.5.3",
   "lua-resty-aws == 1.3.5",
   "lua-resty-openssl == 0.8.25",
   "lua-resty-counter == 0.2.1",


### PR DESCRIPTION
### Summary

- support Lua 5.4
- testsuite with TestAssertion
- minor refactors

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)