### PR TITLE
perf(clustering): store entity only once in lmdb

### DIFF
--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -245,6 +245,16 @@ local function select_by_key(schema, key)
 end
 
 
+local function select_by_ref(schema, ref)
+  local key, err = lmdb_get(ref)
+  if not key then
+    return nil, err
+  end
+
+  return select_by_key(schema, key)
+end
+
+
 local function page(self, size, offset, options)
   local schema = self.schema
   local ws_id = ws(schema, options)
@@ -258,6 +268,9 @@ local function select(self, pk, options)
   local ws_id = ws(schema, options)
   local id = declarative_config.pk_string(schema, pk)
   local key = schema.name .. ":" .. id .. ":::::" .. ws_id
+  if ws_id == "*" then
+    return select_by_ref(schema, key)
+  end
   return select_by_key(schema, key)
 end
 
@@ -271,19 +284,19 @@ local function select_by_field(self, field, value, options)
   local schema = self.schema
   local ws_id = ws(schema, options)
 
-  local key
+  local ref
   if field ~= "cache_key" then
     local unique_across_ws = schema.fields[field].unique_across_ws
     -- only accept global query by field if field is unique across workspaces
     assert(not options or options.workspace ~= null or unique_across_ws)
 
-    key = unique_field_key(schema.name, ws_id, field, value, unique_across_ws)
+    ref = unique_field_key(schema.name, ws_id, field, value, unique_across_ws)
   else
     -- if select_by_cache_key, use the provided cache_key as key directly
-    key = value
+    ref = value
   end
 
-  return select_by_key(schema, key)
+  return select_by_ref(schema, ref)
 end
 
 


### PR DESCRIPTION
### Summary

Getting data from LMDB is slightly slower in some cases as it requires two LMDB reads instead of one, but the memory usage difference is quite big:

```
Single: LMDB shared memory size: 481M
Master: LMDB shared memory size: 681M
```

```
Process Name                   PID   Max Mem  Min Mem  Mean Mem  Median Mem  Standard Deviation
Single: nginx: worker process  87638    467M     301M      438M        449M                 31M
Master: nginx: worker process   6762    439M     308M      405M        409M                 29M
```

```
Process Name                   PID    Max Mem  Min Mem  Mean Mem  Median Mem  Standard Deviation
Single: nginx: priv. agent     87639     776M     736M      757M        758M                7.7M
Master: nginx: priv. agent      6763     1.6G     909M      1.4G        1.4G                148M
```

```
Total   Max Mem  Min Mem  Mean Mem  Median Mem
Single:    1.3G     1.1G      1.2G        1.2G
Master:    2.1G     1.2G      1.8G        1.8G
```

```
                       min       mean         50         90         95       99       max
Single: Latencies 37.959µs  370.850µs  140.239µs  416.418µs  709.358µs  3.749ms  76.638ms
Master: Latencies 41.000µs  351.938µs  142.353µs  406.417µs  662.329µs  3.542ms  61.037ms
```

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE