### PR TITLE
refactor(tools): remove gzip module reference in utils.lua

### DIFF
--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -10,7 +10,7 @@ local table_insert = table.insert
 local table_sort = table.sort
 local gsub = string.gsub
 local split = utils.split
-local deflate_gzip = utils.deflate_gzip
+local deflate_gzip = require("kong.tools.gzip").deflate_gzip
 local cjson_encode = cjson.encode
 
 local ngx = ngx

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -5,7 +5,6 @@ local _MT = { __index = _M, }
 local semaphore = require("ngx.semaphore")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
-local utils = require("kong.tools.utils")
 local clustering_utils = require("kong.clustering.utils")
 local compat = require("kong.clustering.compat")
 local constants = require("kong.constants")
@@ -40,8 +39,8 @@ local sleep = ngx.sleep
 
 local plugins_list_to_map = compat.plugins_list_to_map
 local update_compatible_payload = compat.update_compatible_payload
-local deflate_gzip = utils.deflate_gzip
-local yield = utils.yield
+local deflate_gzip = require("kong.tools.gzip").deflate_gzip
+local yield = require("kong.tools.yield").yield
 local connect_dp = clustering_utils.connect_dp
 
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -8,7 +8,6 @@ local config_helper = require("kong.clustering.config_helper")
 local clustering_utils = require("kong.clustering.utils")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local utils = require("kong.tools.utils")
 local pl_stringx = require("pl.stringx")
 
 
@@ -25,8 +24,8 @@ local cjson_decode = cjson.decode
 local cjson_encode = cjson.encode
 local exiting = ngx.worker.exiting
 local ngx_time = ngx.time
-local inflate_gzip = utils.inflate_gzip
-local yield = utils.yield
+local inflate_gzip = require("kong.tools.gzip").inflate_gzip
+local yield = require("kong.tools.yield").yield
 
 
 local ngx_ERR = ngx.ERR

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -965,7 +965,6 @@ _M.topological_sort = topological_sort
 
 do
   local modules = {
-    "kong.tools.gzip",
     "kong.tools.table",
     "kong.tools.sha256",
     "kong.tools.yield",

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -754,6 +754,8 @@ describe("Utils", function()
   end)
 
   describe("gzip_[de_in]flate()", function()
+    local utils = require "kong.tools.gzip"
+
     it("empty string", function()
       local gz = assert(utils.deflate_gzip(""))
       assert.equal(utils.inflate_gzip(gz), "")

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -1,7 +1,7 @@
 local compat = require("kong.clustering.compat")
 local helpers = require ("spec.helpers")
 local declarative = require("kong.db.declarative")
-local inflate_gzip = require("kong.tools.utils").inflate_gzip
+local inflate_gzip = require("kong.tools.gzip").inflate_gzip
 local cjson_decode = require("cjson.safe").decode
 local ssl_fixtures = require ("spec.fixtures.ssl")
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3788,6 +3788,8 @@ local function clustering_client(opts)
   assert(opts.cert)
   assert(opts.cert_key)
 
+  local inflate_gzip = require("kong.tools.gzip").inflate_gzip
+
   local c = assert(ws_client:new())
   local uri = "wss://" .. opts.host .. ":" .. opts.port ..
               "/v1/outlet?node_id=" .. (opts.node_id or utils.uuid()) ..
@@ -3820,7 +3822,7 @@ local function clustering_client(opts)
   c:close()
 
   if typ == "binary" then
-    local odata = assert(utils.inflate_gzip(data))
+    local odata = assert(inflate_gzip(data))
     local msg = assert(cjson.decode(odata))
     return msg
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`utils.lua` includes many small modules, after some refactor PRs, it's time to use them directly.
This PR remove gzip functions from `utils.lua`, now we should use `require("kong.tools.gzip")`.

Do you think it is reasonable?

KAG-3060

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
