### PR TITLE
chore(ci): fix workflow webhook notification

### DIFF
--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -8,30 +8,44 @@ jobs:
   check_comment:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request != null && contains(github.event.comment.body, 'To backport manually, run these commands in your terminal')
-    steps:
-      - name: Generate Slack Payload
-        id: generate-payload
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const slack_mapping = JSON.parse(process.env.SLACK_MAPPING);
-            const pr_url = "${{ github.event.issue.pull_request.html_url}}";
-            const pr_author_github_id = "${{ github.event.issue.user.login }}"
-            const pr_author_slack_id = slack_mapping[pr_author_github_id];
-            const author = (pr_author_slack_id ? `<@${pr_author_slack_id}>` : pr_author_github_id);
-            const payload = {
-              text: `Backport failed in PR: ${pr_url}. Please check it ${author}.`,
-              channel: process.env.SLACK_CHANNEL,
-            };
-            return JSON.stringify(payload);
-          result-encoding: string
-        env:
-          SLACK_CHANNEL: gateway-notifications
-          SLACK_MAPPING: "${{ vars.GH_ID_2_SLACK_ID_MAPPING }}"
 
-      - name: Send Slack Message
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        with:
-          payload: ${{ steps.generate-payload.outputs.result }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GATEWAY_NOTIFICATIONS_WEBHOOK }}
+    steps:
+    - name: Fetch mapping file
+      id: fetch_mapping
+      uses: actions/github-script@v6
+      env:
+        ACCESS_TOKEN: ${{ secrets.PAT }}
+      with:
+        script: |
+          const url = 'https://raw.githubusercontent.com/Kong/github-slack-mapping/main/mapping.json';
+          const headers = {Authorization: `token ${process.env.ACCESS_TOKEN}`};
+          const response = await fetch(url, {headers});
+          const mapping = await response.json();
+          return mapping;
+
+    - name: Generate Slack Payload
+      id: generate-payload
+      uses: actions/github-script@v6
+      env:
+        SLACK_CHANNEL: gateway-notifications
+        SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"
+      with:
+        script: |
+          const pr_url = ${{ github.event.issue.pull_request.html_url }};
+          const slack_mapping = JSON.parse(process.env.SLACK_MAPPING);
+          const pr_author_github_id = ${{ github.event.issue.user.login }};
+          const pr_author_slack_id = slack_mapping[pr_author_github_id];
+          const author = pr_author_slack_id ? `<@${pr_author_slack_id}>` : pr_author_github_id;
+          const payload = {
+            text: `Hello ${author} , backport failed in PR: ${pr_url}.`,
+            channel: process.env.SLACK_CHANNEL,
+          };
+          return JSON.stringify(payload);
+        result-encoding: string
+
+    - name: Send Slack Message
+      uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      with:
+        payload: ${{ steps.generate-payload.outputs.result }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GATEWAY_NOTIFICATIONS_WEBHOOK }}

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -37,7 +37,7 @@ jobs:
           const pr_author_slack_id = slack_mapping[pr_author_github_id];
           const author = pr_author_slack_id ? `<@${pr_author_slack_id}>` : pr_author_github_id;
           const payload = {
-            text: `Hello ${author} , backport failed in PR: ${pr_url}.`,
+            text: `${pr_url} from ${author} failed to backport.`,
             channel: process.env.SLACK_CHANNEL,
           };
           return JSON.stringify(payload);

--- a/.github/workflows/release-and-tests-fail-bot.yml
+++ b/.github/workflows/release-and-tests-fail-bot.yml
@@ -15,25 +15,37 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule' }}
     steps:
+    - name: Fetch mapping file
+      id: fetch_mapping
+      uses: actions/github-script@v6
+      env:
+        ACCESS_TOKEN: ${{ secrets.PAT }}
+      with:
+        script: |
+          const url = 'https://raw.githubusercontent.com/Kong/github-slack-mapping/main/mapping.json';
+          const headers = {Authorization: `token ${process.env.ACCESS_TOKEN}`};
+          const response = await fetch(url, {headers});
+          const mapping = await response.json();
+          return mapping;
+
     - name: Generate Slack Payload
       id: generate-payload
       env:
         SLACK_CHANNEL: gateway-notifications
-        SLACK_MAPPING: "${{ vars.GH_ID_2_SLACK_ID_MAPPING }}"
+        SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"
       uses: actions/github-script@v7
       with:
         script: |
-          const slack_mapping = JSON.parse(process.env.SLACK_MAPPING);
-          const repo_name = "${{ github.event.workflow_run.repository.full_name }}";
-          const run_id = ${{ github.event.workflow_run.id }};
-          const run_url = `https://github.com/${repo_name}/actions/runs/${run_id}`;
           const workflow_name = "${{ github.event.workflow_run.name }}";
+          const repo_name = "${{ github.event.workflow_run.repository.full_name }}";
           const branch_name = "${{ github.event.workflow_run.head_branch }}";
+          const run_url = "${{ github.event.workflow_run.html_url }}";
+          const slack_mapping = JSON.parse(process.env.SLACK_MAPPING);
           const actor_github_id = "${{ github.event.workflow_run.actor.login }}";
           const actor_slack_id = slack_mapping[actor_github_id];
           const actor = actor_slack_id ? `<@${actor_slack_id}>` : actor_github_id;
           const payload = {
-            text: `Workflow “${workflow_name}” failed in repo: "${repo_name}", branch: "${branch_name}". Run URL: ${run_url}. Please check it ${actor} .`,
+            text: `Hello ${actor} , workflow “${workflow_name}” failed in repo: "${repo_name}", branch: "${branch_name}". Please check it: ${run_url}.`,
             channel: process.env.SLACK_CHANNEL,
           };
           return JSON.stringify(payload);


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Based on https://github.com/Kong/github-slack-mapping. It is already verified by https://github.com/Kong/kong/pull/12009.

Once merged, cherry-pick to EE to fix EE notification. Only diff is `runs-on: ${{ vars.RUNS_ON }}`.

### Checklist

- [n/a] The Pull Request has tests
- [n/a] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* fix workflow webhook notification based on <https://github.com/Kong/github-slack-mapping>.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5564]_


[FTI-5564]: https://konghq.atlassian.net/browse/FTI-5564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ