### PR TITLE
feat(core): enable status api by default

### DIFF
--- a/changelog/unreleased/kong/default_status_port.yml
+++ b/changelog/unreleased/kong/default_status_port.yml
@@ -1,0 +1,3 @@
+message: Enable `status_listen` on `127.0.0.1:8007` by default
+type: feature
+scope: Admin API

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -680,7 +680,8 @@
                          #
                          # Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
 
-#status_listen = off     # Comma-separated list of addresses and ports on
+#status_listen = 127.0.0.1:8007 reuseport backlog=16384
+                         # Comma-separated list of addresses and ports on
                          # which the Status API should listen.
                          # The Status API is a read-only endpoint
                          # allowing monitoring tools to retrieve metrics,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -28,7 +28,7 @@ proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reus
 stream_listen = off
 admin_listen = 127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 http2 ssl reuseport backlog=16384
 admin_gui_listen = 0.0.0.0:8002, 0.0.0.0:8445 ssl
-status_listen = off
+status_listen = 127.0.0.1:8007 reuseport backlog=16384
 cluster_listen = 0.0.0.0:8005
 cluster_control_plane = 127.0.0.1:8005
 cluster_cert = NONE

--- a/spec/02-integration/08-status_api/04-config_spec.lua
+++ b/spec/02-integration/08-status_api/04-config_spec.lua
@@ -1,0 +1,32 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+for _, strategy in helpers.all_strategies() do
+  describe("Status API - with strategy #" .. strategy, function()
+    it("default enable", function()
+      assert.truthy(helpers.kong_exec("start -c spec/fixtures/default_status_listen.conf"))
+      local client = helpers.http_client("127.0.0.1", 8007, 20000)
+      finally(function()
+        helpers.stop_kong()
+        client:close()
+      end)
+
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status",
+      })
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.is_table(json.server)
+
+      assert.is_number(json.server.connections_accepted)
+      assert.is_number(json.server.connections_active)
+      assert.is_number(json.server.connections_handled)
+      assert.is_number(json.server.connections_reading)
+      assert.is_number(json.server.connections_writing)
+      assert.is_number(json.server.connections_waiting)
+      assert.is_number(json.server.total_requests)
+    end)
+  end)
+end

--- a/spec/fixtures/default_status_listen.conf
+++ b/spec/fixtures/default_status_listen.conf
@@ -1,0 +1,26 @@
+# 1st digit is 9 for our test instances
+admin_listen = 127.0.0.1:9001
+proxy_listen = 0.0.0.0:9000, 0.0.0.0:9443 ssl
+
+ssl_cert = spec/fixtures/kong_spec.crt
+ssl_cert_key = spec/fixtures/kong_spec.key
+
+admin_ssl_cert = spec/fixtures/kong_spec.crt
+admin_ssl_cert_key = spec/fixtures/kong_spec.key
+
+database = postgres
+pg_host = 127.0.0.1
+pg_port = 5432
+pg_timeout = 10000
+pg_database = kong_tests
+anonymous_reports = off
+
+dns_hostsfile = spec/fixtures/hosts
+
+nginx_main_worker_processes = 1
+nginx_main_worker_rlimit_nofile = NONE
+nginx_events_worker_connections = NONE
+nginx_events_multi_accept = off
+
+prefix = servroot
+log_level = debug

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -2,6 +2,8 @@
 admin_listen = 127.0.0.1:9001
 admin_gui_listen = off
 proxy_listen = 0.0.0.0:9000, 0.0.0.0:9443 http2 ssl, 0.0.0.0:9002 http2
+# avoid port conflicts when multiple Kong instances needed for tests
+status_listen = off
 stream_listen = off
 
 ssl_cert = spec/fixtures/kong_spec.crt


### PR DESCRIPTION
### Summary

Redoing https://github.com/Kong/kong/pull/12254

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Issue reference

KAG-3359
