### PR TITLE
tests(rate-limiting): clear expired key in shared dict

### DIFF
--- a/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
@@ -5,7 +5,7 @@ local timestamp = require "kong.tools.timestamp"
 local SYNC_RATE_REALTIME = -1
 
 --[[
-  basically a copy of `get_local_key()` 
+  basically a copy of `get_local_key()`
   in `kong/plugins/rate-limiting/policies/init.lua`
 --]]
 local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
@@ -41,7 +41,7 @@ describe("Plugin: rate-limiting (policies)", function()
   lazy_setup(function()
     package.loaded["kong.plugins.rate-limiting.policies"] = nil
     policies = require "kong.plugins.rate-limiting.policies"
-    
+
     if not _G.kong then
       _G.kong.db = {}
     end
@@ -80,18 +80,24 @@ describe("Plugin: rate-limiting (policies)", function()
     end)
 
     it("expires after due time", function ()
-      local timestamp = 569000048000
-      local key = get_local_key(conf, identifier, 'second', timestamp)
+      local current_timestamp = 1553263548
+      local periods = timestamp.get_timestamps(current_timestamp)
 
-      assert(policies['local'].increment(conf, {second=100}, identifier, timestamp+20, 1))
-      local v = assert(shm:ttl(key))
+      local limits = {
+        second = 100,
+      }
+      local cache_key = get_local_key(conf, identifier, 'second', periods.second)
+
+      assert(policies['local'].increment(conf, limits, identifier, current_timestamp, 1))
+      local v = assert(shm:ttl(cache_key))
       assert(v > 0, "wrong value")
       ngx.sleep(1.020)
 
-      v = shm:ttl(key)
-      assert(v < 0, "expected ttl to be negative")
-      local val = shm:get(key)
-      assert.is_nil(val)
+      shm:flush_expired()
+      local err
+      v, err = shm:ttl(cache_key)
+      assert(v == nil, "still there")
+      assert.matches("not found", err)
     end)
   end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Clear expired key in shared dict. Otherwise, we got negative value.

```bash
~ $ resty --http-conf 'lua_shared_dict jim 1m;' -e 'local shm = ngx.shared.jim; shm:set("age", 17, 1); local v = shm:get("age"); print(v); ngx.sleep(1.001); print(shm:ttl("age"))'
17
-0.032
```

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5674]_


[FTI-5674]: https://konghq.atlassian.net/browse/FTI-5674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ