### PR TITLE
chore(patches): fix ldoc intermittent fail caused by LuaJIT

### DIFF
--- a/build/openresty/patches/LuaJIT-2.1-20230410_08_ldoc_error_fix.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20230410_08_ldoc_error_fix.patch
@@ -1,0 +1,22 @@
+From 65c849390702b1150d52e64db86cbc6b3c98413e Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Thu, 9 Nov 2023 11:02:36 +0100
+Subject: [PATCH] Invalidate SCEV entry when returning to lower frame.
+
+Thanks to Zhongwei Yao. #1115
+---
+ src/lj_record.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bundle/LuaJIT-2.1-20230410/src/lj_record.c b/bundle/LuaJIT-2.1-20230410/src/lj_record.c
+index a49f942a..0122105b 100644
+--- a/bundle/LuaJIT-2.1-20230410/src/lj_record.c
++++ b/bundle/LuaJIT-2.1-20230410/src/lj_record.c
+@@ -975,6 +975,7 @@
+       emitir(IRTG(IR_RETF, IRT_PGC), trpt, trpc);
+       J->retdepth++;
+       J->needsnap = 1;
++      J->scev.idx = REF_NIL;
+       lj_assertJ(J->baseslot == 1+LJ_FR2, "bad baseslot for return");
+       /* Shift result slots up and clear the slots of the new frame below. */
+       memmove(J->base + cbase, J->base-1-LJ_FR2, sizeof(TRef)*nresults);

--- a/changelog/unreleased/kong/fix-ldoc-intermittent-fail.yml
+++ b/changelog/unreleased/kong/fix-ldoc-intermittent-fail.yml
@@ -1,0 +1,3 @@
+message: fix ldoc intermittent failure caused by LuaJIT error.
+type: bugfix
+scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

ldoc intermittently fails caused by an error in LuaJIT. Refer details in [KAG-1761].

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-1761]_


[KAG-1761]: https://konghq.atlassian.net/browse/KAG-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ