### PR TITLE
fix(tests): execute all shell commands using resty.shell

### DIFF
--- a/spec/02-integration/02-cmd/09-prepare_spec.lua
+++ b/spec/02-integration/02-cmd/09-prepare_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local signals = require "kong.cmd.utils.nginx_signals"
-local pl_utils = require "pl.utils"
+local shell = require "resty.shell"
 
 
 local fmt = string.format
@@ -115,7 +115,7 @@ describe("kong prepare", function()
         assert.is_nil(err)
 
         local cmd = fmt("%s -p %s -c %s", nginx_bin, TEST_PREFIX, "nginx.conf")
-        local ok, _, _, stderr = pl_utils.executeex(cmd)
+        local ok, _, stderr = shell.run(cmd, nil, 0)
 
         assert.equal("", stderr)
         assert.truthy(ok)
@@ -149,7 +149,7 @@ describe("kong prepare", function()
         assert.is_nil(err)
 
         local cmd = fmt("%s -p %s -c %s", nginx_bin, TEST_PREFIX, "nginx.conf")
-        local ok, _, _, stderr = pl_utils.executeex(cmd)
+        local ok, _, stderr = shell.run(cmd, nil, 0)
 
         assert.matches("kong_tests_unknown", stderr)
         assert.falsy(ok)

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -1,8 +1,8 @@
 local helpers = require "spec.helpers"
-local pl_utils = require "pl.utils"
 local utils = require "kong.tools.utils"
 local DB = require "kong.db.init"
 local tb_clone = require "table.clone"
+local shell = require "resty.shell"
 
 
 -- Current number of migrations to execute in a new install
@@ -73,7 +73,7 @@ for _, strategy in helpers.each_strategy() do
         local cmd = string.format(helpers.unindent [[
           echo y | %s KONG_DATABASE=%s %s migrations reset --v -c %s
         ]], lua_path, strategy, helpers.bin_path, helpers.test_conf_path)
-        local ok, code, _, stderr = pl_utils.executeex(cmd)
+        local ok, _, stderr, _, code = shell.run(cmd, nil, 0)
         assert.falsy(ok)
         assert.same(1, code)
         assert.match("not a tty", stderr, 1, true)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -3,6 +3,7 @@ local constants = require "kong.constants"
 local cjson = require "cjson"
 local lyaml = require "lyaml"
 local lfs = require "lfs"
+local shell = require "resty.shell"
 
 
 local function sort_by_name(a, b)
@@ -692,11 +693,11 @@ describe("kong config", function()
     local kong_yml_exists = false
     if lfs.attributes("kong.yml") then
       kong_yml_exists = true
-      os.execute("mv kong.yml kong.yml~")
+      shell.run("mv kong.yml kong.yml~", nil, 0)
     end
     finally(function()
       if kong_yml_exists then
-        os.execute("mv kong.yml~ kong.yml")
+        shell.run("mv kong.yml~ kong.yml", nil, 0)
       else
         os.remove("kong.yml")
       end

--- a/spec/02-integration/02-cmd/15-utils_spec.lua
+++ b/spec/02-integration/02-cmd/15-utils_spec.lua
@@ -2,6 +2,7 @@ local signals = require "kong.cmd.utils.nginx_signals"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
 local pl_dir = require "pl.dir"
+local shell = require "resty.shell"
 
 describe("kong cli utils", function()
 
@@ -28,7 +29,7 @@ describe("kong cli utils", function()
 echo 'nginx version: openresty/%s' >&2]], version
         ))
 
-        assert(os.execute("chmod +x " .. nginx))
+        assert(shell.run("chmod +x " .. nginx, nil, 0))
 
         return nginx
       end

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -3,6 +3,7 @@ local utils = require "kong.tools.utils"
 local cjson = require "cjson"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
+local shell = require "resty.shell"
 
 
 local LOG_WAIT_TIMEOUT = 10
@@ -410,7 +411,7 @@ for _, strategy in helpers.each_strategy() do
 
       before_each(function()
         helpers.clean_logfile(FILE_LOG_PATH)
-        os.execute("chmod 0777 " .. FILE_LOG_PATH)
+        shell.run("chmod 0777 " .. FILE_LOG_PATH, nil, 0)
       end)
 
       it("execute a log plugin", function()
@@ -750,7 +751,7 @@ for _, strategy in helpers.each_strategy() do
       before_each(function()
         proxy_client = helpers.proxy_client()
         helpers.clean_logfile(FILE_LOG_PATH)
-        os.execute("chmod 0777 " .. FILE_LOG_PATH)
+        shell.run("chmod 0777 " .. FILE_LOG_PATH, nil, 0)
       end)
 
 

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -409,7 +409,7 @@ for _, strategy in helpers.each_strategy() do
     describe("ssl_certificates / snis", function()
 
       local function get_cert(port, sn)
-        local pl_utils = require "pl.utils"
+        local shell = require "resty.shell"
 
         local cmd = [[
           echo "" | openssl s_client \
@@ -418,7 +418,7 @@ for _, strategy in helpers.each_strategy() do
           -servername %s \
         ]]
 
-        local _, _, stderr = pl_utils.executeex(string.format(cmd, port, sn))
+        local _, _, stderr = shell.run(string.format(cmd, port, sn), nil, 0)
 
         return stderr
       end

--- a/spec/02-integration/17-admin_gui/01-admin-gui-path_spec.lua
+++ b/spec/02-integration/17-admin_gui/01-admin-gui-path_spec.lua
@@ -2,6 +2,7 @@ local lfs = require "lfs"
 local pl_path = require "pl.path"
 local helpers = require "spec.helpers"
 local test_prefix = helpers.test_conf.prefix
+local shell = require "resty.shell"
 
 local _
 
@@ -24,7 +25,7 @@ describe("Admin GUI - admin_gui_path", function()
 
     local err, gui_dir_path, gui_index_file_path
     gui_dir_path = pl_path.join(test_prefix, "gui")
-    os.execute("rm -rf " .. gui_dir_path)
+    shell.run("rm -rf " .. gui_dir_path, nil, 0)
     _, err = lfs.mkdir(gui_dir_path)
     assert.is_nil(err)
 
@@ -62,7 +63,7 @@ describe("Admin GUI - admin_gui_path", function()
 
     local err, gui_dir_path, gui_index_file_path
     gui_dir_path = pl_path.join(test_prefix, "gui")
-    os.execute("rm -rf " .. gui_dir_path)
+    shell.run("rm -rf " .. gui_dir_path, nil, 0)
     _, err = lfs.mkdir(gui_dir_path)
     assert.is_nil(err)
 

--- a/spec/02-integration/17-admin_gui/03-reports_spec.lua
+++ b/spec/02-integration/17-admin_gui/03-reports_spec.lua
@@ -1,6 +1,7 @@
 local cjson = require "cjson"
 local lfs = require "lfs"
 local pl_path = require "pl.path"
+local shell = require "resty.shell"
 
 local helpers = require "spec.helpers"
 local constants = require "kong.constants"
@@ -26,7 +27,7 @@ describe("anonymous reports for kong manager", function ()
   local prepare_gui_dir = function ()
     local err, gui_dir_path
     gui_dir_path = pl_path.join(helpers.test_conf.prefix, "gui")
-    os.execute("rm -rf " .. gui_dir_path)
+    shell.run("rm -rf " .. gui_dir_path, nil, 0)
     err = select(2, lfs.mkdir(gui_dir_path))
     assert.is_nil(err)
     return gui_dir_path

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -478,7 +478,8 @@ for _, strategy in helpers.each_strategy() do
 
     it("gracefully handles layer 4 failures", function()
       -- setup: cleanup logs
-      os.execute(":> " .. helpers.test_conf.nginx_err_logs)
+      local shell = require "resty.shell"
+      shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0)
 
       local res = proxy_client:get("/status/200", {
         headers = {

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -1302,7 +1302,8 @@ describe(desc, function ()
       delete_route(admin_client, route)
       delete_service(admin_client, service)
       red:close()
-      os.execute("cat servroot/logs/error.log")
+      local shell = require "resty.shell"
+      shell.run("cat servroot/logs/error.log", nil, 0)
     end)
 
     helpers.wait_for_all_config_update({

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local shell = require "resty.shell"
 
 local tcp_service_port = helpers.get_available_port()
 local tcp_proxy_port = helpers.get_available_port()
@@ -216,7 +217,7 @@ describe("Plugin: prometheus (access)", function()
 
   it("does not log error if no service was matched", function()
     -- cleanup logs
-    os.execute(":> " .. helpers.test_conf.nginx_err_logs)
+    shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0)
 
     local res = assert(proxy_client:send {
       method  = "POST",
@@ -230,7 +231,7 @@ describe("Plugin: prometheus (access)", function()
 
   it("does not log error during a scrape", function()
     -- cleanup logs
-    os.execute(":> " .. helpers.test_conf.nginx_err_logs)
+    shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0)
 
     local res = assert(admin_client:send {
       method  = "GET",

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local shell = require "resty.shell"
 
 local tcp_service_port = helpers.get_available_port()
 local tcp_proxy_port = helpers.get_available_port()
@@ -260,7 +261,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
   it("does not log error if no service was matched", function()
     -- cleanup logs
-    os.execute(":> " .. helpers.test_conf.nginx_err_logs)
+    shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0)
 
     local res = assert(proxy_client:send {
       method  = "POST",
@@ -274,7 +275,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
   it("does not log error during a scrape", function()
     -- cleanup logs
-    os.execute(":> " .. helpers.test_conf.nginx_err_logs)
+    shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0)
 
     get_metrics()
 

--- a/spec/03-plugins/27-aws-lambda/06-request-util_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/06-request-util_spec.lua
@@ -154,7 +154,8 @@ for _, strategy in helpers.each_strategy() do
     before_each(function()
       proxy_client = helpers.proxy_client()
       admin_client = helpers.admin_client()
-      os.execute(":> " .. helpers.test_conf.nginx_err_logs) -- clean log files
+      local shell = require "resty.shell"
+      shell.run(":> " .. helpers.test_conf.nginx_err_logs, nil, 0) -- clean log files
     end)
 
     after_each(function ()

--- a/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
@@ -75,7 +75,8 @@ for _, strategy in helpers.each_strategy() do
 
       lazy_setup(function()
         -- clear file
-        os.execute("cat /dev/null > " .. OTELCOL_FILE_EXPORTER_PATH)
+        local shell = require "resty.shell"
+        shell.run("cat /dev/null > " .. OTELCOL_FILE_EXPORTER_PATH, nil, 0)
         setup_instrumentations("all")
       end)
 

--- a/spec/04-perf/01-rps/06-core_entities_crud_spec.lua
+++ b/spec/04-perf/01-rps/06-core_entities_crud_spec.lua
@@ -4,6 +4,7 @@ local utils = require "spec.helpers.perf.utils"
 local workspaces = require "kong.workspaces"
 local stringx = require "pl.stringx"
 local tablex = require "pl.tablex"
+local shell = require "resty.shell"
 
 local fmt = string.format
 
@@ -346,7 +347,7 @@ local gen_wrk_script = function(entity, action)
   return script
 end
 
-os.execute("mkdir -p output")
+shell.run("mkdir -p output", nil, 0)
 
 for _, mode in ipairs(KONG_MODES) do
 for _, version in ipairs(versions) do

--- a/spec/04-perf/01-rps/07-upstream_lock_regression_spec.lua
+++ b/spec/04-perf/01-rps/07-upstream_lock_regression_spec.lua
@@ -1,3 +1,4 @@
+local shell = require "resty.shell"
 local perf = require "spec.helpers.perf"
 local split = require "pl.stringx".split
 local utils = require "spec.helpers.perf.utils"
@@ -23,7 +24,7 @@ end
 
 local LOAD_DURATION = 60
 
-os.execute("mkdir -p output")
+shell.run("mkdir -p output", nil, 0)
 
 local function patch(helpers, patch_interval)
   local status, bsize

--- a/spec/04-perf/02-flamegraph/01-simple_spec.lua
+++ b/spec/04-perf/02-flamegraph/01-simple_spec.lua
@@ -1,6 +1,7 @@
 local perf = require("spec.helpers.perf")
 local split = require("pl.stringx").split
 local utils = require("spec.helpers.perf.utils")
+local shell = require "resty.shell"
 
 perf.enable_charts(false) -- don't generate charts, we need flamegraphs only
 perf.use_defaults()
@@ -38,7 +39,7 @@ local wrk_script = [[
   end
 ]]
 
-os.execute("mkdir -p output")
+shell.run("mkdir -p output", nil, 0)
 
 for _, version in ipairs(versions) do
   describe("perf test for Kong " .. version .. " #simple #no_plugins", function()

--- a/spec/04-perf/02-flamegraph/05-prometheus.lua
+++ b/spec/04-perf/02-flamegraph/05-prometheus.lua
@@ -1,6 +1,7 @@
 local perf = require("spec.helpers.perf")
 local split = require("pl.stringx").split
 local utils = require("spec.helpers.perf.utils")
+local shell = require "resty.shell"
 
 perf.enable_charts(false) -- don't generate charts, we need flamegraphs only
 perf.use_defaults()
@@ -37,7 +38,7 @@ local wrk_script = [[
   end
 ]]
 
-os.execute("mkdir -p output")
+shell.run("mkdir -p output", nil, 0)
 
 local function scrape(helpers, scrape_interval)
   local starting = ngx.now()

--- a/spec/04-perf/02-flamegraph/07-upstream_lock_regression_spec.lua
+++ b/spec/04-perf/02-flamegraph/07-upstream_lock_regression_spec.lua
@@ -1,3 +1,4 @@
+local shell = require "resty.shell"
 local perf = require("spec.helpers.perf")
 local split = require("pl.stringx").split
 local utils = require("spec.helpers.perf.utils")
@@ -19,7 +20,7 @@ end
 
 local LOAD_DURATION = 180
 
-os.execute("mkdir -p output")
+shell.run("mkdir -p output", nil, 0)
 
 local function patch(helpers, patch_interval)
   local status, bsize

--- a/spec/fixtures/https_server.lua
+++ b/spec/fixtures/https_server.lua
@@ -13,6 +13,7 @@ local pl_stringx = require "pl.stringx"
 local uuid = require "resty.jit-uuid"
 local http_client = require "resty.http"
 local cjson = require "cjson"
+local shell = require "resty.shell"
 
 
 -- we need this to get random UUIDs
@@ -192,7 +193,7 @@ function https_server.start(self)
   end
 
   for _ = 1, HTTPS_SERVER_START_MAX_RETRY do
-    if os.execute("nginx -c " .. file .. " -p " .. self.base_path) then
+    if shell.run("nginx -c " .. file .. " -p " .. self.base_path, nil, 0) then
       return
     end
 
@@ -213,7 +214,7 @@ function https_server.shutdown(self)
     end
 
     local kill_nginx_cmd = fmt("kill -s TERM %s", tostring(pid))
-    local status = os.execute(kill_nginx_cmd)
+    local status = shell.run(kill_nginx_cmd, nil, 0)
     if not status then
       error(fmt("could not kill nginx test server. %s was not removed", self.base_path), 2)
     end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -67,6 +67,7 @@ local pkey = require "resty.openssl.pkey"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local log = require "kong.cmd.utils.log"
 local DB = require "kong.db"
+local shell = require "resty.shell"
 local ffi = require "ffi"
 local ssl = require "ngx.ssl"
 local ws_client = require "resty.websocket.client"
@@ -104,7 +105,7 @@ end
 -- @function openresty_ver_num
 local function openresty_ver_num()
   local nginx_bin = assert(nginx_signals.find_nginx_bin())
-  local _, _, _, stderr = pl_utils.executeex(string.format("%s -V", nginx_bin))
+  local _, _, stderr = shell.run(string.format("%s -V", nginx_bin), nil, 0)
 
   local a, b, c, d = string.match(stderr or "", "openresty/(%d+)%.(%d+)%.(%d+)%.(%d+)")
   if not a then
@@ -203,7 +204,7 @@ do
       if not USED_PORTS[port] then
           USED_PORTS[port] = true
 
-          local ok = os.execute("netstat -lnt | grep \":" .. port .. "\" > /dev/null")
+          local ok = shell.run("netstat -lnt | grep \":" .. port .. "\" > /dev/null", nil, 0)
 
           if not ok then
             -- return code of 1 means `grep` did not found the listening port
@@ -1114,23 +1115,18 @@ local function http2_client(host, port, tls)
       cmd = cmd .. " -http1"
     end
 
-    local body_filename
+    --shell.run does not support '<'
     if body then
-      body_filename = pl_path.tmpname()
-      pl_file.write(body_filename, body)
-      cmd = cmd .. " -post < " .. body_filename
+      cmd = cmd .. " -post"
     end
 
     if http2_debug then
       print("HTTP/2 cmd:\n" .. cmd)
     end
 
-    local ok, _, stdout, stderr = pl_utils.executeex(cmd)
+    --100MB for retrieving stdout & stderr
+    local ok, stdout, stderr = shell.run(cmd, body, 0, 1024*1024*100)
     assert(ok, stderr)
-
-    if body_filename then
-      pl_file.delete(body_filename)
-    end
 
     if http2_debug then
       print("HTTP/2 debug:\n")
@@ -3147,14 +3143,14 @@ end
 -- used on an assertion.
 -- @function execute
 -- @param cmd command string to execute
--- @param pl_returns (optional) boolean: if true, this function will
+-- @param returns (optional) boolean: if true, this function will
 -- return the same values as Penlight's executeex.
--- @return if `pl_returns` is true, returns four return values
--- (ok, code, stdout, stderr); if `pl_returns` is false,
+-- @return if `returns` is true, returns four return values
+-- (ok, code, stdout, stderr); if `returns` is false,
 -- returns either (false, stderr) or (true, stderr, stdout).
-function exec(cmd, pl_returns)
-  local ok, code, stdout, stderr = pl_utils.executeex(cmd)
-  if pl_returns then
+function exec(cmd, returns)
+  local ok, stdout, stderr, _, code = shell.run(cmd, nil, 0)
+  if returns then
     return ok, code, stdout, stderr
   end
   if not ok then
@@ -3170,14 +3166,14 @@ end
 -- @param env (optional) table with kong parameters to set as environment
 -- variables, overriding the test config (each key will automatically be
 -- prefixed with `KONG_` and be converted to uppercase)
--- @param pl_returns (optional) boolean: if true, this function will
+-- @param returns (optional) boolean: if true, this function will
 -- return the same values as Penlight's `executeex`.
 -- @param env_vars (optional) a string prepended to the command, so
 -- that arbitrary environment variables may be passed
--- @return if `pl_returns` is true, returns four return values
--- (ok, code, stdout, stderr); if `pl_returns` is false,
+-- @return if `returns` is true, returns four return values
+-- (ok, code, stdout, stderr); if `returns` is false,
 -- returns either (false, stderr) or (true, stderr, stdout).
-function kong_exec(cmd, env, pl_returns, env_vars)
+function kong_exec(cmd, env, returns, env_vars)
   cmd = cmd or ""
   env = env or {}
 
@@ -3214,7 +3210,7 @@ function kong_exec(cmd, env, pl_returns, env_vars)
     env_vars = string.format("%s KONG_%s='%s'", env_vars, k:upper(), v)
   end
 
-  return exec(env_vars .. " " .. BIN_PATH .. " " .. cmd, pl_returns)
+  return exec(env_vars .. " " .. BIN_PATH .. " " .. cmd, returns)
 end
 
 
@@ -3257,7 +3253,7 @@ local function clean_prefix(prefix)
 
         local res, err = pl_path.rmdir(root)
         -- skip errors when trying to remove mount points
-        if not res and os.execute("findmnt " .. root .. " 2>&1 >/dev/null") == 0 then
+        if not res and shell.run("findmnt " .. root .. " 2>&1 >/dev/null", nil, 0) == 0 then
           return nil, err .. ": " .. root
         end
       end
@@ -3294,7 +3290,7 @@ local function pid_dead(pid, timeout)
   local max_time = ngx.now() + (timeout or 10)
 
   repeat
-    if not pl_utils.execute("ps -p " .. pid .. " >/dev/null 2>&1") then
+    if not shell.run("ps -p " .. pid .. " >/dev/null 2>&1", nil, 0) then
       return true
     end
     -- still running, wait some more
@@ -3324,7 +3320,7 @@ local function wait_pid(pid_path, timeout, is_retry)
     end
 
     -- Timeout reached: kill with SIGKILL
-    pl_utils.execute("kill -9 " .. pid .. " >/dev/null 2>&1")
+    shell.run("kill -9 " .. pid .. " >/dev/null 2>&1", nil, 0)
 
     -- Sanity check: check pid again, but don't loop.
     wait_pid(pid_path, timeout, true)
@@ -3431,15 +3427,15 @@ end
 
 local function build_go_plugins(path)
   if pl_path.exists(pl_path.join(path, "go.mod")) then
-    local ok, _, _, stderr = pl_utils.executeex(string.format(
-            "cd %s; go mod tidy; go mod download", path))
+    local ok, _, stderr = shell.run(string.format(
+            "cd %s; go mod tidy; go mod download", path), nil, 0)
     assert(ok, stderr)
   end
   for _, go_source in ipairs(pl_dir.getfiles(path, "*.go")) do
-    local ok, _, _, stderr = pl_utils.executeex(string.format(
+    local ok, _, stderr = shell.run(string.format(
             "cd %s; go build %s",
             path, pl_path.basename(go_source)
-    ))
+    ), nil, 0)
     assert(ok, stderr)
   end
 end
@@ -3462,7 +3458,7 @@ local function make(workdir, specs)
     for _, src in ipairs(spec.src) do
       local srcpath = pl_path.join(workdir, src)
       if isnewer(targetpath, srcpath) then
-        local ok, _, _, stderr = pl_utils.executeex(string.format("cd %s; %s", workdir, spec.cmd))
+        local ok, _, stderr = shell.run(string.format("cd %s; %s", workdir, spec.cmd), nil, 0)
         assert(ok, stderr)
         if isnewer(targetpath, srcpath) then
           error(string.format("couldn't make %q newer than %q", targetpath, srcpath))
@@ -3685,7 +3681,7 @@ local function stop_kong(prefix, preserve_prefix, preserve_dc, signal, nowait)
     return nil, err
   end
 
-  local ok, _, _, err = pl_utils.executeex(string.format("kill -%s %d", signal, pid))
+  local ok, _, err = shell.run(string.format("kill -%s %d", signal, pid), nil, 0)
   if not ok then
     return nil, err
   end
@@ -4133,7 +4129,7 @@ end
     end
 
     local cmd = string.format("pkill %s -P `cat %s`", signal, pid_path)
-    local _, code = pl_utils.execute(cmd)
+    local _, _, _, _, code = shell.run(cmd)
 
     if not pid_dead(pid_path) then
       return false

--- a/spec/helpers/http_mock/nginx_instance.lua
+++ b/spec/helpers/http_mock/nginx_instance.lua
@@ -7,7 +7,7 @@ local pl_path = require "pl.path"
 local pl_dir = require "pl.dir"
 local pl_file = require "pl.file"
 local pl_utils = require "pl.utils"
-local os = require "os"
+local shell = require "resty.shell"
 
 local print = print
 local error = error
@@ -60,7 +60,7 @@ function http_mock:stop(no_clean, signal, timeout)
   pid_file:close()
 
   local kill_nginx_cmd = "kill -s " .. signal .. " " .. pid
-  if not os.execute(kill_nginx_cmd) then
+  if not shell.run(kill_nginx_cmd, nil, 0) then
     error("failed to kill nginx at " .. self.prefix, 2)
   end
 

--- a/spec/helpers/perf/charts.lua
+++ b/spec/helpers/perf/charts.lua
@@ -16,6 +16,7 @@ local unsaved_results_lookup = {}
 local unsaved_results = {}
 
 local function gen_plots(results, fname, opts)
+  local shell = require "resty.shell"
   opts = opts or options
 
   if not results or not next(results) then
@@ -23,7 +24,7 @@ local function gen_plots(results, fname, opts)
     return
   end
 
-  os.execute("mkdir -p output")
+  shell.run("mkdir -p output", nil, 0)
 
   local output_data = {
     options = opts,

--- a/spec/helpers/perf/utils.lua
+++ b/spec/helpers/perf/utils.lua
@@ -225,7 +225,8 @@ local function clear_loaded_package()
 end
 
 local function print_and_save(s, path)
-  os.execute("mkdir -p output")
+  local shell = require "resty.shell"
+  shell.run("mkdir -p output", nil, 0)
   print(s)
   local f = io.open(path or "output/result.txt", "a")
   f:write(s)


### PR DESCRIPTION
Due to the use of `pl.utils.execute` and `os.execute`, the execution time on both Lua code and the shell commands it launches exceeded the timeout set for the TCP connection. And as it is unable to return from Nginx C event code, it is unable to handle TCP I/O events properly. This resulted in abnormal data reception for some TCP connections.

So, except for one `pl.utils.executeex`, all occurrences of `os.execute`, `pl.utils.execute`, and `pl.utils.executeex` have been replaced with `shell.run`.

By switching to `shell.run`, the current Lua will be suspended, waiting for the command to complete, allowing Nginx's I/O events to be handled properly

KAG-3157

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
