### PR TITLE
refactor(router): move some declarations into local scope

### DIFF
--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -3,11 +3,11 @@ local hostname_type = require("kong.tools.utils").hostname_type
 local normalize = require("kong.tools.uri").normalize
 
 
-local type  = type
+local type = type
 local error = error
-local find  = string.find
-local sub   = string.sub
-local byte  = string.byte
+local find = string.find
+local sub = string.sub
+local byte = string.byte
 
 
 local SLASH  = byte("/")

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -1,15 +1,14 @@
 local constants = require("kong.constants")
 local hostname_type = require("kong.tools.utils").hostname_type
 local normalize = require("kong.tools.uri").normalize
-local yield = require("kong.tools.yield").yield
 
 
 local type  = type
 local error = error
-local find = string.find
-local sub = string.sub
-local byte = string.byte
-local get_phase = ngx.get_phase
+local find  = string.find
+local sub   = string.sub
+local byte  = string.byte
+
 
 local SLASH  = byte("/")
 
@@ -251,7 +250,9 @@ local phonehome_statistics
 do
   local reports = require("kong.reports")
   local nkeys = require("table.nkeys")
+  local yield = require("kong.tools.yield").yield
   local worker_id = ngx.worker.id
+  local get_phase = ngx.get_phase
 
   local TILDE = byte("~")
   is_regex_magic = function(path)

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -5,6 +5,7 @@ local normalize = require("kong.tools.uri").normalize
 
 local type = type
 local error = error
+local ipairs = ipairs
 local find = string.find
 local sub = string.sub
 local byte = string.byte


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It is a small improvement of #12008，moving some declarations into `do end` block.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
