### PR TITLE
refactor(globalpatches): remove the compatibility code for the sock:connect bug

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -549,7 +549,7 @@ return function(options)
         end
       end
 
-      return f(sock, host, port, opts)
+      return f(sock, host, port, port and opts or nil)
     end
 
     local function tcp_resolve_connect(sock, host, port, opts)

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -539,15 +539,6 @@ return function(options)
     local old_tcp_connect
     local old_udp_setpeername
 
-    -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
-    local function strip_nils(first, second)
-      if second then
-        return first, second
-      elseif first then
-        return first
-      end
-    end
-
     local function resolve_connect(f, sock, host, port, opts)
       if sub(host, 1, 5) ~= "unix:" then
         local try_list
@@ -558,7 +549,7 @@ return function(options)
         end
       end
 
-      return f(sock, host, strip_nils(port, opts))
+      return f(sock, host, port, opts)
     end
 
     local function tcp_resolve_connect(sock, host, port, opts)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary


The official OpenResty has fixed the bug of sock:connect API, so we do not need to make it compatible for this. For more details of this bug, see https://github.com/openresty/lua-nginx-module/issues/860.

### Checklist

- [ ] The Pull Request has tests
  - [x] Reusing the original test cases is sufficient.
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
