### PR TITLE
fix(core): respect custom proxy_access_log

### DIFF
--- a/changelog/unreleased/kong/respect-custom-proxy_access_log.yml
+++ b/changelog/unreleased/kong/respect-custom-proxy_access_log.yml
@@ -1,0 +1,3 @@
+message: "respect custom `proxy_access_log`"
+type: bugfix
+scope: Configuration

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -257,8 +257,9 @@ local function compile_conf(kong_config, conf_template, template_env_inject)
     if custom_format then
       compile_env.proxy_access_log_custom = true
 
-      if not string.match(kong_config.nginx_http_log_format or "", "^" .. custom_format) then
-        log.debug(table.concat({"a custom access_log format is set: '", custom_format, "', but not defined"}))
+      local format_pattern = string.gsub(custom_format, "%-", "%%-")
+      if not string.match(kong_config.nginx_http_log_format or "", "^" .. format_pattern) then
+        log.debug(table.concat({"a custom access_log format is configured: '", custom_format, "', but not defined"}))
       end
     end
   end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -256,14 +256,7 @@ local function compile_conf(kong_config, conf_template, template_env_inject)
     -- example: 'logs/some-file.log apigw_json'
     local _, custom_format_name = string.match(kong_proxy_access_log, "^(%S+)%s(%S+)")
     if custom_format_name then
-      -- example: 'apigw_json ...'
-      local nginx_http_log_format_name = string.match(kong_config.nginx_http_log_format or "", "^%S+")
-      if custom_format_name == nginx_http_log_format_name then
-        compile_env.proxy_access_log_custom = true
-
-      else
-        return nil, table.concat({"configured access_log format: ", custom_format_name, ", but got: ", tostring(nginx_http_log_format_name)})
-      end
+      compile_env.proxy_access_log_custom = true
     end
   end
 

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -239,7 +239,6 @@ local function compile_conf(kong_config, conf_template, template_env_inject)
   -- computed config properties for templating
   local compile_env = {
     _escape = ">",
-    proxy_access_log_custom = false,
     pairs = pairs,
     ipairs = ipairs,
     tostring = tostring,
@@ -253,10 +252,10 @@ local function compile_conf(kong_config, conf_template, template_env_inject)
     compile_env.proxy_access_log_enabled = true
   end
   if kong_proxy_access_log then
-    -- example: 'logs/some-file.log apigw_json'
+    -- example: proxy_access_log = 'logs/some-file.log apigw_json'
     local _, custom_format_name = string.match(kong_proxy_access_log, "^(%S+)%s(%S+)")
     if custom_format_name then
-      compile_env.proxy_access_log_custom = true
+      compile_env.custom_proxy_access_log = true
     end
   end
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -89,7 +89,11 @@ server {
     lua_kong_error_log_request_id $kong_request_id;
 
 > if proxy_access_log_enabled then
+>   if proxy_access_log_custom then
+    access_log ${{PROXY_ACCESS_LOG}};
+>   else
     access_log ${{PROXY_ACCESS_LOG}} kong_log_format;
+>   end
 > else
     access_log off;
 > end

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -89,7 +89,7 @@ server {
     lua_kong_error_log_request_id $kong_request_id;
 
 > if proxy_access_log_enabled then
->   if proxy_access_log_custom then
+>   if custom_proxy_access_log then
     access_log ${{PROXY_ACCESS_LOG}};
 >   else
     access_log ${{PROXY_ACCESS_LOG}} kong_log_format;

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -507,22 +507,22 @@ describe("NGINX conf compiler", function()
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
-          proxy_access_log = "/dev/stdout apigw_json",
+          proxy_access_log = "/dev/stdout apigw-json",
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/dev/stdout%sapigw_json;", nginx_conf)
+        assert.matches("access_log%s/dev/stdout%sapigw%-json;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
-          proxy_access_log = "/tmp/not_exist.log",
+          proxy_access_log = "/tmp/not-exist.log",
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/tmp/not_exist.log%skong_log_format;", nginx_conf)
+        assert.matches("access_log%s/tmp/not%-exist.log%skong_log_format;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -518,19 +518,19 @@ describe("NGINX conf compiler", function()
         nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
+        -- configure an undefined log format will error
+        -- on kong start. This is expected
         conf = assert(conf_loader(nil, {
-          proxy_access_log = "/dev/stdout apigw-json",
-          nginx_http_log_format = 'not-exist "$kong_request_id"',
+          proxy_access_log = "/dev/stdout not-exist",
+          nginx_http_log_format = 'apigw-json "$kong_request_id"',
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",
         }))
         nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/dev/stdout%sapigw%-json;", nginx_conf)
+        assert.matches("access_log%s/dev/stdout%snot%-exist;", nginx_conf)
         nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
-        -- configure an undefined log format will error
-        -- on kong start. This is expected
         conf = assert(conf_loader(nil, {
           proxy_access_log = "/tmp/not-exist.log",
           stream_listen = "0.0.0.0:9100",

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -485,7 +485,7 @@ describe("NGINX conf compiler", function()
     end)
 
     describe("injected NGINX directives", function()
-      it("#test injects proxy_access_log directive", function()
+      it("injects proxy_access_log directive", function()
         local conf, nginx_conf
         conf = assert(conf_loader(nil, {
           proxy_access_log = "/dev/stdout",
@@ -529,6 +529,8 @@ describe("NGINX conf compiler", function()
         nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
+        -- configure an undefined log format will error
+        -- on kong start. This is expected
         conf = assert(conf_loader(nil, {
           proxy_access_log = "/tmp/not-exist.log",
           stream_listen = "0.0.0.0:9100",

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -485,8 +485,8 @@ describe("NGINX conf compiler", function()
     end)
 
     describe("injected NGINX directives", function()
-      it("injects proxy_access_log directive", function()
-        local conf, nginx_conf, err
+      it("#test injects proxy_access_log directive", function()
+        local conf, nginx_conf
         conf = assert(conf_loader(nil, {
           proxy_access_log = "/dev/stdout",
           stream_listen = "0.0.0.0:9100",
@@ -524,12 +524,10 @@ describe("NGINX conf compiler", function()
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",
         }))
-        nginx_conf, err = prefix_handler.compile_kong_conf(conf)
-        assert.is_nil(nginx_conf)
-        assert.are_equal(err, "configured access_log format: apigw-json, but got: not-exist")
-        nginx_conf, err = prefix_handler.compile_kong_stream_conf(conf)
-        assert.is_nil(nginx_conf)
-        assert.are_equal(err, "configured access_log format: apigw-json, but got: not-exist")
+        nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/dev/stdout%sapigw%-json;", nginx_conf)
+        nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         conf = assert(conf_loader(nil, {
           proxy_access_log = "/tmp/not-exist.log",

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -507,10 +507,33 @@ describe("NGINX conf compiler", function()
         assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
+          proxy_access_log = "/dev/stdout apigw_json",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/dev/stdout%sapigw_json;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
+          proxy_access_log = "/tmp/not_exist.log",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/tmp/not_exist.log%skong_log_format;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
+          prefix = "servroot_tmp",
+          nginx_stream_log_format = "custom '$protocol $status'",
           proxy_stream_access_log = "/dev/stdout custom",
           stream_listen = "0.0.0.0:9100",
           nginx_stream_tcp_nodelay = "on",
         }))
+        assert(prefix_handler.prepare_prefix(conf))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
         assert.matches("access_log%slogs/access.log%skong_log_format;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Kong now has a fixed access log format `kong_log_format` that prevents customization. Introduced by #11663.

Resolves #12061.

If the `proxy_access_log` has a log format specified, then replace `kong_log_format` with the custom value.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* replace `kong_log_format` with custom value set by end users.
* update tests to be more robust.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5580]_


[FTI-5580]: https://konghq.atlassian.net/browse/FTI-5580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ