### PR TITLE
chore(response-rl): standarize redis configuration

### DIFF
--- a/changelog/unreleased/kong/standardize-redis-conifguration-response-rl.yml
+++ b/changelog/unreleased/kong/standardize-redis-conifguration-response-rl.yml
@@ -1,0 +1,3 @@
+message: "**Response-RateLimiting**: Standardize redis configuration across plugins. The redis configuration right now follows common schema that is shared across other plugins."
+type: deprecation
+scope: Plugin

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -383,6 +383,7 @@ build = {
 
     ["kong.plugins.response-ratelimiting.migrations"] = "kong/plugins/response-ratelimiting/migrations/init.lua",
     ["kong.plugins.response-ratelimiting.migrations.000_base_response_rate_limiting"] = "kong/plugins/response-ratelimiting/migrations/000_base_response_rate_limiting.lua",
+    ["kong.plugins.response-ratelimiting.migrations.001_350_to_360"] = "kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua",
     ["kong.plugins.response-ratelimiting.handler"] = "kong/plugins/response-ratelimiting/handler.lua",
     ["kong.plugins.response-ratelimiting.access"] = "kong/plugins/response-ratelimiting/access.lua",
     ["kong.plugins.response-ratelimiting.header_filter"] = "kong/plugins/response-ratelimiting/header_filter.lua",
@@ -390,6 +391,7 @@ build = {
     ["kong.plugins.response-ratelimiting.schema"] = "kong/plugins/response-ratelimiting/schema.lua",
     ["kong.plugins.response-ratelimiting.policies"] = "kong/plugins/response-ratelimiting/policies/init.lua",
     ["kong.plugins.response-ratelimiting.policies.cluster"] = "kong/plugins/response-ratelimiting/policies/cluster.lua",
+    ["kong.plugins.response-ratelimiting.clustering.compat.redis_translation"] = "kong/plugins/response-ratelimiting/clustering/compat/redis_translation.lua",
 
     ["kong.plugins.request-size-limiting.handler"] = "kong/plugins/request-size-limiting/handler.lua",
     ["kong.plugins.request-size-limiting.schema"] = "kong/plugins/request-size-limiting/schema.lua",

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -29,6 +29,7 @@ local compatible_checkers = {
       local redis_plugins_update = {
         acme = require("kong.plugins.acme.clustering.compat.redis_translation").adapter,
         ['rate-limiting'] = require("kong.plugins.rate-limiting.clustering.compat.redis_translation").adapter,
+        ['response-ratelimiting'] = require("kong.plugins.response-ratelimiting.clustering.compat.redis_translation").adapter
       }
 
       for _, plugin in ipairs(config_table.plugins or {}) do

--- a/kong/plugins/response-ratelimiting/clustering/compat/redis_translation.lua
+++ b/kong/plugins/response-ratelimiting/clustering/compat/redis_translation.lua
@@ -1,0 +1,23 @@
+local function adapter(config_to_update)
+    if config_to_update.policy == "redis" then
+        config_to_update.redis_host = config_to_update.redis.host
+        config_to_update.redis_port = config_to_update.redis.port
+        config_to_update.redis_username = config_to_update.redis.username
+        config_to_update.redis_password = config_to_update.redis.password
+        config_to_update.redis_database = config_to_update.redis.database
+        config_to_update.redis_timeout = config_to_update.redis.timeout
+        config_to_update.redis_ssl = config_to_update.redis.ssl
+        config_to_update.redis_ssl_verify = config_to_update.redis.ssl_verify
+        config_to_update.redis_server_name = config_to_update.redis.server_name
+
+        config_to_update.redis = nil
+
+        return true
+    end
+
+    return false
+end
+
+return {
+    adapter = adapter
+}

--- a/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
+++ b/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
@@ -1,0 +1,38 @@
+return {
+    postgres = {
+      up = [[
+        DO $$
+        BEGIN
+          UPDATE plugins
+          SET config =
+            config::jsonb
+              - 'redis_host'
+              - 'redis_port'
+              - 'redis_password'
+              - 'redis_username'
+              - 'redis_ssl'
+              - 'redis_ssl_verify'
+              - 'redis_server_name'
+              - 'redis_timeout'
+              - 'redis_database'
+            || jsonb_build_object(
+              'redis',
+              jsonb_build_object(
+                'host', config->'redis_host',
+                'port', config->'redis_port',
+                'password', config->'redis_password',
+                'username', config->'redis_username',
+                'ssl', config->'redis_ssl',
+                'ssl_verify', config->'redis_ssl_verify',
+                'server_name', config->'redis_server_name',
+                'timeout', config->'redis_timeout',
+                'database', config->'redis_database'
+              )
+            )
+            WHERE name = 'response-ratelimiting';
+        EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+          -- Do nothing, accept existing state
+        END$$;
+      ]],
+    },
+}

--- a/kong/plugins/response-ratelimiting/migrations/init.lua
+++ b/kong/plugins/response-ratelimiting/migrations/init.lua
@@ -1,3 +1,4 @@
 return {
   "000_base_response_rate_limiting",
+  "001_350_to_360",
 }

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -25,6 +25,19 @@ local function is_present(str)
   return str and str ~= "" and str ~= null
 end
 
+local function get_redis_configuration(plugin_conf)
+  return {
+     host = plugin_conf.redis.host or plugin_conf.redis_host,
+     port = plugin_conf.redis.port or plugin_conf.redis_port,
+     username = plugin_conf.redis.username or plugin_conf.redis_username,
+     password = plugin_conf.redis.password or plugin_conf.redis_password,
+     database = plugin_conf.redis.database or plugin_conf.redis_database,
+     timeout = plugin_conf.redis.timeout or plugin_conf.redis_timeout,
+     ssl = plugin_conf.redis.ssl or plugin_conf.redis_ssl,
+     ssl_verify = plugin_conf.redis.ssl_verify or plugin_conf.redis_ssl_verify,
+     server_name = plugin_conf.redis.server_name or plugin_conf.redis_server_name,
+  }
+end
 
 local function get_service_and_route_ids(conf)
   conf = conf or {}
@@ -53,22 +66,23 @@ end
 local sock_opts = {}
 local function get_redis_connection(conf)
   local red = redis:new()
-  red:set_timeout(conf.redis_timeout)
+  local redis_config = get_redis_configuration(conf)
+  red:set_timeout(redis_config.timeout)
 
-  sock_opts.ssl = conf.redis_ssl
-  sock_opts.ssl_verify = conf.redis_ssl_verify
-  sock_opts.server_name = conf.redis_server_name
+  sock_opts.ssl = redis_config.ssl
+  sock_opts.ssl_verify = redis_config.ssl_verify
+  sock_opts.server_name = redis_config.server_name
 
-  -- use a special pool name only if redis_database is set to non-zero
+  -- use a special pool name only if redis_config.database is set to non-zero
   -- otherwise use the default pool name host:port
-  if conf.redis_database ~= 0 then
+  if redis_config.database ~= 0 then
     sock_opts.pool = fmt( "%s:%d;%d",
-                          conf.redis_host,
-                          conf.redis_port,
-                          conf.redis_database)
+                          redis_config.host,
+                          redis_config.port,
+                          redis_config.database)
   end
 
-  local ok, err = red:connect(conf.redis_host, conf.redis_port,
+  local ok, err = red:connect(redis_config.host, redis_config.port,
                               sock_opts)
   if not ok then
     kong.log.err("failed to connect to Redis: ", err)
@@ -82,16 +96,16 @@ local function get_redis_connection(conf)
   end
 
   if times == 0 then
-    if is_present(conf.redis_password) then
+    if is_present(redis_config.password) then
       local ok, err
-      if is_present(conf.redis_username) then
+      if is_present(redis_config.username) then
         ok, err = kong.vault.try(function(cfg)
-          return red:auth(cfg.redis_username, cfg.redis_password)
-        end, conf)
+          return red:auth(cfg.username, cfg.password)
+        end, redis_config)
       else
         ok, err = kong.vault.try(function(cfg)
-          return red:auth(cfg.redis_password)
-        end, conf)
+          return red:auth(cfg.password)
+        end, redis_config)
       end
       if not ok then
         kong.log.err("failed to auth Redis: ", err)
@@ -99,11 +113,11 @@ local function get_redis_connection(conf)
       end
     end
 
-    if conf.redis_database ~= 0 then
+    if redis_config.database ~= 0 then
       -- Only call select first time, since we know the connection is shared
       -- between instances that use the same redis database
 
-      local ok, err = red:select(conf.redis_database)
+      local ok, err = red:select(redis_config.database)
       if not ok then
         kong.log.err("failed to change Redis database: ", err)
         return nil, err

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
-
+local redis_schema = require "kong.tools.redis.schema"
+local deprecation = require "kong.deprecation"
 
 local ORDERED_PERIODS = { "second", "minute", "hour", "day", "month", "year" }
 
@@ -94,6 +95,7 @@ return {
               default = true
             },
           },
+          { redis = redis_schema.config_schema },
           {
             redis_host = typedefs.redis_host,
           },
@@ -202,29 +204,73 @@ return {
     },
   },
   entity_checks = {
-    {
-      conditional = {
-        if_field = "config.policy",
-        if_match = { eq = "redis" },
-        then_field = "config.redis_host",
-        then_match = { required = true },
-      }
-    },
-    {
-      conditional = {
-        if_field = "config.policy",
-        if_match = { eq = "redis" },
-        then_field = "config.redis_port",
-        then_match = { required = true },
-      }
-    },
-    {
-      conditional = {
-        if_field = "config.policy",
-        if_match = { eq = "redis" },
-        then_field = "config.redis_timeout",
-        then_match = { required = true },
-      }
-    },
+    { conditional_at_least_one_of = {
+      if_field = "config.policy", if_match = { eq = "redis" },
+      then_at_least_one_of = { "config.redis.host", "config.redis_host" },
+      then_err = "must set one of %s when 'policy' is 'redis'",
+    } },
+    { conditional_at_least_one_of = {
+      if_field = "config.policy", if_match = { eq = "redis" },
+      then_at_least_one_of = { "config.redis.port", "config.redis_port" },
+      then_err = "must set one of %s when 'policy' is 'redis'",
+    } },
+    { conditional_at_least_one_of = {
+      if_field = "config.policy", if_match = { eq = "redis" },
+      then_at_least_one_of = { "config.redis.timeout", "config.redis_timeout" },
+      then_err = "must set one of %s when 'policy' is 'redis'",
+    } },
+    { custom_entity_check = {
+      field_sources = {
+        "config.redis_host",
+        "config.redis_port",
+        "config.redis_password",
+        "config.redis_username",
+        "config.redis_ssl",
+        "config.redis_ssl_verify",
+        "config.redis_server_name",
+        "config.redis_timeout",
+        "config.redis_database"
+      },
+      fn = function(entity)
+        if (entity.config.redis_host or ngx.null) ~= ngx.null then
+          deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_port or ngx.null) ~= ngx.null and entity.config.redis_port ~= 6379 then
+          deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_password or ngx.null) ~= ngx.null then
+          deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_username or ngx.null) ~= ngx.null then
+          deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_ssl or ngx.null) ~= ngx.null and entity.config.redis_ssl ~= false then
+          deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_ssl_verify or ngx.null) ~= ngx.null and entity.config.redis_ssl_verify ~= false then
+          deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_server_name or ngx.null) ~= ngx.null then
+          deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_timeout or ngx.null) ~= ngx.null and entity.config.redis_timeout ~= 2000 then
+          deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
+            { after = "4.0", })
+        end
+        if (entity.config.redis_database or ngx.null) ~= ngx.null and entity.config.redis_database ~= 0 then
+          deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
+            { after = "4.0", })
+        end
+
+        return true
+      end
+    } }
   },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -407,6 +407,55 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           admin.plugins:remove({ id = rl.id })
         end)
       end)
+
+      describe("response-ratelimiting plugin", function()
+        it("translates standardized redis config to older response-ratelimiting structure", function()
+          -- [[ 3.6.x ]] --
+          local response_rl = admin.plugins:insert {
+            name = "response-ratelimiting",
+            enabled = true,
+            config = {
+              limits = {
+                video = {
+                  minute = 300,
+                }
+              },
+              policy = "redis",
+              -- [[ new structure redis
+              redis = {
+                host = "localhost",
+                port = 57198,
+                username = "test",
+                password = "secret",
+                database = 2,
+                timeout = 1100,
+                ssl = true,
+                ssl_verify = true,
+                server_name = "example.test"
+              }
+              -- ]]
+            }
+          }
+
+          local expected_response_rl_prior_36 = utils.cycle_aware_deep_copy(response_rl)
+          expected_response_rl_prior_36.config.redis = nil
+          expected_response_rl_prior_36.config.redis_host = "localhost"
+          expected_response_rl_prior_36.config.redis_port = 57198
+          expected_response_rl_prior_36.config.redis_username = "test"
+          expected_response_rl_prior_36.config.redis_password = "secret"
+          expected_response_rl_prior_36.config.redis_database = 2
+          expected_response_rl_prior_36.config.redis_timeout = 1100
+          expected_response_rl_prior_36.config.redis_ssl = true
+          expected_response_rl_prior_36.config.redis_ssl_verify = true
+          expected_response_rl_prior_36.config.redis_server_name = "example.test"
+
+
+          do_assert(utils.uuid(), "3.5.0", expected_response_rl_prior_36)
+
+          -- cleanup
+          admin.plugins:remove({ id = response_rl.id })
+        end)
+      end)
     end)
   end)
 end)

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -371,7 +371,6 @@ describe("Plugin: rate-limiting (integration)", function()
       lazy_setup(function()
         assert(helpers.start_kong({
           nginx_conf = "spec/fixtures/custom_nginx.template",
-          lua_ssl_trusted_certificate = config.lua_ssl_trusted_certificate,
         }))
 
         route3 = assert(bp.routes:insert {

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -1,5 +1,7 @@
 local schema_def = require "kong.plugins.response-ratelimiting.schema"
-local v = require("spec.helpers").validate_plugin_config_schema
+local helpers = require "spec.helpers"
+local v = helpers.validate_plugin_config_schema
+
 local null = ngx.null
 
 
@@ -58,6 +60,76 @@ describe("Plugin: response-rate-limiting (schema)", function()
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
       assert.equal("expected a record", err.config.limits)
+    end)
+
+    it("proper config validates with redis new structure", function()
+      local config = {
+        limits = {
+          video = {
+            second = 10
+          }
+        },
+        policy = "redis",
+        redis = {
+          host = helpers.redis_host,
+          port = helpers.redis_port,
+          database = 0,
+          username = "test",
+          password = "testXXX",
+          ssl = true,
+          ssl_verify = false,
+          timeout = 1100,
+          server_name = helpers.redis_ssl_sni,
+      } }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates with redis legacy structure", function()
+      local config = {
+        limits = {
+          video = {
+            second = 10
+          }
+        },
+        policy = "redis",
+        redis_host = helpers.redis_host,
+        redis_port = helpers.redis_port,
+        redis_database = 0,
+        redis_username = "test",
+        redis_password = "testXXX",
+        redis_ssl = true,
+        redis_ssl_verify = false,
+        redis_timeout = 1100,
+        redis_server_name = helpers.redis_ssl_sni,
+      }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("verifies that redis required fields are supplied", function()
+      local config = {
+        limits = {
+          video = {
+            second = 10
+          }
+        },
+        policy = "redis",
+        redis = {
+          port = helpers.redis_port,
+          database = 0,
+          username = "test",
+          password = "testXXX",
+          ssl = true,
+          ssl_verify = false,
+          timeout = 1100,
+          server_name = helpers.redis_ssl_sni,
+      } }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.contains("must set one of 'config.redis.host', 'config.redis_host' when 'policy' is 'redis'", err["@entity"])
     end)
   end)
 end)

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -150,13 +150,15 @@ for _, strategy in helpers.each_strategy() do
             config   = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS } },
             },
           })
@@ -171,13 +173,15 @@ for _, strategy in helpers.each_strategy() do
             config   = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS*2, minute = ITERATIONS*4 },
                                     image = { second = ITERATIONS } },
             },
@@ -197,10 +201,12 @@ for _, strategy in helpers.each_strategy() do
             route = { id = route3.id },
             config   = {
               policy = policy,
-              redis_host     = REDIS_HOST,
-              redis_port     = REDIS_PORT,
-              redis_password = REDIS_PASSWORD,
-              redis_database = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = REDIS_PORT,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits = { video = { second = ITERATIONS - 3 }
             } },
           })
@@ -211,13 +217,15 @@ for _, strategy in helpers.each_strategy() do
             config      = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS - 2 } },
             },
           })
@@ -232,13 +240,15 @@ for _, strategy in helpers.each_strategy() do
             config   = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = {
                 video = { second = ITERATIONS * 2 + 2 },
                 image = { second = ITERATIONS }
@@ -256,13 +266,15 @@ for _, strategy in helpers.each_strategy() do
             config   = {
               fault_tolerant           = false,
               policy                   = policy,
-              redis_host               = REDIS_HOST,
-              redis_port               = redis_conf.redis_port,
-              redis_ssl                = redis_conf.redis_ssl,
-              redis_ssl_verify         = redis_conf.redis_ssl_verify,
-              redis_server_name        = redis_conf.redis_server_name,
-              redis_password           = REDIS_PASSWORD,
-              redis_database           = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               block_on_first_violation = true,
               limits                   = {
                 video = {
@@ -286,13 +298,15 @@ for _, strategy in helpers.each_strategy() do
             config   = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS, minute = ITERATIONS*2 },
                                     image = { second = ITERATIONS-1 } },
             }
@@ -309,13 +323,15 @@ for _, strategy in helpers.each_strategy() do
               fault_tolerant      = false,
               policy              = policy,
               hide_client_headers = true,
-              redis_host          = REDIS_HOST,
-              redis_port          = redis_conf.redis_port,
-              redis_ssl           = redis_conf.redis_ssl,
-              redis_ssl_verify    = redis_conf.redis_ssl_verify,
-              redis_server_name   = redis_conf.redis_server_name,
-              redis_password      = REDIS_PASSWORD,
-              redis_database      = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits              = { video = { second = ITERATIONS } },
             }
           })
@@ -336,13 +352,15 @@ for _, strategy in helpers.each_strategy() do
             config = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS } },
             }
           })
@@ -363,13 +381,15 @@ for _, strategy in helpers.each_strategy() do
             config = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS } },
             }
           })
@@ -605,12 +625,14 @@ for _, strategy in helpers.each_strategy() do
             route = { id = route.id },
             config   = {
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+              },
               fault_tolerant    = false,
               limits            = { video = { second = ITERATIONS } },
             }
@@ -676,13 +698,15 @@ for _, strategy in helpers.each_strategy() do
             config = {
               fault_tolerant    = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS } },
             }
           })
@@ -717,13 +741,15 @@ for _, strategy in helpers.each_strategy() do
             config = {
               fault_tolerant = false,
               policy            = policy,
-              redis_host        = REDIS_HOST,
-              redis_port        = redis_conf.redis_port,
-              redis_ssl         = redis_conf.redis_ssl,
-              redis_ssl_verify  = redis_conf.redis_ssl_verify,
-              redis_server_name = redis_conf.redis_server_name,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DATABASE,
+              redis = {
+                host        = REDIS_HOST,
+                port        = redis_conf.redis_port,
+                ssl         = redis_conf.redis_ssl,
+                ssl_verify  = redis_conf.redis_ssl_verify,
+                server_name = redis_conf.redis_server_name,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DATABASE,
+              },
               limits            = { video = { second = ITERATIONS } },
             }
           })
@@ -786,12 +812,14 @@ for _, strategy in helpers.each_strategy() do
                 config   = {
                   fault_tolerant    = false,
                   policy            = policy,
-                  redis_host        = REDIS_HOST,
-                  redis_port        = redis_conf.redis_port,
-                  redis_ssl         = redis_conf.redis_ssl,
-                  redis_ssl_verify  = redis_conf.redis_ssl_verify,
-                  redis_server_name = redis_conf.redis_server_name,
-                  redis_password    = REDIS_PASSWORD,
+                  redis = {
+                    host        = REDIS_HOST,
+                    port        = redis_conf.redis_port,
+                    ssl         = redis_conf.redis_ssl,
+                    ssl_verify  = redis_conf.redis_ssl_verify,
+                    server_name = redis_conf.redis_server_name,
+                    password    = REDIS_PASSWORD,
+                  },
                   limits            = { video = { second = ITERATIONS} },
                 }
               }
@@ -805,12 +833,14 @@ for _, strategy in helpers.each_strategy() do
                 config   = {
                   fault_tolerant    = true,
                   policy            = policy,
-                  redis_host        = REDIS_HOST,
-                  redis_port        = redis_conf.redis_port,
-                  redis_ssl         = redis_conf.redis_ssl,
-                  redis_ssl_verify  = redis_conf.redis_ssl_verify,
-                  redis_server_name = redis_conf.redis_server_name,
-                  redis_password    = REDIS_PASSWORD,
+                  redis = {
+                    host        = REDIS_HOST,
+                    port        = redis_conf.redis_port,
+                    ssl         = redis_conf.redis_ssl,
+                    ssl_verify  = redis_conf.redis_ssl_verify,
+                    server_name = redis_conf.redis_server_name,
+                    password    = REDIS_PASSWORD,
+                  },
                   limits            = { video = {second = ITERATIONS} }
                 }
               }
@@ -891,7 +921,10 @@ for _, strategy in helpers.each_strategy() do
               config   = {
                 fault_tolerant = false,
                 policy         = policy,
-                redis_host     = "5.5.5.5",
+                redis = {
+                  host = "5.5.5.5",
+                  port = REDIS_PORT
+                },
                 limits         = { video = { second = ITERATIONS } },
               }
             }
@@ -906,7 +939,10 @@ for _, strategy in helpers.each_strategy() do
               config   = {
                 fault_tolerant = true,
                 policy         = policy,
-                redis_host     = "5.5.5.5",
+                redis = {
+                  host = "5.5.5.5",
+                  port = REDIS_PORT
+                },
                 limits         = { video = { second = ITERATIONS } },
               }
             }

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require "spec.helpers"
 local redis = require "resty.redis"
 local version = require "version"
+local cjson = require "cjson"
 local tostring = tostring
 
 
@@ -122,14 +123,16 @@ describe("Plugin: rate-limiting (integration)", function()
           route = { id = route1.id },
           config = {
             policy            = "redis",
-            redis_host        = REDIS_HOST,
-            redis_port        = config.redis_port,
-            redis_database    = REDIS_DB_1,
-            redis_ssl         = config.redis_ssl,
-            redis_ssl_verify  = config.redis_ssl_verify,
-            redis_server_name = config.redis_server_name,
+            redis = {
+              host        = REDIS_HOST,
+              port        = config.redis_port,
+              database    = REDIS_DB_1,
+              ssl         = config.redis_ssl,
+              ssl_verify  = config.redis_ssl_verify,
+              server_name = config.redis_server_name,
+              timeout     = 10000,
+            },
             fault_tolerant    = false,
-            redis_timeout     = 10000,
             limits            = { video = { minute = 6 } },
           },
         })
@@ -142,14 +145,16 @@ describe("Plugin: rate-limiting (integration)", function()
           route = { id = route2.id },
           config = {
             policy            = "redis",
-            redis_host        = REDIS_HOST,
-            redis_port        = config.redis_port,
-            redis_database    = REDIS_DB_2,
-            redis_ssl         = config.redis_ssl,
-            redis_ssl_verify  = config.redis_ssl_verify,
-            redis_server_name = config.redis_server_name,
+            redis = {
+              host        = REDIS_HOST,
+              port        = config.redis_port,
+              database    = REDIS_DB_2,
+              ssl         = config.redis_ssl,
+              ssl_verify  = config.redis_ssl_verify,
+              server_name = config.redis_server_name,
+              timeout     = 10000,
+            },
             fault_tolerant    = false,
-            redis_timeout     = 10000,
             limits            = { video = { minute = 6 } },
           },
         })
@@ -163,16 +168,18 @@ describe("Plugin: rate-limiting (integration)", function()
             route = { id = route3.id },
             config = {
               policy            = "redis",
-              redis_host        = REDIS_HOST,
-              redis_port        = config.redis_port,
-              redis_username    = REDIS_USER_VALID,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DB_3,
-              redis_ssl         = config.redis_ssl,
-              redis_ssl_verify  = config.redis_ssl_verify,
-              redis_server_name = config.redis_server_name,
+              redis = {
+                host        = REDIS_HOST,
+                port        = config.redis_port,
+                username    = REDIS_USER_VALID,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DB_3,
+                ssl         = config.redis_ssl,
+                ssl_verify  = config.redis_ssl_verify,
+                server_name = config.redis_server_name,
+                timeout     = 10000,
+              },
               fault_tolerant    = false,
-              redis_timeout     = 10000,
               limits            = { video = { minute = 6 } },
             },
           })
@@ -185,16 +192,18 @@ describe("Plugin: rate-limiting (integration)", function()
             route = { id = route4.id },
             config = {
               policy            = "redis",
-              redis_host        = REDIS_HOST,
-              redis_port        = config.redis_port,
-              redis_username    = REDIS_USER_INVALID,
-              redis_password    = REDIS_PASSWORD,
-              redis_database    = REDIS_DB_4,
-              redis_ssl         = config.redis_ssl,
-              redis_ssl_verify  = config.redis_ssl_verify,
-              redis_server_name = config.redis_server_name,
+              redis = {
+                host        = REDIS_HOST,
+                port        = config.redis_port,
+                username    = REDIS_USER_INVALID,
+                password    = REDIS_PASSWORD,
+                database    = REDIS_DB_4,
+                ssl         = config.redis_ssl,
+                ssl_verify  = config.redis_ssl_verify,
+                server_name = config.redis_server_name,
+                timeout     = 10000,
+              },
               fault_tolerant    = false,
-              redis_timeout     = 10000,
               limits            = { video = { minute = 6 } },
             },
           })
@@ -360,5 +369,130 @@ describe("Plugin: rate-limiting (integration)", function()
         end
       end)
     end)
-  end
+  end -- end for each strategy
+
+  describe("creating rate-limiting plugins using api", function ()
+    local route3, admin_client
+
+    lazy_setup(function()
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template"
+      }))
+
+      route3 = assert(bp.routes:insert {
+        hosts        = { "redistest3.test" },
+      })
+
+      admin_client = helpers.admin_client()
+    end)
+
+    lazy_teardown(function()
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      helpers.clean_logfile()
+    end)
+
+    local function delete_plugin(admin_client, plugin)
+      local res = assert(admin_client:send({
+        method = "DELETE",
+        path = "/plugins/" .. plugin.id,
+      }))
+
+      assert.res_status(204, res)
+    end
+
+    it("allows to create a plugin with new redis configuration", function()
+      local res = assert(admin_client:send {
+        method = "POST",
+        route = {
+          id = route3.id
+        },
+        path = "/plugins",
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "response-ratelimiting",
+          config = {
+            limits = {
+              video = {
+                minute = 100,
+              }
+            },
+            policy = "redis",
+            redis = {
+              host = helpers.redis_host,
+              port = helpers.redis_port,
+              username = "test1",
+              password = "testX",
+              database = 1,
+              timeout = 1100,
+              ssl = true,
+              ssl_verify = true,
+              server_name = "example.test",
+            },
+          },
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(201, res))
+      delete_plugin(admin_client, json)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead (deprecated after 4.0)", true)
+      assert.logfile().has.no.line("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead (deprecated after 4.0)", true)
+    end)
+
+    it("allows to create a plugin with legacy redis configuration", function()
+      local res = assert(admin_client:send {
+        method = "POST",
+        route = {
+          id = route3.id
+        },
+        path = "/plugins",
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "response-ratelimiting",
+          config = {
+            limits = {
+              video = {
+                minute = 100,
+              }
+            },
+            policy = "redis",
+            redis_host = "custom-host.example.test",
+            redis_port = 55000,
+            redis_username = "test1",
+            redis_password = "testX",
+            redis_database = 1,
+            redis_timeout = 1100,
+            redis_ssl = true,
+            redis_ssl_verify = true,
+            redis_server_name = "example.test",
+          },
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(201, res))
+      delete_plugin(admin_client, json)
+      assert.logfile().has.line("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead (deprecated after 4.0)", true)
+      assert.logfile().has.line("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead (deprecated after 4.0)", true)
+    end)
+  end)
 end)

--- a/spec/05-migration/plugins/response-ratelimiting/migrations/001_350_to_360_spec.lua
+++ b/spec/05-migration/plugins/response-ratelimiting/migrations/001_350_to_360_spec.lua
@@ -1,0 +1,74 @@
+
+local cjson = require "cjson"
+local uh = require "spec.upgrade_helpers"
+
+
+if uh.database_type() == 'postgres' then
+    describe("rate-limiting plugin migration", function()
+        lazy_setup(function()
+            assert(uh.start_kong())
+        end)
+
+        lazy_teardown(function ()
+            assert(uh.stop_kong(nil, true))
+        end)
+
+        uh.setup(function ()
+            local admin_client = assert(uh.admin_client())
+
+            local res = assert(admin_client:send {
+                method = "POST",
+                path = "/plugins/",
+                body = {
+                    name = "response-ratelimiting",
+                    config = {
+                        limits = {
+                            video = {
+                                minute = 200,
+                            }
+                        },
+                        redis_host = "localhost",
+                        redis_port = 57198,
+                        redis_username = "test",
+                        redis_password = "secret",
+                        redis_timeout = 1100,
+                        redis_database = 2,
+                    }
+                },
+                headers = {
+                ["Content-Type"] = "application/json"
+                }
+            })
+            assert.res_status(201, res)
+            admin_client:close()
+        end)
+
+        uh.new_after_up("has updated rate-limiting redis configuration", function ()
+            local admin_client = assert(uh.admin_client())
+            local res = assert(admin_client:send {
+                method = "GET",
+                path = "/plugins/"
+            })
+            local body = cjson.decode(assert.res_status(200, res))
+            assert.equal(1, #body.data)
+            assert.equal("response-ratelimiting", body.data[1].name)
+            local expected_config = {
+                limits = {
+                    video = {
+                        minute = 200,
+                    }
+                },
+                redis = {
+                    host = "localhost",
+                    port = 57198,
+                    username = "test",
+                    password = "secret",
+                    timeout = 1100,
+                    database = 2,
+                }
+            }
+            assert.partial_match(expected_config, body.data[1].config)
+            admin_client:close()
+        end)
+    end)
+end


### PR DESCRIPTION
### Summary

Response-RateLimiting right now has new config structure that reuses common redis connection configuration.

Many plugins differ in the way Redis is configured. The goal of this PR is to introduce a standard Redis config schema that could be shared across plugins.

### Other PRs
This is the last in the chains of PRs that standardize Redis configuration. 

1. ACME: https://github.com/Kong/kong/pull/12300
2. RateLimiting: https://github.com/Kong/kong/pull/12301 
3. Response-RateLimiting: (this PR)

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A (docs automatically generated from plugin schema description) ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~ 

### Issue reference

KAG-3388


