### PR TITLE
feat(ci): trigger a workflow for reviewing patches

### DIFF
--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -4,9 +4,6 @@ on:
     paths:
     - 'build/openresty/patches/**'
 
-permissions:
-  pull-requests: write
-
 jobs:
   create-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -1,0 +1,23 @@
+name: Openresty patches review companion
+on:
+  pull_request:
+    paths:
+    - 'build/openresty/patches/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch the workflow
+        uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1
+        with:
+          workflow: create-pr.yml
+          repo: kong/openresty-patches-review
+          ref: master
+          token: ${{ secrets.PAT }}
+          inputs: |
+            {"pr-branch":"${{ github.event.pull_request.head.repo.owner.login }}:${{ github.head_ref }}", "pr-base":"${{ github.base_ref }}", "ee":${{ contains(github.repository, 'kong-ee') && 'true' || 'false' }}, "pr-id":"${{ github.event.pull_request.number }}"}
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds a workflow that opens a companion PR (the link being displayed as mentioning current PR) when developer
opens a PR that modifies openresty patches.
The companion PR (like https://github.com/Kong/openresty-patches-review/pull/6) automatically creates and updates
_in-place_ when the PR at kong or kong-ee updates, and displays only the diffs for patches files to help reviewer
understand the changes better.

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
