### PR TITLE
docs(changelog): fix a typo in #11258

### DIFF
--- a/changelog/unreleased/kong/atc_reuse_context.yml
+++ b/changelog/unreleased/kong/atc_reuse_context.yml
@@ -1,3 +1,3 @@
-message: "Reuse match copntext between requests to avoid frequent memory allocation/deallocation"
+message: "Reuse match context between requests to avoid frequent memory allocation/deallocation"
 type: performance
 scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

A simple typo fix.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
