### PR TITLE
refactor(dns): use mlcache to implement instance-level caching

### DIFF
--- a/changelog/unreleased/kong/refactor-dns-implement-instance-level-caching.yml
+++ b/changelog/unreleased/kong/refactor-dns-implement-instance-level-caching.yml
@@ -1,0 +1,3 @@
+message: use  mlcache to implement instance-level caching in the dns client library
+type: feature
+scope: Core

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -91,6 +91,12 @@ return function(options)
       _timerng = require("resty.timerng").new({
         min_threads = 16,
         max_threads = 32,
+        -- It avoids adding physical timers in test cases with the wheel over
+        -- 10,000 years.
+        wheel_setting = {
+          level = 7,
+          slots_for_each_level = { 10, 60, 60, 24, 365, 100, 100 },
+        },
       })
 
       _timerng:start()

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -21,6 +21,8 @@ lua_shared_dict kong_core_db_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_core_db_cache_miss     12m;
 lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
+lua_shared_dict kong_dns_cache              12m;
+lua_shared_dict kong_dns_cache_ipc          12m;
 lua_shared_dict kong_secrets                5m;
 
 underscores_in_headers on;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -22,6 +22,8 @@ lua_shared_dict stream_kong_core_db_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict stream_kong_core_db_cache_miss     12m;
 lua_shared_dict stream_kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict stream_kong_db_cache_miss          12m;
+lua_shared_dict stream_kong_dns_cache              12m;
+lua_shared_dict stream_kong_dns_cache_ipc          12m;
 lua_shared_dict stream_kong_secrets                5m;
 
 > if ssl_ciphers then

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -843,6 +843,10 @@ describe("[consistent_hashing]", function()
       -- expire the existing record
       record.expire = 0
       record.expired = true
+      -- targets.resolve_targets() queries DNS record with nil("none") qtype
+      assert(client:getcache():delete("none:short:"..record[1].name))
+      assert(client:getcache():delete(record[1].type..":"..record[1].name))
+
       -- do a lookup to trigger the async lookup
       client.resolve("really.really.really.does.not.exist.host.test", {qtype = client.TYPE_A})
       sleep(1) -- provide time for async lookup to complete

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -1039,6 +1039,10 @@ describe("[round robin balancer]", function()
       -- expire the existing record
       record.expire = 0
       record.expired = true
+      -- targets.resolve_targets() queries DNS record with nil(none) qtype
+      assert(client:getcache():delete("none:short:"..record[1].name))
+      assert(client:getcache():delete(record[1].type..":"..record[1].name))
+
       -- do a lookup to trigger the async lookup
       client.resolve("really.really.really.does.not.exist.hostname.test", {qtype = client.TYPE_A})
       sleep(0.5) -- provide time for async lookup to complete
@@ -1282,6 +1286,9 @@ describe("[round robin balancer]", function()
       local test_name = "really.really.really.does.not.exist.hostname.test"
       local ttl = 0.1
       local staleTtl = 0   -- stale ttl = 0, force lookup upon expiring
+      assert(client.init {
+        staleTtl = staleTtl,
+      })
       local record = dnsA({
         { name = test_name, address = "1.2.3.4", ttl = ttl },
       }, staleTtl)

--- a/spec/01-unit/21-dns-client/03-client_cache_spec.lua
+++ b/spec/01-unit/21-dns-client/03-client_cache_spec.lua
@@ -65,7 +65,7 @@ describe("[DNS client cache]", function()
 
   describe("shortnames", function()
 
-    local lrucache, mock_records, config
+    local dnscache, mock_records, config
     before_each(function()
       config = {
         nameservers = { "198.51.100.0" },
@@ -79,7 +79,7 @@ describe("[DNS client cache]", function()
         enable_ipv6 = false,
       }
       assert(client.init(config))
-      lrucache = client.getcache()
+      dnscache = client.getcache()
 
       query_func = function(self, original_query_func, qname, opts)
         return mock_records[qname..":"..opts.qtype] or { errcode = 3, errstr = "name error" }
@@ -98,7 +98,7 @@ describe("[DNS client cache]", function()
       }
 
       local result = client.resolve("myhost1")
-      assert.equal(result, lrucache:get("none:short:myhost1"))
+      assert.equal(result, dnscache:get("none:short:myhost1"))
     end)
 
     it("are stored in cache with type", function()
@@ -113,12 +113,12 @@ describe("[DNS client cache]", function()
       }
 
       local result = client.resolve("myhost2", { qtype = client.TYPE_A })
-      assert.equal(result, lrucache:get(client.TYPE_A..":short:myhost2"))
+      assert.equal(result, dnscache:get(client.TYPE_A..":short:myhost2"))
     end)
 
     it("are resolved from cache without type", function()
       mock_records = {}
-      lrucache:set("none:short:myhost3", {{
+      dnscache:set("none:short:myhost3", {ttl=30+4}, {{
           type = client.TYPE_A,
           address = "1.2.3.4",
           class = 1,
@@ -127,15 +127,15 @@ describe("[DNS client cache]", function()
         },
         ttl = 30,
         expire = gettime() + 30,
-      }, 30+4)
+      })
 
       local result = client.resolve("myhost3")
-      assert.equal(result, lrucache:get("none:short:myhost3"))
+      assert.equal(result, dnscache:get("none:short:myhost3"))
     end)
 
     it("are resolved from cache with type", function()
       mock_records = {}
-      lrucache:set(client.TYPE_A..":short:myhost4", {{
+      dnscache:set(client.TYPE_A..":short:myhost4", {ttl=30+4}, {{
           type = client.TYPE_A,
           address = "1.2.3.4",
           class = 1,
@@ -144,10 +144,10 @@ describe("[DNS client cache]", function()
         },
         ttl = 30,
         expire = gettime() + 30,
-      }, 30+4)
+      })
 
       local result = client.resolve("myhost4", { qtype = client.TYPE_A })
-      assert.equal(result, lrucache:get(client.TYPE_A..":short:myhost4"))
+      assert.equal(result, dnscache:get(client.TYPE_A..":short:myhost4"))
     end)
 
     it("of dereferenced CNAME are stored in cache", function()
@@ -174,7 +174,7 @@ describe("[DNS client cache]", function()
       -- the type un-specificc query was the CNAME, so that should be in the
       -- shorname cache
       assert.same(mock_records["myhost5.domain.com:"..client.TYPE_CNAME],
-                  lrucache:get("none:short:myhost5"))
+                  dnscache:get("none:short:myhost5"))
     end)
 
     it("ttl in cache is honored for short name entries", function()
@@ -236,7 +236,7 @@ describe("[DNS client cache]", function()
       local result, err = client.resolve("myhost7", { qtype = client.TYPE_A })
       assert.is_nil(result)
       assert.equal("dns server error: 4 server failure", err)
-      assert.is_nil(lrucache:get(client.TYPE_A..":short:myhost7"))
+      assert.is_nil(dnscache:get(client.TYPE_A..":short:myhost7"))
     end)
 
     it("name errors are not stored", function()
@@ -252,7 +252,7 @@ describe("[DNS client cache]", function()
       local result, err = client.resolve("myhost8", { qtype = client.TYPE_A })
       assert.is_nil(result)
       assert.equal("dns server error: 3 name error", err)
-      assert.is_nil(lrucache:get(client.TYPE_A..":short:myhost8"))
+      assert.is_nil(dnscache:get(client.TYPE_A..":short:myhost8"))
     end)
 
   end)
@@ -265,7 +265,7 @@ describe("[DNS client cache]", function()
 
   describe("fqdn", function()
 
-    local lrucache, mock_records, config
+    local dnscache, mock_records, config
     before_each(function()
       config = {
         nameservers = { "198.51.100.0" },
@@ -279,7 +279,7 @@ describe("[DNS client cache]", function()
         enable_ipv6 = false,
       }
       assert(client.init(config))
-      lrucache = client.getcache()
+      dnscache = client.getcache()
 
       query_func = function(self, original_query_func, qname, opts)
         return mock_records[qname..":"..opts.qtype] or { errcode = 3, errstr = "name error" }
@@ -302,7 +302,7 @@ describe("[DNS client cache]", function()
       -- check that the cache is properly populated
       assert.equal(rec1, result)
       assert.is_nil(err)
-      assert.equal(rec1, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec1, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
 
       sleep(0.15) -- make sure we surpass the ttl of 0.1 of the record, so it is now stale.
       -- new mock records, such that we return server failures installed of records
@@ -321,7 +321,7 @@ describe("[DNS client cache]", function()
       sleep(0.1)
       -- background resolve is now complete, check the cache, it should still have the
       -- stale record, and it should not have been replaced by the error
-      assert.equal(rec1, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec1, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
     end)
 
     it("name errors do replace stale records", function()
@@ -340,7 +340,7 @@ describe("[DNS client cache]", function()
       -- check that the cache is properly populated
       assert.equal(rec1, result)
       assert.is_nil(err)
-      assert.equal(rec1, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec1, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
 
       sleep(0.15) -- make sure we surpass the ttl of 0.1 of the record, so it is now stale.
       -- clear mock records, such that we return name errors instead of records
@@ -359,7 +359,7 @@ describe("[DNS client cache]", function()
       sleep(0.1)
       -- background resolve is now complete, check the cache, it should now have been
       -- replaced by the name error
-      assert.equal(rec2, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec2, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
     end)
 
     it("empty records do not replace stale records", function()
@@ -378,7 +378,7 @@ describe("[DNS client cache]", function()
       -- check that the cache is properly populated
       assert.equal(rec1, result)
       assert.is_nil(err)
-      assert.equal(rec1, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec1, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
 
       sleep(0.15) -- make sure we surpass the ttl of 0.1 of the record, so it is now stale.
       -- clear mock records, such that we return name errors instead of records
@@ -394,7 +394,7 @@ describe("[DNS client cache]", function()
       sleep(0.1)
       -- background resolve is now complete, check the cache, it should still have the
       -- stale record, and it should not have been replaced by the empty record
-      assert.equal(rec1, lrucache:get(client.TYPE_A..":myhost9.domain.com"))
+      assert.equal(rec1, dnscache:get(client.TYPE_A..":myhost9.domain.com"))
     end)
 
     it("AS records do replace stale records", function()
@@ -432,7 +432,7 @@ describe("[DNS client cache]", function()
       ngx.sleep(0.2)  -- wait for it to become stale
       assert(client.toip("myhost9"))
 
-      local cached = lrucache:get(client.TYPE_CNAME..":myhost9.domain.com")
+      local cached = dnscache:get(client.TYPE_CNAME..":myhost9.domain.com")
       assert.are.equal(CNAME1, cached[1])
     end)
 
@@ -445,7 +445,7 @@ describe("[DNS client cache]", function()
 
   describe("success types", function()
 
-    local lrucache, mock_records, config  -- luacheck: ignore
+    local dnscache, mock_records, config  -- luacheck: ignore
     before_each(function()
       config = {
         nameservers = { "198.51.100.0" },
@@ -459,7 +459,7 @@ describe("[DNS client cache]", function()
         enable_ipv6 = false,
       }
       assert(client.init(config))
-      lrucache = client.getcache()
+      dnscache = client.getcache()
 
       query_func = function(self, original_query_func, qname, opts)
         return mock_records[qname..":"..opts.qtype] or { errcode = 3, errstr = "name error" }
@@ -545,7 +545,7 @@ describe("[DNS client cache]", function()
           },
         }
       }
-      client.getcache():set("another.name.consul", client.TYPE_AAAA)
+      client.getcache():set("another.name.consul", {ttl = 0}, client.TYPE_AAAA)
       client.toip("demo.service.consul")
       local success = client.getcache():get("another.name.consul")
       assert.equal(client.TYPE_AAAA, success)
@@ -558,7 +558,7 @@ describe("[DNS client cache]", function()
     -- hosts file names are cached for 10 years, verify that
     -- it is not overwritten with validTtl settings.
     -- Regressions reported in https://github.com/Kong/kong/issues/7444
-    local lrucache, mock_records, config  -- luacheck: ignore
+    local dnscache, mock_records, config  -- luacheck: ignore
     before_each(function()
       config = {
         nameservers = { "198.51.100.0" },
@@ -569,7 +569,7 @@ describe("[DNS client cache]", function()
       }
 
       assert(client.init(config))
-      lrucache = client.getcache()
+      dnscache = client.getcache()
     end)
 
     it("entries from hosts file ignores validTtl overrides, Kong/kong #7444", function()

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -45,6 +45,8 @@ http {
 > if database == "off" then
     lua_shared_dict kong_db_cache_miss_2 12m;
 > end
+    lua_shared_dict kong_dns_cache      12m;
+    lua_shared_dict kong_dns_cache_ipc  12m;
     lua_shared_dict kong_secrets        5m;
     lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_cluster_events 5m;
@@ -482,6 +484,8 @@ stream {
 > if database == "off" then
     lua_shared_dict stream_kong_db_cache_miss_2  12m;
 > end
+    lua_shared_dict stream_kong_dns_cache      12m;
+    lua_shared_dict stream_kong_dns_cache_ipc  12m;
     lua_shared_dict stream_kong_locks          8m;
     lua_shared_dict stream_kong_cluster_events 5m;
     lua_shared_dict stream_kong_healthchecks   5m;

--- a/spec/helpers/dns.lua
+++ b/spec/helpers/dns.lua
@@ -79,9 +79,9 @@ function _M.dnsSRV(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, records[1].type)
+  dnscache:set(records[1].name, {ttl=0}, records[1].type)
   return records
 end
 
@@ -120,9 +120,9 @@ function _M.dnsA(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, records[1].type)
+  dnscache:set(records[1].name, {ttl=0}, records[1].type)
   return records
 end
 
@@ -160,9 +160,9 @@ function _M.dnsAAAA(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, records[1].type)
+  dnscache:set(records[1].name, {ttl=0}, records[1].type)
   return records
 end
 

--- a/spec/helpers/dns.lua
+++ b/spec/helpers/dns.lua
@@ -79,9 +79,9 @@ function _M.dnsSRV(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, {ttl=0}, records[1].type)
+  dnscache:set(records[1].name, records[1].type)
   return records
 end
 
@@ -120,9 +120,9 @@ function _M.dnsA(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, {ttl=0}, records[1].type)
+  dnscache:set(records[1].name, records[1].type)
   return records
 end
 
@@ -160,9 +160,9 @@ function _M.dnsAAAA(client, records, staleTtl)
 
   -- create key, and insert it
   local key = records[1].type..":"..records[1].name
-  dnscache:set(key, {ttl=records[1].ttl + (staleTtl or 4)}, records)
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
   -- insert last-succesful lookup type
-  dnscache:set(records[1].name, {ttl=0}, records[1].type)
+  dnscache:set(records[1].name, records[1].type)
   return records
 end
 

--- a/t/03-dns-client/00-sanity.t
+++ b/t/03-dns-client/00-sanity.t
@@ -9,6 +9,11 @@ run_tests();
 __DATA__
 
 === TEST 1: load lua-resty-dns-client
+--- http_config eval
+qq {
+    lua_shared_dict kong_dns_cache              12m;
+    lua_shared_dict kong_dns_cache_ipc          12m;
+}
 --- config
     location = /t {
         access_by_lua_block {

--- a/t/03-dns-client/01-phases.t
+++ b/t/03-dns-client/01-phases.t
@@ -10,6 +10,11 @@ run_tests();
 __DATA__
 
 === TEST 1: client supports access phase
+--- http_config eval
+qq {
+    lua_shared_dict kong_dns_cache              12m;
+    lua_shared_dict kong_dns_cache_ipc          12m;
+}
 --- config
     location = /t {
         access_by_lua_block {
@@ -40,6 +45,8 @@ API disabled in the context of init_worker_by_lua
 === TEST 2: client does not support init_worker phase
 --- http_config eval
 qq {
+    lua_shared_dict kong_dns_cache              12m;
+    lua_shared_dict kong_dns_cache_ipc          12m;
     init_worker_by_lua_block {
         local client = require("kong.resty.dns.client")
         assert(client.init())

--- a/t/03-dns-client/01-phases.t
+++ b/t/03-dns-client/01-phases.t
@@ -1,5 +1,7 @@
 use Test::Nginx::Socket;
 
+no_long_string();
+
 plan tests => repeat_each() * (blocks() * 4 + 1);
 
 workers(6);
@@ -64,9 +66,8 @@ qq {
     }
 --- request
 GET /t
---- response_body
-answers: nil
-err: nil
---- error_log
+--- response_body_like chomp
+err: callback threw an error: .* API disabled in the context of init_worker_by_lua
+--- no_error_log
 [error]
 API disabled in the context of init_worker_by_lua

--- a/t/03-dns-client/02-timer-usage.t
+++ b/t/03-dns-client/02-timer-usage.t
@@ -9,6 +9,11 @@ run_tests();
 
 __DATA__
 === TEST 1: stale result triggers async timer
+--- http_config eval
+qq {
+    lua_shared_dict kong_dns_cache              12m;
+    lua_shared_dict kong_dns_cache_ipc          12m;
+}
 --- config
     location = /t {
         access_by_lua_block {

--- a/t/03-dns-client/02-timer-usage.t
+++ b/t/03-dns-client/02-timer-usage.t
@@ -1,5 +1,7 @@
 use Test::Nginx::Socket;
 
+no_long_string();
+
 plan tests => repeat_each() * (blocks() * 5);
 
 workers(1);
@@ -72,7 +74,8 @@ first try_list: ["(short)konghq.com:1 - cache-miss","konghq.com:1 - cache-miss/q
 second address name: konghq.com
 second try_list: ["(short)konghq.com:1 - cache-hit/stale","konghq.com:1 - cache-hit/stale/scheduled"]
 third address name: konghq.com
-third try_list: ["(short)konghq.com:1 - cache-hit/stale","konghq.com:1 - cache-hit/stale/in progress (async)"]
+third try_list: ["(short)konghq.com:1 - cache-hit/stale","konghq.com:1 - cache-hit/stale"]
+
 --- no_error_log
 [error]
 dns lookup pool exceeded retries


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
   - [x] depends on this https://github.com/Kong/kong/pull/12173 to fix test cases.
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* use mlcache APIs instead of lrucache APIs
  * `dns_no_sync` will not be usable, it always means `dns_no_sync=off` for using mlcache callback
  * using mlcache:get() callback in place of the original logic of controlling the lrucache
* fix test cases to adapt to new caching solution

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3220
