### PR TITLE
chore: trigger backport on label addition

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled] # runs when the pull request is closed/merged or labeled (to trigger a backport in hindsight)
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests


### PR DESCRIPTION
### Summary

In https://github.com/Kong/kong/pull/11924 we removed the `labeled` from the `pull_request_target` section. This prevents us from triggering backports of pull requests in hindsight by adding a label. This patch adds it back.
 

