### PR TITLE
fix(router): add preserve_host logic in stream subsystem

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -11,7 +11,6 @@ local tb_new = require("table.new")
 local fields = require("kong.router.fields")
 local utils = require("kong.router.utils")
 local yield = require("kong.tools.yield").yield
-local server_name = require("ngx.ssl").server_name
 
 
 local type = type

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -11,6 +11,7 @@ local tb_new = require("table.new")
 local fields = require("kong.router.fields")
 local utils = require("kong.router.utils")
 local yield = require("kong.tools.yield").yield
+local server_name = require("ngx.ssl").server_name
 
 
 local type = type
@@ -655,6 +656,11 @@ function _M:exec(ctx)
 
   else
     route_match_stat(ctx, "pos")
+
+    -- preserve_host logic, modify cache result
+    if match_t.route.preserve_host then
+      match_t.upstream_host = fields.get_value("tls.sni", CACHE_PARAMS)
+    end
   end
 
   return match_t

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -218,15 +218,20 @@ if is_http then
 end -- is_http
 
 
+local function get_value(field, params, ctx)
+  local func = FIELDS_FUNCS[field]
+
+  if not func then  -- unknown field
+    error("unknown router matching schema field: " .. field)
+  end -- if func
+
+  return func(params, ctx)
+end
+
+
 local function fields_visitor(fields, params, ctx, cb)
   for _, field in ipairs(fields) do
-    local func = FIELDS_FUNCS[field]
-
-    if not func then  -- unknown field
-      error("unknown router matching schema field: " .. field)
-    end -- if func
-
-    local value = func(params, ctx)
+    local value = get_value(field, params, ctx)
 
     local res, err = cb(field, value)
     if not res then
@@ -352,6 +357,8 @@ end
 
 
 return {
+  get_value = get_value,
+
   get_cache_key = get_cache_key,
   fill_atc_context = fill_atc_context,
 

--- a/spec/02-integration/01-helpers/01-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/01-helpers_spec.lua
@@ -26,6 +26,7 @@ for _, strategy in helpers.each_strategy() do
       bp.routes:insert {
         hosts     = { "mock_upstream" },
         protocols = { "http" },
+        paths = { "/" },
         service   = service
       }
 

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -877,15 +877,16 @@ for _, strategy in helpers.each_strategy() do
     describe("URI arguments (querystring)", function()
       local routes
 
-      before_each(function()
+      lazy_setup(function()
         routes = insert_routes(bp, {
           {
             hosts = { "mock_upstream" },
+            paths = { "/" },
           },
         })
       end)
 
-      after_each(function()
+      lazy_teardown(function()
         remove_routes(strategy, routes)
       end)
 
@@ -1301,6 +1302,7 @@ for _, strategy in helpers.each_strategy() do
         routes = insert_routes(bp, {
           {
             protocols = { "https" },
+            paths = { "/" },
             snis = { "www.example.org" },
             service = {
               name = "service_behind_www.example.org"
@@ -1343,7 +1345,7 @@ for _, strategy in helpers.each_strategy() do
           path    = "/status/201",
           headers = { ["kong-debug"] = 1 },
         })
-        assert.res_status(flavor == "traditional" and 201 or 200, res)
+        assert.res_status(201, res)
         assert.equal("service_behind_www.example.org",
                      res.headers["kong-service-name"])
 
@@ -1365,7 +1367,7 @@ for _, strategy in helpers.each_strategy() do
           path    = "/status/201",
           headers = { ["kong-debug"] = 1 },
         })
-        assert.res_status(flavor == "traditional" and 201 or 200, res)
+        assert.res_status(201, res)
         assert.equal("service_behind_example.org",
                      res.headers["kong-service-name"])
       end)

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -278,6 +278,7 @@ for _, strategy in helpers.each_strategy() do
 
         assert(bp.routes:insert {
           hosts = { "headers-charset.test" },
+          paths = { "/" },
           service = service,
         })
 

--- a/spec/02-integration/05-proxy/14-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/14-server_tokens_spec.lua
@@ -291,6 +291,7 @@ describe("headers [#" .. strategy .. "]", function()
       return function()
         bp.routes:insert {
           hosts = { "headers-inspect.test" },
+          paths = { "/" },
         }
 
         local service = bp.services:insert({

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -19,6 +19,7 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert {
         hosts = { "logging.test" },
+        paths = { "/" },
       }
 
       local route2 = bp.routes:insert {

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -43,7 +43,7 @@ for _, strategy in helpers.each_strategy() do
       route = assert(admin_api.routes:insert {
         hosts     = { "oauth2.com" },
         protocols = { "http", "https" },
-        paths = { "/" }
+        paths = { "/" },
         service   = service,
       })
 

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -43,6 +43,7 @@ for _, strategy in helpers.each_strategy() do
       route = assert(admin_api.routes:insert {
         hosts     = { "oauth2.com" },
         protocols = { "http", "https" },
+        paths = { "/" }
         service   = service,
       })
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -38,6 +38,7 @@ do
 
       local route1 = assert(bp.routes:insert {
         hosts = { "route-1.test" },
+        paths = { "/" },
       })
       local route2 = assert(bp.routes:insert {
         hosts = { "route-2.test" },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It is a succeeding of #12127.

- add `paths = { "/" }` in routes to enable calculation cache for path 
- add `perserve_host` logic for stream

KAG-3032

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
