### PR TITLE
perf(proxy): use more reasonable keepalive default value for Nginx tuning

### DIFF
--- a/changelog/unreleased/kong/optimize_keepalive_parameters.yml
+++ b/changelog/unreleased/kong/optimize_keepalive_parameters.yml
@@ -1,0 +1,3 @@
+message: Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to 10000.
+type: performance
+scope: Configuration

--- a/changelog/unreleased/kong/optimize_keepalive_parameters.yml
+++ b/changelog/unreleased/kong/optimize_keepalive_parameters.yml
@@ -1,3 +1,3 @@
-message: Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to 10000.
+message: Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to `10000`.
 type: performance
 scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1187,7 +1187,7 @@
                                                 # not make use of the PCRE library and their behavior
                                                 # is unaffected by this setting.
 
-#nginx_http_keepalive_requests = 1000  # Sets the maximum number of client requests that can be served through one
+#nginx_http_keepalive_requests = 10000 # Sets the maximum number of client requests that can be served through one
                                        # keep-alive connection. After the maximum number of requests are made,
                                        # the connection is closed.
                                        # Closing connections periodically is necessary to free per-connection

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -70,7 +70,7 @@ headers_upstream = x-kong-request-id
 trusted_ips = NONE
 error_default_type = text/plain
 upstream_keepalive_pool_size = 512
-upstream_keepalive_max_requests = 1000
+upstream_keepalive_max_requests = 10000
 upstream_keepalive_idle_timeout = 60
 allow_debug_header = off
 
@@ -93,7 +93,7 @@ nginx_http_ssl_session_tickets = NONE
 nginx_http_ssl_session_timeout = NONE
 nginx_http_lua_regex_match_limit = 100000
 nginx_http_lua_regex_cache_max_entries = 8192
-nginx_http_keepalive_requests = 1000
+nginx_http_keepalive_requests = 10000
 nginx_stream_ssl_protocols = NONE
 nginx_stream_ssl_prefer_server_ciphers = NONE
 nginx_stream_ssl_dhparam = NONE


### PR DESCRIPTION



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to `10000`.
### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3360
