### PR TITLE
diagnose flaky test 01-cluster_events_spec.lua:322

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -18,7 +18,7 @@ function get_failed {
     fi
 }
 
-BUSTED_ARGS="--keep-going -o htest -v --exclude-tags=flaky,ipv6"
+BUSTED_ARGS="--no-k -t test -o htest -v --exclude-tags=flaky,ipv6"
 if [ ! -z "$FAILED_TEST_FILES_FILE" ]
 then
     BUSTED_ARGS="--helper=spec/busted-log-failed.lua $BUSTED_ARGS"

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -46,11 +46,12 @@ fi
 if [ "$TEST_SUITE" == "integration" ]; then
     if [[ "$TEST_SPLIT" == first* ]]; then
         # GitHub Actions, run first batch of integration tests
-        files=$(ls -d spec/02-integration/* | sort | grep -v 05-proxy)
-        files=$(get_failed $files)
+        files="spec/02-integration/06-invalidations/01-cluster_events_spec.lua"
+        echo "$TEST_CMD" $files
         eval "$TEST_CMD" $files
 
     elif [[ "$TEST_SPLIT" == second* ]]; then
+        exit 0
         # GitHub Actions, run second batch of integration tests
         # Note that the split here is chosen carefully to result
         # in a similar run time between the two batches, and should
@@ -66,6 +67,7 @@ if [ "$TEST_SUITE" == "integration" ]; then
 fi
 
 if [ "$TEST_SUITE" == "dbless" ]; then
+    exit 0
     eval "$TEST_CMD" $(get_failed spec/02-integration/02-cmd \
                                   spec/02-integration/05-proxy \
                                   spec/02-integration/04-admin_api/02-kong_routes_spec.lua \
@@ -76,6 +78,7 @@ if [ "$TEST_SUITE" == "dbless" ]; then
                                   spec/02-integration/20-wasm)
 fi
 if [ "$TEST_SUITE" == "plugins" ]; then
+    exit 0
     set +ex
     rm -f .failed
 
@@ -155,9 +158,11 @@ if [ "$TEST_SUITE" == "plugins" ]; then
     fi
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
+    exit 0
     prove -I. -r t
 fi
 if [ "$TEST_SUITE" == "unit" ]; then
+    exit 0
     unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
     scripts/autodoc
     bin/busted -v -o htest spec/01-unit

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -349,7 +349,7 @@ for _, strategy in helpers.each_strategy() do
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_not_called() -- still not called
 
-        ngx.sleep(delay) -- go past our desired `nbf` delay
+        ngx.sleep(delay + 0.1) -- go past our desired `nbf` delay
 
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_called(1) -- called

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -319,7 +319,8 @@ for _, strategy in helpers.each_strategy() do
         assert.spy(spy_func).was_called(1) -- called
       end)
 
-      it("broadcasts an event with a polling delay for subscribers", function()
+      for i = 1, 1000 do
+      it("broadcasts an event with a polling delay for subscribers#test"..i, function()
         local delay = 1
 
         local cluster_events_1 = assert(kong_cluster_events.new {
@@ -353,6 +354,7 @@ for _, strategy in helpers.each_strategy() do
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_called(1) -- called
       end)
+    end
     end)
   end)
 end


### PR DESCRIPTION
As this cannot be reproduced on local env, creating a PR to trigger CI.

FAILED spec/02-integration/06-invalidations/01-cluster_events_spec.lua:322: cluster_events with db [#postgres] pub/sub broadcasts an event with a polling delay for subscribers

KAG-3224
