### PR TITLE
fix_error_handler_494

### DIFF
--- a/changelog/unreleased/kong/error_handler_494.yml
+++ b/changelog/unreleased/kong/error_handler_494.yml
@@ -1,0 +1,3 @@
+message: Fix a bug that the error_handler can not provide the meaningful response body when the internal error code 494 is triggered.
+type: bugfix
+scope: Core

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -59,6 +59,10 @@ return function(ctx)
   local status = kong.response.get_status()
   local message = get_body(status)
 
+  if status == 494 then
+    status = 400
+  end
+
   local headers
   if find(accept_header, TYPE_GRPC, nil, true) == 1 then
     message = { message = message }

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -59,6 +59,9 @@ return function(ctx)
   local status = kong.response.get_status()
   local message = get_body(status)
 
+  -- Nginx 494 status code is used internally when the client sends
+  -- too large or invalid HTTP headers. Kong is obliged to convert
+  -- it back to `400 Bad Request`.
   if status == 494 then
     status = 400
   end

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -81,7 +81,8 @@ server {
     listen $(entry.listener);
 > end
 
-    error_page 400 404 405 408 411 412 413 414 417 494 /kong_error_handler;
+    error_page 400 404 405 408 411 412 413 414 417 /kong_error_handler;
+    error_page 494 =494                            /kong_error_handler;
     error_page 500 502 503 504                     /kong_error_handler;
 
     # Append the kong request id to the error log

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -36,7 +36,7 @@ describe("Proxy error handlers", function()
     assert.res_status(400, res)
     local body = res:read_body()
     assert.matches("kong/", res.headers.server, nil, true)
-    assert.matches("Bad request\nrequest_id: %x+\n", body)
+    assert.matches("Request header or cookie too large", body)
   end)
 
   it("Request For Routers With Trace Method Not Allowed", function ()


### PR DESCRIPTION
### Summary

fix the bug that error handler can't recognize status code 494.

There is a dedicated response body for 494 defined in error_handler. However, based on the current configuration for `error_page` in nginx-kong.conf, 494 will not be treated correctly wihout reserving it by the `=response` option in `error_page` directive. In this PR, a `error_page` configuration is added for 494 separately, so that it can be recognized in error handler, and it will be replaced with 400 finally.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-5374
