### PR TITLE
[backport -> release/2.8.x] fix(dns): Eliminate asynchronous timer in syncQuery() to prevent hang

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -9,5 +9,5 @@ jobs:
 
     steps:
     - name: do-not-merge label found
-      run: exit 1
-      if: ${{ contains(github.event.*.labels.*.name, 'do not merge') || contains(github.event.*.labels.*.name, 'do-not-merge') }}
+      run: echo "do-not-merge label found, this PR will not be merged"; exit 1
+      if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,7 @@
 name: Pull Request Label Checker
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, edited, synchronize, labeled, unlabeled]
 jobs:
   check-labels:
     name: prevent merge labels

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,13 @@
+name: Pull Request Label Checker
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+jobs:
+  check-labels:
+    name: prevent merge labels
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: do-not-merge label found
+      run: exit 1
+      if: ${{ contains(github.event.*.labels.*.name, 'do not merge') || contains(github.event.*.labels.*.name, 'do-not-merge') }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,7 @@
 name: Pull Request Label Checker
 on:
   pull_request:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [labeled, unlabeled]
 jobs:
   check-labels:
     name: prevent merge labels
@@ -11,11 +11,3 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
-  schema-change-labels:
-    if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Schema change label found
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -11,3 +11,11 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
+  schema-change-labels:
+    if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Schema change label found
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -11,3 +11,6 @@ jobs:
     - name: do-not-merge label found
       run: echo "do-not-merge label found, this PR will not be merged"; exit 1
       if: ${{ contains(github.event.*.labels.*.name, 'pr/do not merge') || contains(github.event.*.labels.*.name, 'DO NOT MERGE') }}
+    - name: backport master label found
+      run: echo "Please do not backport into master, instead, create a PR targeting master and backport from it instead."; exit 1
+      if: ${{ contains(github.event.*.labels.*.name, 'backport master') }}

--- a/changelog/unreleased/kong/fix_dns_blocking.yml
+++ b/changelog/unreleased/kong/fix_dns_blocking.yml
@@ -1,0 +1,3 @@
+message: Eliminate asynchronous timer in syncQuery() to prevent hang risk
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix_dns_retry_and_timeout_handling.yml
+++ b/changelog/unreleased/kong/fix_dns_retry_and_timeout_handling.yml
@@ -1,0 +1,3 @@
+message: Update the DNS client to follow configured timeouts in a more predictable manner
+type: bugfix
+scope: Core

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -360,9 +360,9 @@ end
 -- @param self the try_list to add to
 -- @param status string with current status, added to the list for the current try
 -- @return the try_list
-local function try_status(self, status)
-  local status_list = self[#self].msg
-  status_list[#status_list + 1] = status
+local function add_status_to_try_list(self, status)
+  local try_list = self[#self].msg
+  try_list[#try_list + 1] = status
   return self
 end
 
@@ -383,8 +383,7 @@ end
 -- @section resolving
 
 
-local poolMaxWait
-local poolMaxRetry
+local resolve_max_wait
 
 --- Initialize the client. Can be called multiple times. When called again it
 -- will clear the cache.
@@ -638,8 +637,7 @@ _M.init = function(options)
 
   config = options -- store it in our module level global
 
-  poolMaxRetry = 1  -- do one retry, dns resolver is already doing 'retrans' number of retries on top
-  poolMaxWait = options.timeout / 1000 * options.retrans -- default is to wait for the dns resolver to hit its timeouts
+  resolve_max_wait = options.timeout / 1000 * options.retrans -- maximum time to wait for the dns resolver to hit its timeouts
 
   return true
 end
@@ -672,7 +670,7 @@ local function parseAnswer(qname, qtype, answers, try_list)
 
     if (answer.type ~= qtype) or (answer.name ~= check_qname) then
       local key = answer.type..":"..answer.name
-      try_status(try_list, key .. " removed")
+      add_status_to_try_list(try_list, key .. " removed")
       local lst = others[key]
       if not lst then
         lst = {}
@@ -710,7 +708,7 @@ local function individualQuery(qname, r_opts, try_list)
     return r, "failed to create a resolver: " .. err, try_list
   end
 
-  try_status(try_list, "querying")
+  add_status_to_try_list(try_list, "querying")
 
   local result
   result, err = r:query(qname, r_opts)
@@ -737,7 +735,7 @@ local function executeQuery(premature, item)
     --[[
     log(DEBUG, PREFIX, "Query executing: ", item.qname, ":", item.r_opts.qtype, " ", fquery(item))
     --]]
-    try_status(item.try_list, "querying")
+    add_status_to_try_list(item.try_list, "querying")
     item.result, item.err = r:query(item.qname, item.r_opts)
     if item.result then
       --[[
@@ -779,7 +777,7 @@ local function asyncQuery(qname, r_opts, try_list)
     --[[
     log(DEBUG, PREFIX, "Query async (exists): ", key, " ", fquery(item))
     --]]
-    try_status(try_list, "in progress (async)")
+    add_status_to_try_list(try_list, "in progress (async)")
     return item    -- already in progress, return existing query
   end
 
@@ -801,7 +799,7 @@ local function asyncQuery(qname, r_opts, try_list)
   --[[
   log(DEBUG, PREFIX, "Query async (scheduled): ", key, " ", fquery(item))
   --]]
-  try_status(try_list, "scheduled")
+  add_status_to_try_list(try_list, "scheduled")
 
   return item
 end
@@ -809,33 +807,24 @@ end
 
 -- schedules a sync query.
 -- This will be synchronized, so multiple calls (sync or async) might result in 1 query.
--- The `poolMaxWait` is how long a thread waits for another to complete the query.
--- The `poolMaxRetry` is how often we wait for another query to complete.
--- The maximum delay would be `poolMaxWait * poolMaxRetry`.
+-- The maximum delay would be `options.timeout * options.retrans`.
 -- @param qname the name to query for
 -- @param r_opts a table with the query options
 -- @param try_list the try_list object to add to
 -- @return `result + nil + try_list`, or `nil + err + try_list` in case of errors
-local function syncQuery(qname, r_opts, try_list, count)
+local function syncQuery(qname, r_opts, try_list)
   local key = qname..":"..r_opts.qtype
   local item = queue[key]
-  count = count or 1
 
   -- if nothing is in progress, we start a new async query
   if not item then
     local err
     item, err = asyncQuery(qname, r_opts, try_list)
-    --[[
-    log(DEBUG, PREFIX, "Query sync (new): ", key, " ", fquery(item)," count=", count)
-    --]]
     if not item then
       return item, err, try_list
     end
   else
-    --[[
-    log(DEBUG, PREFIX, "Query sync (exists): ", key, " ", fquery(item)," count=", count)
-    --]]
-    try_status(try_list, "in progress (sync)")
+    add_status_to_try_list(try_list, "in progress (sync)")
   end
 
   local supported_semaphore_wait_phases = {
@@ -860,7 +849,7 @@ local function syncQuery(qname, r_opts, try_list, count)
   end
 
   -- block and wait for the async query to complete
-  local ok, err = item.semaphore:wait(poolMaxWait)
+  local ok, err = item.semaphore:wait(resolve_max_wait)
   if ok and item.result then
     -- we were released, and have a query result from the
     -- other thread, so all is well, return it
@@ -871,25 +860,16 @@ local function syncQuery(qname, r_opts, try_list, count)
     return item.result, item.err, try_list
   end
 
-  -- there was an error, either a semaphore timeout, or a lookup error
-  -- go retry
-  try_status(try_list, "try "..count.." error: "..(item.err or err or "unknown"))
-  if count > poolMaxRetry then
-    --[[
-    log(DEBUG, PREFIX, "Query sync (fail): ", key, " ", fquery(item)," retries exceeded. count=", count)
-    --]]
-    return nil, "dns lookup pool exceeded retries (" ..
-                tostring(poolMaxRetry) .. "): "..tostring(item.err or err),
-                try_list
-  end
+  err = err or item.err or "unknown"
+  add_status_to_try_list(try_list, "error: "..err)
 
   -- don't block on the same thread again, so remove it from the queue
-  if queue[key] == item then queue[key] = nil end
+  if queue[key] == item then
+    queue[key] = nil
+  end
 
-  --[[
-  log(DEBUG, PREFIX, "Query sync (fail): ", key, " ", fquery(item)," retrying. count=", count)
-  --]]
-  return syncQuery(qname, r_opts, try_list, count + 1)
+  -- there was an error, either a semaphore timeout, or a lookup error
+  return nil, err
 end
 
 -- will lookup a name in the cache, or alternatively query the nameservers.
@@ -928,7 +908,7 @@ local function lookup(qname, r_opts, dnsCacheOnly, try_list)
   try_list = try_add(try_list, qname, r_opts.qtype, "cache-hit")
   if entry.expired then
     -- the cached record is stale but usable, so we do a refresh query in the background
-    try_status(try_list, "stale")
+    add_status_to_try_list(try_list, "stale")
     asyncQuery(qname, r_opts, try_list)
   end
 
@@ -946,7 +926,7 @@ local function check_ipv6(qname, qtype, try_list)
 
   local record = cachelookup(qname, qtype)
   if record then
-    try_status(try_list, "cached")
+    add_status_to_try_list(try_list, "cached")
     return record, nil, try_list
   end
 
@@ -966,7 +946,7 @@ local function check_ipv6(qname, qtype, try_list)
   end
   if qtype == _M.TYPE_AAAA and
      check:match("^%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?:%x%x?%x?%x?$") then
-    try_status(try_list, "validated")
+    add_status_to_try_list(try_list, "validated")
     record = {{
       address = qname,
       type = _M.TYPE_AAAA,
@@ -978,7 +958,7 @@ local function check_ipv6(qname, qtype, try_list)
   else
     -- not a valid IPv6 address, or a bad type (non ipv6)
     -- return a "server error"
-    try_status(try_list, "bad IPv6")
+    add_status_to_try_list(try_list, "bad IPv6")
     record = {
       errcode = 3,
       errstr = "name error",
@@ -999,12 +979,12 @@ local function check_ipv4(qname, qtype, try_list)
 
   local record = cachelookup(qname, qtype)
   if record then
-    try_status(try_list, "cached")
+    add_status_to_try_list(try_list, "cached")
     return record, nil, try_list
   end
 
   if qtype == _M.TYPE_A then
-    try_status(try_list, "validated")
+    add_status_to_try_list(try_list, "validated")
     record = {{
       address = qname,
       type = _M.TYPE_A,
@@ -1016,7 +996,7 @@ local function check_ipv4(qname, qtype, try_list)
   else
     -- bad query type for this ipv4 address
     -- return a "server error"
-    try_status(try_list, "bad IPv4")
+    add_status_to_try_list(try_list, "bad IPv4")
     record = {
       errcode = 3,
       errstr = "name error",
@@ -1160,7 +1140,7 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
         records = nil
         -- luacheck: pop
         err = "recursion detected"
-        try_status(try_list, "recursion detected")
+        add_status_to_try_list(try_list, "recursion detected")
         return nil, err, try_list
       end
     end
@@ -1172,14 +1152,14 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
       -- luacheck: push no unused
       records = nil
       -- luacheck: pop
-      try_list = try_status(try_list, "stale")
+      try_list = add_status_to_try_list(try_list, "stale")
 
     else
       -- a valid non-stale record
       -- check for CNAME records, and dereferencing the CNAME
       if (records[1] or EMPTY).type == _M.TYPE_CNAME and qtype ~= _M.TYPE_CNAME then
         opts.qtype = nil
-        try_status(try_list, "dereferencing")
+        add_status_to_try_list(try_list, "dereferencing")
         return resolve(records[1].cname, opts, dnsCacheOnly, try_list)
       end
 
@@ -1227,8 +1207,10 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
     end
 
     if not records then  -- luacheck: ignore
-      -- nothing to do, an error
-      -- fall through to the next entry in our search sequence
+      -- An error has occurred, terminate the lookup process.  We don't want to try other record types because
+      -- that would potentially cause us to respond with wrong answers (i.e. the contents of an A record if the
+      -- query for the SRV record failed due to a network error).
+      goto failed
 
     elseif records.errcode then
       -- dns error: fall through to the next entry in our search sequence
@@ -1287,7 +1269,7 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
         if records[1].type == _M.TYPE_CNAME and qtype ~= _M.TYPE_CNAME then
           -- dereference CNAME
           opts.qtype = nil
-          try_status(try_list, "dereferencing")
+          add_status_to_try_list(try_list, "dereferencing")
           return resolve(records[1].cname, opts, dnsCacheOnly, try_list)
         end
 
@@ -1296,8 +1278,9 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
     end
 
     -- we had some error, record it in the status list
-    try_status(try_list, err)
+    add_status_to_try_list(try_list, err)
   end
+  ::failed::
 
   -- we failed, clear cache and return last error
   if not dnsCacheOnly then
@@ -1507,7 +1490,7 @@ local function toip(qname, port, dnsCacheOnly, try_list)
     local entry = rec[roundRobinW(rec)]
     -- our SRV entry might still contain a hostname, so recurse, with found port number
     local srvport = (entry.port ~= 0 and entry.port) or port -- discard port if it is 0
-    try_status(try_list, "dereferencing SRV")
+    add_status_to_try_list(try_list, "dereferencing SRV")
     return toip(entry.target, srvport, dnsCacheOnly, try_list)
   else
     -- must be A or AAAA

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -30,10 +30,10 @@ local time = ngx.now
 local log = ngx.log
 local ERR = ngx.ERR
 local WARN = ngx.WARN
+local ALERT = ngx.ALERT
 local DEBUG = ngx.DEBUG
 local PREFIX = "[dns-client] "
 local timer_at = ngx.timer.at
-local get_phase = ngx.get_phase
 
 local math_min = math.min
 local math_max = math.max
@@ -637,7 +637,9 @@ _M.init = function(options)
 
   config = options -- store it in our module level global
 
-  resolve_max_wait = options.timeout / 1000 * options.retrans -- maximum time to wait for the dns resolver to hit its timeouts
+  -- maximum time to wait for the dns resolver to hit its timeouts
+  -- + 1s to ensure some delay in timer execution and semaphore return are accounted for
+  resolve_max_wait = options.timeout / 1000 * options.retrans + 1
 
   return true
 end
@@ -721,44 +723,62 @@ local function individualQuery(qname, r_opts, try_list)
   return result, nil, try_list
 end
 
-
 local queue = setmetatable({}, {__mode = "v"})
+
+local function enqueue_query(key, qname, r_opts, try_list)
+  local item = {
+    key = key,
+    semaphore = semaphore(),
+    qname = qname,
+    r_opts = deepcopy(r_opts),
+    try_list = try_list,
+    expire_time = time() + resolve_max_wait,
+  }
+  queue[key] = item
+  return item
+end
+
+
+local function dequeue_query(item)
+  if queue[item.key] == item then
+    -- query done, but by now many others might be waiting for our result.
+    -- 1) stop new ones from adding to our lock/semaphore
+    queue[item.key] = nil
+    -- 2) release all waiting threads
+    item.semaphore:post(math_max(item.semaphore:count() * -1, 1))
+    item.semaphore = nil
+  end
+end
+
+
+local function queue_get_query(key, try_list)
+  local item = queue[key]
+
+  if not item then
+    return nil
+  end
+
+  -- bug checks: release it actively if the waiting query queue is blocked
+  if item.expire_time < time() then
+    local err = "stale query, key:" ..  key
+    add_status_to_try_list(try_list, err)
+    log(ALERT, PREFIX, err)
+    dequeue_query(item)
+    return nil
+  end
+
+  return item
+end
+
+
 -- to be called as a timer-callback, performs a query and returns the results
 -- in the `item` table.
 local function executeQuery(premature, item)
   if premature then return end
 
-  local r, err = resolver:new(config)
-  if not r then
-    item.result, item.err = r, "failed to create a resolver: " .. err
-  else
-    --[[
-    log(DEBUG, PREFIX, "Query executing: ", item.qname, ":", item.r_opts.qtype, " ", fquery(item))
-    --]]
-    add_status_to_try_list(item.try_list, "querying")
-    item.result, item.err = r:query(item.qname, item.r_opts)
-    if item.result then
-      --[[
-      log(DEBUG, PREFIX, "Query answer: ", item.qname, ":", item.r_opts.qtype, " ", fquery(item),
-              " ", frecord(item.result))
-      --]]
-      parseAnswer(item.qname, item.r_opts.qtype, item.result, item.try_list)
-      --[[
-      log(DEBUG, PREFIX, "Query parsed answer: ", item.qname, ":", item.r_opts.qtype, " ", fquery(item),
-              " ", frecord(item.result))
-    else
-      log(DEBUG, PREFIX, "Query error: ", item.qname, ":", item.r_opts.qtype, " err=", tostring(err))
-      --]]
-    end
-  end
+  item.result, item.err = individualQuery(item.qname, item.r_opts, item.try_list)
 
-  -- query done, but by now many others might be waiting for our result.
-  -- 1) stop new ones from adding to our lock/semaphore
-  queue[item.key] = nil
-  -- 2) release all waiting threads
-  item.semaphore:post(math_max(item.semaphore:count() * -1, 1))
-  item.semaphore = nil
-  ngx.sleep(0)
+  dequeue_query(item)
 end
 
 
@@ -772,7 +792,7 @@ end
 -- the `semaphore` field will be removed). Upon error it returns `nil+error`.
 local function asyncQuery(qname, r_opts, try_list)
   local key = qname..":"..r_opts.qtype
-  local item = queue[key]
+  local item = queue_get_query(key, try_list)
   if item then
     --[[
     log(DEBUG, PREFIX, "Query async (exists): ", key, " ", fquery(item))
@@ -781,14 +801,7 @@ local function asyncQuery(qname, r_opts, try_list)
     return item    -- already in progress, return existing query
   end
 
-  item = {
-    key = key,
-    semaphore = semaphore(),
-    qname = qname,
-    r_opts = deepcopy(r_opts),
-    try_list = try_list,
-  }
-  queue[key] = item
+  item = enqueue_query(key, qname, r_opts, try_list)
 
   local ok, err = timer_at(0, executeQuery, item)
   if not ok then
@@ -814,39 +827,23 @@ end
 -- @return `result + nil + try_list`, or `nil + err + try_list` in case of errors
 local function syncQuery(qname, r_opts, try_list)
   local key = qname..":"..r_opts.qtype
-  local item = queue[key]
 
-  -- if nothing is in progress, we start a new async query
+  local item = queue_get_query(key, try_list)
+
+  -- If nothing is in progress, we start a new sync query
   if not item then
-    local err
-    item, err = asyncQuery(qname, r_opts, try_list)
-    if not item then
-      return item, err, try_list
-    end
-  else
-    add_status_to_try_list(try_list, "in progress (sync)")
+    item = enqueue_query(key, qname, r_opts, try_list)
+
+    item.result, item.err = individualQuery(qname, item.r_opts, try_list)
+
+    dequeue_query(item)
+
+    return item.result, item.err, try_list
   end
 
-  local supported_semaphore_wait_phases = {
-    rewrite = true,
-    access = true,
-    content = true,
-    timer = true,
-    ssl_cert = true,
-    ssl_session_fetch = true,
-  }
+  -- If the query is already in progress, we wait for it.
 
-  local ngx_phase = get_phase()
-
-  if not supported_semaphore_wait_phases[ngx_phase] then
-    -- phase not supported by `semaphore:wait`
-    -- return existing query (item)
-    --
-    -- this will avoid:
-    -- "dns lookup pool exceeded retries" (second try and subsequent retries)
-    -- "API disabled in the context of init_worker_by_lua" (first try)
-    return item, nil, try_list
-  end
+  add_status_to_try_list(try_list, "in progress (sync)")
 
   -- block and wait for the async query to complete
   local ok, err = item.semaphore:wait(resolve_max_wait)
@@ -858,6 +855,14 @@ local function syncQuery(qname, r_opts, try_list)
            " result: ", json({ result = item.result, err = item.err}))
     --]]
     return item.result, item.err, try_list
+  end
+
+  -- bug checks
+  if not ok and not item.err then
+    item.err = err  -- only first expired wait() reports error
+    log(ALERT, PREFIX, "semaphore:wait(", resolve_max_wait, ") failed: ", err,
+                       ", count: ", item.semaphore and item.semaphore:count(),
+                       ", qname: ", qname)
   end
 
   err = err or item.err or "unknown"

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -582,7 +582,10 @@ describe("[DNS client]", function()
             }
           }))
           query_func = function(self, original_query_func, name, options)
-            ngx.sleep(5)
+            -- The first request uses syncQuery not waiting on the
+            -- aysncQuery timer, so the low-level r:query() could not sleep(5s),
+            -- it can only sleep(timeout).
+            ngx.sleep(math.min(timeout, 5))
             return nil
           end
           local start_time = ngx.now()
@@ -1745,9 +1748,12 @@ describe("[DNS client]", function()
     end)
 
     it("timeout while waiting", function()
+
+      local timeout = 500
+      local ip = "1.4.2.3"
       -- basically the local function _synchronized_query
       assert(client.init({
-        timeout = 500,
+        timeout = timeout,
         retrans = 1,
         resolvConf = {
           -- resolv.conf without `search` and `domain` options
@@ -1758,7 +1764,7 @@ describe("[DNS client]", function()
       -- insert a stub thats waits and returns a fixed record
       local name = TEST_DOMAIN
       query_func = function()
-        local ip = "1.4.2.3"
+        local ip = ip
         local entry = {
           {
             type = client.TYPE_A,
@@ -1770,7 +1776,9 @@ describe("[DNS client]", function()
           touch = 0,
           expire = gettime() + 10,
         }
-        sleep(0.5) -- wait before we return the results
+        -- wait before we return the results
+        -- `+ 2` s ensures that the semaphore:wait() expires
+        sleep(timeout/1000 + 2)
         return entry
       end
 
@@ -1800,10 +1808,12 @@ describe("[DNS client]", function()
         ngx.thread.wait(coros[i]) -- this wait will resume the scheduled ones
       end
 
-      -- all results are equal, as they all will wait for the first response
-      for i = 1, 10 do
+      -- results[1~9] are equal, as they all will wait for the first response
+      for i = 1, 9 do
         assert.equal("timeout", results[i])
       end
+      -- results[10] comes from synchronous DNS access of the first request
+      assert.equal(ip, results[10][1]["address"])
     end)
   end)
 

--- a/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
+++ b/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
@@ -95,10 +95,18 @@ resolver.query = function(self, name, options, tries)
   end
 
   if not mocks_only then
-    -- no mock, so invoke original resolver
-    local a, b, c = old_query(self, name, options, tries)
-    return a, b, c
+    -- No mock, so invoke original resolver.  Note that if the original resolver fails (i.e. because an
+    -- invalid domain name like example.com was used), we return an empty result set instead of passing
+    -- the error up to the caller.  This is done so that if the mock contains "A" records (which would
+    -- be the most common case), the initial query for a SRV record does not fail, but appear not to have
+    -- yielded any results.  This will make dns/client.lua try finding an A record next.
+    local records, err, tries = old_query(self, name, options, tries)
+    if records then
+      return records, err, tries
+    end
   end
+
+  return {}, nil, tries
 end
 
 do

--- a/t/03-dns-client/01-phases.t
+++ b/t/03-dns-client/01-phases.t
@@ -1,6 +1,6 @@
 use Test::Nginx::Socket;
 
-plan tests => repeat_each() * (blocks() * 5);
+plan tests => repeat_each() * (blocks() * 4 + 1);
 
 workers(6);
 
@@ -59,8 +59,7 @@ qq {
 GET /t
 --- response_body
 answers: nil
-err: dns client error: 101 empty record received
---- no_error_log
+err: nil
+--- error_log
 [error]
-dns lookup pool exceeded retries
 API disabled in the context of init_worker_by_lua

--- a/t/03-dns-client/02-timer-usage.t
+++ b/t/03-dns-client/02-timer-usage.t
@@ -2,76 +2,72 @@ use Test::Nginx::Socket;
 
 plan tests => repeat_each() * (blocks() * 5);
 
-workers(6);
+workers(1);
 
 no_shuffle();
 run_tests();
 
 __DATA__
-
-=== TEST 1: reuse timers for queries of same name, independent on # of workers
---- http_config eval
-qq {
-    init_worker_by_lua_block {
-        local client = require("kong.resty.dns.client")
-        assert(client.init({
-            nameservers = { "8.8.8.8" },
-            hosts = {}, -- empty tables to parse to prevent defaulting to /etc/hosts
-            resolvConf = {}, -- and resolv.conf files
-            order = { "A" },
-        }))
-        local host = "httpbin.org"
-        local typ = client.TYPE_A
-        for i = 1, 10 do
-            client.resolve(host, { qtype = typ })
-        end
-
-        local host = "mockbin.org"
-        for i = 1, 10 do
-            client.resolve(host, { qtype = typ })
-        end
-
-        workers = ngx.worker.count()
-        timers = ngx.timer.pending_count()
-    }
-}
+=== TEST 1: stale result triggers async timer
 --- config
     location = /t {
         access_by_lua_block {
+            -- init
             local client = require("kong.resty.dns.client")
-            assert(client.init())
-            local host = "httpbin.org"
+            assert(client.init({
+                nameservers = { "127.0.0.53" },
+                hosts = {}, -- empty tables to parse to prevent defaulting to /etc/hosts
+                resolvConf = {}, -- and resolv.conf files
+                order = { "A" },
+                validTtl = 1,
+            }))
+
+            local host = "konghq.com"
             local typ = client.TYPE_A
-            local answers, err = client.resolve(host, { qtype = typ })
 
+            -- first time
+
+            local answers, err, try_list = client.resolve(host, { qtype = typ })
             if not answers then
                 ngx.say("failed to resolve: ", err)
+                return
             end
-
             ngx.say("first address name: ", answers[1].name)
+            ngx.say("first try_list: ", tostring(try_list))
 
-            host = "mockbin.org"
-            answers, err = client.resolve(host, { qtype = typ })
+            -- sleep to wait for dns record to become stale
+            ngx.sleep(1.5)
 
+            -- second time: use stale result and trigger async timer
+
+            answers, err, try_list = client.resolve(host, { qtype = typ })
             if not answers then
                 ngx.say("failed to resolve: ", err)
+                return
             end
-
             ngx.say("second address name: ", answers[1].name)
+            ngx.say("second try_list: ", tostring(try_list))
 
-            ngx.say("workers: ", workers)
+            -- third time: use stale result and find triggered async timer
 
-            -- should be 2 timers maximum (1 for each hostname)
-            ngx.say("timers: ", timers)
+            answers, err, try_list = client.resolve(host, { qtype = typ })
+            if not answers then
+                ngx.say("failed to resolve: ", err)
+                return
+            end
+            ngx.say("third address name: ", answers[1].name)
+            ngx.say("third try_list: ", tostring(try_list))
         }
     }
 --- request
 GET /t
 --- response_body
-first address name: httpbin.org
-second address name: mockbin.org
-workers: 6
-timers: 2
+first address name: konghq.com
+first try_list: ["(short)konghq.com:1 - cache-miss","konghq.com:1 - cache-miss/querying"]
+second address name: konghq.com
+second try_list: ["(short)konghq.com:1 - cache-hit/stale","konghq.com:1 - cache-hit/stale/scheduled"]
+third address name: konghq.com
+third try_list: ["(short)konghq.com:1 - cache-hit/stale","konghq.com:1 - cache-hit/stale/in progress (async)"]
 --- no_error_log
 [error]
 dns lookup pool exceeded retries


### PR DESCRIPTION
backport https://github.com/Kong/kong/pull/11900 and https://github.com/Kong/kong/pull/11386 to 2.8.x
backport some commits about `pr/do not merge` label to 2.8.x

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. fix(dns): eliminate asynchronous timer in `syncQuery()` to prevent deadlock risk (#11900)

```
    * Revert "fix(conf): set default value of `dns_no_sync` to `on` (#11869)"
     
    This reverts commit 3be2513a60b9f5f0a89631ff17c202e6113981c0.

    * fix(dns): introduce the synchronous query in syncQuery() to prevent hang risk

    Originally the first request to `syncQuery()` will trigger an asynchronous timer
    event, which added the risk of thread pool hanging.

    With this patch, cold synchronously DNS query will always happen in the current
    thread if current phase supports yielding.
```

2. fix(dns): fix retry and timeout handling (#11386)

```
    - Stop retrying in dns/client.lua, let the resolver handle this.  This
       change also makes it possible to disable retries, which previously
       was not possible
     - Be more faithful to the timeouts set by the user.  Previously, the
       timeout configured was used only for the ultimate request sent to
       the DNS server, but asynchronous requests allowed longer timeouts
       which was not transparent.
     - When the DNS server fails, stop trying other query types.  Previously,
       the behavior was such that after an (intermediate) failure to query
       for one record type (say "SRV"), the client would try the next record
       type (say "A") and succeed with that.  It would then return the
       contents of the "A" record even if the "SRV" record pointed to a
       different address.
     - Change domain names used for testing the DNS client into the
       kong-gateway-testing.link zone, which is controlled by the Kong Gateway
       team.

    Fixes https://github.com/Kong/kong/issues/10182
    KAG-2300
```

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
