### PR TITLE
refactor(tools): remove reference of sha256 from utils

### DIFF
--- a/kong/db/schema/json.lua
+++ b/kong/db/schema/json.lua
@@ -7,12 +7,13 @@ local _M = {}
 local lrucache = require "resty.lrucache"
 local jsonschema = require "resty.ljsonschema"
 local metaschema = require "resty.ljsonschema.metaschema"
-local utils = require "kong.tools.utils"
 local cjson = require "cjson"
+
+local sha256_hex = require("kong.tools.sha256").sha256_hex
+local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 
 local type = type
 local cjson_encode = cjson.encode
-local sha256_hex = utils.sha256_hex
 
 
 ---@class kong.db.schema.json.schema_doc : table
@@ -156,7 +157,7 @@ end
 ---@param name   string
 ---@param schema kong.db.schema.json.schema_doc
 function _M.add_schema(name, schema)
-  schemas[name] = utils.cycle_aware_deep_copy(schema, true)
+  schemas[name] = cycle_aware_deep_copy(schema, true)
 end
 
 

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -1,7 +1,9 @@
 local constants = require "kong.constants"
-local sha256 = require "resty.sha256"
 local openssl_hmac = require "resty.openssl.hmac"
-local utils = require "kong.tools.utils"
+
+
+local sha256_base64 = require "kong.tools.sha256".sha256_base64
+local string_split = require "kong.tools.string".split
 
 
 local ngx = ngx
@@ -115,7 +117,7 @@ local function retrieve_hmac_fields(authorization_header)
     if m and #m >= 4 then
       hmac_params.username = m[1]
       hmac_params.algorithm = m[2]
-      hmac_params.hmac_headers = utils.split(m[3], " ")
+      hmac_params.hmac_headers = string_split(m[3], " ")
       hmac_params.signature = m[4]
     end
   end
@@ -231,9 +233,7 @@ local function validate_body()
     return body == ""
   end
 
-  local digest = sha256:new()
-  digest:update(body or '')
-  local digest_created = "SHA-256=" .. encode_base64(digest:final())
+  local digest_created = "SHA-256=" .. sha256_base64(body or '')
 
   return digest_created == digest_received
 end

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -2,8 +2,8 @@ local constants = require "kong.constants"
 local openssl_hmac = require "resty.openssl.hmac"
 
 
-local sha256_base64 = require "kong.tools.sha256".sha256_base64
-local string_split = require "kong.tools.string".split
+local sha256_base64 = require("kong.tools.sha256").sha256_base64
+local string_split = require("kong.tools.string").split
 
 
 local ngx = ngx

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -12,7 +12,6 @@ local error = error
 local time = ngx.time
 local abs = math.abs
 local decode_base64 = ngx.decode_base64
-local encode_base64 = ngx.encode_base64
 local parse_time = ngx.parse_http_time
 local re_gmatch = ngx.re.gmatch
 local hmac_sha1 = ngx.hmac_sha1

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -13,7 +13,7 @@ local upper = string.upper
 local sub = string.sub
 local fmt = string.format
 local tcp = ngx.socket.tcp
-local sha256_hex = require "kong.tools.sha256".sha256_hex
+local sha256_hex = require("kong.tools.sha256").sha256_hex
 
 
 local AUTHORIZATION = "authorization"

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -13,7 +13,7 @@ local upper = string.upper
 local sub = string.sub
 local fmt = string.format
 local tcp = ngx.socket.tcp
-local sha256_hex = require "kong.tools.utils".sha256_hex
+local sha256_hex = require "kong.tools.sha256".sha256_hex
 
 
 local AUTHORIZATION = "authorization"

--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -6,7 +6,7 @@ local sort = table.sort
 local insert = table.insert
 local concat = table.concat
 
-local sha256_hex = require "kong.tools.utils".sha256_hex
+local sha256_hex = require "kong.tools.sha256".sha256_hex
 
 local _M = {}
 

--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -6,7 +6,7 @@ local sort = table.sort
 local insert = table.insert
 local concat = table.concat
 
-local sha256_hex = require "kong.tools.sha256".sha256_hex
+local sha256_hex = require("kong.tools.sha256").sha256_hex
 
 local _M = {}
 

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -106,7 +106,7 @@ local hash_chain
 do
   local buffer = require "string.buffer"
 
-  local sha256 = utils.sha256_bin
+  local sha256 = require "kong.tools.sha256".sha256_bin
 
   local HASH_DISABLED = sha256("disabled")
   local HASH_NONE     = sha256("none")

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -106,7 +106,7 @@ local hash_chain
 do
   local buffer = require "string.buffer"
 
-  local sha256 = require "kong.tools.sha256".sha256_bin
+  local sha256 = require("kong.tools.sha256").sha256_bin
 
   local HASH_DISABLED = sha256("disabled")
   local HASH_NONE     = sha256("none")

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -19,7 +19,6 @@ local _M = {}
 do
   local modules = {
     "kong.tools.table",
-    "kong.tools.sha256",
     "kong.tools.yield",
     "kong.tools.string",
     "kong.tools.uuid",

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 
 local lower = string.lower
 local fmt = string.format
-local sha256_hex = require "kong.tools.utils".sha256_hex
+local sha256_hex = require "kong.tools.sha256".sha256_hex
 
 
 local function cache_key(conf, username, password)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 
 local lower = string.lower
 local fmt = string.format
-local sha256_hex = require "kong.tools.sha256".sha256_hex
+local sha256_hex = require("kong.tools.sha256").sha256_hex
 
 
 local function cache_key(conf, username, password)

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local fmt = string.format
 local lower = string.lower
-local sha256_hex = require "kong.tools.utils".sha256_hex
+local sha256_hex = require "kong.tools.sha256".sha256_hex
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local fmt = string.format
 local lower = string.lower
-local sha256_hex = require "kong.tools.sha256".sha256_hex
+local sha256_hex = require("kong.tools.sha256").sha256_hex
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Now we have separated sha256 module ,  It's time to remove the reference of `utils.lua`.
KAG-3226

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
