### PR TITLE
chore(deps): bump busted from 2.1.2 to 2.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.1.2" "busted-htest 1.0.0" "luacheck 1.1.1" "lua-llthreads2 0.1.6" "ldoc 1.5.0" "luacov 0.15.0"
+DEV_ROCKS = "busted 2.2.0" "busted-htest 1.0.0" "luacheck 1.1.1" "lua-llthreads2 0.1.6" "ldoc 1.5.0" "luacov 0.15.0"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Features
- Add Korean localization — @marocchino
- Add --exclude-name-file and --log-success options — @hanshuebner (When combined can automate re-running only failed tests)
- Add --name option to easily run single tests — @hanshuebner

#### Bug Fixes

- Remove unused luafilesystem dependency — @dundargoc
- Correct installation and example documentation — @C3pa and @alerque
- Use escape sequences to output UTF-8 characters in more environments — @Commandcracker
- Output more standard tracing notation in gtest handler — @Tieske
- Fix casting to string before encoding errors in JSON — @svermeulen
- Correct TAP handler to not error on no test files — @notomo
### Checklist

~- [ ] The Pull Request has tests~
~- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~
~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~