### PR TITLE
style(pdk): remove outdated comments of kong.singletons

### DIFF
--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -103,10 +103,6 @@
 -- @redirect kong.nginx
 
 
---- Singletons
--- @section singletons
-
-
 ---
 -- Instance of Kong's DAO (the `kong.db` module). Contains accessor objects
 -- to various entities.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Since Kong 3.0 (#8874), we have already removed "kong.singletons", this comment is outdated.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
