### PR TITLE
chore(tests): fix flaky due to too close time for a timer

### DIFF
--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -348,7 +348,7 @@ for _, strategy in helpers.each_strategy() do
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_not_called() -- still not called
 
-        ngx.sleep(delay) -- go past our desired `nbf` delay
+        ngx.sleep(delay + 0.1) -- go past our desired `nbf` delay
 
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_called(1) -- called


### PR DESCRIPTION
Timers doe not always trigger precisely on time.

I ran the test on local env 3000 times, in 3 batches and it does not reproduce.

Then I ran it on CI looping 1000 times for each run. It failed the 2nd time on the first 2 tries and succeeded 1000 times on the 3rd try.

Timers do not always trigger at the exact precise time thus the flaky. I added a 0.5s extra delay to the sleep call and tried 3 times. It succeeded every time after the change.

Fix KAG-3224