### PR TITLE
chore(pdk): doc a known issue of get_headers()

### DIFF
--- a/kong/pdk/service/response.lua
+++ b/kong/pdk/service/response.lua
@@ -198,6 +198,8 @@ local function new(pdk, major_version)
   --   kong.log.inspect(headers.x_another[1])    -- "foo bar"
   --   kong.log.inspect(headers["X-Another"][2]) -- "baz"
   -- end
+  -- Note that this function returns a proxy table
+  -- which cannot be iterated with pairs or used as oprand of #.
   function response.get_headers(max_headers)
     check_phase(header_body_log)
 

--- a/kong/pdk/service/response.lua
+++ b/kong/pdk/service/response.lua
@@ -199,7 +199,7 @@ local function new(pdk, major_version)
   --   kong.log.inspect(headers["X-Another"][2]) -- "baz"
   -- end
   -- Note that this function returns a proxy table
-  -- which cannot be iterated with pairs or used as oprand of #.
+  -- which cannot be iterated with `pairs` or used as operand of `#`.
   function response.get_headers(max_headers)
     check_phase(header_body_log)
 


### PR DESCRIPTION
### Summary

`get_headers` does not work as it looks like. We should document the behavior.

### Issue reference

Addressing KAG-2602, fix #11546
