### PR TITLE
fix(globalpatches): remove timer from SharedDict APIs

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -362,11 +362,10 @@ return function(options)
         if expire_at == nil then
           return 0
         end
-        local remaining = expire_at - ngx.now()
-        if remaining == 0 then
-          return nil, "not found"
-        end
-        return remaining
+        -- There is a problem that also exists in the official OpenResty:
+        -- 0 means the key never expires. So it's hard to distinguish between a
+        -- never-expired key and an expired key with a TTL value of 0.
+        return expire_at - ngx.now()
       end
 
       -- hack


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary


For testing and CLI scenarios, we will not add timer to avoid exhausting timer resources.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests (rerun the original tests)
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Details

1. It checks the expiration of an item when referring it instead of using timer.
2. The API `set()` returns the item now, which will be used in the API `SharedDict:incr()`.
3. It introduces a new internal API `get(data, key)` to check and retrieve non-expired items.
4. It fixes the returned ttl value to align with the `ngx.shared.DICT:ttl()` API of lua-nginx-module.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3398
