### PR TITLE
refactor(router): only load configured flavor module

### DIFF
--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -53,11 +53,9 @@ function _M.new(routes, cache, cache_neg, old_router)
       return nil, err
     end
 
-    -- for unit-tests only
-    _M._set_ngx = router._set_ngx
-
     return setmetatable({
       trad = trad,
+      _set_ngx = trad._set_ngx, -- for unit-testing only
     }, _MT)
   end
 

--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -15,8 +15,8 @@ _M.DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
 local FLAVOR_TO_MODULE = {
-  traditional = "kong.router.traditional",
-  expressions = "kong.router.expressions",
+  traditional            = "kong.router.traditional",
+  expressions            = "kong.router.expressions",
   traditional_compatible = "kong.router.compat",
 }
 
@@ -53,8 +53,8 @@ function _M.new(routes, cache, cache_neg, old_router)
       return nil, err
     end
 
+    -- for unit-tests only
     _M._set_ngx = router._set_ngx
-    _M.split_port = router.split_port
 
     return setmetatable({
       trad = trad,

--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -5,9 +5,6 @@ local _MT = { __index = _M, }
 local kong = kong
 
 
-local traditional = require("kong.router.traditional")
-local expressions = require("kong.router.expressions")
-local compat      = require("kong.router.compat")
 local utils       = require("kong.router.utils")
 
 
@@ -15,6 +12,13 @@ local phonehome_statistics = utils.phonehome_statistics
 
 
 _M.DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
+
+
+local FLAVOR_TO_MODULE = {
+  traditional = "kong.router.traditional",
+  expressions = "kong.router.expressions",
+  traditional_compatible = "kong.router.compat",
+}
 
 
 function _M:exec(ctx)
@@ -36,33 +40,30 @@ end
 function _M.new(routes, cache, cache_neg, old_router)
   local flavor = kong and
                  kong.configuration and
-                 kong.configuration.router_flavor
+                 kong.configuration.router_flavor or
+                 "traditional"
+
+  local router = require(FLAVOR_TO_MODULE[flavor])
 
   phonehome_statistics(routes)
 
-  if not flavor or flavor == "traditional" then
-
-    local trad, err = traditional.new(routes, cache, cache_neg)
+  if flavor == "traditional" then
+    local trad, err = router.new(routes, cache, cache_neg)
     if not trad then
       return nil, err
     end
+
+    _M._set_ngx = router._set_ngx
+    _M.split_port = router.split_port
 
     return setmetatable({
       trad = trad,
     }, _MT)
   end
 
-  if flavor == "expressions" then
-    return expressions.new(routes, cache, cache_neg, old_router)
-  end
-
-  -- flavor == "traditional_compatible"
-  return compat.new(routes, cache, cache_neg, old_router)
+  -- flavor == "expressions" or "traditional_compatible"
+  return router.new(routes, cache, cache_neg, old_router)
 end
-
-
-_M._set_ngx = traditional._set_ngx
-_M.split_port = traditional.split_port
 
 
 return _M

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -92,7 +92,9 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
     local it_trad_only = (flavor == "traditional") and it or pending
 
     describe("split_port()", function()
-      it("splits port number", function()
+      local router = assert(new_router({}))
+
+      it_trad_only("splits port number", function()
         for _, case in ipairs({
           { { "" }, { "", "", false } },
           { { "localhost" }, { "localhost", "localhost", false } },
@@ -120,7 +122,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           { { "[::1]:80b", 88 }, { "[::1]:80b", "[::1]:80b:88", false } },
           { { "[::1]/96", 88 }, { "[::1]/96", "[::1]/96:88", false } },
         }) do
-          assert.same(case[2], { Router.split_port(unpack(case[1])) })
+          assert.same(case[2], { router.split_port(unpack(case[1])) })
         end
       end)
     end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -92,9 +92,9 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
     local it_trad_only = (flavor == "traditional") and it or pending
 
     describe("split_port()", function()
-      local router = assert(new_router({}))
+      local split_port = require("kong.router.traditional").split_port
 
-      it_trad_only("splits port number", function()
+      it("splits port number", function()
         for _, case in ipairs({
           { { "" }, { "", "", false } },
           { { "localhost" }, { "localhost", "localhost", false } },
@@ -122,7 +122,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           { { "[::1]:80b", 88 }, { "[::1]:80b", "[::1]:80b:88", false } },
           { { "[::1]/96", 88 }, { "[::1]/96", "[::1]/96:88", false } },
         }) do
-          assert.same(case[2], { router.split_port(unpack(case[1])) })
+          assert.same(case[2], { split_port(unpack(case[1])) })
         end
       end)
     end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Kong gateway only use one flavor when it starts, we need not to load all router modules at once.
This will reduce the usage of memory to a degree.

KAG-3135

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
