### PR TITLE
refactor(tracing): add tracing context

### DIFF
--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -549,6 +549,7 @@ build = {
     ["kong.tracing.instrumentation"] = "kong/tracing/instrumentation.lua",
     ["kong.tracing.propagation"] = "kong/tracing/propagation.lua",
     ["kong.tracing.request_id"] = "kong/tracing/request_id.lua",
+    ["kong.tracing.tracing_context"] = "kong/tracing/tracing_context.lua",
 
     ["kong.timing"] = "kong/timing/init.lua",
     ["kong.timing.context"] = "kong/timing/context.lua",

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -3,6 +3,7 @@ local http = require "resty.http"
 local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
+local tracing_context = require "kong.tracing.tracing_context"
 
 
 local ngx = ngx
@@ -103,8 +104,7 @@ function OpenTelemetryHandler:access(conf)
     kong.ctx.plugin.should_sample = false
   end
 
-  local injected_parent_span = ngx.ctx.tracing and
-                               ngx.ctx.tracing.injected.balancer_span or root_span
+  local injected_parent_span = tracing_context.get_unlinked_span("balancer") or root_span
 
   local header_type, trace_id, span_id, parent_id, should_sample, _ = propagation_parse(headers, conf.header_type)
   if should_sample == false then
@@ -118,7 +118,8 @@ function OpenTelemetryHandler:access(conf)
     -- to propagate the correct trace ID we have to set it here
     -- before passing this span to propagation.set()
     injected_parent_span.trace_id = trace_id
-    kong.ctx.plugin.trace_id = trace_id
+    -- update the Tracing Context with the trace ID extracted from headers
+    tracing_context.set_raw_trace_id(trace_id)
   end
 
   -- overwrite root span's parent_id
@@ -135,7 +136,7 @@ end
 
 function OpenTelemetryHandler:header_filter(conf)
   if conf.http_response_header_for_traceid then
-    local trace_id = kong.ctx.plugin.trace_id
+    local trace_id = tracing_context.get_raw_trace_id()
     if not trace_id then
       local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
       trace_id = root_span and root_span.trace_id
@@ -156,7 +157,7 @@ function OpenTelemetryHandler:log(conf)
     end
 
     -- overwrite
-    local trace_id = kong.ctx.plugin.trace_id
+    local trace_id = tracing_context.get_raw_trace_id()
     if trace_id then
       span.trace_id = trace_id
     end

--- a/kong/tracing/tracing_context.lua
+++ b/kong/tracing/tracing_context.lua
@@ -1,0 +1,111 @@
+local table_new = require "table.new"
+
+local ngx = ngx
+
+
+local function init_tracing_context(ctx)
+  ctx.TRACING_CONTEXT = {
+    -- trace ID information which includes its raw value (binary) and all the
+    -- available formats set during headers propagation
+    trace_id = {
+      raw = nil,
+      formatted = table_new(0, 6),
+    },
+    -- Unlinked spans are spans that were created (to generate their ID)
+    -- but not added to `KONG_SPANS` (because their execution details were not
+    -- yet available).
+    unlinked_spans = table_new(0, 1)
+  }
+
+  return ctx.TRACING_CONTEXT
+end
+
+
+local function get_tracing_context(ctx)
+  ctx = ctx or ngx.ctx
+
+  if not ctx.TRACING_CONTEXT then
+    return init_tracing_context(ctx)
+  end
+
+  return ctx.TRACING_CONTEXT
+end
+
+
+-- Performs a table merge to add trace ID formats to the current request's
+-- trace ID and returns a table containing all the formats.
+--
+-- Plugins can handle different formats of trace ids depending on their headers
+-- configuration, multiple plugins executions may result in additional formats
+-- of the current request's trace id.
+--
+-- Each item in the resulting table represents a format associated with the
+-- trace ID for the current request.
+--
+-- @param trace_id_new_fmt table containing the trace ID formats to be added
+-- @param ctx table the current ctx, if available
+-- @returns propagation_trace_id_all_fmt table contains all the formats for
+-- the current request
+--
+-- @example
+--
+--    propagation_trace_id_all_fmt = { datadog = "1234",
+--                                     w3c     = "abcd" }
+--
+--    trace_id_new_fmt             = { ot = "abcd",
+--                                     w3c = "abcd" }
+--
+--    propagation_trace_id_all_fmt = { datadog = "1234",
+--                                     ot = "abcd",
+--                                     w3c = "abcd" }
+--
+local function add_trace_id_formats(trace_id_new_fmt, ctx)
+  local tracing_context = get_tracing_context(ctx)
+  local trace_id_all_fmt = tracing_context.trace_id.formatted
+
+  if next(trace_id_all_fmt) == nil then
+    tracing_context.trace_id.formatted = trace_id_new_fmt
+    return trace_id_new_fmt
+  end
+
+  -- add new formats to existing trace ID formats table
+  for format, value in pairs(trace_id_new_fmt) do
+    trace_id_all_fmt[format] = value
+  end
+
+  return trace_id_all_fmt
+end
+
+
+local function get_raw_trace_id(ctx)
+  local tracing_context = get_tracing_context(ctx)
+  return tracing_context.trace_id.raw
+end
+
+
+local function set_raw_trace_id(trace_id, ctx)
+  local tracing_context = get_tracing_context(ctx)
+  tracing_context.trace_id.raw = trace_id
+end
+
+
+local function get_unlinked_span(name, ctx)
+  local tracing_context = get_tracing_context(ctx)
+  return tracing_context.unlinked_spans[name]
+end
+
+
+local function set_unlinked_span(name, span, ctx)
+  local tracing_context = get_tracing_context(ctx)
+  tracing_context.unlinked_spans[name] = span
+end
+
+
+
+return {
+  add_trace_id_formats = add_trace_id_formats,
+  get_raw_trace_id = get_raw_trace_id,
+  set_raw_trace_id = set_raw_trace_id,
+  get_unlinked_span = get_unlinked_span,
+  set_unlinked_span = set_unlinked_span,
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/trace-propagator/handler.lua
@@ -1,4 +1,5 @@
 local propagation = require "kong.tracing.propagation"
+local tracing_context = require "kong.tracing.tracing_context"
 
 local ngx = ngx
 local kong = kong
@@ -18,8 +19,7 @@ function _M:access(conf)
   if not root_span then
     root_span = tracer.start_span("root")
   end
-  local injected_parent_span = ngx.ctx.tracing and
-                               ngx.ctx.tracing.injected.balancer_span or root_span
+  local injected_parent_span = tracing_context.get_unlinked_span("balancer") or root_span
 
   local header_type, trace_id, span_id, parent_id, should_sample = propagation_parse(headers)
 


### PR DESCRIPTION
### Summary

Add a Tracing Context module for managing request-scoped tracing-related information. This provides an interface with `ngx.ctx.TRACING_CONTEXT` for plugins and core to read/update tracing information through.

This commit adds support to read/write:
* Trace ID (raw and all formats)
* Unlinked spans

Follow up will probably include:
* Extracted/Injecjted tracing headers information

### Checklist

- [x] The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-3125](https://konghq.atlassian.net/browse/KAG-3125)


[KAG-3125]: https://konghq.atlassian.net/browse/KAG-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ