### PR TITLE
bump: bump lua-resty-healthcheck to 1.5.4

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-healthcheck-1.5.4.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-healthcheck-1.5.4.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-healthcheck from 1.5.3 to 1.5.4"
+type: dependency
+scope: Core

--- a/changelog/unreleased/kong/bump_lua_resty_healthcheck.yml
+++ b/changelog/unreleased/kong/bump_lua_resty_healthcheck.yml
@@ -1,0 +1,3 @@
+message: Bump lua-resty-healthcheck version to fix target delay clear bug
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/bump_lua_resty_healthcheck.yml
+++ b/changelog/unreleased/kong/bump_lua_resty_healthcheck.yml
@@ -1,3 +1,0 @@
-message: Bump lua-resty-healthcheck version to fix target delay clear bug
-type: bugfix
-scope: Core

--- a/kong-2.8.4-0.rockspec
+++ b/kong-2.8.4-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-healthcheck == 1.5.3",
+  "lua-resty-healthcheck == 1.5.4",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.8.7",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

bump lua-resty-healthcheck to 1.5.4

https://github.com/Kong/lua-resty-healthcheck/tree/release/1.5.x#154-22-dec-2023

https://github.com/Kong/lua-resty-healthcheck/pull/147

FTI-5478


