### PR TITLE
fix(cache): mlcache invalidation use separate cluster event channels to avoid useless invalidation

### DIFF
--- a/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
+++ b/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
@@ -1,3 +1,3 @@
-message: From this version, the "invalidation" cluster event channel will be deprecated and removed in future versions.
+message: Starting with this version, the "invalidation" cluster event channel is marked as deprecated and is slated for removal in upcoming releases. Developers are advised to remove any relevant subscribers to this channel.
 type: deprecation
 scope: Core

--- a/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
+++ b/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
@@ -1,3 +1,0 @@
-message: Starting with this version, the "invalidation" cluster event channel is marked as deprecated and is slated for removal in upcoming releases. Developers are advised to remove any relevant subscribers to this channel.
-type: deprecation
-scope: Core

--- a/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
+++ b/changelog/unreleased/kong/cluster_events_invalidation_channel_deprecation.yml
@@ -1,0 +1,3 @@
+message: From this version, the "invalidation" cluster event channel will be deprecated and removed in future versions.
+type: deprecation
+scope: Core

--- a/changelog/unreleased/kong/separate_kong_cache_invalidation_cluster_event_channel.yml
+++ b/changelog/unreleased/kong/separate_kong_cache_invalidation_cluster_event_channel.yml
@@ -1,4 +1,4 @@
 message: |
-  Every kong cache instance now uses separate cluster event channel for invalidating caches, to avoid generating useless worker events.
+  Each Kong cache instance now utilizes its own cluster event channel. This approach isolates cache invalidation events and reducing the generation of unnecessary worker events.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/separate_kong_cache_invalidation_cluster_event_channel.yml
+++ b/changelog/unreleased/kong/separate_kong_cache_invalidation_cluster_event_channel.yml
@@ -1,0 +1,4 @@
+message: |
+  Every kong cache instance now uses separate cluster event channel for invalidating caches, to avoid generating useless worker events.
+type: bugfix
+scope: Core

--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -147,7 +147,6 @@ function _M.new(opts)
     invalidation_channel = invalidation_channel,
   }
 
-
   local ok, err = cluster_events:subscribe(self.invalidation_channel, function(key)
     log(DEBUG, self.shm_name .. " received invalidate event from cluster for key: '", key, "'")
     self:invalidate_local(key)

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -249,16 +249,17 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
    end
 
   return kong_cache.new({
-    shm_name        = "kong_db_cache",
-    cluster_events  = cluster_events,
-    worker_events   = worker_events,
-    ttl             = db_cache_ttl,
-    neg_ttl         = db_cache_neg_ttl or db_cache_ttl,
-    resurrect_ttl   = kong_config.resurrect_ttl,
-    page            = page,
-    cache_pages     = cache_pages,
-    resty_lock_opts = LOCK_OPTS,
-    lru_size        = get_lru_size(kong_config),
+    shm_name             = "kong_db_cache",
+    cluster_events       = cluster_events,
+    worker_events        = worker_events,
+    ttl                  = db_cache_ttl,
+    neg_ttl              = db_cache_neg_ttl or db_cache_ttl,
+    resurrect_ttl        = kong_config.resurrect_ttl,
+    page                 = page,
+    cache_pages          = cache_pages,
+    resty_lock_opts      = LOCK_OPTS,
+    lru_size             = get_lru_size(kong_config),
+    invalidation_channel = "invalidations",
   })
 end
 

--- a/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
@@ -12,7 +12,11 @@ local Invalidations = {
 
 
 function Invalidations:init_worker()
-  assert(kong.cluster_events:subscribe("invalidations", function(key)
+  assert(kong.cluster_events:subscribe("invalidations_kong_db_cache", function(key)
+    counts[key] = (counts[key] or 0) + 1
+  end))
+
+  assert(kong.cluster_events:subscribe("invalidations_kong_core_db_cache", function(key)
     counts[key] = (counts[key] or 0) + 1
   end))
 end

--- a/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
@@ -12,7 +12,7 @@ local Invalidations = {
 
 
 function Invalidations:init_worker()
-  assert(kong.cluster_events:subscribe("invalidations_kong_db_cache", function(key)
+  assert(kong.cluster_events:subscribe("invalidations", function(key)
     counts[key] = (counts[key] or 0) + 1
   end))
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Currently, the kong_db_cache and kong_core_db_cache use the same invalidations channel named "invalidations" in the cluster event hook. In a traditional cluster(in which multiple Kong nodes use the same database and communicate with each other through cluster events), whenever an invalidation happens on a node A, any other single node X in the cluster will call `invalidate_local` on both kong_db_cache and kong_core_db_cache although the entity usually exists in only one cache, thus generates useless worker events. Not sure if this is an intentional design.

The PR tries to separate every kong.cache instance to use its own invalidations channel to avoid generating useless "invalidations" worker events in a traditional cluster.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Tries to alleviate FTI-5559
