### PR TITLE
fix(request-debugging): add missing `router` section of the timing output

### DIFF
--- a/changelog/unreleased/kong/fix-missing-router-section-of-request-debugging.yml
+++ b/changelog/unreleased/kong/fix-missing-router-section-of-request-debugging.yml
@@ -1,0 +1,3 @@
+message: Fix the missing router section for the output of the request-debugging
+type: bugfix
+scope: Core

--- a/kong/timing/init.lua
+++ b/kong/timing/init.lua
@@ -306,6 +306,14 @@ function _M.register_hooks()
     _M.leave_context() -- leave plugin_id
     _M.leave_context() -- leave plugin_name
   end)
+
+  req_dyn_hook.hook("timing", "before:router", function()
+    _M.enter_context("router")
+  end)
+
+  req_dyn_hook.hook("timing", "after:router", function()
+    _M.leave_context() -- leave router
+  end)
 end
 
 

--- a/spec/02-integration/21-request-debug/01-request-debug_spec.lua
+++ b/spec/02-integration/21-request-debug/01-request-debug_spec.lua
@@ -535,6 +535,7 @@ describe(desc, function()
     assert.truthy(header_output.child.rewrite)
     assert.truthy(header_output.child.access)
     assert.truthy(header_output.child.access.child.dns) -- upstream is resolved in access phase
+    assert.truthy(header_output.child.access.child.router) -- router is executed in access phase
     assert(header_output.child.access.child.dns.child.localhost.child.resolve.cache_hit ~= nil, "dns cache hit should be recorded")
     assert.truthy(header_output.child.balancer)
     assert.truthy(header_output.child.header_filter)
@@ -542,6 +543,7 @@ describe(desc, function()
     assert.truthy(log_output.child.rewrite)
     assert.truthy(log_output.child.access)
     assert.truthy(log_output.child.access.child.dns) -- upstream is resolved in access phase
+    assert.truthy(log_output.child.access.child.router) -- router is executed in access phase
     assert(log_output.child.access.child.dns.child.localhost.child.resolve.cache_hit ~= nil, "dns cache hit should be recorded")
     assert.truthy(log_output.child.balancer)
     assert.truthy(log_output.child.header_filter)
@@ -573,11 +575,13 @@ describe(desc, function()
     assert.truthy(header_output.child.rewrite)
     assert.truthy(header_output.child.access)
     assert.truthy(header_output.child.access.child.dns) -- upstream is resolved in access phase
+    assert.truthy(header_output.child.access.child.router) -- router is executed in access phase
     assert.truthy(header_output.child.response)
 
     assert.truthy(log_output.child.rewrite)
     assert.truthy(log_output.child.access)
     assert.truthy(log_output.child.access.child.dns) -- upstream is resolved in access phase
+    assert.truthy(header_output.child.access.child.router) -- router is executed in access phase
     assert.truthy(log_output.child.body_filter)
     assert.truthy(log_output.child.log)
 


### PR DESCRIPTION
<del>## Blocked by https://github.com/Kong/kong/pull/12580</del>

### Summary

We have already added calls of the hook to measure the time consumed by the router.

https://github.com/Kong/kong/blob/f7e6eeefe006af11129d1b0e39a1c06449a53d42/kong/runloop/handler.lua#L1152-L1162

But forgot to setup the hook function, this PR setups the hook function for the router.

And also fix some tests that might cause flakiness.

### Checklist

- [X] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3438]_

[KAG-3438]: https://konghq.atlassian.net/browse/KAG-3438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ