### PR TITLE
docs(pdk): fix missing doc for set_header related pdk #12164

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -412,7 +412,7 @@ local function new(self, major_version)
   -- @function kong.response.set_header
   -- @phases rewrite, access, header_filter, response, admin_api
   -- @tparam string name The name of the header
-  -- @tparam string|number|boolean value The new value for the header.
+  -- @tparam array of strings|string|number|boolean value The new value for the header.
   -- @return Nothing; throws an error on invalid input.
   -- @usage
   -- kong.response.set_header("X-Foo", "value")
@@ -445,7 +445,7 @@ local function new(self, major_version)
   -- @function kong.response.add_header
   -- @phases rewrite, access, header_filter, response, admin_api
   -- @tparam string name The header name.
-  -- @tparam string|number|boolean value The header value.
+  -- @tparam array of strings|string|number|boolean value The header value.
   -- @return Nothing; throws an error on invalid input.
   -- @usage
   -- kong.response.add_header("Cache-Control", "no-cache")

--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -287,7 +287,7 @@ local function new(self)
   -- @function kong.service.request.set_header
   -- @phases `rewrite`, `access`, `balancer`
   -- @tparam string header The header name. Example: "X-Foo".
-  -- @tparam string|boolean|number value The header value. Example: "hello world".
+  -- @tparam array of strings|string|boolean|number value The header value. Example: "hello world".
   -- @return Nothing; throws an error on invalid inputs.
   -- @usage
   -- kong.service.request.set_header("X-Foo", "value")
@@ -323,7 +323,7 @@ local function new(self)
   -- @function kong.service.request.add_header
   -- @phases `rewrite`, `access`
   -- @tparam string header The header name. Example: "Cache-Control".
-  -- @tparam string|number|boolean value The header value. Example: "no-cache".
+  -- @tparam array of strings|string|number|boolean value The header value. Example: "no-cache".
   -- @return Nothing; throws an error on invalid inputs.
   -- @usage
   -- kong.service.request.add_header("Cache-Control", "no-cache")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

fix missing doc for https://github.com/Kong/kong/pull/12164

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests (no need)
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md) (no need)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
