### PR TITLE
fix(build): use NGX_WASM_MODULE_BRANCH environment variable

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -195,9 +195,6 @@ time to control how the ngx_wasm_module repository is sourced:
     tells bazel to build from a branch rather than using the tag found in our
     `.requirements` file
 
-**NOTE:** these environment variables currently do not integrate very well with
-bazel's cache mechanism, so you may need to clear cache after changing their value.
-
 ## Cross compiling
 
 Cross compiling is currently only tested on Ubuntu 22.04 x86_64 with following targeting platforms:

--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -110,6 +110,7 @@ load_bindings = repository_rule(
         "INSTALL_DESTDIR",
         "RPM_SIGNING_KEY_FILE",
         "NFPM_RPM_PASSPHRASE",
+        "NGX_WASM_MODULE_BRANCH",
         "NGX_WASM_MODULE_REMOTE",
     ],
 )

--- a/build/kong_bindings.bzl
+++ b/build/kong_bindings.bzl
@@ -64,6 +64,9 @@ def _load_vars(ctx):
     ngx_wasm_module_remote = ctx.os.environ.get("NGX_WASM_MODULE_REMOTE", "https://github.com/Kong/ngx_wasm_module.git")
     content += '"NGX_WASM_MODULE_REMOTE": "%s",' % ngx_wasm_module_remote
 
+    ngx_wasm_module_branch = ctx.os.environ.get("NGX_WASM_MODULE_BRANCH", "")
+    content += '"NGX_WASM_MODULE_BRANCH": "%s",' % ngx_wasm_module_branch
+
     ctx.file("BUILD.bazel", "")
     ctx.file("variables.bzl", "KONG_VAR = {\n" + content + "\n}")
 

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -53,9 +53,13 @@ wasm_runtimes = {
 }
 
 def wasmx_repositories():
+    wasm_module_branch = KONG_VAR["NGX_WASM_MODULE_BRANCH"]
+    if wasm_module_branch == "":
+        wasm_module_branch = KONG_VAR["NGX_WASM_MODULE"]
+
     new_git_repository(
         name = "ngx_wasm_module",
-        branch = KONG_VAR["NGX_WASM_MODULE"],
+        branch = wasm_module_branch,
         remote = KONG_VAR["NGX_WASM_MODULE_REMOTE"],
         build_file_content = """
 filegroup(

--- a/changelog/unreleased/kong/fix-wasm-module-branch.yml
+++ b/changelog/unreleased/kong/fix-wasm-module-branch.yml
@@ -1,0 +1,3 @@
+message: use NGX_WASM_MODULE_BRANCH environment variable to set ngx_wasm_module repository branch when building Kong.
+type: bugfix
+scope: Core


### PR DESCRIPTION
### Summary

To improve the development and testing experience of the integration between Kong and Wasmx, the `NGX_WASM_MODULE_BRANCH` environment variable should be used to overwrite the `ngx_wasm_module` branch/commit in the `.requirements` file, as it is documented in `build/README.md`. But this variable was being ignored by the build system.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3396
