### PR TITLE
chore(deps): bump grpcurl from 1.8.5 to 1.8.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,14 @@ endif
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
-GRPCURL_VERSION ?= 1.8.5
+GRPCURL_VERSION ?= 1.8.9
 BAZLISK_VERSION ?= 1.18.0
 H2CLIENT_VERSION ?= 0.4.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
 
-# Use x86_64 grpcurl v1.8.5 for Apple silicon chips
-ifeq ($(GRPCURL_OS)_$(MACHINE)_$(GRPCURL_VERSION), osx_arm64_1.8.5)
+# Use x86_64 grpcurl v1.8.9 for Apple silicon chips
+ifeq ($(GRPCURL_OS)_$(MACHINE)_$(GRPCURL_VERSION), osx_arm64_1.8.9)
 GRPCURL_MACHINE = x86_64
 endif
 


### PR DESCRIPTION
### Summary

#### v1.8.9

- Disable CGO for improved compatibility across distros (https://github.com/fullstorydev/grpcurl/pull/420)
- Bump golang.org/x/net from 0.9.0 to 0.17.0 (https://github.com/fullstorydev/grpcurl/pull/419)
- SIGSEGV: panic: runtime error: invalid memory address or nil pointer dereference in protoreflect (https://github.com/fullstorydev/grpcurl/pull/416)
- Added alts credential option (https://github.com/fullstorydev/grpcurl/pull/341)

#### v1.8.8

- Update go.mod, goreleaser for v1.8.8 (https://github.com/fullstorydev/grpcurl/pull/413)
- Run tests on Go 1.21 (https://github.com/fullstorydev/grpcurl/pull/408)
- Update protoreflect v1.15.2 and grpc v1.57.0 (https://github.com/fullstorydev/grpcurl/pull/406)
- Use grpc.reflection.v1.ServerReflection (https://github.com/fullstorydev/grpcurl/pull/407)
- Bump google.golang.org/protobuf from 1.30.0 to 1.31.0 (https://github.com/fullstorydev/grpcurl/pull/401)
- Bump google.golang.org/grpc from 1.55.0 to 1.56.1 (https://github.com/fullstorydev/grpcurl/pull/400)
- Fix issues with error details (https://github.com/fullstorydev/grpcurl/pull/379)
- fix nil-dereference panic (https://github.com/fullstorydev/grpcurl/pull/395)
- Bump google.golang.org/grpc from 1.54.0 to 1.55.0 (https://github.com/fullstorydev/grpcurl/pull/390)
- Add "checkgenerate" make target to CI (https://github.com/fullstorydev/grpcurl/pull/385)
- Bump google.golang.org/grpc from 1.53.0 to 1.54.0 (https://github.com/fullstorydev/grpcurl/pull/383)
- Bump google.golang.org/protobuf from 1.29.1 to 1.30.0 (https://github.com/fullstorydev/grpcurl/pull/378)
- Bump google.golang.org/protobuf from 1.29.0 to 1.29.1 (https://github.com/fullstorydev/grpcurl/pull/376)
- Bump google.golang.org/protobuf from 1.28.1 to 1.29.0 (https://github.com/fullstorydev/grpcurl/pull/375)
- Bump github.com/golang/protobuf from 1.5.2 to 1.5.3 (https://github.com/fullstorydev/grpcurl/pull/374)
- Bump google.golang.org/grpc from 1.52.3 to 1.53.0 (https://github.com/fullstorydev/grpcurl/pull/370)
- Install the CodeSee workflow. Learn more at https://docs.codesee.io (https://github.com/fullstorydev/grpcurl/pull/368)
- Bump google.golang.org/grpc from 1.51.0 to 1.52.3 (https://github.com/fullstorydev/grpcurl/pull/365)
- Bump github.com/jhump/protoreflect from 1.14.0 to 1.14.1 (https://github.com/fullstorydev/grpcurl/pull/361)
- Bump google.golang.org/grpc from 1.50.1 to 1.51.0 (https://github.com/fullstorydev/grpcurl/pull/348)
- fix funcname in comment (https://github.com/fullstorydev/grpcurl/pull/346)
- Bump github.com/jhump/protoreflect from 1.13.0 to 1.14.0 (https://github.com/fullstorydev/grpcurl/pull/343)
- Bump google.golang.org/grpc from 1.50.0 to 1.50.1 (https://github.com/fullstorydev/grpcurl/pull/338)
- Bump google.golang.org/grpc from 1.49.0 to 1.50.0 (https://github.com/fullstorydev/grpcurl/pull/336)
- Bump github.com/jhump/protoreflect from 1.12.0 to 1.13.0 (https://github.com/fullstorydev/grpcurl/pull/335)
- Bump google.golang.org/grpc from 1.48.0 to 1.49.0 (https://github.com/fullstorydev/grpcurl/pull/330)
- fixup release process (https://github.com/fullstorydev/grpcurl/pull/328)

#### v1.8.7

- Unix sockets for windows
- Lots of dependency version updates
- Support for Go 1.18
- Add go 1.18 support; set Dockerfile to go 1.18 (https://github.com/fullstorydev/grpcurl/pull/325)
- build alpine base image (https://github.com/fullstorydev/grpcurl/pull/311)
- fix some typos (https://github.com/fullstorydev/grpcurl/pull/314)
- Bump google.golang.org/grpc from 1.47.0 to 1.48.0 (https://github.com/fullstorydev/grpcurl/pull/324)
- Adding power(ppc64le) arch support (https://github.com/fullstorydev/grpcurl/pull/296)
- Enable support for Unix sockets for Windows by enabling -unix flag for Windows builds. (https://github.com/fullstorydev/grpcurl/pull/317)
- Bump google.golang.org/grpc from 1.46.2 to 1.47.0 (https://github.com/fullstorydev/grpcurl/pull/315)
- Bump github.com/jhump/protoreflect from 1.10.3 to 1.12.0 (https://github.com/fullstorydev/grpcurl/pull/294)
- Bump google.golang.org/grpc from 1.44.0 to 1.46.2 (https://github.com/fullstorydev/grpcurl/pull/310)
- Bump google.golang.org/protobuf from 1.27.1 to 1.28.0 (https://github.com/fullstorydev/grpcurl/pull/298)
- use newer goreleaser (https://github.com/fullstorydev/grpcurl/pull/293)
- Restore support for linux/s390x for the next release. (https://github.com/fullstorydev/grpcurl/pull/292)
- Bump google.golang.org/protobuf from 1.26.0 to 1.27.1 (https://github.com/fullstorydev/grpcurl/pull/288)

#### v1.8.6

- Some bugs have been addressed in the library used to parse proto source files. Previously grpcurl would accept proto source files that could not actually be compiled with protoc. The converse could also happen: grpcurl could reject some proto source files that could successfully be compiled with protoc. More details can be found in the release notes for the changes to the protoparse library, versions v1.10.2 and v1.10.3.
- Some implementations of the server reflection service have been observed to return multiple (even superfluous) file descriptors, in response to requests made by grpcurl. These extra files, if not returned in a particular order, would cause grpcurl to report an error that the service or method to be invoked could be not be resolved. The reflection client in grpcurl is now more robust to this condition and can handle responses with file descriptors in any order, so it should be interoperable with a larger variety of servers.
- When a request message includes a field of type google.protobuf.Value and a value for that field that was a JSON array, grpcurl would incorrectly interpret the JSON array as if it were a single atomic value, the last value that was in the array. This has been fixed.
- When a response message includes non-printable characters or code points outside the ASCII 7-bit range in the name of a field in a JSON object, it could be improperly encoded with escape characters that are not valid JSON. Standard tools/libraries could then fail to parse the JSON output from grpcurl. This has been fixed.

### Checklist

~- [ ] The Pull Request has tests~
~- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~
~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~