### PR TITLE
chore(core): enable status_listen by default

### DIFF
--- a/changelog/unreleased/kong/default_status_port.yml.yml
+++ b/changelog/unreleased/kong/default_status_port.yml.yml
@@ -1,0 +1,3 @@
+message: Enable `status_listen` on `127.0.0.1:8007` by default
+type: feature
+scope: Admin API

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -680,7 +680,8 @@
                          #
                          # Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
 
-#status_listen = off     # Comma-separated list of addresses and ports on
+#status_listen = 127.0.0.7:8007 reuseport backlog=16384
+                         # Comma-separated list of addresses and ports on
                          # which the Status API should listen.
                          # The Status API is a read-only endpoint
                          # allowing monitoring tools to retrieve metrics,

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -680,7 +680,7 @@
                          #
                          # Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
 
-#status_listen = 127.0.0.7:8007 reuseport backlog=16384
+#status_listen = 127.0.0.1:8007 reuseport backlog=16384
                          # Comma-separated list of addresses and ports on
                          # which the Status API should listen.
                          # The Status API is a read-only endpoint

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -28,7 +28,7 @@ proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reus
 stream_listen = off
 admin_listen = 127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 http2 ssl reuseport backlog=16384
 admin_gui_listen = 0.0.0.0:8002, 0.0.0.0:8445 ssl
-status_listen = 127.0.0.7:8007 reuseport backlog=16384
+status_listen = 127.0.0.1:8007 reuseport backlog=16384
 cluster_listen = 0.0.0.0:8005
 cluster_control_plane = 127.0.0.1:8005
 cluster_cert = NONE

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -28,7 +28,7 @@ proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reus
 stream_listen = off
 admin_listen = 127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 http2 ssl reuseport backlog=16384
 admin_gui_listen = 0.0.0.0:8002, 0.0.0.0:8445 ssl
-status_listen = off
+status_listen = 127.0.0.7:8007 reuseport backlog=16384
 cluster_listen = 0.0.0.0:8005
 cluster_control_plane = 127.0.0.1:8005
 cluster_cert = NONE


### PR DESCRIPTION
### Summary

We now by default enable status port.

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3359
