### PR TITLE
fix(core): remove and restore nulls before and after transformations

### DIFF
--- a/changelog/unreleased/kong/declarative_config_fix.yml
+++ b/changelog/unreleased/kong/declarative_config_fix.yml
@@ -1,0 +1,5 @@
+message: |
+  Remove nulls only if the schema has transformations definitions.
+  Improve performance as most schemas does not define transformations.
+type: bugfix
+scope: Core

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -311,7 +311,6 @@ local function load_into_cache(entities, meta, hash)
       assert(type(ws_id) == "string")
 
       local cache_key = dao:cache_key(id, nil, nil, nil, nil, item.ws_id)
-      -- only do transformations if have definitions
       if transform and schema:has_transformations(item) then
         local transformed_item = utils.cycle_aware_deep_copy(item)
         remove_nulls(transformed_item)

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -102,18 +102,76 @@ local function load_into_db(entities, meta)
 end
 
 
+--- Remove all nulls from declarative config.
+-- Declarative config is a huge table. Use iteration
+-- instead of recursion to improve performance.
 local function remove_nulls(tbl)
-  for k,v in pairs(tbl) do
-    if v == null then
-      tbl[k] = nil
+  local stk = { tbl }
+  local n = #stk
 
-    elseif type(v) == "table" then
-      tbl[k] = remove_nulls(v)
+  local cur
+  while n > 0 do
+    cur = stk[n]
+
+    stk[n] = nil
+    n = n - 1
+
+    if type(cur) == "table" then
+      for k, v in pairs(cur) do
+        if v == null then
+          cur[k] = nil
+
+        elseif type(v) == "table" then
+          n = n + 1
+          stk[n] = v
+        end
+      end
     end
   end
+
   return tbl
 end
 
+--- Restore all nulls for declarative config.
+-- Declarative config is a huge table. Use iteration
+-- instead of recursion to improve performance.
+local function restore_nulls(original_tbl, transformed_tbl)
+  local o_stk = { original_tbl }
+  local o_n = #o_stk
+
+  local t_stk = { transformed_tbl }
+  local t_n = #t_stk
+
+  local o_cur, t_cur
+  while o_n > 0 and o_n == t_n do
+    o_cur = o_stk[o_n]
+    o_stk[o_n] = nil
+    o_n = o_n - 1
+
+    t_cur = t_stk[t_n]
+    t_stk[t_n] = nil
+    t_n = t_n - 1
+
+    for k, v in pairs(o_cur) do
+      if v == null and
+         t_cur[k] == nil
+      then
+        t_cur[k] = null
+
+      elseif type(v) == "table" and
+             type(t_cur[k]) == "table"
+      then
+        o_n = o_n + 1
+        o_stk[o_n] = v
+
+        t_n = t_n + 1
+        t_stk[t_n] = t_cur[k]
+      end
+    end
+  end
+
+  return transformed_tbl
+end
 
 local function get_current_hash()
   return lmdb.get(DECLARATIVE_HASH_KEY)
@@ -185,10 +243,11 @@ local function load_into_cache(entities, meta, hash)
   t:db_drop(false)
 
   local phase = get_phase()
+  yield(false, phase)   -- XXX
   local transform = meta._transform == nil and true or meta._transform
 
   for entity_name, items in pairs(entities) do
-    yield(false, phase)
+    yield(true, phase)
 
     local dao = db[entity_name]
     if not dao then
@@ -252,11 +311,18 @@ local function load_into_cache(entities, meta, hash)
       assert(type(ws_id) == "string")
 
       local cache_key = dao:cache_key(id, nil, nil, nil, nil, item.ws_id)
+      -- only do transformations if have definitions
+      if transform and schema:has_transformations(item) then
+        local transformed_item = utils.cycle_aware_deep_copy(item)
+        remove_nulls(transformed_item)
 
-      item = remove_nulls(item)
-      if transform then
         local err
-        item, err = schema:transform(item)
+        transformed_item, err = schema:transform(transformed_item)
+        if not transformed_item then
+          return nil, err
+        end
+
+        item = restore_nulls(item, transformed_item)
         if not item then
           return nil, err
         end
@@ -290,7 +356,7 @@ local function load_into_cache(entities, meta, hash)
       for i = 1, #uniques do
         local unique = uniques[i]
         local unique_key = item[unique]
-        if unique_key then
+        if unique_key and unique_key ~= null then
           if type(unique_key) == "table" then
             local _
             -- this assumes that foreign keys are not composite
@@ -306,7 +372,7 @@ local function load_into_cache(entities, meta, hash)
 
       for fname, ref in pairs(foreign_fields) do
         local item_fname = item[fname]
-        if item_fname then
+        if item_fname and item_fname ~= null then
           local fschema = db[ref].schema
 
           local fid = declarative_config.pk_string(fschema, item_fname)
@@ -324,7 +390,7 @@ local function load_into_cache(entities, meta, hash)
       end
 
       local item_tags = item.tags
-      if item_tags then
+      if item_tags and item_tags ~= null then
         local ws = schema.workspaceable and ws_id or ""
         for i = 1, #item_tags do
           local tag_name = item_tags[i]

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -930,6 +930,7 @@ function Schema:validate_field(field, value)
     local field_schema = get_field_schema(field)
     -- TODO return nested table or string?
     local copy = field_schema:process_auto_fields(value, "insert")
+    -- Changes in custom entity check only applies to copy, not to value
     local ok, err = field_schema:validate(copy)
     if not ok then
       return nil, err
@@ -2345,6 +2346,21 @@ local function run_transformations(self, transformations, input, original_input,
   return output or input
 end
 
+--- Check if the schema has transformation definitions.
+-- @param input a table holding entities
+-- @return a boolean value: 'true' or 'false'
+function Schema:has_transformations(input)
+  if self.transformations then
+    return true
+  end
+
+  local subschema = get_subschema(self, input)
+  if subschema and subschema.transformations then
+    return true
+  end
+
+  return false
+end
 
 --- Run transformations on fields.
 -- @param input The input table.

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -930,7 +930,7 @@ function Schema:validate_field(field, value)
     local field_schema = get_field_schema(field)
     -- TODO return nested table or string?
     local copy = field_schema:process_auto_fields(value, "insert")
-    -- Changes in custom entity check only applies to copy, not to value
+    -- TODO: explain why we need to make a copy?
     local ok, err = field_schema:validate(copy)
     if not ok then
       return nil, err

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -23,12 +23,6 @@ local lmdb_get = lmdb.get
 local get_workspace_id = workspaces.get_workspace_id
 
 
-local PROCESS_AUTO_FIELDS_OPTS = {
-  no_defaults = true,
-  show_ws_id = true,
-}
-
-
 local off = {}
 
 
@@ -213,7 +207,7 @@ local function page_for_key(self, key, size, offset, options)
     end
 
     if item then
-      ret[ret_idx] = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
+      ret[ret_idx] = item
       ret_idx = ret_idx + 1
     end
   end
@@ -238,8 +232,6 @@ local function select_by_key(schema, key)
       return nil
     end
   end
-
-  entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
   return entity
 end

--- a/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
+++ b/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
@@ -34,6 +34,7 @@ do
       end
     },
   }))
+  lmdb_mlcache:purge(true)
 
   _G.lmdb_mlcache = lmdb_mlcache
 end

--- a/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
+++ b/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
@@ -1,0 +1,245 @@
+-- This software is copyright Kong Inc. and its licensors.
+-- Use of the software is subject to the agreement between your organization
+-- and Kong Inc. If there is no such agreement, use is governed by and
+-- subject to the terms of the Kong Master Software License Agreement found
+-- at https://konghq.com/enterprisesoftwarelicense/.
+-- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
+
+local helpers
+local buffer
+local kong_global
+local conf_loader
+local declarative
+local DB
+
+local kong
+
+
+local ngx_log = ngx.log
+local ngx_debug = ngx.DEBUG
+local lmdb_mlcache
+do
+  local resty_mlcache = require "kong.resty.mlcache"
+  lmdb_mlcache = assert(resty_mlcache.new("lmdb_mlcache", "lmdb_mlcache", {
+    lru_size = 1000,
+    ttl      = 0,
+    neg_ttl  = 0,
+    resurrect_ttl = 30,
+    ipc      = {
+      register_listeners = function(events)
+        ngx_log(ngx_debug, "register lmdb worker events ", tostring(events))
+      end,
+      broadcast = function(channel, data)
+        ngx_log(ngx_debug, "broadcast lmdb worker events ", tostring(channel), tostring(data))
+      end
+    },
+  }))
+
+  _G.lmdb_mlcache = lmdb_mlcache
+end
+
+local function mocking_lmdb_transaction()
+  local _lmdb_txn = {}
+  local _lmdb_txn_mt = { __index = _lmdb_txn }
+  function _lmdb_txn.begin(x)
+    ngx_log(ngx_debug, "new lmdb: ", x)
+    local self = {
+      cache = lmdb_mlcache,
+      DEFAULT_DB = "_default",
+    }
+    return setmetatable(self, _lmdb_txn_mt)
+  end
+
+  function _lmdb_txn:db_drop(delete, db)
+    ngx_log(ngx_debug, "drop db = ", db or self.DEFAULT_DB, ", delete = ", delete)
+    return true
+  end
+
+  function _lmdb_txn:set(key, value, db)
+    ngx_log(ngx_debug, "set db = ", db or self.DEFAULT_DB, ", ", key, " = ", value)
+    self.cache:set(key, nil, value)
+    return true
+  end
+
+  function _lmdb_txn:get(key, db)
+    ngx_log(ngx_debug, "get db = ", db or self.DEFAULT_DB, ", key = ", key)
+    return self.cache:get(key)
+  end
+
+  function _lmdb_txn:commit()
+    ngx_log(ngx_debug, "commit lmdb transactions")
+    return true
+  end
+
+  _G.package.loaded["resty.lmdb.transaction"] = _lmdb_txn
+end
+
+local function mocking_lmdb()
+  local _lmdb = {
+    cache = lmdb_mlcache,
+    DEFAULT_DB = "_default"
+  }
+  local _lmdb_mt = { __index = _lmdb, }
+
+  function _lmdb.get(key, db)
+    ngx_log(ngx_debug, "get db = ", db or _lmdb.DEFAULT_DB, ", key = ", key)
+    return _lmdb.cache:get(key)
+  end
+
+  setmetatable(_lmdb, _lmdb_mt)
+
+  _G.package.loaded["resty.lmdb"] = _lmdb
+end
+
+local function unmocking()
+  _G.package.loaded["resty.lmdb.transaction"] = nil
+  _G["resty.lmdb.transaction"] = nil
+
+  _G.package.loaded["resty.lmdb"] = nil
+  _G["resty.lmdb"] = nil
+end
+
+describe("#off preserve nulls", function()
+  local PLUGIN_NAME = "preserve-nulls"
+  local PASSWORD = "fti-110"
+  local YAML_CONTENTS = string.format([=[
+    _format_version: '3.0'
+    services:
+    - name: fti-110
+      url: http://localhost/ip
+      routes:
+      - name: fti-110
+        paths:
+        - /fti-110
+        plugins:
+        - name: basic-auth
+          config:
+            hide_credentials: false
+        - name: preserve-nulls
+          config:
+            request_header: "Hello-Foo"
+            response_header: "Bye-Bar"
+            large: ~
+            ttl: null
+    consumers:
+    - username: fti-110
+      custom_id: fti-110-cid
+      basicauth_credentials:
+      - username: fti-110
+        password: %s
+      keyauth_credentials:
+      - key: fti-5260
+  ]=], PASSWORD)
+
+  lazy_setup(function()
+    mocking_lmdb_transaction()
+    require "resty.lmdb.transaction"
+    mocking_lmdb()
+    require "resty.lmdb"
+
+    helpers = require "spec.helpers"
+    kong = _G.kong
+    kong.core_cache = nil
+
+    buffer      = require "string.buffer"
+    kong_global = require "kong.global"
+    conf_loader = require "kong.conf_loader"
+    declarative = require "kong.db.declarative"
+    DB = require "kong.db"
+  end)
+
+  lazy_teardown(function()
+    unmocking()
+  end)
+
+  it("when loading into LMDB", function()
+    local null = ngx.null
+    local concat = table.concat
+
+    local kong_config = assert(conf_loader(helpers.test_conf_path, {
+      database = "off",
+      plugins = "bundled," .. PLUGIN_NAME,
+    }))
+
+    local db = assert(DB.new(kong_config))
+    assert(db:init_connector())
+    db.plugins:load_plugin_schemas(kong_config.loaded_plugins)
+    db.vaults:load_vault_schemas(kong_config.loaded_vaults)
+    kong.db = db
+
+    local dc = assert(declarative.new_config(kong_config))
+    local dc_table, _, _, current_hash = assert(dc:unserialize(YAML_CONTENTS, "yaml"))
+    assert.are_equal(PASSWORD, dc_table.consumers[1].basicauth_credentials[1].password)
+
+    local entities, _, _, meta, new_hash = assert(dc:parse_table(dc_table, current_hash))
+    assert.is_not_falsy(meta._transform)
+    assert.are_equal(current_hash, new_hash)
+
+    for _,v in pairs(entities.plugins) do
+      if v.name == PLUGIN_NAME then
+        assert.are_equal(v.config.large, null)
+        assert.are_equal(v.config.ttl, null)
+        break
+      end
+    end
+
+    kong.configuration = kong_config
+    kong.worker_events = kong.worker_events or
+                         kong.cache and kong.cache.worker_events or
+                         assert(kong_global.init_worker_events())
+    kong.cluster_events = kong.cluster_events or
+                          kong.cache and kong.cache.cluster_events or
+                          assert(kong_global.init_cluster_events(kong.configuration, kong.db))
+    kong.cache = kong.cache or
+                 assert(kong_global.init_cache(kong.configuration, kong.cluster_events, kong.worker_events))
+    kong.core_cache = assert(kong_global.init_core_cache(kong.configuration, kong.cluster_events, kong.worker_events))
+
+    kong.cache.worker_events = kong.cache.worker_events or kong.worker_events
+    kong.cache.cluster_events = kong.cache.cluster_events or kong.cluster_events
+
+    assert(declarative.load_into_cache(entities, meta, current_hash))
+
+    local id, item = next(entities.basicauth_credentials)
+    local cache_key = concat({
+      "basicauth_credentials:",
+      id,
+      ":::::",
+      item.ws_id
+    })
+
+    local lmdb = require "resty.lmdb"
+    local value, err, hit_lvl = lmdb.get(cache_key)
+    assert.is_nil(err)
+    assert.are_equal(hit_lvl, 1)
+
+    local cached_item = buffer.decode(value)
+    assert.are_not_same(cached_item, item)
+    assert.are_equal(cached_item.id, item.id)
+    assert.are_equal(cached_item.username, item.username)
+    assert.are_not_equal(PASSWORD, cached_item.password)
+    assert.are_not_equal(cached_item.password, item.password)
+
+    for _, plugin in pairs(entities.plugins) do
+      if plugin.name == PLUGIN_NAME then
+        cache_key = concat({
+          "plugins:" .. PLUGIN_NAME .. ":",
+          plugin.route.id,
+          "::::",
+          plugin.ws_id
+        })
+        value, err, hit_lvl = lmdb.get(cache_key)
+        assert.is_nil(err)
+        assert.are_equal(hit_lvl, 1)
+
+        cached_item = buffer.decode(value)
+        assert.are_same(cached_item, plugin)
+        assert.are_equal(cached_item.config.large, null)
+        assert.are_equal(cached_item.config.ttl, null)
+
+        break
+      end
+    end
+
+  end)
+
+end)

--- a/spec/02-integration/20-wasm/09-filter-meta_spec.lua
+++ b/spec/02-integration/20-wasm/09-filter-meta_spec.lua
@@ -457,8 +457,6 @@ describe("filter metadata [#off] yaml config", function()
                 append:
                   headers:
                   - x-response-transformer-2:TEST
-                rename: ~
-                remove: null
     ]]):format(helpers.mock_upstream_port))
 
     assert(helpers.start_kong({

--- a/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/handler.lua
@@ -1,0 +1,24 @@
+-- This software is copyright Kong Inc. and its licensors.
+-- Use of the software is subject to the agreement between your organization
+-- and Kong Inc. If there is no such agreement, use is governed by and
+-- subject to the terms of the Kong Master Software License Agreement found
+-- at https://konghq.com/enterprisesoftwarelicense/.
+-- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
+
+local kong = kong
+
+local PreserveNullsHandler = {
+  PRIORITY = 1000,
+  VERSION = "0.1.0",
+}
+
+function PreserveNullsHandler:access(plugin_conf)
+  kong.service.request.set_header(plugin_conf.request_header, "this is on a request")
+end
+
+function PreserveNullsHandler:header_filter(plugin_conf)
+  kong.response.set_header(plugin_conf.response_header, "this is on the response")
+end
+
+
+return PreserveNullsHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/schema.lua
@@ -1,0 +1,38 @@
+-- This software is copyright Kong Inc. and its licensors.
+-- Use of the software is subject to the agreement between your organization
+-- and Kong Inc. If there is no such agreement, use is governed by and
+-- subject to the terms of the Kong Master Software License Agreement found
+-- at https://konghq.com/enterprisesoftwarelicense/.
+-- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
+
+local typedefs = require "kong.db.schema.typedefs"
+
+
+local PLUGIN_NAME = "PreserveNulls"
+
+local schema = {
+  name = PLUGIN_NAME,
+  fields = {
+    { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { request_header = typedefs.header_name {
+              required = true,
+              default = "Hello-World" } },
+          { response_header = typedefs.header_name {
+              required = true,
+              default = "Bye-World" } },
+          { large = {
+              type = "integer",
+              default = 100 } },
+          { ttl = {
+            type = "integer" } },
+        },
+      },
+    },
+  },
+}
+
+return schema


### PR DESCRIPTION
Current declarative config uncondtionally removes nulls before loading into LMDB, which would reset relavant config fields to their default values.

If their default values are `nil` and the code fails to dectect it, Kong will error! For example, config update may not be applied to core entities or plugins.

This PR removes nulls only if relevant schemas have transformations defined, and restore those nulls after transformation. Therefore, when loaded, entities preserve their nulls.

This fix does not prevent other components removing nulls accidentally. So please always check both `nil` and `null` for code robustness.

This PR will skip transformations if there is not transformation defitions. As most schemas do not have transformations, this would greatly improve performance.

Addtionally, this PR change recursive function to be iterative to boost performance.

---

Local debug info.

```
2024/01/04 11:36:11 [error] 38655#0: *2 [lua] import.lua:357: load_into_cache(): preserve-nulls config = {
  config = {
    large = <userdata 1>,
    request_header = "Hello-Foo",
    response_header = "Bye-Bar",
    ttl = <userdata 1>
  },
  consumer = <userdata 1>,
  consumer_group = <userdata 1>,
  created_at = 1704339371,
  enabled = true,
  id = "4833cef7-0628-502f-a417-84775ab7d49d",
  instance_name = <userdata 1>,
  name = "preserve-nulls",
  ordering = <userdata 1>,
  protocols = { "grpc", "grpcs", "http", "https",
    <metatable> = {}
  },
  route = {
    id = "2a69e506-6ca5-57db-8bda-fa910f3d2f17"
  },
  service = <userdata 1>,
  tags = <userdata 1>,
  updated_at = 1704339371,
  ws_id = "0dc6f45b-8f8d-40d2-a504-473544ee190b"
}, context: ngx.timer
2024/01/04 11:36:11 [error] 38655#0: *2 [lua] import.lua:526: load_into_cache(): preserve-nulls from lmdb = {
  config = {
    large = <userdata 1>,
    request_header = "Hello-Foo",
    response_header = "Bye-Bar",
    ttl = <userdata 1>
  },
  consumer = <userdata 1>,
  consumer_group = <userdata 1>,
  created_at = 1704339371,
  enabled = true,
  id = "4833cef7-0628-502f-a417-84775ab7d49d",
  instance_name = <userdata 1>,
  name = "preserve-nulls",
  ordering = <userdata 1>,
  protocols = { "grpc", "grpcs", "http", "https" },
  route = {
    id = "2a69e506-6ca5-57db-8bda-fa910f3d2f17"
  },
  service = <userdata 1>,
  tags = <userdata 1>,
  updated_at = 1704339371,
  ws_id = "0dc6f45b-8f8d-40d2-a504-473544ee190b"
}, context: ngx.timer
●
1 success / 0 failures / 0 errors / 0 pending : 1.197774 seconds
(kong-dev) 11:36:12 zachary@Zacharys-MacBook-Pro ~/workspace/kong-ee
```

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5260]_


[FTI-5260]: https://konghq.atlassian.net/browse/FTI-5260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ