### PR TITLE
chore(deps): bump lua-resty-openssl to 1.0.2

### DIFF
--- a/changelog/unreleased/kong/bump-resty-openssl-1.0.1.yml
+++ b/changelog/unreleased/kong/bump-resty-openssl-1.0.1.yml
@@ -1,3 +1,0 @@
-message: Bump resty-openssl from 0.8.25 to 1.0.1
-type: dependency
-scope: Core

--- a/changelog/unreleased/kong/bump-resty-openssl-1.0.2.yml
+++ b/changelog/unreleased/kong/bump-resty-openssl-1.0.2.yml
@@ -1,0 +1,3 @@
+message: Bump resty-openssl from 0.8.25 to 1.0.2
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.0.0",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.3.5",
-  "lua-resty-openssl == 1.0.1",
+  "lua-resty-openssl == 1.0.2",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.12.0",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

changelog:

[1.0.2](https://github.com/fffonion/lua-resty-openssl/compare/1.0.1...1.0.2) - 2023-11-21
bug fixes
jwk: fix EC key dump parameters (https://github.com/fffonion/lua-resty-openssl/issues/131) [c659347](https://github.com/fffonion/lua-resty-openssl/commit/c659347b356acfcb808ce659ae3094ba7fb2b9f1)

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* chore(deps): bump lua-resty-openssl to 1.0.2

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
