### PR TITLE
fix(router): always calculate `match_t.upstream_uri` to avoid wrong cache

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -404,12 +404,11 @@ local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 local function get_upstream_uri(req_uri, match_t)
   local matched_route = match_t.route
-  local matched_path = match_t.matches.path
 
   local request_prefix = match_t.prefix
   local service_path = match_t.upstream_url_t.path
 
-  local request_postfix = request_prefix and req_uri:sub(#matched_path + 1) or req_uri:sub(2, -1)
+  local request_postfix = request_prefix and req_uri:sub(#request_prefix + 1) or req_uri:sub(2, -1)
   request_postfix = sanitize_uri_postfix(request_postfix) or ""
 
   local upstream_base = service_path or "/"
@@ -464,7 +463,6 @@ function _M:matching(params)
     service         = service,
     prefix          = request_prefix,
     matches = {
-      path = matched_path,
       uri_captures = (captures and captures[1]) and captures or nil,
     },
     upstream_url_t = {

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -402,11 +402,10 @@ local add_debug_headers    = utils.add_debug_headers
 local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
-local function get_upstream_uri(matched_route, matched_path, req_uri, service_path)
+local function get_upstream_uri(matched_route, matched_path,
+                                request_prefix, req_uri, service_path)
   --local matched_route = match_t.route
   --local matched_path = match_t.matches.path
-
-  local request_prefix = matched_route.strip_path and matched_path or nil
 
   local request_postfix = request_prefix and req_uri:sub(#matched_path + 1) or req_uri:sub(2, -1)
   request_postfix = sanitize_uri_postfix(request_postfix) or ""
@@ -456,8 +455,10 @@ function _M:matching(params)
         service_host, service_port,
         service_hostname_type, service_path = get_service_info(service)
 
-  local upstream_uri = get_upstream_uri(matched_route, matched_path, req_uri,
-                                        service_path)
+  local request_prefix = matched_route.strip_path and matched_path or nil
+
+  local upstream_uri = get_upstream_uri(matched_route, matched_path,
+                                        request_prefix, req_uri, service_path)
 
   return {
     route           = matched_route,
@@ -465,7 +466,6 @@ function _M:matching(params)
     prefix          = request_prefix,
     matches = {
       uri_captures = (captures and captures[1]) and captures or nil,
-      path = matched_path,
     },
     upstream_url_t = {
       type = service_hostname_type,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -404,8 +404,6 @@ local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 local function get_upstream_uri(matched_route, matched_path,
                                 request_prefix, req_uri, service_path)
-  --local matched_route = match_t.route
-  --local matched_path = match_t.matches.path
 
   local request_postfix = request_prefix and req_uri:sub(#matched_path + 1) or req_uri:sub(2, -1)
   request_postfix = sanitize_uri_postfix(request_postfix) or ""
@@ -466,11 +464,13 @@ function _M:matching(params)
     prefix          = request_prefix,
     matches = {
       uri_captures = (captures and captures[1]) and captures or nil,
+      path = matched_path,
     },
     upstream_url_t = {
       type = service_hostname_type,
       host = service_host,
       port = service_port,
+      path = service_path,
     },
     upstream_scheme = service_protocol,
     upstream_uri    = upstream_uri,
@@ -556,6 +556,13 @@ function _M:exec(ctx)
     if match_t.route.preserve_host then
       match_t.upstream_host = req_host
     end
+
+    -- update upstream_uri in cache result
+    --[[
+    match_t.upstream_uri = get_upstream_uri(match_t.route, match_t.matches.path,
+                                            match_t.request_prefix, req_uri,
+                                            match_t.upstream_url_t.path)
+    --]]
   end
 
   -- found a match

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -402,6 +402,24 @@ local add_debug_headers    = utils.add_debug_headers
 local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
+local function get_upstream_uri(matched_route, matched_path, req_uri, service_path)
+  --local matched_route = match_t.route
+  --local matched_path = match_t.matches.path
+
+  local request_prefix = matched_route.strip_path and matched_path or nil
+
+  local request_postfix = request_prefix and req_uri:sub(#matched_path + 1) or req_uri:sub(2, -1)
+  request_postfix = sanitize_uri_postfix(request_postfix) or ""
+
+  local upstream_base = service_path or "/"
+
+  local upstream_uri = get_upstream_uri_v0(matched_route, request_postfix, req_uri,
+                                           upstream_base)
+
+  return upstream_uri
+end
+
+
 function _M:matching(params)
   local req_uri = params.uri
   local req_host = params.host
@@ -438,13 +456,8 @@ function _M:matching(params)
         service_host, service_port,
         service_hostname_type, service_path = get_service_info(service)
 
-  local request_prefix = matched_route.strip_path and matched_path or nil
-  local request_postfix = request_prefix and req_uri:sub(#matched_path + 1) or req_uri:sub(2, -1)
-  request_postfix = sanitize_uri_postfix(request_postfix) or ""
-  local upstream_base = service_path or "/"
-
-  local upstream_uri = get_upstream_uri_v0(matched_route, request_postfix, req_uri,
-                                           upstream_base)
+  local upstream_uri = get_upstream_uri(matched_route, matched_path, req_uri,
+                                        service_path)
 
   return {
     route           = matched_route,
@@ -452,6 +465,7 @@ function _M:matching(params)
     prefix          = request_prefix,
     matches = {
       uri_captures = (captures and captures[1]) and captures or nil,
+      path = matched_path,
     },
     upstream_url_t = {
       type = service_hostname_type,

--- a/spec/02-integration/01-helpers/01-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/01-helpers_spec.lua
@@ -26,7 +26,6 @@ for _, strategy in helpers.each_strategy() do
       bp.routes:insert {
         hosts     = { "mock_upstream" },
         protocols = { "http" },
-        paths = { "/" },
         service   = service
       }
 

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -881,7 +881,6 @@ for _, strategy in helpers.each_strategy() do
         routes = insert_routes(bp, {
           {
             hosts = { "mock_upstream" },
-            paths = { "/" },
           },
         })
       end)
@@ -1302,7 +1301,6 @@ for _, strategy in helpers.each_strategy() do
         routes = insert_routes(bp, {
           {
             protocols = { "https" },
-            paths = { "/" },
             snis = { "www.example.org" },
             service = {
               name = "service_behind_www.example.org"

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -278,7 +278,6 @@ for _, strategy in helpers.each_strategy() do
 
         assert(bp.routes:insert {
           hosts = { "headers-charset.test" },
-          paths = { "/" },
           service = service,
         })
 

--- a/spec/02-integration/05-proxy/14-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/14-server_tokens_spec.lua
@@ -291,7 +291,6 @@ describe("headers [#" .. strategy .. "]", function()
       return function()
         bp.routes:insert {
           hosts = { "headers-inspect.test" },
-          paths = { "/" },
         }
 
         local service = bp.services:insert({

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -59,7 +59,6 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert {
         hosts   = { "http_logging.test" },
-        paths   = { "/" },
         service = service1
       }
 
@@ -628,7 +627,6 @@ for _, strategy in helpers.each_strategy() do
 
         local route = bp.routes:insert {
           hosts   = { "http_queue_logging.test" },
-          paths   = { "/" },
           service = service
         }
 

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -19,7 +19,6 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert {
         hosts = { "logging.test" },
-        paths = { "/" },
       }
 
       local route2 = bp.routes:insert {

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -237,7 +237,6 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert({
         hosts = { "cors1.test" },
-        paths = { "/" },
       })
 
       local route2 = bp.routes:insert({

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -43,7 +43,6 @@ for _, strategy in helpers.each_strategy() do
       route = assert(admin_api.routes:insert {
         hosts     = { "oauth2.com" },
         protocols = { "http", "https" },
-        paths = { "/" },
         service   = service,
       })
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -38,7 +38,6 @@ do
 
       local route1 = assert(bp.routes:insert {
         hosts = { "route-1.test" },
-        paths = { "/" },
       })
       local route2 = assert(bp.routes:insert {
         hosts = { "route-2.test" },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-3505

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
