### PR TITLE
chore(tests): re-enable disabled mlcache tests

### DIFF
--- a/t/05-mlcache/02-get.t
+++ b/t/05-mlcache/02-get.t
@@ -2379,7 +2379,6 @@ is stale: true
 
 
 === TEST 50: get() does not cache value in LRU indefinitely when retrieved from shm on last ms (see GH PR #58)
---- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2419,8 +2418,6 @@ is stale: true
             assert(data == 42, err or "invalid data value: " .. data)
             ngx.say("hit_lvl: ", hit_lvl)
 
-            ngx.update_time()
-            local start = ngx.now() * 1000
             while true do
                 lru:delete("key")
                 data, err, hit_lvl = cache:get("key", nil, cb)
@@ -2431,9 +2428,6 @@ is stale: true
                 end
                 ngx.sleep(0)
             end
-            ngx.update_time()
-            local took = ngx.now() * 1000 - start
-            assert(took > 198 and took < 202)
 
             data, err, hit_lvl = cache:get("key", nil, cb)
             assert(data == 42, err or "invalid data value: " .. data)

--- a/t/05-mlcache/03-peek.t
+++ b/t/05-mlcache/03-peek.t
@@ -100,7 +100,6 @@ ttl: nil
 
 
 === TEST 3: peek() returns the remaining ttl if a key has been fetched before
---- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -117,11 +116,13 @@ ttl: nil
                 return nil
             end
 
-            local val, err = cache:get("my_key", { neg_ttl = 19 }, cb)
+            local val, err = cache:get("my_key", { neg_ttl = 20 }, cb)
             if err then
                 ngx.log(ngx.ERR, err)
                 return
             end
+
+            ngx.sleep(1.1)
 
             local ttl, err = cache:peek("my_key")
             if err then
@@ -129,9 +130,9 @@ ttl: nil
                 return
             end
 
-            ngx.say("ttl: ", math.ceil(ttl))
+            ngx.say("ttl < 19: ", tostring(math.floor(ttl) < 19))
 
-            ngx.sleep(1)
+            ngx.sleep(1.1)
 
             local ttl, err = cache:peek("my_key")
             if err then
@@ -139,14 +140,14 @@ ttl: nil
                 return
             end
 
-            ngx.say("ttl: ", math.ceil(ttl))
+            ngx.say("ttl < 18: ", tostring(math.floor(ttl) < 18))
         }
     }
 --- request
 GET /t
 --- response_body
-ttl: 19
-ttl: 18
+ttl < 19: true
+ttl < 18: true
 --- no_error_log
 [error]
 
@@ -359,7 +360,6 @@ no ttl: false
 
 
 === TEST 8: peek() returns remaining ttl if shm_miss is specified
---- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -374,11 +374,13 @@ no ttl: false
                 return nil
             end
 
-            local val, err = cache:get("my_key", { neg_ttl = 19 }, cb)
+            local val, err = cache:get("my_key", { neg_ttl = 20 }, cb)
             if err then
                 ngx.log(ngx.ERR, err)
                 return
             end
+
+            ngx.sleep(1.1)
 
             local ttl, err = cache:peek("my_key")
             if err then
@@ -386,9 +388,9 @@ no ttl: false
                 return
             end
 
-            ngx.say("ttl: ", math.ceil(ttl))
+            ngx.say("ttl < 19: ", tostring(math.floor(ttl) < 19))
 
-            ngx.sleep(1)
+            ngx.sleep(1.1)
 
             local ttl, err = cache:peek("my_key")
             if err then
@@ -396,14 +398,14 @@ no ttl: false
                 return
             end
 
-            ngx.say("ttl: ", math.ceil(ttl))
+            ngx.say("ttl < 18: ", tostring(math.floor(ttl) < 18))
         }
     }
 --- request
 GET /t
 --- response_body
-ttl: 19
-ttl: 18
+ttl < 19: true
+ttl < 18: true
 --- no_error_log
 [error]
 

--- a/t/05-mlcache/15-renew.t
+++ b/t/05-mlcache/15-renew.t
@@ -2378,7 +2378,6 @@ is stale: true
 
 
 === TEST 48: renew() does not cache value in LRU indefinitely when retrieved from shm on last ms (see GH PR #58)
---- SKIP
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2419,8 +2418,6 @@ is stale: true
             assert(data == 42, err or "invalid data value: " .. data)
             ngx.say("hit_lvl: ", hit_lvl)
 
-            ngx.update_time()
-            local start = ngx.now() * 1000
             while true do
                 lru:delete("key")
                 data, err, hit_lvl = cache:get("key", nil, cb)
@@ -2431,9 +2428,6 @@ is stale: true
                 end
                 ngx.sleep(0)
             end
-            ngx.update_time()
-            local took = ngx.now() * 1000 - start
-            assert(took > 198 and took < 202)
 
             data, err, hit_lvl = cache:get("key", nil, cb)
             assert(data == 42, err or "invalid data value: " .. data)


### PR DESCRIPTION
### Summary

Some mlcache tests were disabled because of flakiness. This commit re-enables them (hopefully this time without flakiness).

[KAG-2480](https://konghq.atlassian.net/browse/KAG-2480)
[KAG-2985](https://konghq.atlassian.net/browse/KAG-2985)

[KAG-2480]: https://konghq.atlassian.net/browse/KAG-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAG-2985]: https://konghq.atlassian.net/browse/KAG-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ