### PR TITLE
docs(changelog): tune the message of atc-router version bump

### DIFF
--- a/changelog/unreleased/kong/bump-atc-router-1.3.1.yml
+++ b/changelog/unreleased/kong/bump-atc-router-1.3.1.yml
@@ -1,2 +1,3 @@
 message: Bumped atc-router from 1.2.0 to 1.3.1
 type: dependency
+scope: Core

--- a/changelog/unreleased/kong/bump-atc-router-1.3.1.yml
+++ b/changelog/unreleased/kong/bump-atc-router-1.3.1.yml
@@ -1,0 +1,2 @@
+message: Bumped atc-router from 1.2.0 to 1.3.1
+type: dependency

--- a/changelog/unreleased/kong/bump_atc_router.yml
+++ b/changelog/unreleased/kong/bump_atc_router.yml
@@ -1,2 +1,0 @@
-message: Bump `atc-router` to `v1.3.1`
-type: "dependency"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Change the change log message to the normal form as usual.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
