### PR TITLE
fix(tracing): patch dns query function earlier

### DIFF
--- a/changelog/unreleased/kong/tracing-dns-query-patch.yml
+++ b/changelog/unreleased/kong/tracing-dns-query-patch.yml
@@ -1,0 +1,3 @@
+message: "**Tracing**: dns spans are now correctly generated for upstream dns queries (in addition to cosocket ones)" 
+type: bugfix
+scope: Core

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -511,13 +511,17 @@ return function(options)
   do -- cosockets connect patch for dns resolution for: cli, rbusted and OpenResty
     local sub = string.sub
 
+    local client = package.loaded["kong.resty.dns.client"]
+    if not client then
+      client = require("kong.tools.dns")()
+    end
+
     --- Patch the TCP connect and UDP setpeername methods such that all
     -- connections will be resolved first by the internal DNS resolver.
     -- STEP 1: load code that should not be using the patched versions
     require "resty.dns.resolver" -- will cache TCP and UDP functions
 
     -- STEP 2: forward declaration of locals to hold stuff loaded AFTER patching
-    local toip
 
     -- STEP 3: store original unpatched versions
     local old_tcp = ngx.socket.tcp
@@ -538,7 +542,7 @@ return function(options)
     local function resolve_connect(f, sock, host, port, opts)
       if sub(host, 1, 5) ~= "unix:" then
         local try_list
-        host, port, try_list = toip(host, port)
+        host, port, try_list = client.toip(host, port)
         if not host then
           return nil, "[cosocket] DNS resolution failed: " .. tostring(port) ..
                       ". Tried: " .. tostring(try_list)
@@ -588,21 +592,10 @@ return function(options)
 
     -- STEP 5: load code that should be using the patched versions, if any (because of dependency chain)
     do
-      local client = package.loaded["kong.resty.dns.client"]
-      if not client then
-        client = require("kong.tools.dns")()
-      end
-
-      toip = client.toip
-
-      -- DNS query is lazily patched, it will only be wrapped
-      -- when instrumentation module is initialized later and
-      -- `tracing_instrumentations` includes "dns_query" or set
-      -- to "all".
+      -- dns query patch
       local instrumentation = require "kong.tracing.instrumentation"
-      instrumentation.set_patch_dns_query_fn(toip, function(wrap)
-        toip = wrap
-      end)
+      client.toip = instrumentation.get_wrapped_dns_query(client.toip)
+
       -- patch request_uri to record http_client spans
       instrumentation.http_client()
     end

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -272,16 +272,18 @@ function _M.precreate_balancer_span(ctx)
 end
 
 
-local patch_dns_query
 do
   local raw_func
-  local patch_callback
 
-  local function wrap(host, port)
-    local span = tracer.start_span("kong.dns", {
-      span_kind = 3, -- client
-    })
-    local ip_addr, res_port, try_list = raw_func(host, port)
+  local function wrap(host, port, ...)
+    local span
+    if _M.dns_query ~= NOOP then
+      span = tracer.start_span("kong.dns", {
+        span_kind = 3, -- client
+      })
+    end
+
+    local ip_addr, res_port, try_list = raw_func(host, port, ...)
     if span then
       span:set_attribute("dns.record.domain", host)
       span:set_attribute("dns.record.port", port)
@@ -292,23 +294,15 @@ do
     return ip_addr, res_port, try_list
   end
 
-  --- Patch DNS query
-  -- It will be called before Kong's config loader.
+  --- Get Wrapped DNS Query
+  -- Called before Kong's config loader.
   --
-  -- `callback` is a function that accept a wrap function,
-  -- it could be used to replace the orignal func lazily.
-  --
-  -- e.g. patch_dns_query(func, function(wrap)
-  --   toip = wrap
-  -- end)
-  function _M.set_patch_dns_query_fn(func, callback)
-    raw_func = func
-    patch_callback = callback
-  end
-
-  -- patch lazily
-  patch_dns_query = function()
-    patch_callback(wrap)
+  -- returns a wrapper for the provided input function `f`
+  -- that stores dns info in the `kong.dns` span when the dns
+  -- instrumentation is enabled.
+  function _M.get_wrapped_dns_query(f)
+    raw_func = f
+    return wrap
   end
 
   -- append available_types
@@ -425,11 +419,6 @@ function _M.init(config)
       sampling_rate = sampling_rate,
     })
     tracer.set_global_tracer(tracer)
-
-    -- global patch
-    if _M.dns_query ~= NOOP then
-      patch_dns_query()
-    end
   end
 end
 


### PR DESCRIPTION
### Summary

The dns query lazy patch was only effective for cosockets, not for the upstream dns queries, because the patch happened too late when the `toip` function had already been cached in some modules (i.e. balancer)

This change moves the patch to `globalpatches.lua` so that dns spans are correctly generated both for cosocket and upstream dns queries.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* moved dns query patch away from instrumentation, into globalpatches

### Issue reference

KAG-3057