### PR TITLE
chore(ci): apply fixes to the ngx_wasm_module update workflow

### DIFF
--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -25,8 +25,12 @@ jobs:
     - name: Detect current version of NGX_WASM_MODULE in .requirements
       id: check-kong
       run: |
-        SHA=$(sed -nre 's/^NGX_WASM_MODULE=([^ ]+) .*/\1/p' < .requirements)
+        SHA=$(sed -nre 's/^NGX_WASM_MODULE=([^ ]+).*/\1/p' < .requirements)
         echo "sha=$SHA" | tee -a "$GITHUB_OUTPUT"
+        if [[ -z ${SHA:-} ]]; then
+          echo "fatal: failed to parse ngx_wasm_module sha from .requirements file"
+          exit 1
+        fi
 
     - name: Check Kong/ngx_wasm_module HEAD
       id: check-repo
@@ -35,6 +39,10 @@ jobs:
       run: |
         SHA=$(gh api repos/Kong/ngx_wasm_module/commits/main --jq '.sha')
         echo "sha=$SHA" | tee -a "$GITHUB_OUTPUT"
+        if [[ -z ${SHA:-} ]]; then
+          echo "fatal: failed to fetch sha from Kong/ngx_wasm_module repo"
+          exit 1
+        fi
 
     - name: Update .requirements and create a pull request
       if: steps.check-kong.outputs.sha != steps.check-repo.outputs.sha
@@ -44,16 +52,16 @@ jobs:
         TO: ${{ steps.check-repo.outputs.sha }}
       run: |
         set -x
+
+        # masquerade as team-gateway-bot for the purposes of this commit/PR
+        git config --global user.email "team-gateway@konghq.com"
+        git config --global user.name "team-gateway-bot"
+
         gh auth status
         gh auth setup-git
 
-        # masquerade as dependabot for the purposes of this commit/PR
-        git config --global user.email \
-          "49699333+dependabot[bot]@users.noreply.github.com"
-        git config --global user.name "dependabot[bot]"
-
         readonly BRANCH=chore/deps-bump-ngx-wasm-module
-        if gh api repos/Kong/kong/branches/"$BRANCH"; then
+        if gh api repos/Kong/kong/branches/"$BRANCH" >/dev/null; then
           echo "branch ($BRANCH) already exists, exiting"
           exit  1
         fi
@@ -123,14 +131,30 @@ jobs:
             '"* [`\(.sha)`](\(.url)) - \(.message)"' \
             < commits.json
 
-          printf '\n\n'
-          printf '**IMPORTANT: Remember to scan this commit log for updates '
-          printf 'to Wasmtime/V8/Wasmer and update `.requirements` manually '
-          printf 'as needed**\n'
+          cat << 'EOF'
+
+        ## TODO
+
+        - [ ] scan this commit log for updates to Wasmtime/V8/Wasmer and update `.requirements` as needed
+        - [ ] ensure the full integration test suite has been triggered. This can be accomplished by pushing an empty commit to the branch from an authorized github account:
+          ```shell
+          cd path/to/kong/repo
+          git fetch
+          git switch chore/deps-bump-ngx-wasm-module
+          git pull -r
+          git commit --allow-empty -m "chore(*): empty commit, please squash"
+          git push origin HEAD
+          ```
+        EOF
+
         } > body.md
 
         gh pr create \
+          --draft \
+          --assignee "flrgh" \
           --base master \
           --head "$BRANCH" \
           --title "$HEADER" \
+          --label "cherry-pick kong-ee" \
+          --label "core/wasm" \
           --body-file body.md


### PR DESCRIPTION
# changes

* update regex used to match NGX_WASM_MODULE in .requirements file
* improve error-handling
* cleanup workflow stdout/stderr a little bit
* convert the "scan this commit log for important things" reminder to a checklist
* add the `cherry-pick kong-ee` label to created PRs
* change commit author to `team-gateway-bot`
* mark the PR as draft
* assign the PR to me (@flrgh)

## why create the PR as draft and assign to @flrgh?

There is a big flaw in all of this in that PRs created using GITHUB_TOKEN do not trigger the integration test suite. For the life of me, I cannot figure out a fully-automated workaround:

![image](https://github.com/Kong/kong/assets/3277009/37671027-bc21-4ade-8541-53b72960ca5b)


We don't want maintainers to merge the dependency update without running the tests, so _for now,_ the PR is created as a draft as a safeguard against somebody seeing that the PR is green and merging it anyways. The PR body will include a checklist item reminding maintainers to ensure the test suite has been triggered:

![image](https://github.com/Kong/kong/assets/3277009/7b450b06-71af-4b64-beec-f8a324797d94)

