### PR TITLE
perf(plugins/jwt): use string.buffer to replace table.concat

### DIFF
--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -7,6 +7,7 @@
 
 local json = require "cjson"
 local b64 = require "ngx.base64"
+local buffer = require "string.buffer"
 local openssl_digest = require "resty.openssl.digest"
 local openssl_hmac = require "resty.openssl.hmac"
 local openssl_pkey = require "resty.openssl.pkey"
@@ -20,7 +21,6 @@ local time = ngx.time
 local pairs = pairs
 local error = error
 local pcall = pcall
-local concat = table.concat
 local insert = table.insert
 local unpack = unpack
 local assert = assert
@@ -242,12 +242,17 @@ local function encode_token(data, key, alg, header)
     base64_encode(json.encode(data))
   }
 
-  local signing_input = concat(segments, ".")
-  local signature = alg_sign[alg](signing_input, key)
+  local buf = buffer.new()
 
-  segments[#segments+1] = base64_encode(signature)
+  buf:put(base64_encode(json.encode(header))):put(".")
+     :put(base64_encode(json.encode(data)))
 
-  return concat(segments, ".")
+  local signature = alg_sign[alg](buf:tostring(), key)
+
+  buf:put(".")
+     :put(base64_encode(signature))
+
+  return buf:get()
 end
 
 

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -237,11 +237,6 @@ local function encode_token(data, key, alg, header)
   end
 
   local header = header or { typ = "JWT", alg = alg }
-  local segments = {
-    base64_encode(json.encode(header)),
-    base64_encode(json.encode(data))
-  }
-
   local buf = buffer.new()
 
   buf:put(base64_encode(json.encode(header))):put(".")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

As other PRs did, string.buffer can replace table.concat to get more performance.

Reference: https://github.com/Kong/kong/pull/11304#issuecomment-1671212708

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
