### PR TITLE
chore(deps): bump kong-lapis from 1.14.0.3 to 1.16.0.1

### DIFF
--- a/changelog/unreleased/kong/bump-lapis-1.16.0.1.yml
+++ b/changelog/unreleased/kong/bump-lapis-1.16.0.1.yml
@@ -1,0 +1,3 @@
+message: "Bumped kong-lapis from 1.14.0.3 to 1.16.0.1"
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "lua-ffi-zlib == 0.6",
   "multipart == 0.5.9",
   "version == 1.0.1",
-  "kong-lapis == 1.14.0.3",
+  "kong-lapis == 1.16.0.1",
   "kong-pgmoon == 1.16.2",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",


### PR DESCRIPTION
### Summary

#### v1.16.0 – November 2 2023

##### Additions

- lapis.validate.types — Add types.params_map validation type, the params compatible variant of types.map_of

##### Changes

- model:update will now only assign the update object to the model instnance if the update completes successfully
- model:update support the returns option to control the RETURNING clause of the generated query
- model:update when timestamps are enabled, the generated updated_at value is assigned to the model instance

##### Fixes

- lapis.validate.types — Fix bug where types.params_shape would not return the state object
- model:update will avoid storing db.raw values on passed as update object to the model instance if the update does not complmete successfully

#### v1.15.0 – October 6 2023

##### Additions

- Model:include_in can now use computed keys to dynamically calculate a foreign key value by applying a function to each passed in object to load. This can be done by specifying a function instead of a field name when defining the column mapping table
- Relations can use compured keys where appropriate by passing a function instead of a field name when defining the column mapping table
- lapis.validate.types — add types.params_array for validating an array of objects with a common shape
- lapis.validate.types — add types.flatten_errors for error output compatibility with tableshape
- lapis.validate.types — types.params_shape can now accept numerical names for fields for validating array like objects with a fixed number of entries
- lapis generate — Rockspec generator can now specify --moonscript and --cqueues to automatically append dependencies
- lapis migrate — Add the --dry-run flag to to run all pending migrations in a transaction that is never commited. (Note: in some databases, there are queries that can not be rolled back)

##### Misc

- Various updates to documentation
- Fix error message for types.truncated_text

### Checklist

~- [ ] The Pull Request has tests~
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~