### PR TITLE
refactor(tools): move sort_by_handler_priority to DAO

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -5,7 +5,6 @@ local plugin_loader = require "kong.db.schema.plugin_loader"
 local reports = require "kong.reports"
 local plugin_servers = require "kong.runloop.plugin_servers"
 local version = require "version"
-local sort_by_handler_priority = utils.sort_by_handler_priority
 
 local Plugins = {}
 
@@ -333,6 +332,23 @@ function Plugins:load_plugin_schemas(plugin_set)
   self.handlers = handlers
 
   return true
+end
+
+
+---
+-- Sort by handler priority and check for collisions. In case of a collision
+-- sorting will be applied based on the plugin's name.
+-- @tparam table plugin table containing `handler` table and a `name` string
+-- @tparam table plugin table containing `handler` table and a `name` string
+-- @treturn boolean outcome of sorting
+local sort_by_handler_priority = function (a, b)
+  local prio_a = a.handler.PRIORITY or 0
+  local prio_b = b.handler.PRIORITY or 0
+  if prio_a == prio_b and not
+      (prio_a == 0 or prio_b == 0) then
+    return a.name > b.name
+  end
+  return prio_a > prio_b
 end
 
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1017,22 +1017,6 @@ local topological_sort do
 end
 _M.topological_sort = topological_sort
 
----
--- Sort by handler priority and check for collisions. In case of a collision
--- sorting will be applied based on the plugin's name.
--- @tparam table plugin table containing `handler` table and a `name` string
--- @tparam table plugin table containing `handler` table and a `name` string
--- @treturn boolean outcome of sorting
-function _M.sort_by_handler_priority(a, b)
-  local prio_a = a.handler.PRIORITY or 0
-  local prio_b = b.handler.PRIORITY or 0
-  if prio_a == prio_b and not
-      (prio_a == 0 or prio_b == 0) then
-    return a.name > b.name
-  end
-  return prio_a > prio_b
-end
-
 
 local time_ns
 do


### PR DESCRIPTION
KAG-2956

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
