### PR TITLE
fix(globalpatches): support exptime in SharedDict:set() api

### DIFF
--- a/changelog/unreleased/kong/fix-cli-shdict-set-api.yml
+++ b/changelog/unreleased/kong/fix-cli-shdict-set-api.yml
@@ -1,0 +1,3 @@
+message: fix cli SharedDict:set API to support exptime parameter
+type: bugfix
+scope: CLI Command

--- a/changelog/unreleased/kong/fix-cli-shdict-set-api.yml
+++ b/changelog/unreleased/kong/fix-cli-shdict-set-api.yml
@@ -1,3 +1,0 @@
-message: fix cli SharedDict:set API to support exptime parameter
-type: bugfix
-scope: CLI Command

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -265,16 +265,7 @@ return function(options)
         return self.data[key] and self.data[key].value, nil
       end
       SharedDict.get_stale = SharedDict.get
-      function SharedDict:set(key, value)
-        set(self.data, key, value)
-        return true, nil, false
-      end
-      SharedDict.safe_set = SharedDict.set
-      function SharedDict:add(key, value, exptime)
-        if self.data[key] ~= nil then
-          return false, "exists", false
-        end
-
+      function SharedDict:set(key, value, exptime)
         local expire_at = nil
 
         if exptime then
@@ -286,6 +277,14 @@ return function(options)
 
         set(self.data, key, value, expire_at)
         return true, nil, false
+      end
+      SharedDict.safe_set = SharedDict.set
+      function SharedDict:add(key, value, exptime)
+        if self.data[key] ~= nil then
+          return false, "exists", false
+        end
+
+        return self:set(key, value, exptime)
       end
       SharedDict.safe_add = SharedDict.add
       function SharedDict:replace(key, value)


### PR DESCRIPTION
This commit introduces support for the exptime parameter in SharedDict:set() to align its functionality with that of the original ngx.shared.DICT.set(). And it refines the logic of SharedDict:add() by using SharedDict:set().

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests -- reuse the original test cases in kong
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

fix KAG-3303
