### PR TITLE
fix(tracing): don't print error when passing nil to span:set_attribute

### DIFF
--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -296,11 +296,12 @@ end
 --
 -- @function span:set_attribute
 -- @tparam string key
--- @tparam string|number|boolean value
+-- @tparam string|number|boolean|nil value
 -- @usage
 -- span:set_attribute("net.transport", "ip_tcp")
 -- span:set_attribute("net.peer.port", 443)
 -- span:set_attribute("exception.escaped", true)
+-- span:set_attribute("unset.this", nil)
 function span_mt:set_attribute(key, value)
   -- key is decided by the programmer, so if it is not a string, we should
   -- error out.
@@ -308,8 +309,14 @@ function span_mt:set_attribute(key, value)
     error("invalid key", 2)
   end
 
-  local vtyp = type(value)
-  if vtyp ~= "string" and vtyp ~= "number" and vtyp ~= "boolean" then
+  local vtyp
+  if value == nil then
+   vtyp = value
+  else
+   vtyp = type(value)
+  end
+
+  if vtyp ~= "string" and vtyp ~= "number" and vtyp ~= "boolean" and vtyp ~= nil then
     -- we should not error out here, as most of the caller does not catch
     -- errors, and they are hooking to core facilities, which may cause
     -- unexpected behavior.

--- a/spec/01-unit/26-tracing/01-tracer_pdk_spec.lua
+++ b/spec/01-unit/26-tracing/01-tracer_pdk_spec.lua
@@ -189,11 +189,20 @@ describe("Tracer PDK", function()
       assert.has_no.error(function () span:finish() end)
     end)
 
-    it("fails set_attribute", function ()
+    it("set_attribute validation", function ()
       local span = c_tracer.start_span("meow")
 
+      -- nil value is allowed as a noop
       span:set_attribute("key1")
-      assert.spy(log_spy).was_called_with(ngx.ERR, match.is_string())
+      assert.spy(log_spy).was_not_called_with(ngx.ERR, match.is_string())
+      assert.is_nil(span.attributes["key1"])
+
+      span:set_attribute("key1", "value1")
+      assert.equal("value1", span.attributes["key1"])
+
+      -- nil value unsets the attribute
+      span:set_attribute("key1")
+      assert.is_nil(span.attributes["key1"])
 
       span:set_attribute("key1", function() end)
       assert.spy(log_spy).was_called_with(ngx.ERR, match.is_string())


### PR DESCRIPTION
### Summary

An error log was printed whenever a nil attribute was set for a span. This implies every variable has to be nil-checked before it can be assigned to some span attribute. In general it feels more natural to expect that passing `nil` is accepted without producing any error log or warning.

* passing a nil value to `span:set_attribute` is a NOOP if the attribute does not already exist, else it means unsetting that attribute (just like before). Now both of these are applied silently, without printing an error.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
