### PR TITLE
fix(grpc-web): err when > client_body_buffer_size

### DIFF
--- a/changelog/unreleased/kong/grpc-web-large-req-error.yml
+++ b/changelog/unreleased/kong/grpc-web-large-req-error.yml
@@ -1,0 +1,3 @@
+message: "**grpc-web**: fix an issue where large requests would result in an error"
+type: bugfix
+scope: Plugin


### PR DESCRIPTION
### Summary

`grpc-web` uses `get_raw_body()` to fetch the request body, and does not handle the error when the body exceeds `client_body_buffer_size`.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Issue reference

Fix FTI-5624
