### PR TITLE
refactor(tools): move topological_sort from tools.utils to db.utils

### DIFF
--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -200,6 +200,7 @@ build = {
     ["kong.workspaces"] = "kong/workspaces/init.lua",
 
     ["kong.db"] = "kong/db/init.lua",
+    ["kong.db.utils"] = "kong/db/utils.lua",
     ["kong.db.errors"] = "kong/db/errors.lua",
     ["kong.db.iteration"] = "kong/db/iteration.lua",
     ["kong.db.dao"] = "kong/db/dao/init.lua",

--- a/kong/db/schema/topological_sort.lua
+++ b/kong/db/schema/topological_sort.lua
@@ -1,5 +1,5 @@
 local constants = require "kong.constants"
-local utils = require "kong.tools.utils"
+local utils = require "kong.db.utils"
 
 
 local utils_toposort = utils.topological_sort

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -6,6 +6,7 @@ local stringx      = require "pl.stringx"
 local semaphore    = require "ngx.semaphore"
 local kong_global = require "kong.global"
 local constants = require "kong.constants"
+local db_utils  = require "kong.db.utils"
 
 
 local setmetatable = setmetatable
@@ -28,7 +29,7 @@ local log          = ngx.log
 local match        = string.match
 local fmt          = string.format
 local sub          = string.sub
-local utils_toposort = utils.topological_sort
+local utils_toposort = db_utils.topological_sort
 local insert       = table.insert
 local table_merge  = utils.table_merge
 

--- a/kong/db/utils.lua
+++ b/kong/db/utils.lua
@@ -1,0 +1,73 @@
+local insert = table.insert
+
+
+local _M = {}
+
+
+local function visit(current, neighbors_map, visited, marked, sorted)
+  if visited[current] then
+    return true
+  end
+
+  if marked[current] then
+    return nil, "Cycle detected, cannot sort topologically"
+  end
+
+  marked[current] = true
+
+  local schemas_pointing_to_current = neighbors_map[current]
+  if schemas_pointing_to_current then
+    local neighbor, ok, err
+    for i = 1, #schemas_pointing_to_current do
+      neighbor = schemas_pointing_to_current[i]
+      ok, err = visit(neighbor, neighbors_map, visited, marked, sorted)
+      if not ok then
+        return nil, err
+      end
+    end
+  end
+
+  marked[current] = false
+
+  visited[current] = true
+
+  insert(sorted, 1, current)
+
+  return true
+end
+
+
+function _M.topological_sort(items, get_neighbors)
+  local neighbors_map = {}
+  local source, destination
+  local neighbors
+  for i = 1, #items do
+    source = items[i] -- services
+    neighbors = get_neighbors(source)
+    for j = 1, #neighbors do
+      destination = neighbors[j] --routes
+      neighbors_map[destination] = neighbors_map[destination] or {}
+      insert(neighbors_map[destination], source)
+    end
+  end
+
+  local sorted = {}
+  local visited = {}
+  local marked = {}
+
+  local current, ok, err
+  for i = 1, #items do
+    current = items[i]
+    if not visited[current] and not marked[current] then
+      ok, err = visit(current, neighbors_map, visited, marked, sorted)
+      if not ok then
+        return nil, err
+      end
+    end
+  end
+
+  return sorted
+end
+
+
+return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -20,7 +20,6 @@ local tostring      = tostring
 local tonumber      = tonumber
 local sort          = table.sort
 local concat        = table.concat
-local insert        = table.insert
 local fmt           = string.format
 local join          = pl_stringx.join
 local split         = pl_stringx.split
@@ -588,75 +587,6 @@ end
 _M.get_mime_type = get_mime_type
 _M.get_response_type = get_response_type
 _M.get_error_template = get_error_template
-
-
-local topological_sort do
-
-  local function visit(current, neighbors_map, visited, marked, sorted)
-    if visited[current] then
-      return true
-    end
-
-    if marked[current] then
-      return nil, "Cycle detected, cannot sort topologically"
-    end
-
-    marked[current] = true
-
-    local schemas_pointing_to_current = neighbors_map[current]
-    if schemas_pointing_to_current then
-      local neighbor, ok, err
-      for i = 1, #schemas_pointing_to_current do
-        neighbor = schemas_pointing_to_current[i]
-        ok, err = visit(neighbor, neighbors_map, visited, marked, sorted)
-        if not ok then
-          return nil, err
-        end
-      end
-    end
-
-    marked[current] = false
-
-    visited[current] = true
-
-    insert(sorted, 1, current)
-
-    return true
-  end
-
-  topological_sort = function(items, get_neighbors)
-    local neighbors_map = {}
-    local source, destination
-    local neighbors
-    for i = 1, #items do
-      source = items[i] -- services
-      neighbors = get_neighbors(source)
-      for j = 1, #neighbors do
-        destination = neighbors[j] --routes
-        neighbors_map[destination] = neighbors_map[destination] or {}
-        insert(neighbors_map[destination], source)
-      end
-    end
-
-    local sorted = {}
-    local visited = {}
-    local marked = {}
-
-    local current, ok, err
-    for i = 1, #items do
-      current = items[i]
-      if not visited[current] and not marked[current] then
-        ok, err = visit(current, neighbors_map, visited, marked, sorted)
-        if not ok then
-          return nil, err
-        end
-      end
-    end
-
-    return sorted
-  end
-end
-_M.topological_sort = topological_sort
 
 
 do

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -831,7 +831,7 @@ describe("Utils", function()
 
   describe("topological_sort", function()
     local get_neighbors = function(x) return x end
-    local ts = utils.topological_sort
+    local ts = require("kong.db.utils").topological_sort
 
     it("it puts destinations first", function()
       local a = { id = "a" }


### PR DESCRIPTION
### Summary

`topological_sort` is moved to `kong/db/utils.lua` because it is only used in the db.

### Issue reference

KAG-2959