### PR TITLE
fix(cherry-pick): respect squash-merges and rebase-merges

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -19,14 +19,14 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
-        contains(github.event.comment.body, '/cherry-pick')
+        startsWith(github.event.comment.body, '/cherry-pick')
       )
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
       - name: Create backport pull requests
-        uses: jschmid1/cross-repo-cherrypick-action@2366f50fd85e8966aa024a4dd6fbf70e7019d7e1
+        uses: jschmid1/cross-repo-cherrypick-action@5976eb414878ce8a412e0dfebf0068d1a41ee928
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
           pull_title: '[cherry-pick -> ${target_branch}] ${pull_title}'


### PR DESCRIPTION
### Summary

Detect if the merge method was either "Squash and Merge" or "Rebase and Merge" by looking at the `merge_commit_sha` field that gets populated when the PR is merged. When the `merge_commit_sha` and the parent of this commit have an association to the pullrequest we can assume that this was "rebased" as the squash method would only produce one commit (the squashed one).
When the PR was squashed, we can use the `merge_commit_sha` to create a cherry-pick.
When the PR was rebased, we can fall back to the existing method and use the commits associated with the PR before merging.

### Issue reference

Fix https://konghq.atlassian.net/browse/KAG-3198
