### PR TITLE
refactor(plugins): replace usage or resty.openssl.hmac with resty.openssl.mac

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -1,5 +1,5 @@
 local constants = require "kong.constants"
-local openssl_hmac = require "resty.openssl.hmac"
+local openssl_mac = require "resty.openssl.mac"
 
 
 local sha256_base64 = require("kong.tools.sha256").sha256_base64
@@ -37,13 +37,13 @@ local hmac = {
     return hmac_sha1(secret, data)
   end,
   ["hmac-sha256"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha256"):final(data)
+    return openssl_mac.new(secret, "HMAC", nil, "sha256"):final(data)
   end,
   ["hmac-sha384"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha384"):final(data)
+    return openssl_mac.new(secret, "HMAC", nil, "sha384"):final(data)
   end,
   ["hmac-sha512"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha512"):final(data)
+    return openssl_mac.new(secret, "HMAC", nil, "sha512"):final(data)
   end,
 }
 

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -9,7 +9,7 @@ local json = require "cjson"
 local b64 = require "ngx.base64"
 local buffer = require "string.buffer"
 local openssl_digest = require "resty.openssl.digest"
-local openssl_hmac = require "resty.openssl.hmac"
+local openssl_mac = require "resty.openssl.mac"
 local openssl_pkey = require "resty.openssl.pkey"
 
 
@@ -33,9 +33,9 @@ local decode_base64url = b64.decode_base64url
 
 --- Supported algorithms for signing tokens.
 local alg_sign = {
-  HS256 = function(data, key) return openssl_hmac.new(key, "sha256"):final(data) end,
-  HS384 = function(data, key) return openssl_hmac.new(key, "sha384"):final(data) end,
-  HS512 = function(data, key) return openssl_hmac.new(key, "sha512"):final(data) end,
+  HS256 = function(data, key) return openssl_mac.new(key, "HMAC", nil, "sha256"):final(data) end,
+  HS384 = function(data, key) return openssl_mac.new(key, "HMAC", nil, "sha384"):final(data) end,
+  HS512 = function(data, key) return openssl_mac.new(key, "HMAC", nil, "sha512"):final(data) end,
   RS256 = function(data, key)
     local digest = openssl_digest.new("sha256")
     assert(digest:update(data))

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -1,5 +1,5 @@
 local cjson = require "cjson"
-local openssl_hmac = require "resty.openssl.hmac"
+local openssl_mac = require "resty.openssl.mac"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local resty_sha256 = require "resty.sha256"
@@ -8,7 +8,7 @@ local fmt = string.format
 
 
 local hmac_sha1_binary = function(secret, data)
-  return openssl_hmac.new(secret, "sha1"):final(data)
+  return openssl_mac.new(secret, "HMAC", nil, "sha1"):final(data)
 end
 
 
@@ -816,7 +816,7 @@ for _, strategy in helpers.each_strategy() do
       it("should not pass with GET with wrong algorithm", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha256"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha256"):final("date: " .. date .. "\n"
             .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",algorithm="hmac-sha",]]
           .. [[  headers="date content-md5 request-line",signature="]]
@@ -839,7 +839,7 @@ for _, strategy in helpers.each_strategy() do
       it("should pass the right headers to the upstream server", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha256"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha256"):final("date: " .. date .. "\n"
                              .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",algorithm="hmac-sha256",]]
           .. [[  headers="date content-md5 request-line",signature="]]
@@ -1592,7 +1592,7 @@ for _, strategy in helpers.each_strategy() do
       it("should pass with GET with hmac-sha384", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha384"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha384"):final("date: " .. date .. "\n"
                   .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha384", ]]
                 .. [[headers="date content-md5 request-line", signature="]]
@@ -1614,7 +1614,7 @@ for _, strategy in helpers.each_strategy() do
       it("should pass with GET with hmac-sha512", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha512"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha512"):final("date: " .. date .. "\n"
                   .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha512", ]]
                 .. [[headers="date content-md5 request-line", signature="]]
@@ -1636,7 +1636,7 @@ for _, strategy in helpers.each_strategy() do
       it("should not pass with hmac-sha512", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha512"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha512"):final("date: " .. date .. "\n"
                   .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha512", ]]
                 .. [[headers="date content-md5 request-line", signature="]]
@@ -1673,7 +1673,7 @@ for _, strategy in helpers.each_strategy() do
       it("should pass with hmac-sha1", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
-          openssl_hmac.new("secret", "sha1"):final("date: " .. date .. "\n"
+          openssl_mac.new("secret", "HMAC", nil, "sha1"):final("date: " .. date .. "\n"
                   .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
                 .. [[headers="date content-md5 request-line", signature="]]

--- a/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
-local openssl_hmac = require "resty.openssl.hmac"
+local openssl_mac = require "resty.openssl.mac"
 
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: hmac-auth (invalidations) [#" .. strategy .. "]", function()
@@ -62,7 +62,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     local function hmac_sha1_binary(secret, data)
-      return openssl_hmac.new(secret, "sha1"):final(data)
+      return openssl_mac.new(secret, "HMAC", nil, "sha1"):final(data)
     end
 
     local function get_authorization(username)


### PR DESCRIPTION
### Summary

Replace all usage of `resty.openssl.hmac` (which binds `HMAC_*` low level APIs) with `resty.openssl.mac` in Kong.


### Issue reference

KAG-3445
