### PR TITLE
feat(conf): add DHE-RSA-CHACHA20-POLY1305 cipher to the intermediate configuration

### DIFF
--- a/changelog/unreleased/kong/feat-add-cipher-to-the-intermediate.yml
+++ b/changelog/unreleased/kong/feat-add-cipher-to-the-intermediate.yml
@@ -1,0 +1,3 @@
+message: add DHE-RSA-CHACHA20-POLY1305 cipher to the intermediate configuration
+type: feature
+scope: Configuration

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -11,7 +11,7 @@ local BUNDLED_VAULTS = constants.BUNDLED_VAULTS
 local BUNDLED_PLUGINS = constants.BUNDLED_PLUGINS
 
 
--- Version 5: https://wiki.mozilla.org/Security/Server_Side_TLS
+-- Version 5.7: https://wiki.mozilla.org/Security/Server_Side_TLS
 local CIPHER_SUITES = {
                    modern = {
                 protocols = "TLSv1.3",
@@ -27,7 +27,8 @@ local CIPHER_SUITES = {
                          .. "ECDHE-ECDSA-CHACHA20-POLY1305:"
                          .. "ECDHE-RSA-CHACHA20-POLY1305:"
                          .. "DHE-RSA-AES128-GCM-SHA256:"
-                         .. "DHE-RSA-AES256-GCM-SHA384",
+                         .. "DHE-RSA-AES256-GCM-SHA384:"
+                         .. "DHE-RSA-CHACHA20-POLY1305",
                  dhparams = "ffdhe2048",
     prefer_server_ciphers = "off",
   },
@@ -63,7 +64,7 @@ local CIPHER_SUITES = {
   },
                      fips = { -- https://wiki.openssl.org/index.php/FIPS_mode_and_TLS
                           -- TLSv1.0 and TLSv1.1 is not completely not FIPS compliant,
-                          -- but must be used under certain condititions like key sizes,
+                          -- but must be used under certain conditions like key sizes,
                           -- signatures in the full chain that Kong can't control.
                           -- In that case, we disables TLSv1.0 and TLSv1.1 and user
                           -- can optionally turn them on if they are aware of the caveats.
@@ -638,4 +639,3 @@ return {
 
   LMDB_VALIDATION_TAG = LMDB_VALIDATION_TAG,
 }
-

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1241,7 +1241,7 @@ describe("Configuration loader", function()
         it("defines ssl_ciphers by default", function()
           local conf, err = conf_loader(nil, {})
           assert.is_nil(err)
-          assert.equal("ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384", conf.ssl_ciphers)
+          assert.equal("ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305", conf.ssl_ciphers)
         end)
         it("explicitly defines ssl_ciphers", function()
           local conf, err = conf_loader(nil, {


### PR DESCRIPTION
### Summary

Mozilla TLS recommendations added `DHE-RSA-CHACHA20-POLY1305` cipher to intermediate in their version 5.7, see: https://wiki.mozilla.org/Security/Server_Side_TLS

KAG-3257

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- ~[ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~