### PR TITLE
fix(dbless): fix error data loss caused by weakly typed of function  in declarative_config_flattened function

### DIFF
--- a/changelog/unreleased/kong/fix-declarative-config-flattened-data-loss.yml
+++ b/changelog/unreleased/kong/fix-declarative-config-flattened-data-loss.yml
@@ -1,0 +1,3 @@
+message: fix error data loss caused by weakly typed of function in declarative_config_flattened function
+type: bugfix
+scope: Configuration

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -680,6 +680,7 @@ do
     end
 
     t[key] = nil
+
     return key, value
   end
 
@@ -1158,6 +1159,7 @@ function _M:declarative_config_flattened(err_t, input)
   end
 
   local flattened = flatten_errors(input, err_t)
+
   err_t = self:declarative_config(err_t)
 
   err_t.flattened_errors = flattened

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -1032,6 +1032,12 @@ do
       for i, err_t_i in drain(section_errors) do
         local entity = entities[i]
 
+
+        -- promote error strings to `@entity` type errors
+        if type(err_t_i) == "string" then
+          err_t_i = { ["@entity"] = err_t_i }
+        end
+
         if type(entity) == "table" and type(err_t_i) == "table" then
           add_entity_errors(entity_type, entity, err_t_i, flattened)
 
@@ -1039,7 +1045,6 @@ do
           log(WARN, "failed to resolve errors for ", entity_type, " at ",
                     "index '", i, "'")
           section_errors[i] = err_t_i
-          err_t[entity_type] = section_errors
         end
       end
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -681,7 +681,8 @@ do
     end
 
     t[key] = nil
-
+    local cjson = require("cjson")
+    ngx.log(ngx.ERR, "drain_iter: ", key, " => ", cjson.encode(value))
     return key, value
   end
 
@@ -1034,13 +1035,14 @@ do
       for i, err_t_i in drain(section_errors) do
         local entity = entities[i]
 
-        if type(entity) == "table" then
+        if type(entity) == "table" and type(err_t_i) == "table" then
           add_entity_errors(entity_type, entity, err_t_i, flattened)
 
         else
           log(WARN, "failed to resolve errors for ", entity_type, " at ",
                     "index '", i, "'")
           section_errors[i] = err_t_i
+          err_t[entity_type] = section_errors
         end
       end
 
@@ -1153,8 +1155,7 @@ function _M:declarative_config_flattened(err_t, input)
     error("err_t input is nil or not a table", 2)
   end
 
-  local err_t_f = pl_table_deepcopy(err_t)
-  local flattened = flatten_errors(input, err_t_f)
+  local flattened = flatten_errors(input, err_t)
   err_t = self:declarative_config(err_t)
 
   err_t.flattened_errors = flattened

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -681,8 +681,6 @@ do
     end
 
     t[key] = nil
-    local cjson = require("cjson")
-    ngx.log(ngx.ERR, "drain_iter: ", key, " => ", cjson.encode(value))
     return key, value
   end
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -1,5 +1,6 @@
 local pl_pretty = require("pl.pretty").write
 local pl_keys = require("pl.tablex").keys
+local pl_table_deepcopy = require("pl.tablex").deepcopy
 local nkeys = require("table.nkeys")
 local table_isarray = require("table.isarray")
 local utils = require("kong.tools.utils")
@@ -1152,8 +1153,8 @@ function _M:declarative_config_flattened(err_t, input)
     error("err_t input is nil or not a table", 2)
   end
 
-  local flattened = flatten_errors(input, err_t)
-
+  local err_t_f = pl_table_deepcopy(err_t)
+  local flattened = flatten_errors(input, err_t_f)
   err_t = self:declarative_config(err_t)
 
   err_t.flattened_errors = flattened

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -1,6 +1,5 @@
 local pl_pretty = require("pl.pretty").write
 local pl_keys = require("pl.tablex").keys
-local pl_table_deepcopy = require("pl.tablex").deepcopy
 local nkeys = require("table.nkeys")
 local table_isarray = require("table.isarray")
 local utils = require("kong.tools.utils")

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -2704,20 +2704,35 @@ R6InCcH2Wh8wSeY5AuDXvu2tv9g/PW9wIJmPuKSHMA==
         {
           id = "a73dc9a7-93df-584d-97c0-7f41a1bbce3d",
           username = "test-consumer-1",
+          tags =  { "consumer-1" },
         },
         {
           id = "a73dc9a7-93df-584d-97c0-7f41a1bbce32",
           username = "test-consumer-1",
+          tags =  { "consumer-2" },
         },
       },
     }
-
     local flattened = post_config(input)
-
-    assert.equals(1, #flattened,
-                  "unexpected number of flattened errors")
-    assert.equals("uniqueness violation: 'consumers' entity with username set to 'test-consumer-1' already declared", flattened[1].errors[1].message)
-    assert.equals("entity", flattened[1].errors[1].type)
+    validate({
+      {
+        entity_type = "consumer",
+        entity_id   = "a73dc9a7-93df-584d-97c0-7f41a1bbce32",
+        entity_name = nil,
+        entity_tags = { "consumer-2" },
+        entity      =  {
+          id = "a73dc9a7-93df-584d-97c0-7f41a1bbce32",
+          username = "test-consumer-1",
+          tags =  { "consumer-2" },
+        },
+        errors = {
+          {
+            type    = "entity",
+            message = "uniqueness violation: 'consumers' entity with username set to 'test-consumer-1' already declared",
+          }
+        },
+      },
+    }, flattened)
   end)
 end)
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -2702,40 +2702,22 @@ R6InCcH2Wh8wSeY5AuDXvu2tv9g/PW9wIJmPuKSHMA==
       _format_version = "3.0",
       consumers = {
         {
+          id = "a73dc9a7-93df-584d-97c0-7f41a1bbce3d",
           username = "test-consumer-1",
         },
         {
+          id = "a73dc9a7-93df-584d-97c0-7f41a1bbce32",
           username = "test-consumer-1",
         },
       },
     }
 
-    local res = client:post("/config?flatten_errors=1", {
-      body = input,
-      headers = {
-        ["Content-Type"] = "application/json"
-      },
-    })
+    local flattened = post_config(input)
 
-    assert.response(res).has.status(400)
-    local body = assert.response(res).has.jsonbody()
-
-    local errors = body.flattened_errors
-
-    assert.not_nil(errors, "`flattened_errors` is missing from the response")
-    assert.is_table(errors, "`flattened_errors` is not a table")
-
-    assert.logfile().has.no.line("[emerg]", true, 0)
-    assert.logfile().has.no.line("[crit]",  true, 0)
-    assert.logfile().has.no.line("[alert]", true, 0)
-    assert.logfile().has.no.line("[error]", true, 0)
-
-    -- empty flattened errors
-    assert.equals(0, #errors, "unexpected number of flattened errors")
-
-    -- original errors exist
-    assert.equals(body.fields.consumers[2], "uniqueness violation: 'consumers' entity with username set to 'test-consumer-1' already declared", "unexpected original errors")
-
+    assert.equals(1, #flattened,
+                  "unexpected number of flattened errors")
+    assert.equals("uniqueness violation: 'consumers' entity with username set to 'test-consumer-1' already declared", flattened[1].errors[1].message)
+    assert.equals("entity", flattened[1].errors[1].type)
   end)
 end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
fix error data loss caused by weakly typed of function in declarative_config_flattened function

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5584
