### PR TITLE
fix(plugins/request-transformer): remove lower-cased name when setting header value

### DIFF
--- a/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
@@ -2,4 +2,3 @@ message: |
   fix an error where the request transformer may not rename header correctly.
 type: bugfix
 scope: Plugin
-

--- a/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
@@ -1,4 +1,0 @@
-message: |
-  fix an error where the request transformer may not rename header correctly.
-type: bugfix
-scope: Plugin

--- a/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-rename-header.yml
@@ -1,0 +1,5 @@
+message: |
+  fix an error where the request transformer may not rename header correctly.
+type: bugfix
+scope: Plugin
+

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -168,8 +168,8 @@ local function transform_headers(conf, template_env)
     old_name = old_name:lower()
     local value = headers[old_name]
     if value then
-      headers[new_name] = value
       headers[new_name:lower()] = nil   -- remove lower-cased name
+      headers[new_name] = value
 
       headers[old_name] = nil
       headers_to_remove[old_name] = true

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -168,7 +168,9 @@ local function transform_headers(conf, template_env)
     old_name = old_name:lower()
     local value = headers[old_name]
     if value then
-      headers[new_name:lower()] = value
+      headers[new_name] = value
+      headers[new_name:lower()] = nil   -- remove lower-cased name
+
       headers[old_name] = nil
       headers_to_remove[old_name] = true
     end

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -168,7 +168,7 @@ local function transform_headers(conf, template_env)
     old_name = old_name:lower()
     local value = headers[old_name]
     if value then
-      headers[new_name] = value
+      headers[new_name:lower()] = value
       headers[old_name] = nil
       headers_to_remove[old_name] = true
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

As OpenResty's doc says (https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#ngxreqget_headers), the result of `ngx.req.get_headers()` always has lower-case header name,
So if we set a `X-Name` header, it will not overwrite the existing header `x-name`.

This PR also fixed some flaky test cases(spec/03-plugins/36-request-transformer).

KAG-3462

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
