### PR TITLE
tests(plugins): refactor tests to address flakiness

### DIFF
--- a/spec/03-plugins/17-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/02-access_spec.lua
@@ -581,19 +581,17 @@ for _, strategy in helpers.each_strategy() do
       })
       assert.res_status(200, res)
 
-      local cache_key = db.plugins:cache_key(plugin)
-
-      helpers.wait_for_invalidation(cache_key)
-
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          ["Host"] = "ip-restriction2.test"
-        }
-      })
-      local body = assert.res_status(403, res)
-      assert.matches("IP address not allowed", body)
+      helpers.pwait_until(function()
+        res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "ip-restriction2.test"
+          }
+        })
+        local body = assert.res_status(403, res)
+        assert.matches("IP address not allowed", body)
+      end)
 
       res = assert(admin_client:send {
         method  = "PATCH",
@@ -607,18 +605,16 @@ for _, strategy in helpers.each_strategy() do
       })
       assert.res_status(200, res)
 
-      local cache_key = db.plugins:cache_key(plugin)
-
-      helpers.wait_for_invalidation(cache_key)
-
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          ["Host"] = "ip-restriction2.test"
-        }
-      })
-      assert.res_status(200, res)
+      helpers.pwait_until(function()
+        res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "ip-restriction2.test"
+          }
+        })
+        assert.res_status(200, res)
+      end)
     end)
 
     describe("#regression", function()


### PR DESCRIPTION
## Summary

Refactor ip-restriction test cases to address flakiness; `helpers.wait_for_invalidation` would hit a different worker than the subsequent proxy request, leading to flakiness in tests. Instead of issuing two requests, one for the Admin and another for the Proxy, wait until the proxy request returns the expected result. 

Fix KAG-3207.