### PR TITLE
feat(admin-api): add gateway edition info to the endpoint `/`

### DIFF
--- a/changelog/unreleased/kong/add-gateway-edition-to-root-endpoint-admin-api.yml
+++ b/changelog/unreleased/kong/add-gateway-edition-to-root-endpoint-admin-api.yml
@@ -1,0 +1,3 @@
+message: add gateway edition to the root endpoint of the admin api
+type: feature
+scope: Admin API

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -130,6 +130,7 @@ return {
       return kong.response.exit(200, {
         tagline = tagline,
         version = version,
+        edition = meta._VERSION:match("enterprise") and "enterprise" or "community",
         hostname = knode.get_hostname(),
         node_id = node_id,
         timers = {

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -71,7 +71,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.not_nil(res.headers["X-Kong-Admin-Latency"])
     end)
 
-    it("returns Kong's version number and tagline", function()
+    it("returns Kong's version number, edition info and tagline", function()
       local res = assert(client:send {
         method = "GET",
         path = "/"
@@ -79,6 +79,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local body = assert.res_status(200, res)
       local json = cjson.decode(body)
       assert.equal(meta._VERSION, json.version)
+      assert.equal(meta._VERSION:match("enterprise") and "enterprise" or "community", json.edition)
       assert.equal("Welcome to kong", json.tagline)
     end)
     it("returns a UUID as the node_id", function()


### PR DESCRIPTION
this commit is the follow-up change to the PR https://github.com/Kong/kong/pull/12045, since the the edition info is still useful to the kong manager, we choose to introduce the gateway edition information in the response of the `/` endpoint.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-5557
