### PR TITLE
Revert new backport bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,27 +1,24 @@
 name: Backport
 on:
   pull_request_target:
-    types: [closed]
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
+    types:
+      - closed
+      - labeled
+
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
-      - uses: actions/checkout@v4
-      - name: Create backport pull requests
-        uses: korthout/backport-action@cb79e4e5f46c7d7d653dd3d5fa8a9b0a945dfe4b # v2.1.0
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           github_token: ${{ secrets.PAT }}
-          pull_title: '[backport -> ${target_branch}] ${pull_title}'
-          merge_commits: 'skip'
-          copy_labels_pattern: ^(?!backport ).* # copies all labels except those starting with "backport "
-          label_pattern: ^backport (release\/[^ ]+)$ # filters for labels starting with "backport " and extracts the branch name
-          pull_description: |-
-            Automated backport to `${target_branch}`, triggered by a label in #${pull_number}.
-          copy_assignees: true
-          copy_milestone: true
-          copy_requested_reviewers: true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport
 on:
   pull_request_target:
-    types: [closed, labeled] # runs when the pull request is closed/merged or labeled (to trigger a backport in hindsight)
+    types: [closed]
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
-        uses: korthout/backport-action@08bafb375e6e9a9a2b53a744b987e5d81a133191 # v2.1.1
+        uses: korthout/backport-action@cb79e4e5f46c7d7d653dd3d5fa8a9b0a945dfe4b # v2.1.0
         with:
           github_token: ${{ secrets.PAT }}
           pull_title: '[backport -> ${target_branch}] ${pull_title}'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,6 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
-  actions: write
 jobs:
   backport:
     name: Backport


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

REBASE MERGE if needed.

This PR reverts the backport bot related changes

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3198
