### PR TITLE
fix(*): rename Kong-Transaction-Id header to Kong-Test-Transaction-Id

### DIFF
--- a/changelog/unreleased/reconfiguration-completion-detection.yml
+++ b/changelog/unreleased/reconfiguration-completion-detection.yml
@@ -1,3 +1,3 @@
-message: Provide mechanism to detect completion of reconfiguration on the proxy path
+message: Provide mechanism to detect completion of reconfiguration on the proxy path. This is for internal testing only.
 type: feature
 scope: Core

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1832,7 +1832,7 @@ local function serve_content(module)
   ngx.header["Access-Control-Allow-Origin"] = ngx.req.get_headers()["Origin"] or "*"
 
   if kong.configuration.log_level == "debug" then
-    ngx.header["Kong-Transaction-Id"] = kong_global.get_current_transaction_id()
+    ngx.header["Kong-Test-Transaction-Id"] = kong_global.get_current_transaction_id()
   end
 
   lapis.serve(module)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -86,6 +86,7 @@ local QUESTION_MARK = byte("?")
 local ARRAY_MT = require("cjson.safe").array_mt
 
 local HOST_PORTS = {}
+local IS_DEBUG = false
 
 
 local SUBSYSTEMS = constants.PROTOCOLS_WITH_SUBSYSTEM
@@ -893,6 +894,7 @@ return {
 
   init_worker = {
     before = function()
+      IS_DEBUG = (kong.configuration.log_level == "debug")
       -- TODO: PR #9337 may affect the following line
       local prefix = kong.configuration.prefix or ngx.config.prefix()
 
@@ -1108,7 +1110,7 @@ return {
   },
   access = {
     before = function(ctx)
-      if kong.configuration.log_level == "debug" then
+      if IS_DEBUG then
         -- If this is a version-conditional request, abort it if this dataplane has not processed at least the
         -- specified configuration version yet.
         local if_kong_transaction_id = kong.request and kong.request.get_header('if-kong-test-transaction-id')

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1111,7 +1111,7 @@ return {
       if kong.configuration.log_level == "debug" then
         -- If this is a version-conditional request, abort it if this dataplane has not processed at least the
         -- specified configuration version yet.
-        local if_kong_transaction_id = kong.request and kong.request.get_header('if-kong-transaction-id')
+        local if_kong_transaction_id = kong.request and kong.request.get_header('if-kong-test-transaction-id')
         if if_kong_transaction_id then
           if_kong_transaction_id = tonumber(if_kong_transaction_id)
           if if_kong_transaction_id and if_kong_transaction_id >= global.CURRENT_TRANSACTION_ID then

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -50,8 +50,8 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       res2.headers["Date"] = nil
       res1.headers["X-Kong-Admin-Latency"] = nil
       res2.headers["X-Kong-Admin-Latency"] = nil
-      res1.headers["Kong-Transaction-Id"] = nil
-      res2.headers["Kong-Transaction-Id"] = nil
+      res1.headers["Kong-Test-Transaction-Id"] = nil
+      res2.headers["Kong-Test-Transaction-Id"] = nil
 
       assert.same(res1.headers, res2.headers)
     end)

--- a/spec/02-integration/04-admin_api/24-reconfiguration-completion_spec.lua
+++ b/spec/02-integration/04-admin_api/24-reconfiguration-completion_spec.lua
@@ -56,13 +56,13 @@ describe("Admin API - Reconfiguration Completion -", function()
         headers = { ["Content-Type"] = "application/json" },
       })
       assert.res_status(201, res)
-      kong_transaction_id = res.headers['kong-transaction-id']
+      kong_transaction_id = res.headers['kong-test-transaction-id']
       assert.is_string(kong_transaction_id)
 
       res = proxy_client:get(service_path,
               {
                 headers = {
-                  ["If-Kong-Transaction-Id"] = kong_transaction_id
+                  ["If-Kong-Test-Transaction-Id"] = kong_transaction_id
                 }
               })
       assert.res_status(503, res)
@@ -76,7 +76,7 @@ describe("Admin API - Reconfiguration Completion -", function()
       res = proxy_client:get(service_path,
               {
                 headers = {
-                  ["If-Kong-Transaction-Id"] = kong_transaction_id
+                  ["If-Kong-Test-Transaction-Id"] = kong_transaction_id
                 }
               })
       body = assert.res_status(200, res)


### PR DESCRIPTION
### Summary

Rename header so that it is clearly indicating its purpose.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

