### PR TITLE
chore(globalpatches): moved `require kong.constants` to the closure

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -1,5 +1,3 @@
-local constants = require "kong.constants"
-
 local ran_before
 
 
@@ -15,6 +13,7 @@ return function(options)
 
   options = options or {}
   local meta = require "kong.meta"
+  local constants = require "kong.constants"
 
 
   local cjson_safe = require("cjson.safe")


### PR DESCRIPTION
### Summary

This is necessary because EE has changed `package.path` in this closure, and if we continue leave that in the top-level scope of this file, EE's e2e test will report the following error:

```
stack traceback:
	/usr/local/share/lua/5.1/kong/constants.lua:8: in main chunk
	[C]: in function 'require'
	/usr/local/share/lua/5.1/kong/globalpatches.lua:8: in main chunk
	[C]: in function 'require'
	/usr/local/bin/kong:6: in function 'file_gen'
	init_worker_by_lua(nginx.conf:118):46: in function <init_worker_by_lua(nginx.conf:118):44>
	[C]: in function 'xpcall'
	init_worker_by_lua(nginx.conf:118):53: in function <init_worker_by_lua(nginx.conf:118):51>
```

### Checklist

- NA The Pull Request has tests
- NA A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- NA There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

