### PR TITLE
fix(tests): fix reconfiguration completion detection

### DIFF
--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -215,6 +215,7 @@ build = {
     ["kong.db.dao.workspaces"] = "kong/db/dao/workspaces.lua",
     ["kong.db.dao.services"] = "kong/db/dao/services.lua",
     ["kong.db.dao.ca_certificates"] = "kong/db/dao/ca_certificates.lua",
+    ["kong.db.dao.invalidate"] = "kong/db/dao/invalidate.lua",
     ["kong.db.declarative"] = "kong/db/declarative/init.lua",
     ["kong.db.declarative.marshaller"] = "kong/db/declarative/marshaller.lua",
     ["kong.db.declarative.export"] = "kong/db/declarative/export.lua",

--- a/kong/clustering/config_helper.lua
+++ b/kong/clustering/config_helper.lua
@@ -246,9 +246,7 @@ function _M.update(declarative_config, msg)
     return nil, err
   end
 
-  if kong.configuration.log_level == "debug" then
-     ngx_log(ngx.DEBUG, _log_prefix, "loaded configuration with transaction ID " .. msg.current_transaction_id)
-  end
+  ngx_log(ngx.DEBUG, _log_prefix, "loaded configuration with transaction ID " .. msg.current_transaction_id)
 
   return true
 end

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -160,9 +160,7 @@ function _M:export_deflated_reconfigure_payload()
   self.current_config_hash = config_hash
   self.deflated_reconfigure_payload = payload
 
-  if kong.configuration.log_level == "debug" then
-    ngx_log(ngx_DEBUG, _log_prefix, "exported configuration with transaction id " .. current_transaction_id)
-  end
+  ngx_log(ngx_DEBUG, _log_prefix, "exported configuration with transaction id " .. current_transaction_id)
 
   return payload, nil, config_hash
 end

--- a/kong/db/dao/invalidate.lua
+++ b/kong/db/dao/invalidate.lua
@@ -1,0 +1,198 @@
+local kong_global = require "kong.global"
+local workspaces = require "kong.workspaces"
+local kong_pdk_vault = require "kong.pdk.vault"
+local constants = require "kong.constants"
+
+local null = ngx.null
+local log = ngx.log
+local ERR = ngx.ERR
+local DEBUG = ngx.DEBUG
+local ENTITY_CACHE_STORE = constants.ENTITY_CACHE_STORE
+
+
+local function certificate()
+  -- Need to require kong.runloop.certificate late in the game to retain testability
+  return require "kong.runloop.certificate"
+end
+
+
+local function invalidate_wasm_filters(schema_name, operation)
+  -- cache is invalidated on service/route deletion to ensure we don't
+  -- have orphaned filter chain data cached
+  local is_delete = operation == "delete"
+          and (schema_name == "services"
+          or schema_name == "routes")
+
+  local updated = schema_name == "filter_chains" or is_delete
+
+  if updated then
+    log(DEBUG, "[events] wasm filter chains updated, invalidating cache")
+    kong.core_cache:invalidate("filter_chains:version")
+  end
+
+  return updated
+end
+
+
+local function invalidate_ca_certificates(operation, ca)
+  if operation ~= "update" then
+    return
+  end
+
+  local invalidated = false
+
+  log(DEBUG, "[events] CA certificate updated, invalidating ca certificate store caches")
+
+  local ca_id = ca.id
+
+  local done_keys = {}
+  for _, entity in ipairs(certificate().get_ca_certificate_reference_entities()) do
+    local elements, err = kong.db[entity]:select_by_ca_certificate(ca_id)
+    if err then
+      log(ERR, "[events] failed to select ", entity, " by ca certificate ", ca_id, ": ", err)
+      return
+    end
+
+    if elements then
+      for _, e in ipairs(elements) do
+        local key = certificate().ca_ids_cache_key(e.ca_certificates)
+
+        if not done_keys[key] then
+          done_keys[key] = true
+          kong.core_cache:invalidate(key)
+          invalidated = true
+        end
+      end
+    end
+  end
+
+  local plugin_done_keys = {}
+  local plugins, err = kong.db.plugins:select_by_ca_certificate(ca_id, nil,
+          certificate().get_ca_certificate_reference_plugins())
+  if err then
+    log(ERR, "[events] failed to select plugins by ca certificate ", ca_id, ": ", err)
+    return
+  end
+
+  if plugins then
+    for _, e in ipairs(plugins) do
+      local key = certificate().ca_ids_cache_key(e.config.ca_certificates)
+
+      if not plugin_done_keys[key] then
+        plugin_done_keys[key] = true
+        kong.cache:invalidate(key)
+        invalidated = true
+      end
+    end
+  end
+
+  return invalidated
+end
+
+
+local function invalidate(operation, workspace, schema_name, entity, old_entity)
+  if not kong or not kong.core_cache or not kong.core_cache.invalidate then
+    return
+  end
+
+  workspaces.set_workspace(workspace)
+
+  local invalidated = false
+  local function invalidate_key(key)
+    local cache_obj = kong[ENTITY_CACHE_STORE[schema_name]]
+    cache_obj:invalidate(key)
+    invalidated = true
+  end
+
+  -- invalidate this entity anywhere it is cached if it has a
+  -- caching key
+
+  local cache_key = kong.db[schema_name]:cache_key(entity)
+
+  if cache_key then
+    invalidate_key(cache_key)
+  end
+
+  -- if we had an update, but the cache key was part of what was updated,
+  -- we need to invalidate the previous entity as well
+
+  if old_entity then
+    local old_cache_key = kong.db[schema_name]:cache_key(old_entity)
+    if old_cache_key and cache_key ~= old_cache_key then
+      invalidate_key(old_cache_key)
+    end
+  end
+
+  if schema_name == "routes" then
+    invalidate_key("router:version")
+
+  elseif schema_name == "services" then
+    if operation == "update" then
+
+      -- no need to rebuild the router if we just added a Service
+      -- since no Route is pointing to that Service yet.
+      -- ditto for deletion: if a Service if being deleted, it is
+      -- only allowed because no Route is pointing to it anymore.
+      invalidate_key("router:version")
+    end
+
+  elseif schema_name == "snis" then
+    log(DEBUG, "[events] SNI updated, invalidating cached certificates")
+
+    local sni = old_entity or entity
+    local sni_name = sni.name
+    local sni_wild_pref, sni_wild_suf = certificate().produce_wild_snis(sni_name)
+    invalidate_key("snis:" .. sni_name)
+
+    if sni_wild_pref then
+      invalidate_key("snis:" .. sni_wild_pref)
+    end
+
+    if sni_wild_suf then
+      invalidate_key("snis:" .. sni_wild_suf)
+    end
+
+  elseif schema_name == "plugins" then
+    invalidate_key("plugins_iterator:version")
+
+  elseif schema_name == "vaults" then
+    if kong_pdk_vault.invalidate_vault_entity(entity, old_entity) then
+      invalidated = true
+    end
+
+  elseif schema_name == "consumers" then
+    -- As we support config.anonymous to be configured as Consumer.username,
+    -- so invalidate the extra cache in case of data inconsistency
+    local old_username
+    if old_entity then
+      old_username = old_entity.username
+      if old_username and old_username ~= null and old_username ~= "" then
+        invalidate_key(kong.db.consumers:cache_key(old_username))
+      end
+    end
+
+    if entity then
+      local username = entity.username
+      if username and username ~= null and username ~= "" and username ~= old_username then
+        invalidate_key(kong.db.consumers:cache_key(username))
+      end
+    end
+
+  elseif schema_name == "ca_certificates" then
+    if invalidate_ca_certificates(operation, entity) then
+      invalidated = true
+    end
+  end
+
+  if invalidate_wasm_filters(schema_name, operation) then
+    invalidated = true
+  end
+
+  if invalidated then
+    local transaction_id = kong_global.get_current_transaction_id()
+    ngx.ctx.transaction_id = transaction_id
+    ngx.shared.kong:set("test:current_transaction_id", transaction_id)
+  end
+end
+
+return invalidate

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -13,7 +13,7 @@ local function invalidate_cache(self, old_entity, err, err_t)
     return nil, err, err_t
   end
   if old_entity then
-    self:post_crud_event("update", old_entity)
+    self:invalidate_cache_and_post_crud_events("update", old_entity)
   end
 end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1831,10 +1831,6 @@ local function serve_content(module)
 
   ngx.header["Access-Control-Allow-Origin"] = ngx.req.get_headers()["Origin"] or "*"
 
-  if kong.configuration.log_level == "debug" then
-    ngx.header["Kong-Test-Transaction-Id"] = kong_global.get_current_transaction_id()
-  end
-
   lapis.serve(module)
 
   ctx.KONG_ADMIN_CONTENT_ENDED_AT = get_updated_now_ms()
@@ -1887,6 +1883,11 @@ function Kong.admin_header_filter()
 
   else
     header[headers.SERVER] = nil
+  end
+
+  if kong.configuration.log_level == "debug" and ngx.ctx.transaction_id then
+    kong.log.info("Reporting Kong-Test-Transaction-Id ", ngx.ctx.transaction_id)
+    ngx.header["Kong-Test-Transaction-Id"] = ngx.ctx.transaction_id
   end
 
   -- this is not used for now, but perhaps we need it later?

--- a/kong/plugins/acl/acls.lua
+++ b/kong/plugins/acl/acls.lua
@@ -26,13 +26,13 @@ end
 local _ACLs = {}
 
 
-function _ACLs:post_crud_event(operation, entity, options)
+function _ACLs:invalidate_cache_and_post_crud_events(operation, entity, options)
   local _, err, err_t = invalidate_cache(self, entity, options)
   if err then
     return nil, err, err_t
   end
 
-  return self.super.post_crud_event(self, operation, entity, options)
+  return self.super.invalidate_cache_and_post_crud_events(self, operation, entity, options)
 end
 
 

--- a/spec/01-unit/01-db/09-no_broadcast_crud_event_spec.lua
+++ b/spec/01-unit/01-db/09-no_broadcast_crud_event_spec.lua
@@ -36,7 +36,7 @@ describe("option no_broadcast_crud_event", function()
       local dao = DAO.new(mock_db, entity, strategy, errors)
 
       dao.events = {
-        post_local = spy.new(function() end)
+        post_local = spy.new(function() return true end)
       }
 
       local row, err = dao:update({ a = 42 }, { b = "world" }, { no_broadcast_crud_event = true })
@@ -68,20 +68,20 @@ describe("option no_broadcast_crud_event", function()
       local dao = DAO.new(mock_db, entity, strategy, errors)
 
       dao.events = {
-        post_local = spy.new(function() end)
+        post_local = spy.new(function() return true end)
       }
 
       local row, err = dao:update({ a = 42 }, { b = "three" }, { no_broadcast_crud_event = false })
       assert.falsy(err)
       assert.same({ a = 42, b = "three" }, row)
 
-      assert.spy(dao.events.post_local).was_called(1)
+      assert.spy(dao.events.post_local).was_called(3)
 
       local row, err = dao:update({ a = 42 }, { b = "four" })
       assert.falsy(err)
       assert.same({ a = 42, b = "four" }, row)
 
-      assert.spy(dao.events.post_local).was_called(2)
+      assert.spy(dao.events.post_local).was_called(6)
 
     end)
   end)

--- a/spec/02-integration/03-db/12-dao_hooks_spec.lua
+++ b/spec/02-integration/03-db/12-dao_hooks_spec.lua
@@ -30,13 +30,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:page_for:pre", function()
+        hooks.register_hook("dao:page_for:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:page_for:post", function()
+        hooks.register_hook("dao:page_for:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -56,13 +56,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:select_by:pre", function()
+        hooks.register_hook("dao:select_by:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:select_by:post", function()
+        hooks.register_hook("dao:select_by:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -82,13 +82,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:update_by:pre", function()
+        hooks.register_hook("dao:update_by:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:update_by:post", function()
+        hooks.register_hook("dao:update_by:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -110,13 +110,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:upsert_by:pre", function()
+        hooks.register_hook("dao:upsert_by:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:upsert_by:post", function()
+        hooks.register_hook("dao:upsert_by:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -142,13 +142,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:delete_by:pre", function()
+        hooks.register_hook("dao:delete_by:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:delete_by:post", function()
+        hooks.register_hook("dao:delete_by:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -168,13 +168,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:select:pre", function()
+        hooks.register_hook("dao:select:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:select:post", function()
+        hooks.register_hook("dao:select:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -194,13 +194,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:page:pre", function()
+        hooks.register_hook("dao:page:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:page:post", function()
+        hooks.register_hook("dao:page:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -220,13 +220,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:insert:pre", function()
+        hooks.register_hook("dao:insert:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:insert:post", function()
+        hooks.register_hook("dao:insert:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 
@@ -251,13 +251,13 @@ for _, strategy in helpers.each_strategy() do
       local post_hook = spy.new(function() end)
 
       lazy_setup(function()
-        hooks.register_hook("dao:update:pre", function()
+        hooks.register_hook("dao:update:pre", function(...)
           pre_hook()
-          return true
+          return (...)
         end)
-        hooks.register_hook("dao:update:post", function()
+        hooks.register_hook("dao:update:post", function(...)
           post_hook()
-          return true
+          return (...)
         end)
       end)
 

--- a/spec/02-integration/04-admin_api/24-reconfiguration-completion_spec.lua
+++ b/spec/02-integration/04-admin_api/24-reconfiguration-completion_spec.lua
@@ -1,9 +1,31 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("Admin API - Reconfiguration Completion -", function()
+local function get_log(typ, n)
+  local entries
+  helpers.wait_until(function()
+    local client = assert(helpers.http_client(
+            helpers.mock_upstream_host,
+            helpers.mock_upstream_port
+    ))
+    local res = client:get("/read_log/" .. typ, {
+      headers = {
+        Accept = "application/json"
+      }
+    })
+    local raw = assert.res_status(200, res)
+    local body = cjson.decode(raw)
 
-  local WORKER_STATE_UPDATE_FREQ = 1
+    entries = body.entries
+    return #entries > 0
+  end, 10)
+  if n then
+    assert(#entries == n, "expected " .. n .. " log entries, but got " .. #entries)
+  end
+  return entries
+end
+
+describe("Admin API - Reconfiguration Completion -", function()
 
   local admin_client
   local proxy_client
@@ -25,7 +47,7 @@ describe("Admin API - Reconfiguration Completion -", function()
     res = admin_client:post("/services", {
       body = {
         name = "test-service",
-        url = "http://127.0.0.1",
+        url = helpers.mock_upstream_url,
       },
       headers = { ["Content-Type"] = "application/json" },
     })
@@ -35,19 +57,21 @@ describe("Admin API - Reconfiguration Completion -", function()
     -- We're running the route setup in `eventually` to cover for the unlikely case that reconfiguration completes
     -- between adding the route and requesting the path through the proxy path.
 
-    local next_path do
+    local next_path_suffix do
       local path_suffix = 0
-      function next_path()
+      function next_path_suffix()
         path_suffix = path_suffix + 1
-        return "/" .. tostring(path_suffix)
+        return tostring(path_suffix)
       end
     end
 
+    local path_suffix
     local service_path
     local kong_transaction_id
 
     assert.eventually(function()
-      service_path = next_path()
+      path_suffix = next_path_suffix()
+      service_path = "/" .. path_suffix
 
       res = admin_client:post("/services/" .. service.id .. "/routes", {
         body = {
@@ -55,7 +79,26 @@ describe("Admin API - Reconfiguration Completion -", function()
         },
         headers = { ["Content-Type"] = "application/json" },
       })
+      body = assert.res_status(201, res)
+      local route = cjson.decode(body)
+
+      kong_transaction_id = res.headers['kong-test-transaction-id']
+      assert.is_string(kong_transaction_id)
+
+      res = admin_client:post("/routes/" .. route.id .. "/plugins", {
+        body = {
+          name = "http-log",
+          config = {
+            http_endpoint = "http://" .. helpers.mock_upstream_host
+                    .. ":"
+                    .. helpers.mock_upstream_port
+                    .. "/post_log/reconf" .. path_suffix
+          }
+        },
+        headers = { ["Content-Type"] = "application/json" },
+      })
       assert.res_status(201, res)
+
       kong_transaction_id = res.headers['kong-test-transaction-id']
       assert.is_string(kong_transaction_id)
 
@@ -83,14 +126,19 @@ describe("Admin API - Reconfiguration Completion -", function()
       assert.equals("kong terminated the request", body)
     end)
             .has_no_error()
+
+    get_log("reconf" .. path_suffix, 1)
+
   end
 
   describe("#traditional mode -", function()
     lazy_setup(function()
       helpers.get_db_utils()
       assert(helpers.start_kong({
-        worker_consistency = "eventual",
-        worker_state_update_frequency = WORKER_STATE_UPDATE_FREQ,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        db_update_frequency = 0.05,
+        db_cache_neg_ttl = 0.01,
+        worker_state_update_frequency = 0.1,
       }))
       admin_client = helpers.admin_client()
       proxy_client = helpers.proxy_client()
@@ -123,6 +171,10 @@ describe("Admin API - Reconfiguration Completion -", function()
         cluster_listen = "127.0.0.1:9005",
         cluster_telemetry_listen = "127.0.0.1:9006",
         nginx_conf = "spec/fixtures/custom_nginx.template",
+        db_update_frequency = 0.05,
+        db_cache_neg_ttl = 0.01,
+        worker_consistency = "eventual",
+        worker_state_update_frequency = 0.1,
       }))
 
       assert(helpers.start_kong({
@@ -135,6 +187,9 @@ describe("Admin API - Reconfiguration Completion -", function()
         cluster_control_plane = "127.0.0.1:9005",
         cluster_telemetry_endpoint = "127.0.0.1:9006",
         proxy_listen = "0.0.0.0:9002",
+        db_update_frequency = 0.05,
+        db_cache_neg_ttl = 0.01,
+        worker_state_update_frequency = 0.1,
       }))
       admin_client = helpers.admin_client()
       proxy_client = helpers.proxy_client("127.0.0.1", 9002)


### PR DESCRIPTION
### Summary

Previously, the transaction ID that was reported was from before the admin API request was finished.  Also, invalidations could sometimes be delayed long enough to cause a conditional request to be executed even though a subsystem has not been rebuilt.

This change fixes the behavior in multiple ways:

 - Invalidations are invoked from the DAO:post_crud_event in a synchronous fashion rather than having event handlers invalidate. This ensures that when the admin API request finishes, the cache is invalidated as well.

 - The transaction ID is saved to the nginx context in `DAO:post_crud_event` and set in the response header in the `Kong.admin_header_filter` function.

 - The current transaction ID is retrieved by the data plane from the shared cache instead of from Postgres.  Previously, every iteration of the rebuild cycle incremented the current transaction ID by one, making debugging more difficult.

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3195