### PR TITLE
refactor(plugins/oauth2): use build-in functions to replace sha256

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -16,6 +16,7 @@ local error = error
 local split = utils.split
 local strip = utils.strip
 local string_find = string.find
+local string_gsub = string.gsub
 local string_byte = string.byte
 local check_https = utils.check_https
 local encode_args = utils.encode_args

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -5,9 +5,7 @@ local timestamp = require "kong.tools.timestamp"
 local secret = require "kong.plugins.oauth2.secret"
 
 
-local base64url_sha256 = require "kong.tools.sha256".sha256_base64url
-local base64url_encode = require "ngx.base64".encode_base64url
-local base64url_decode = require "ngx.base64".decode_base64url
+local sha256_base64url = require "kong.tools.sha256".sha256_base64url
 
 
 local kong = kong
@@ -28,6 +26,7 @@ local table_contains = utils.table_contains
 local ngx_decode_args = ngx.decode_args
 local ngx_re_gmatch = ngx.re.gmatch
 local ngx_decode_base64 = ngx.decode_base64
+local ngx_encode_base64 = ngx.encode_base64
 
 
 local _M = {}
@@ -57,6 +56,38 @@ local GRANT_REFRESH_TOKEN = "refresh_token"
 local GRANT_PASSWORD = "password"
 local ERROR = "error"
 local AUTHENTICATED_USERID = "authenticated_userid"
+
+
+local base64url_encode
+local base64url_decode
+do
+  local BASE64URL_ENCODE_CHARS = "[+/]"
+  local BASE64URL_ENCODE_SUBST = {
+    ["+"] = "-",
+    ["/"] = "_",
+  }
+
+  base64url_encode = function(value)
+    value = ngx_encode_base64(value, true)
+    if not value then
+      return nil
+    end
+
+    return string_gsub(value, BASE64URL_ENCODE_CHARS, BASE64URL_ENCODE_SUBST)
+  end
+
+
+  local BASE64URL_DECODE_CHARS = "[-_]"
+  local BASE64URL_DECODE_SUBST = {
+    ["-"] = "+",
+    ["_"] = "/",
+  }
+
+  base64url_decode = function(value)
+    value = string_gsub(value, BASE64URL_DECODE_CHARS, BASE64URL_DECODE_SUBST)
+    return ngx_decode_base64(value)
+  end
+end
 
 
 local function generate_token(conf, service, credential, authenticated_userid,
@@ -455,7 +486,7 @@ local function validate_pkce_verifier(parameters, auth_code)
     }
   end
 
-  local challenge = base64url_sha256(verifier)
+  local challenge = sha256_base64url(verifier)
 
   if not challenge
   or not auth_code.challenge


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Use build-in functions of`tools.sha256`  to simplify code.
KAG-3156

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
