### PR TITLE
fix(plugin server): an instance for every request

### DIFF
--- a/changelog/unreleased/kong/plugin-server-instance-leak.yml
+++ b/changelog/unreleased/kong/plugin-server-instance-leak.yml
@@ -1,0 +1,3 @@
+message: "**Plugin Server**: fix an issue where every request causes a new plugin instance to be created"
+type: bugfix
+scope: PDK

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -213,7 +213,7 @@ function get_instance_id(plugin_name, conf)
 
   if instance_info
     and instance_info.id
-    and instance_info.conf and instance_info.conf.__key__ == key
+    and instance_info.conf and instance_info.conf.__plugin_id == key
   then
     -- exact match, return it
     return instance_info.id


### PR DESCRIPTION
### Summary

As the __key__ changes its definition (cache key) it can never match a plugin's uuid. change to use __plugin_id.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-2969
