### PR TITLE
style(tools): `ngx.var.scheme` is always lower case

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -205,7 +205,7 @@ end
 -- @param allow_terminated if truthy, the `X-Forwarded-Proto` header will be checked as well.
 -- @return boolean or nil+error in case the header exists multiple times
 _M.check_https = function(trusted_ip, allow_terminated)
-  if ngx.var.scheme:lower() == "https" then
+  if ngx.var.scheme == "https" then
     return true
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

As the nginx's doc and source shows, the var `$scheme` is always lower case string `https`,
so the call `lower()` is unnecessary.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
