### PR TITLE
fix(plugin): request transformer to preserve header cases

### DIFF
--- a/changelog/unreleased/kong/fix_req_transformer_case_sensitive.yml
+++ b/changelog/unreleased/kong/fix_req_transformer_case_sensitive.yml
@@ -1,0 +1,3 @@
+message: "**request-transformer**: now the plugin respect the letter case of new names when renaming headers."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -168,7 +168,7 @@ local function transform_headers(conf, template_env)
     old_name = old_name:lower()
     local value = headers[old_name]
     if value then
-      headers[new_name:lower()] = value
+      headers[new_name] = value
       headers[old_name] = nil
       headers_to_remove[old_name] = true
     end

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -227,7 +227,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       name = "request-transformer",
       config = {
         rename = {
-          headers = {"x-to-rename:x-is-renamed"},
+          headers = {"x-to-rename:X-Is-Renamed"},
           querystring = {"originalparam:renamedparam"},
           body = {"originalparam:renamedparam"}
         }
@@ -712,7 +712,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.response(r).has.status(200)
       assert.response(r).has.jsonbody()
       assert.request(r).has.no.header("x-to-rename")
-      assert.request(r).has.header("x-is-renamed")
+      assert.request(r).has.header("X-Is-Renamed")
       assert.request(r).has.header("x-another-header")
     end)
     it("does not add as new header if header does not exist", function()
@@ -738,13 +738,13 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
         headers = {
           host = "test9.test",
           ["x-to-rename"] = "new-result",
-          ["x-is-renamed"] = "old-result",
+          ["X-Is-Renamed"] = "old-result",
         }
       })
       assert.response(r).has.status(200)
       assert.response(r).has.jsonbody()
       assert.request(r).has.no.header("x-to-rename")
-      local h_is_renamed = assert.request(r).has.header("x-is-renamed")
+      local h_is_renamed = assert.request(r).has.header("X-Is-Renamed")
       assert.equals("new-result", h_is_renamed)
     end)
     for _, seq in ipairs({ 1, 2, 3, 4, 5, 6}) do
@@ -761,7 +761,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
         assert.response(r).has.status(200)
         assert.response(r).has.jsonbody()
         assert.request(r).has.no.header("x-to-rename")
-        local h_is_renamed = assert.request(r).has.header("x-is-renamed")
+        local h_is_renamed = assert.request(r).has.header("X-Is-Renamed")
         assert.equals("new-result", h_is_renamed)
       end)
     end


### PR DESCRIPTION
### Summary

Request-transformer used to ignore cases when renaming header. This PR makes it case-sensitive when renaming headers.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Issue reference

Fix KAG-2599 #11579
