### PR TITLE
chore: re-introduce improved backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,24 +1,32 @@
 name: Backport
 on:
   pull_request_target:
-    types:
-      - closed
-      - labeled
-
+    types: [closed, labeled] # runs when the pull request is closed/merged or labeled (to trigger a backport in hindsight)
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+  actions: write
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
+    if: github.event.pull_request.merged
     steps:
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
+      - uses: actions/checkout@v4
+      - name: Create backport pull requests
+        uses: korthout/backport-action@e355f68e2fc1cb0063b1c1b717882290ffc994bf #v2.2.0
         with:
           github_token: ${{ secrets.PAT }}
+          pull_title: '[backport -> ${target_branch}] ${pull_title}'
+          merge_commits: 'skip'
+          copy_labels_pattern: ^(?!backport ).* # copies all labels except those starting with "backport "
+          label_pattern: ^backport (release\/[^ ]+)$ # filters for labels starting with "backport " and extracts the branch name
+          pull_description: |-
+            Automated backport to `${target_branch}`, triggered by a label in #${pull_number}.
+          copy_assignees: true
+          copy_milestone: true
+          copy_requested_reviewers: true
+          experimental: >
+            {
+              "detect_merge_method": true
+            }


### PR DESCRIPTION
### Summary

This now correctly detects the available merge strategies and adapts it's behavior accordingly.

Rebase -> Use commits from the PR
Squash -> Use the newly created, squashed commit

(Merge commit -> We don't use that in our repository.)

Fix https://konghq.atlassian.net/browse/KAG-3198
