### PR TITLE
chore(ci): pin CI to test scheduler release v1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,12 +99,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download runtimes file
-      uses: Kong/gh-storage/download@main
+      uses: Kong/gh-storage/download@v1
       with:
         repo-path: Kong/gateway-action-storage/main/.ci/runtimes.json
 
     - name: Schedule tests
-      uses: Kong/gateway-test-scheduler/schedule@main
+      uses: Kong/gateway-test-scheduler/schedule@v1
       with:
         test-suites-file: .ci/test_suites.json
         test-file-runtime-file: .ci/runtimes.json
@@ -267,7 +267,7 @@ jobs:
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
         DD_TRACE_GIT_METADATA_ENABLED: true
         DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-      uses: Kong/gateway-test-scheduler/runner@main
+      uses: Kong/gateway-test-scheduler/runner@v1
       with:
         tests-to-run-file: test-chunk.${{ matrix.runner }}.json
         failed-test-files-file: ${{ env.FAILED_TEST_FILES_FILE }}

--- a/.github/workflows/update-test-runtime-statistics.yml
+++ b/.github/workflows/update-test-runtime-statistics.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Process statistics
-        uses: Kong/gateway-test-scheduler/analyze@main
+        uses: Kong/gateway-test-scheduler/analyze@v1
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
@@ -28,7 +28,7 @@ jobs:
           artifact-name-regexp: "^test-runtime-statistics-\\d+$"
 
       - name: Upload new runtimes file
-        uses: Kong/gh-storage/upload@main
+        uses: Kong/gh-storage/upload@v1
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:


### PR DESCRIPTION
### Summary

This commit pins Kong to the v1 release of the gateway-test-scheduler and gh-storage action.

### Checklist

- [X] The Pull Request has tests (implicitly tested if CI passes)
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

