### PR TITLE
chore(ci): add labeler config for core/wasm

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,6 +74,10 @@ core/tracing:
 - changed-files:
   - any-glob-to-any-file: ['kong/tracing/**/*', 'kong/pdk/tracing.lua']
 
+core/wasm:
+- changed-files:
+  - any-glob-to-any-file: ['kong/runloop/wasm.lua', 'kong/runloop/wasm/**/*']
+
 chore:
 - changed-files:
   - any-glob-to-any-file: ['.github/**/*', '.devcontainer/**/*']


### PR DESCRIPTION
This sets up automation for the new `core/wasm` label.

- [x] The label has been created here and in the Enterprise repo