### PR TITLE
refactor(pdk): move ffi.cdef gethostname from tools into pdk

### DIFF
--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -27,6 +27,11 @@ local shms = {}
 local n_workers = ngx.worker.count()
 
 
+ffi.cdef[[
+int gethostname(char *name, size_t len);
+]]
+
+
 for shm_name, shm in pairs(shared) do
   insert(shms, {
     zone = shm,

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -31,11 +31,6 @@ local re_match      = ngx.re.match
 local setmetatable  = setmetatable
 
 
-ffi.cdef[[
-int gethostname(char *name, size_t len);
-]]
-
-
 local _M = {}
 
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -8,7 +8,6 @@
 -- @license [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 -- @module kong.tools.utils
 
-local ffi = require "ffi"
 local pl_stringx = require "pl.stringx"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`gethostname` is only used by pdk, it should not be in utils.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
