### PR TITLE
feat(gha): pass version as cloudsmith tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -638,6 +638,7 @@ jobs:
         ARTIFACT_VERSION: ${{ matrix.artifact-version }}
         ARTIFACT_TYPE: ${{ matrix.artifact-type }}
         ARTIFACT: ${{ matrix.artifact }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
         PACKAGE_TYPE: ${{ matrix.package }}
         KONG_RELEASE_LABEL: ${{ needs.metadata.outputs.release-label }}
         VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
@@ -648,6 +649,17 @@ jobs:
         USE_PULP: ${{ vars.USE_PULP }}
       run: |
         sha256sum bazel-bin/pkg/*
+
+        # set the version input as tags passed to release-scripts
+        # note: release-scripts rejects user tags if missing internal flag
+        #
+        # this can be a comma-sepratated list of tags to apply
+        if [[ "$OFFICIAL_RELEASE" == 'false' ]]; then
+          if echo "$INPUT_VERSION" | grep -qs -E 'rc|alpha|beta|nightly'; then
+            PACKAGE_TAGS="$INPUT_VERSION"
+            export PACKAGE_TAGS
+          fi
+        fi
 
         scripts/release-kong.sh
 

--- a/scripts/release-kong.sh
+++ b/scripts/release-kong.sh
@@ -102,18 +102,32 @@ function push_package () {
     dist_version="--dist-version jammy"
   fi
 
-  set -x
+  # test for sanitized github actions input
+  if [[ -n "$(echo "$PACKAGE_TAGS" | tr -d 'a-zA-Z0-9._,')" ]]; then
+    echo 'invalid characters in PACKAGE_TAGS'
+    echo "passed to script: ${PACKAGE_TAGS}"
+    tags=''
+  else
+    tags="$PACKAGE_TAGS"
+  fi
 
-  local release_args="--package-type gateway"
+  set -x
+  release_args=''
+
+  if [ -n "${tags:-}" ]; then
+    release_args="${release_args} --tags ${tags}"
+  fi
+
+  release_args="${release_args} --package-type gateway"
   if [[ "$EDITION" == "enterprise" ]]; then
-    release_args="$release_args --enterprise"
+    release_args="${release_args} --enterprise"
   fi
 
   # pre-releases go to `/internal/`
   if [[ "$OFFICIAL_RELEASE" == "true" ]]; then
-    release_args="$release_args --publish"
+    release_args="${release_args} --publish"
   else
-    release_args="$release_args --internal"
+    release_args="${release_args} --internal"
   fi
 
   docker run \


### PR DESCRIPTION
(cherry picked from commit 851ebcf5e65d6ba12aa5026a453e10f978f95ceb)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This is the sister PRs:
- https://github.com/Kong/release-scripts/pull/108 &
- https://github.com/Kong/kong-ee/pull/7356

It will allow the `version` input to the `release.yml` workflow to be passed as a Cloudsmith tag when uploading packages (assuming it meets the criteria). This will in turn allow us to keep better track of special packages in Cloudsmith, like the recent `rc` packages.

An existing example of such a tag is the `fips` tag: https://cloudsmith.io/~kong/packages/?q=tag%3Afips

For this to work, the input must contain: `rc`,`alpha`,`beta`, or `nightly`
And cannot contain characters outside of: `a-zA-Z0-9._,`

So an input like "3.0.0.0-rc.3" will work, but an input like "3.0.0.0-gamma.5", "9.9.9.isa%is%cool", or "3.5.0.0+1" will not.

Here's an example of what this looks like on the Cloudsmith side of things (input was `3.6.0.0.rc.0`): https://cloudsmith.io/~kong/packages/?q=tag%3A3.6.0.0.rc.0

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-3299]_


[KAG-3299]: https://konghq.atlassian.net/browse/KAG-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ