### PR TITLE
fix(tests): fix malloc assertion error by replacing thread tcp server.

### DIFF
--- a/changelog/unreleased/kong/fix_malloc_assertion_error.yml
+++ b/changelog/unreleased/kong/fix_malloc_assertion_error.yml
@@ -1,0 +1,3 @@
+message: "fix malloc assertion error by replacing thread tcp server in reports_spec.lua."
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix_malloc_assertion_error.yml
+++ b/changelog/unreleased/kong/fix_malloc_assertion_error.yml
@@ -1,3 +1,0 @@
-message: "fix malloc assertion error by replacing thread tcp server in reports_spec.lua."
-type: bugfix
-scope: Core

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -7,7 +7,7 @@ describe("reports", function()
   local expected_data = "version"
   local port = 8189
 
-  setup(function()
+  lazy_setup(function()
     -- start the echo server
     assert(helpers.start_kong({
                nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -23,7 +23,7 @@ describe("reports", function()
     assert(helpers.is_echo_server_ready())
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
     helpers.echo_server_reset()
   end)

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -8,11 +8,24 @@ describe("reports", function()
   local port = 8189
 
   setup(function()
-    helpers.start_echo_server(port)
+    -- start the echo server
+    assert(helpers.start_kong({
+               nginx_conf = "spec/fixtures/custom_nginx.template",
+               -- we don't actually use any stream proxy features in tcp_server,
+               -- but this is needed in order to load the echo server defined at
+               -- nginx_kong_test_tcp_echo_server_custom_inject_stream.lua
+               stream_listen = helpers.get_proxy_ip(false) .. ":19000",
+               -- to fix "Database needs bootstrapping or is older than Kong 1.0" in CI.
+               database = "off",
+               log_level = "info",
+                      }))
+
+    assert(helpers.is_echo_server_ready())
   end)
 
   teardown(function()
-    helpers.stop_echo_server()
+    helpers.stop_kong()
+    helpers.echo_server_reset()
   end)
 
   before_each(function()

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -2,11 +2,10 @@ local meta = require "kong.meta"
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-
 describe("reports", function()
   local reports, bytes, err
   local port = 8189
-  local opts = { tls = true }
+  local expected_data = "version"
   before_each(function()
     package.loaded["kong.reports"] = nil
     reports = require "kong.reports"
@@ -44,7 +43,7 @@ describe("reports", function()
     end)
 
     it("sends report over TCP[TLS]", function()
-      local thread = helpers.tcp_server(port, opts)
+      local ngx_run_dir = helpers.start_echo_server(port)
 
       bytes, err = reports.send("stub", {
         hello = "world",
@@ -58,8 +57,9 @@ describe("reports", function()
       assert.truthy(bytes>0)
       assert.is_nil(err)
 
-      local ok, res = thread:join()
-      assert.True(ok)
+      local res = helpers.get_echo_server_received_data(ngx_run_dir, expected_data)
+      helpers.stop_echo_server(ngx_run_dir)
+
       assert.matches("^<14>", res)
       res = res:sub(5)
       assert.matches("cores=%d+", res)
@@ -73,12 +73,12 @@ describe("reports", function()
       assert.not_matches("nilval", res, nil, true)
       assert.matches("foobar=" .. cjson.encode({ foo = "bar" }), res, nil, true)
       assert.matches("bazbat=" .. cjson.encode({ baz = "bat" }), res, nil, true)
+      helpers.cleanup_echo_server(ngx_run_dir)
     end)
 
     it("doesn't send if not enabled", function()
       reports.toggle(false)
-
-      local thread = helpers.tcp_server(port, { requests = 1, timeout = 0.1 })
+      local ngx_run_dir = helpers.start_echo_server(port)
 
       bytes, err = reports.send({
         foo = "bar"
@@ -86,15 +86,16 @@ describe("reports", function()
       assert.is_nil(bytes)
       assert.equal(err, "disabled")
 
-      local ok, res = thread:join()
-      assert.True(ok)
+      local res = helpers.get_echo_server_received_data(ngx_run_dir, expected_data, 0.1)
+      helpers.stop_echo_server(ngx_run_dir)
       assert.equal("timeout", res)
+      helpers.cleanup_echo_server(ngx_run_dir)
     end)
 
     it("accepts custom immutable items", function()
       reports.toggle(true)
 
-      local thread = helpers.tcp_server(port, opts)
+      local ngx_run_dir = helpers.start_echo_server(port)
 
       reports.add_immutable_value("imm1", "fooval")
       reports.add_immutable_value("imm2", "barval")
@@ -103,16 +104,31 @@ describe("reports", function()
       assert.truthy(bytes > 0)
       assert.is_nil(err)
 
-      local ok, res = thread:join()
-      assert.True(ok)
+      local res = helpers.get_echo_server_received_data(ngx_run_dir, expected_data)
+      helpers.stop_echo_server(ngx_run_dir)
       assert.matches("imm1=fooval", res)
       assert.matches("imm2=barval", res)
       assert.matches("k1=bazval", res)
+      helpers.cleanup_echo_server(ngx_run_dir)
     end)
   end)
 
   describe("configure_ping()", function()
     local conf_loader = require "kong.conf_loader"
+    local function send_reports_and_check_result(reports, conf, port, matches)
+      reports.configure_ping(conf)
+      local ngx_run_dir = helpers.start_echo_server(port)
+
+      reports.send_ping("127.0.0.1", port)
+      local res = helpers.get_echo_server_received_data(ngx_run_dir, expected_data)
+      helpers.stop_echo_server(ngx_run_dir)
+
+      for _,m in ipairs(matches) do
+        assert.matches(m, res, nil, true)
+      end
+
+      helpers.cleanup_echo_server(ngx_run_dir)
+    end
 
     before_each(function()
       reports.toggle(true)
@@ -124,13 +140,11 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           database = "postgres",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert._matches("cluster_id=123e4567-e89b-12d3-a456-426655440000", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"cluster_id=123e4567-e89b-12d3-a456-426655440000"})
       end)
     end)
 
@@ -139,39 +153,33 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           database = "postgres",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert._matches("database=postgres", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"database=postgres"})
       end)
 
       it("off", function()
         local conf = assert(conf_loader(nil, {
           database = "off",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("database=off", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"database=off"})
       end)
     end)
 
     describe("sends 'role'", function()
-      it("traditional", function()
+               it("traditional", function()
         local conf = assert(conf_loader(nil))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert._matches("role=traditional", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"cluster_id=123e4567-e89b-12d3-a456-426655440000"})
       end)
 
       it("control_plane", function()
@@ -180,13 +188,11 @@ describe("reports", function()
           cluster_cert = "spec/fixtures/kong_spec.crt",
           cluster_cert_key = "spec/fixtures/kong_spec.key",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("role=control_plane", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"role=control_plane"})
       end)
 
       it("data_plane", function()
@@ -196,39 +202,33 @@ describe("reports", function()
           cluster_cert = "spec/fixtures/kong_spec.crt",
           cluster_cert_key = "spec/fixtures/kong_spec.key",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("role=data_plane", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"role=data_plane"})
       end)
     end)
 
     describe("sends 'kic'", function()
       it("default (off)", function()
         local conf = assert(conf_loader(nil))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert._matches("kic=false", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"kic=false"})
       end)
 
       it("enabled", function()
         local conf = assert(conf_loader(nil, {
           kic = "on",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("kic=true", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"kic=true"})
       end)
     end)
 
@@ -237,26 +237,22 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           admin_listen = "off",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_admin=0", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_admin=0"})
       end)
 
       it("on", function()
         local conf = assert(conf_loader(nil, {
           admin_listen = "127.0.0.1:8001",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_admin=1", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_admin=1"})
       end)
     end)
 
@@ -265,26 +261,22 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           admin_gui_listen = "off",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_admin_gui=0", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_admin_gui=0"})
       end)
 
       it("on", function()
         local conf = assert(conf_loader(nil, {
           admin_gui_listen = "127.0.0.1:8001",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_admin_gui=1", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_admin_gui=1"})
       end)
     end)
 
@@ -293,26 +285,22 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           proxy_listen = "off",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_proxy=0", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_proxy=0"})
       end)
 
       it("on", function()
         local conf = assert(conf_loader(nil, {
           proxy_listen = "127.0.0.1:8000",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_proxy=1", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_proxy=1"})
       end)
     end)
 
@@ -321,41 +309,36 @@ describe("reports", function()
         local conf = assert(conf_loader(nil, {
           stream_listen = "off",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_stream=0", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_stream=0"})
       end)
 
       it("on", function()
         local conf = assert(conf_loader(nil, {
           stream_listen = "127.0.0.1:8000",
         }))
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("_stream=1", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"_stream=1"})
       end)
     end)
 
     it("default configuration ping contents", function()
         local conf = assert(conf_loader())
-        reports.configure_ping(conf)
-
-        local thread = helpers.tcp_server(port, opts)
-        reports.send_ping("127.0.0.1", port)
-
-        local _, res = assert(thread:join())
-        assert.matches("database=" .. helpers.test_conf.database, res, nil, true)
-        assert.matches("_admin=1", res, nil, true)
-        assert.matches("_proxy=1", res, nil, true)
-        assert.matches("_stream=0", res, nil, true)
+        send_reports_and_check_result(
+          reports,
+          conf,
+          port,
+          {"database=" .. helpers.test_conf.database,
+           "_admin=1",
+           "_proxy=1",
+           "_stream=0"
+        })
     end)
   end)
 

--- a/spec/fixtures/template_inject/nginx_kong_test_tcp_echo_server_custom_inject_stream.lua
+++ b/spec/fixtures/template_inject/nginx_kong_test_tcp_echo_server_custom_inject_stream.lua
@@ -1,0 +1,23 @@
+return [[
+server {
+    listen 8188;
+    listen 8189 ssl;
+
+> for i = 1, #ssl_cert do
+    ssl_certificate     $(ssl_cert[i]);
+    ssl_certificate_key $(ssl_cert_key[i]);
+> end
+    ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+
+    content_by_lua_block {
+        local sock = assert(ngx.req.socket())
+        local data = sock:receive()  -- read a line from downstream
+        if data then
+            sock:send(data.."\n") -- echo whatever was sent
+            ngx.log(ngx.INFO, "received data: " .. data)
+        else
+            ngx.log(ngx.WARN, "Nothing received")
+        end
+    }
+}
+]]

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1393,168 +1393,6 @@ local function kill_tcp_server(port)
   return tonumber(oks), tonumber(fails)
 end
 
---- Execute command and capture the output.
---
--- @function execute_command
--- @param command command to run.
--- @return command status code and standard output.
-local function execute_command(command)
-  local handle = io.popen(command)
-  local result = handle:read("*a")
-  local ret = handle:close()
-  return ret, string.gsub(result, "\n", "")
-end
-
---- Run a TCP echo nginx server.
---
--- @function run_nginx_as_echo_server
--- @param dir server running directory.
--- @param port server running port.
--- @return true if ok.
-local function run_nginx_as_echo_server(dir, port)
-  -- the brace expansion does not work under github action
-  -- environment, like "mkdir {conf,logs}".
-  assert(execute_command("mkdir "..dir.."/conf"))
-  assert(execute_command("mkdir "..dir.."/logs"))
-  local conf_file_path = dir.."/conf/nginx.conf"
-  local conf_file = assert(io.open(conf_file_path, "w"))
-  local spec_dir = pl_path.dirname(pl_path.abspath(debug.getinfo(1).short_src))
-  local test_port = 16383
-  if conf_file then
-    local config_template = [[
-worker_processes 1;
-daemon on;
-error_log  logs/error.log info;
-
-events {
-    worker_connections 1024;
-}
-
-stream {
-    server {
-        listen localhost:%s ssl;
-        listen localhost:%s;
-
-        ssl_certificate %s/fixtures/kong_spec.crt;
-        ssl_certificate_key %s/fixtures/kong_spec.key;
-
-        ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-        ssl_prefer_server_ciphers off;
-
-        content_by_lua_block {
-            local sock = assert(ngx.req.socket())
-            local data = sock:receive()  -- read a line from downstream
-            if data then
-              sock:send(data.."\n") -- echo whatever was sent
-              ngx.log(ngx.INFO, "received data: " .. data)
-            else
-              ngx.log(ngx.WARN, "Nothing received")
-            end
-        }
-    }
-}
-    ]]
-    local config = string.format(config_template, port, test_port, spec_dir, spec_dir)
-    conf_file:write(config)
-    conf_file:close()
-  else
-    assert(nil, "can not write config file to path: "..conf_file_path)
-  end
-
-  assert(execute_command("nginx -p "..dir))
-
-  -- ensure server is ready.
-  local sock = ngx.socket.tcp()
-  sock:settimeout(0.1)
-  local retry = 0
-  while true do
-    if sock:connect("localhost", test_port) then
-      sock:send("START\n")
-      local ok = sock:receive()
-      sock:close()
-      if ok == "START" then
-        return true
-      end
-    else
-      retry = retry + 1
-      if retry > 10 then
-        assert(nil, "can not create server after "..retry.." retries")
-      end
-    end
-  end
-end
-
---- Run a echo TCP server.
---
--- @function start_echo_server
--- @param port the port to run the server.
--- @return  the server running directory.
-local function start_echo_server(port)
-  local ret, dir = execute_command("mktemp -d")
-  assert(ret)
-  run_nginx_as_echo_server(dir, port)
-  return dir
-end
-
---- Stop a echo server.
---
--- @function stop_echo_server
--- @param dir the running server directory.
--- @return  nothing.
-local function stop_echo_server(dir)
-  local ret, pid = execute_command("cat "..dir.."/logs/nginx.pid")
-  assert(ret)
-  assert(execute_command("kill "..pid))
-end
-
---- Clean up a echo server.
---
--- @function cleanup_echo_server
--- @param dir the running server directory.
--- @return  nothing.
-local function cleanup_echo_server(dir)
-  assert(execute_command("rm -rf "..dir))
-end
-
---- Get the echo server's received data.
--- This function check the part of expected data with a timeout.
---
--- @function get_echo_server_received_data
--- @param server_dir the running server directory.
--- @param expected part of the data expected.
--- @param timeout (optional) timeout in seconds, default is 0.5.
--- @return  the data the echo server received. If timeouts, return "timeout".
-local function get_echo_server_received_data(server_dir, expected, timeout)
-  if timeout == nil then
-    timeout = 0.5
-  end
-
-  local extract_cmd = "grep content_by_lua "..server_dir.."/logs/error.log | tail -1"
-  local ret, log = execute_command(extract_cmd)
-  assert(ret)
-  local pattern = "received data: " .. "(.*)"
-  local _, _, data = string.find(log, pattern)
-  -- unit is second.
-  local t = 0.1
-  local time_acc = 0
-
-  -- retry it when data is not available. because sometime,
-  -- the error.log has not been flushed yet.
-  while string.find(data, expected) == nil do
-    ngx.sleep(t)
-    time_acc = time_acc + t
-    if time_acc >= timeout then
-      return "timeout"
-    end
-
-    ret, log = execute_command(extract_cmd)
-    assert(ret)
-    _, _, data = string.find(log, pattern)
-  end
-
-  return data
-end
-
 local code_status = {
   [200] = "OK",
   [201] = "Created",
@@ -4008,6 +3846,109 @@ local function reload_kong(strategy, ...)
   return ok, err
 end
 
+--- Run an echo TCP server.
+--
+-- @function start_echo_server
+-- @param port the port to run the server.
+-- @return  the server running directory.
+local function start_echo_server(port)
+  local test_port = 15383
+  local conf_template = [[
+    server {
+      listen localhost:%s ssl;
+      listen localhost:%s;
+
+      ssl_certificate ../spec/fixtures/kong_spec.crt;
+      ssl_certificate_key ../spec/fixtures/kong_spec.key;
+
+      error_log logs/error.log info;
+
+      content_by_lua_block {
+          local sock = assert(ngx.req.socket())
+          local data = sock:receive()  -- read a line from downstream
+          if data then
+            sock:send(data.."\n") -- echo whatever was sent
+            ngx.log(ngx.INFO, "received data: " .. data)
+          else
+            ngx.log(ngx.WARN, "Nothing received")
+          end
+      }
+    }
+  ]]
+  local conf = string.format(conf_template, port, test_port)
+  local fixtures = { stream_mock = { conf } }
+  local server_dir = "servroot_tcp_echo"
+  
+  assert(start_kong({
+             nginx_conf = "spec/fixtures/custom_nginx.template",
+             -- we don't actually use any stream proxy features in tcp_server,
+             -- but this is needed in order to load above stream_mock fixture.
+             stream_listen = get_proxy_ip(false) .. ":19000",
+             prefix = server_dir,
+             -- to fix "Database needs bootstrapping or is older than Kong 1.0" in CI.
+             database = "off",
+             log_level = "info",
+                    }, nil, nil, fixtures))
+
+  -- ensure server is ready.
+  local sock = ngx.socket.tcp()
+  sock:settimeout(0.1)
+  local retry = 0
+  while true do
+    if sock:connect("localhost", test_port) then
+      sock:send("START\n")
+      local ok = sock:receive()
+      sock:close()
+      if ok == "START" then
+        return true, server_dir
+      end
+    else
+      retry = retry + 1
+      if retry > 10 then
+        assert(nil, "can not create server after "..retry.." retries")
+      end
+    end
+  end
+end
+
+--- Get the echo server's received data.
+-- This function check the part of expected data with a timeout.
+--
+-- @function get_echo_server_received_data
+-- @param server_dir the running server directory.
+-- @param expected part of the data expected.
+-- @param timeout (optional) timeout in seconds, default is 0.5.
+-- @return  the data the echo server received. If timeouts, return "timeout".
+local function get_echo_server_received_data(server_dir, expected, timeout)
+  if timeout == nil then
+    timeout = 0.5
+  end
+
+  local extract_cmd = "grep content_by_lua "..server_dir.."/logs/error.log | tail -1"
+  local ok, _, log = exec(extract_cmd)
+  assert(ok)
+  local pattern = "received data: " .. "(.*)"
+  local _, _, data = string.find(log, pattern)
+  -- unit is second.
+  local t = 0.1
+  local time_acc = 0
+
+  -- retry it when data is not available. because sometime,
+  -- the error.log has not been flushed yet.
+  while string.find(data, expected) == nil do
+    ngx.sleep(t)
+    time_acc = time_acc + t
+    if time_acc >= timeout then
+      return "timeout"
+    end
+
+    ok, _, log = exec(extract_cmd)
+    assert(ok)
+    _, _, data = string.find(log, pattern)
+  end
+
+  return data
+end
 
 --- Simulate a Hybrid mode DP and connect to the CP specified in `opts`.
 -- @function clustering_client
@@ -4247,8 +4188,6 @@ end
   kill_tcp_server = kill_tcp_server,
   start_echo_server = start_echo_server,
   get_echo_server_received_data = get_echo_server_received_data,
-  stop_echo_server = stop_echo_server,
-  cleanup_echo_server = cleanup_echo_server,
   http_mock = http_mock,
   get_proxy_ip = get_proxy_ip,
   get_proxy_port = get_proxy_port,


### PR DESCRIPTION
Due to many OpenSSL objects are not thread-safe (https://www.openssl.org/docs/faq.html) and it causes intermittent crash when those objects are used in thread based tcp server. Replace it with process based tcp server resolves this error.

This change only replaces the thread tcp server usage in 11-reports_spec.lua file to keep the scope small.

Before this fix, crash like "malloc_consolidate(): unaligned fastbin chunk detected." happens when running spec/01-unit/11-reports_spec.lua about 200 times.

After this fix, there is no crash after running the same test suites more than 5000 times.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-3241]_


[KAG-3241]: https://konghq.atlassian.net/browse/KAG-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ