### PR TITLE
perf(tracing): avoid unnecessary creations and garbage-collections of spans (from timers)

### DIFF
--- a/changelog/unreleased/kong/perf-tracing-from-timers.yml
+++ b/changelog/unreleased/kong/perf-tracing-from-timers.yml
@@ -1,0 +1,3 @@
+message: "Performance optimization to avoid unnecessary creations and garbage-collections of spans"
+type: "performance"
+scope: "PDK"

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -9,7 +9,6 @@ local require = require
 local ffi = require "ffi"
 local tablepool = require "tablepool"
 local new_tab = require "table.new"
-local base = require "resty.core.base"
 local utils = require "kong.tools.utils"
 local phase_checker = require "kong.pdk.private.phases"
 
@@ -421,6 +420,15 @@ noop_tracer.set_active_span = NOOP
 noop_tracer.process_span = NOOP
 noop_tracer.set_should_sample = NOOP
 
+local VALID_TRACING_PHASES = {
+  rewrite = true,
+  access = true,
+  header_filter = true,
+  body_filter = true,
+  log = true,
+  content = true,
+}
+
 --- New Tracer
 local function new_tracer(name, options)
   name = name or "default"
@@ -450,7 +458,7 @@ local function new_tracer(name, options)
   -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
   -- @treturn table span
   function self.active_span()
-    if not base.get_request() then
+    if not VALID_TRACING_PHASES[ngx.get_phase()] then
       return
     end
 
@@ -463,7 +471,7 @@ local function new_tracer(name, options)
   -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
   -- @tparam table span
   function self.set_active_span(span)
-    if not base.get_request() then
+    if not VALID_TRACING_PHASES[ngx.get_phase()] then
       return
     end
 
@@ -482,7 +490,7 @@ local function new_tracer(name, options)
   -- @tparam table options TODO(mayo)
   -- @treturn table span
   function self.start_span(...)
-    if not base.get_request() then
+    if not VALID_TRACING_PHASES[ngx.get_phase()] then
       return noop_span
     end
 

--- a/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
@@ -44,16 +44,22 @@ local pb_decode_span = function(data)
 end
 
 describe("Plugin: opentelemetry (otlp)", function()
+  local old_ngx_get_phase
+
   lazy_setup(function ()
     -- overwrite for testing
     pb.option("enum_as_value")
     pb.option("auto_default_values")
+    old_ngx_get_phase = ngx.get_phase
+    -- trick the pdk into thinking we are not in the timer context
+    _G.ngx.get_phase = function() return "access" end  -- luacheck: ignore
   end)
 
   lazy_teardown(function()
     -- revert it back
     pb.option("enum_as_name")
     pb.option("no_default_values")
+    _G.ngx.get_phase = old_ngx_get_phase  -- luacheck: ignore
   end)
 
   after_each(function ()


### PR DESCRIPTION
### Summary

Before this change timers would generate spans, which means [DB](https://github.com/Kong/kong/blob/0485a76276da23064c593326178c6b04fb6ee117/kong/tracing/instrumentation.lua#L39) and [DNS](https://github.com/Kong/kong/blob/0485a76276da23064c593326178c6b04fb6ee117/kong/tracing/instrumentation.lua#L281) spans in recurring timers would be continuously generated and garbage-collected.

This commit checks the exact ngx phase and runs it against a whitelist of allowed phases to ensure the `timer` phase does not generate spans.

### Checklist

- [ ] The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

[KAG-3169](https://konghq.atlassian.net/browse/KAG-3169)


[KAG-3169]: https://konghq.atlassian.net/browse/KAG-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ