### PR TITLE
fix(cherry-picks): prevent comment flood in case of errors

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -19,7 +19,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
-        contains(github.event.comment.body, '/cherry-pick')
+        startsWith(github.event.comment.body, '/cherry-pick')
       )
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Summary

That is caused by an nice bootloop. The action is triggered by a comment in the PR that contains “/cherry-pick”. When the action fails it prints the branch to the screen(by adding a comment). The branch name by default contains a “/cherry-pick” substring, which starts the action again. 
Fixing by using `startsWith` instead of `contains`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-3197