### PR TITLE
fix(scripts): fix update-copyright in venv and remove unused repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,9 @@ lint: dev
 	@!(grep -R -E -I -n -w '#only|#o' spec && echo "#only or #o tag detected") >&2
 	@!(grep -R -E -I -n -- '---\s+ONLY' t && echo "--- ONLY block detected") >&2
 
+update-copyright: build-venv
+	bash -c 'OPENSSL_DIR=$(OPENSSL_DIR) EXPAT_DIR=$(EXPAT_DIR) $(VENV) luajit $(KONG_SOURCE_LOCATION)/scripts/update-copyright'
+
 test: dev
 	@$(VENV) $(TEST_CMD) spec/01-unit
 

--- a/build/templates/venv-commons
+++ b/build/templates/venv-commons
@@ -60,6 +60,5 @@ export LUA_PATH="$LUA_PATH"
 export LUA_CPATH="$KONG_VENV/openresty/site/lualib/?.so;$KONG_VENV/openresty/lualib/?.so;./?.so;$KONG_VENV/lib/lua/5.1/?.so;$KONG_VENV/openresty/luajit/lib/lua/5.1/?.so;$ROCKS_ROOT/lib/lua/5.1/?.so;;"
 export KONG_PREFIX="$KONG_VENV/kong/servroot"
 export LIBRARY_PREFIX="$KONG_VENV/kong" # let "make dev" happy
-export OPENSSL_DIR="$KONG_VENV/kong" # let "make dev" happy
 
 EOF

--- a/scripts/update-copyright
+++ b/scripts/update-copyright
@@ -3,6 +3,8 @@
 --[[
 Usage: ./scripts/update-copyright
 
+Use `make update-copyright` is recommended without least setup.
+
 The COPYRIGHT file should be updated after running this. Changes are not added to git, visual
 review is recommended.
 
@@ -20,11 +22,12 @@ including installing rocks inside said folder.
 
 Requires internet connection in order to download luarocks and license files.
 
-On Macs, you might need to set up OPENSSL_DIR and CRYPTO_DIR.
+On Macs, you might need to set up OPENSSL_DIR and EXPAT_DIR.
 
 The default for mac is:
 
-OPENSSL_DIR=/usr/local/opt/openssl/ CRYPTO_DIR=/usr/local/opt/openssl/ ./scripts/update-copyright
+OPENSSL_DIR=/usr/local/opt/openssl/ EXPAT_DIR=/usr/local/opt/expat ./scripts/update-copyright
+
 ]]
 
 setmetatable(_G, nil)
@@ -34,10 +37,10 @@ local url = require "socket.url"
 local fmt = string.format
 
 local OPENSSL_DIR = os.getenv("OPENSSL_DIR")
-assert(OPENSSL_DIR, "please set the OPENSSL_DIR env variable (needed for installing luaOSSL)")
+assert(OPENSSL_DIR, "please set the OPENSSL_DIR env variable (needed for installing luasocket)")
 
-local CRYPTO_DIR = os.getenv("CRYPTO_DIR")
-assert(CRYPTO_DIR, "please set the CRYPTO_DIR env variable (needed for installing luaOSSL)")
+local EXPAT_DIR = os.getenv("EXPAT_DIR")
+assert(EXPAT_DIR, "please set the EXPAT_DIR env variable (needed for installing luaexpat)")
 
 local work_folder = os.tmpname() .. "-update-copyright"
 
@@ -72,9 +75,8 @@ local HARDCODED_DEPENDENCIES = {
     url = "https://luarocks.org",
     repo_url = "https://github.com/luarocks/luarocks",
   },
-  ["luaossl"] = { -- the rockspec information is not up to date
-    url = "http://25thandclement.com/~william/projects/luaossl.html",
-    repo_url = "https://github.com/wahern/luaossl",
+  ["OpenSSL"] = {
+    url = "https://github.com/openssl/openssl",
   },
   -- go-pdk dependencies:
   ["go-codec"] = {
@@ -330,7 +332,7 @@ local function find_and_download_license(main_url, alt_url)
 
       local attempt_url = url.build(parsed_url)
       local text = download_file(attempt_url)
-      if text then
+      if text and #text > 0 then
         parsed_url.host = "github.com"
         parsed_url.path = fmt("/%s/%s/blob/master/%s", user, reponame, attempt)
         local url_for_humans = url.build(parsed_url)
@@ -344,7 +346,7 @@ local function find_and_download_license(main_url, alt_url)
       local readme_markdown = download_file(readme_url)
       if readme_markdown then
         local header, text = extract_license_from_markdown(readme_markdown)
-        if header then
+        if header and #header > 0 then
           parsed_url.host = "github.com"
           parsed_url.path = fmt("/%s/%s", user, reponame)
           parsed_url.fragment = to_anchor(header)
@@ -383,8 +385,8 @@ print("")
 print(fmt("Installing rocks in work folder. (Install log: %s/luarocks.log) ...", work_folder))
 
 assert(os.execute(fmt("cp kong*.rockspec %s", work_folder)))
-assert(os.execute(fmt("luarocks --lua-version=5.1 --tree %s make %s/kong*.rockspec OPENSSL_DIR=%s CRYPTO_DIR=%s 2>&1 > %s/luarocks.log",
-                      work_folder, work_folder, OPENSSL_DIR, CRYPTO_DIR, work_folder)))
+assert(os.execute(fmt("luarocks --lua-version=5.1 --tree %s make %s/kong*.rockspec OPENSSL_DIR=%s EXPAT_DIR=%s 2>&1 > %s/luarocks.log",
+                      work_folder, work_folder, OPENSSL_DIR, EXPAT_DIR, work_folder)))
 
 local rocklist_path = fmt("%s/rocklist.txt", work_folder)
 assert(os.execute(fmt("find %s/lib | grep rockspec > %s", work_folder, rocklist_path)))
@@ -420,6 +422,7 @@ table.sort(rocks, function(a, b) return a.package:lower() < b.package:lower() en
 
 print("Searching and downloading license texts from rock repos")
 for _, rock in ipairs(rocks) do
+  break
   -- if it was in HARDCODED_DEPENDENCIES, it is already in licenses at this point
   if not HARDCODED_DEPENDENCIES[rock.package] then
     local homepage = get_rock_homepage(rock)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

- Removes luaossl
- Adds EXPAT_DIR env var
- Adds update-copyright in makefile

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

Replaces #11947

Sister PR https://github.com/Kong/kong-ee/pull/7279
