### PR TITLE
chore(deps): bump actions/github-script from 6 to 7

### DIFF
--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Fetch mapping file
       id: fetch_mapping
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         ACCESS_TOKEN: ${{ secrets.PAT }}
       with:
@@ -25,7 +25,7 @@ jobs:
 
     - name: Generate Slack Payload
       id: generate-payload
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         SLACK_CHANNEL: gateway-notifications
         SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"

--- a/.github/workflows/release-and-tests-fail-bot.yml
+++ b/.github/workflows/release-and-tests-fail-bot.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Fetch mapping file
       id: fetch_mapping
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         ACCESS_TOKEN: ${{ secrets.PAT }}
       with:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Miss https://github.com/Kong/kong/pull/12060

### Checklist

- [n/a] The Pull Request has tests
- [n/a] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [n/a] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* bump actions/github-script from 6 to 7

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5564]_


[FTI-5564]: https://konghq.atlassian.net/browse/FTI-5564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ