### PR TITLE
chore: improve cherry-picking process

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -1,0 +1,41 @@
+name: Cherry Pick to remote repository
+on:
+  pull_request_target:
+    types: [closed, labeled]
+  issue_comment:
+    types: [created]
+jobs:
+  cross-repo-cherrypick:
+    name: Cherry pick to remote repository
+    runs-on: ubuntu-latest
+    # Only run when pull request is merged, or labeled
+    # or when a comment containing `/cherry-pick` is created
+    # and the author is a member, collaborator or owner
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
+        contains(github.event.comment.body, '/cherry-pick')
+      )
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHERRY_PICK_TOKEN }}
+      - name: Create backport pull requests
+        uses: jschmid1/cross-repo-cherrypick-action@2366f50fd85e8966aa024a4dd6fbf70e7019d7e1
+        with:
+          token: ${{ secrets.CHERRY_PICK_TOKEN }}
+          pull_title: '[cherry-pick -> ${target_branch}] ${pull_title}'
+          merge_commits: 'skip'
+          trigger_label: 'cherry-pick kong-ee' # trigger based on this label
+          pull_description: |-
+            Automated cherry-pick to `${target_branch}`, triggered by a label in https://github.com/${owner}/${repo}/pull/${pull_number} :robot:.
+          upstream_repo: 'kong/kong-ee'
+          branch_map: |-
+            {
+              "master": "master"
+            }


### PR DESCRIPTION
### Summary

Introduces a GitHub Action to our workflows, designed to automate the cherry-picking process for transferring commits to another repository, specifically 'kong-ee'. This action is triggered by a configurable label (`cherry-pick kong-ee`) when a pull request is merged.

Additionally, it automatically requests a review from the individual who merged the original pull request.

The action can be found here: https://github.com/jschmid1/cross-repo-cherrypick-action

### Todos:

- [x] Create a fine-grained PAT (Personal Access Token) that has the required rights.
  - [x] update action according to secret name 
- [x] Create the label `cherry-pick kong-ee` and ensure that only kong employees are able to set this.

Fix: https://konghq.atlassian.net/browse/KAG-2980
