### PR TITLE
tests(workflows): continue execution of subscribers

### DIFF
--- a/spec/busted-log-failed.lua
+++ b/spec/busted-log-failed.lua
@@ -13,10 +13,12 @@ local FAILED_FILES = {}
 
 busted.subscribe({ 'failure' }, function(element, parent, message, debug)
   FAILED_FILES[element.trace.source] = true
+  return nil, true --continue
 end)
 
 busted.subscribe({ 'error' }, function(element, parent, message, debug)
   FAILED_FILES[element.trace.source] = true
+  return nil, true --continue
 end)
 
 busted.subscribe({ 'suite', 'end' }, function(suite, count, total)
@@ -30,4 +32,5 @@ busted.subscribe({ 'suite', 'end' }, function(suite, count, total)
     end
   end
   output:close()
+  return nil, true --continue
 end)


### PR DESCRIPTION
### Summary

add the correct return value to the busted helper so that other subscribers are also called, see: https://github.com/Olivine-Labs/mediator_lua/blob/ae97959308b462d84d0255f511c8e14cdf06667f/src/mediator.lua#L103C24-L103C32 also related to: https://github.com/Kong/kong/pull/12286

This is currently not causing any visible issues, but it might block execution of any other existing subscribers for those events.

### Checklist

- [x] The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-3481](https://konghq.atlassian.net/browse/KAG-3481)


[KAG-3481]: https://konghq.atlassian.net/browse/KAG-3481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ