### PR TITLE
chore(cd): remove trigger of tags to avoid it overwriting release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ on:  # yamllint disable-line rule:truthy
   schedule:
   - cron:  '0 0 * * *'
   push:
-    tags:
-    - '**'
     branches:
     - master
   workflow_dispatch:


### PR DESCRIPTION
Fix #11776

If tag is created after the release workflow_dispatch is finished, it may overwrite existing ubuntu docker image.