### PR TITLE
style(dns): minor code style clean

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -1275,9 +1275,8 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
           cacheShortInsert(records, qname, qtype)
         end
 
-        -- check if we need to dereference a CNAME
+        -- dereference CNAME
         if records[1].type == _M.TYPE_CNAME and qtype ~= _M.TYPE_CNAME then
-          -- dereference CNAME
           opts.qtype = nil
           add_status_to_try_list(try_list, "dereferencing CNAME")
           return resolve(records[1].cname, opts, dnsCacheOnly, try_list)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. luacheck could be passed now, so we do not need to suppress its warnings.
2. `sock:connect(targetIp, targetPort, sock_opts)` could correctly deal with the nil value of `sock_opts` now.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests: rerun original tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
fix KAG-3329
