### PR TITLE
perf(router): cooperatively yield when building statistics of routes

### DIFF
--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -1,13 +1,15 @@
 local constants = require("kong.constants")
 local hostname_type = require("kong.tools.utils").hostname_type
 local normalize = require("kong.tools.uri").normalize
+local yield = require("kong.tools.yield").yield
 
-local type   = type
-local error  = error
-local find   = string.find
-local sub    = string.sub
-local byte   = string.byte
 
+local type  = type
+local error = error
+local find = string.find
+local sub = string.sub
+local byte = string.byte
+local get_phase = ngx.get_phase
 
 local SLASH  = byte("/")
 
@@ -291,7 +293,11 @@ do
     local v0              = 0
     local v1              = 0
 
+    local phase = get_phase()
+
     for _, route in ipairs(routes) do
+      yield(true, phase)
+
       local r = route.route
 
       local paths_t     = r.paths or empty_table


### PR DESCRIPTION
### Summary

There is a tight loop when building Router phone home statistics that can introduce latency spikes on worker 0. This commit adds yield to that loop.

KAG-3062

### Checklist

~- [ ] The Pull Request has tests~
~- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~
~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~