### PR TITLE
fix(ci): skip the openresty patches workflow if it's a fork

### DIFF
--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the workflow
+        if: ${{ github.repository_owner == 'Kong' }}
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1
         with:
           workflow: create-pr.yml


### PR DESCRIPTION
Forks doesn't have access to secrets and public forks doesn't have `write` scope for the automatic tokens.