### PR TITLE
feat(plugins): ai-prompt-decorator-plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -92,7 +92,11 @@ plugins/acme:
 
 plugins/ai-proxy:
 - changed-files:
-  - any-glob-to-any-file: ['kong/plugins/ai-proxy/**/*', 'kong/llm/**/*'] 
+  - any-glob-to-any-file: ['kong/plugins/ai-proxy/**/*', 'kong/llm/**/*']
+
+plugins/ai-prompt-decorator:
+- changed-files:
+  - any-glob-to-any-file: kong/plugins/ai-prompt-decorator/**/*
 
 plugins/aws-lambda:
 - changed-files:

--- a/changelog/unreleased/kong/add-ai-prompt-decorator-plugin.yml
+++ b/changelog/unreleased/kong/add-ai-prompt-decorator-plugin.yml
@@ -1,0 +1,3 @@
+message: Introduced the new **AI Prompt Decorator** plugin that enables prepending and appending llm/v1/chat messages onto consumer LLM requests, for prompt tuning.
+type: feature
+scope: Plugin

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -574,6 +574,9 @@ build = {
     ["kong.llm.drivers.mistral"] = "kong/llm/drivers/mistral.lua",
     ["kong.llm.drivers.llama2"] = "kong/llm/drivers/llama2.lua",
 
+    ["kong.plugins.ai-prompt-decorator.handler"] = "kong/plugins/ai-prompt-decorator/handler.lua",
+    ["kong.plugins.ai-prompt-decorator.schema"]  = "kong/plugins/ai-prompt-decorator/schema.lua",
+
     ["kong.vaults.env"] = "kong/vaults/env/init.lua",
     ["kong.vaults.env.schema"] = "kong/vaults/env/schema.lua",
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -36,6 +36,7 @@ local plugins = {
   "azure-functions",
   "zipkin",
   "opentelemetry",
+  "ai-prompt-decorator",
   "ai-proxy",
 }
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -36,8 +36,8 @@ local plugins = {
   "azure-functions",
   "zipkin",
   "opentelemetry",
-  "ai-prompt-decorator",
   "ai-proxy",
+  "ai-prompt-decorator",
 }
 
 local plugin_map = {}

--- a/kong/plugins/ai-prompt-decorator/handler.lua
+++ b/kong/plugins/ai-prompt-decorator/handler.lua
@@ -11,7 +11,7 @@ _M.VERSION = kong_meta.version
 
 
 local function bad_request(msg)
-  kong.log.warn(msg)
+  kong.log.debug(msg)
   return kong.response.exit(400, { error = { message = msg } })
 end
 
@@ -49,21 +49,16 @@ end
 
 function _M:access(conf)
   kong.service.request.enable_buffering()
-  kong.ctx.shared.prompt_decorated = true
+  kong.ctx.shared.ai_prompt_decorated = true  -- future use
 
   -- if plugin ordering was altered, receive the "decorated" request
-  local err
-  local request = kong.ctx.replacement_request
-  if not request then
-    request, err = kong.request.get_body("application/json")
-
-    if err then
-      return bad_request("ai-prompt-decorator only supports application/json requests")
-    end
+  local request, err = kong.request.get_body("application/json")
+  if err then
+    return bad_request("this LLM route only supports application/json requests")
   end
 
   if not request.messages or #request.messages < 1 then
-    return bad_request("ai-prompt-decorator only supports llm/chat type requests")
+    return bad_request("this LLM route only supports llm/chat type requests")
   end
 
   local decorated_request, err = self.execute(request, conf)
@@ -71,8 +66,7 @@ function _M:access(conf)
     return bad_request(err)
   end
   
-  -- later AI plugins looks for decorated request in thread contesxt
-  kong.ctx.shared.replacement_request = decorated_request
+  kong.service.request.set_body(decorated_request, "application/json")
 end
 
 return _M

--- a/kong/plugins/ai-prompt-decorator/handler.lua
+++ b/kong/plugins/ai-prompt-decorator/handler.lua
@@ -1,0 +1,78 @@
+local _M = {}
+
+-- imports
+local kong_meta    = require "kong.meta"
+local new_tab      = require("table.new")
+local EMPTY = {}
+--
+
+_M.PRIORITY = 772
+_M.VERSION = kong_meta.version
+
+
+local function bad_request(msg)
+  kong.log.warn(msg)
+  return kong.response.exit(400, { error = { message = msg } })
+end
+
+function _M.execute(request, conf)
+  local prepend = conf.prompts.prepend or EMPTY
+  local append = conf.prompts.append or EMPTY
+
+  if #prepend == 0 and #append == 0 then
+    return request, nil
+  end
+
+  local old_messages = request.messages
+  local new_messages = new_tab(#append + #prepend + #old_messages, 0)
+  request.messages = new_messages
+
+  local n = 0
+
+  for _, msg in ipairs(prepend) do
+    n = n + 1
+    new_messages[n] = { role = msg.role, content = msg.content }
+  end
+
+  for _, msg in ipairs(old_messages) do
+    n = n + 1
+    new_messages[n] = msg
+  end
+
+  for _, msg in ipairs(append) do
+    n = n + 1
+    new_messages[n] = { role = msg.role, content = msg.content }
+  end
+
+  return request, nil
+end
+
+function _M:access(conf)
+  kong.service.request.enable_buffering()
+  kong.ctx.shared.prompt_decorated = true
+
+  -- if plugin ordering was altered, receive the "decorated" request
+  local err
+  local request = kong.ctx.replacement_request
+  if not request then
+    request, err = kong.request.get_body("application/json")
+
+    if err then
+      return bad_request("ai-prompt-decorator only supports application/json requests")
+    end
+  end
+
+  if not request.messages or #request.messages < 1 then
+    return bad_request("ai-prompt-decorator only supports llm/chat type requests")
+  end
+
+  local decorated_request, err = self.execute(request, conf)
+  if err then
+    return bad_request(err)
+  end
+  
+  -- later AI plugins looks for decorated request in thread contesxt
+  kong.ctx.shared.replacement_request = decorated_request
+end
+
+return _M

--- a/kong/plugins/ai-prompt-decorator/schema.lua
+++ b/kong/plugins/ai-prompt-decorator/schema.lua
@@ -33,7 +33,7 @@ local prompts_record = {
 }
 
 return {
-  name = "ai-prompt-injector",
+  name = "ai-prompt-decorator",
   fields = {
     { protocols = typedefs.protocols_http },
     { config = {

--- a/kong/plugins/ai-prompt-decorator/schema.lua
+++ b/kong/plugins/ai-prompt-decorator/schema.lua
@@ -1,0 +1,50 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+local prompt_record = {
+  type = "record",
+  required = false,
+  fields = {
+    { role = { type = "string", required = true, one_of = { "system", "assistant", "user" }, default = "system" }},
+    { content = { type = "string", required = true, len_min = 1, len_max = 500 } },
+  }
+}
+
+local prompts_record = {
+  type = "record",
+  required = false,
+  fields = {
+    { prepend = {
+      type = "array",
+      description = "Insert chat messages at the beginning of the chat message array. "
+                 .. "This array preserves exact order when adding messages.",
+      elements = prompt_record,
+      required = false,
+      len_max = 15,
+    }},
+    { append = {
+      type = "array",
+      description = "Insert chat messages at the end of the chat message array. "
+                 .. "This array preserves exact order when adding messages.",
+      elements = prompt_record,
+      required = false,
+      len_max = 15,
+    }},
+  }
+}
+
+return {
+  name = "ai-prompt-injector",
+  fields = {
+    { protocols = typedefs.protocols_http },
+    { config = {
+      type = "record",
+      fields = {
+          { prompts = prompts_record }
+        }
+      }
+    }
+  },
+  entity_checks = {
+    { at_least_one_of = { "config.prompts.prepend", "config.prompts.append" } },
+  },
+}

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -72,6 +72,7 @@ describe("Plugins", function()
       "response-ratelimiting",
       "request-transformer",
       "response-transformer",
+      "ai-prompt-decorator",
       "ai-proxy",
       "aws-lambda",
       "azure-functions",

--- a/spec/03-plugins/41-ai-prompt-decorator/00-config_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/00-config_spec.lua
@@ -1,0 +1,90 @@
+local PLUGIN_NAME = "ai-prompt-decorator"
+
+
+-- helper function to validate data against a schema
+local validate do
+  local validate_entity = require("spec.helpers").validate_plugin_config_schema
+  local plugin_schema = require("kong.plugins."..PLUGIN_NAME..".schema")
+
+  function validate(data)
+    return validate_entity(data, plugin_schema)
+  end
+end
+
+describe(PLUGIN_NAME .. ": (schema)", function()
+  it("won't allow empty config object", function()
+    local config = {
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.not_nil(err)
+    assert.equal("at least one of these fields must be non-empty: 'config.prompts.prepend', 'config.prompts.append'", err["@entity"][1])
+  end)
+
+  it("won't allow both head and tail to be unset", function()
+    local config = {
+      prompts = {},
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.not_nil(err)
+    assert.equal("at least one of these fields must be non-empty: 'config.prompts.prepend', 'config.prompts.append'", err["@entity"][1])
+  end)
+
+  it("won't allow both allow_patterns and deny_patterns to be empty arrays", function()
+    local config = {
+      prompts = {
+        prepend = {},
+        append = {},
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.not_nil(err)
+    assert.equal("at least one of these fields must be non-empty: 'config.prompts.prepend', 'config.prompts.append'", err["@entity"][1])
+  end)
+
+  it("allows prepend only", function()
+    local config = {
+      prompts = {
+        prepend = {
+          [1] = {
+            role = "system",
+            content = "Prepend text 1 here.",
+          },
+        },
+        append = {},
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_truthy(ok)
+    assert.is_nil(err)
+  end)
+
+  it("allows append only", function()
+    local config = {
+      prompts = {
+        prepend = {},
+        append = {
+          [1] = {
+            role = "system",
+            content = "Prepend text 1 here.",
+          },
+        },
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_truthy(ok)
+    assert.is_nil(err)
+  end)
+end)

--- a/spec/03-plugins/41-ai-prompt-decorator/01-unit_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/01-unit_spec.lua
@@ -1,0 +1,163 @@
+local PLUGIN_NAME = "ai-prompt-decorator"
+
+-- imports
+local access_handler = require("kong.plugins.ai-prompt-decorator.handler")
+--
+
+local function deepcopy(o, seen)
+  seen = seen or {}
+  if o == nil then return nil end
+  if seen[o] then return seen[o] end
+
+  local no
+  if type(o) == 'table' then
+    no = {}
+    seen[o] = no
+
+    for k, v in next, o, nil do
+      no[deepcopy(k, seen)] = deepcopy(v, seen)
+    end
+    setmetatable(no, deepcopy(getmetatable(o), seen))
+  else -- number, string, boolean, etc
+    no = o
+  end
+  return no
+end
+
+local general_chat_request = {
+  messages = {
+    [1] = {
+      role = "system",
+      content = "You are a mathematician."
+    },
+    [2] = {
+      role = "user",
+      content = "What is 1 + 1?"
+    },
+    [3] = {
+      role = "assistant",
+      content = "The answer is 2?"
+    },
+    [4] = {
+      role = "user",
+      content = "Now double it."
+    },
+  },
+}
+
+local injector_conf_prepend = {
+  prompts = {
+    prepend = {
+      [1] = {
+        role = "system",
+        content = "Give me answers in French language."
+      },
+      [2] = {
+        role = "user",
+        content = "Consider you are a mathematician."
+      },
+      [3] = {
+        role = "assistant",
+        content = "Okay I am a mathematician. What is your maths question?"
+      },
+    },
+  },
+}
+
+local injector_conf_append = {
+  prompts = {
+    append = {
+      [1] = {
+        role = "system",
+        content = "Give me answers in French language."
+      },
+      [2] = {
+        role = "system",
+        content = "Give me the answer in JSON format."
+      },
+    },
+  },
+}
+
+local injector_conf_both = {
+  prompts = {
+    prepend = {
+      [1] = {
+        role = "system",
+        content = "Give me answers in French language."
+      },
+      [2] = {
+        role = "user",
+        content = "Consider you are a mathematician."
+      },
+      [3] = {
+        role = "assistant",
+        content = "Okay I am a mathematician. What is your maths question?"
+      },
+    },
+    append = {
+      [1] = {
+        role = "system",
+        content = "Give me answers in French language."
+      },
+      [2] = {
+        role = "system",
+        content = "Give me the answer in JSON format."
+      },
+    },
+  },
+}
+
+describe(PLUGIN_NAME .. ": (unit)", function()
+
+  describe("chat v1 operations", function()
+
+    it("adds messages to the start of the array", function()
+      local request_copy = deepcopy(general_chat_request)
+      local expected_request_copy = deepcopy(general_chat_request)
+
+      -- combine the tables manually, and check the code does the same
+      table.insert(expected_request_copy.messages, 1, injector_conf_prepend.prompts.prepend[1])
+      table.insert(expected_request_copy.messages, 2, injector_conf_prepend.prompts.prepend[2])
+      table.insert(expected_request_copy.messages, 3, injector_conf_prepend.prompts.prepend[3])
+
+      local decorated_request, err = access_handler.execute(request_copy, injector_conf_prepend)
+
+      assert.is_nil(err)
+      assert.same(decorated_request, expected_request_copy)
+    end)
+
+    it("adds messages to the end of the array", function()
+      local request_copy = deepcopy(general_chat_request)
+      local expected_request_copy = deepcopy(general_chat_request)
+
+      -- combine the tables manually, and check the code does the same
+      table.insert(expected_request_copy.messages, #expected_request_copy.messages + 1, injector_conf_append.prompts.append[1])
+      table.insert(expected_request_copy.messages, #expected_request_copy.messages + 1, injector_conf_append.prompts.append[2])
+
+      local decorated_request, err = access_handler.execute(request_copy, injector_conf_append)
+
+      assert.is_nil(err)
+      assert.same(expected_request_copy, decorated_request)
+    end)
+
+    it("adds messages to the start and the end of the array", function()
+      local request_copy = deepcopy(general_chat_request)
+      local expected_request_copy = deepcopy(general_chat_request)
+
+      -- combine the tables manually, and check the code does the same
+      table.insert(expected_request_copy.messages, 1, injector_conf_both.prompts.prepend[1])
+      table.insert(expected_request_copy.messages, 2, injector_conf_both.prompts.prepend[2])
+      table.insert(expected_request_copy.messages, 3, injector_conf_both.prompts.prepend[3])
+      table.insert(expected_request_copy.messages, #expected_request_copy.messages + 1, injector_conf_both.prompts.append[1])
+      table.insert(expected_request_copy.messages, #expected_request_copy.messages + 1, injector_conf_both.prompts.append[2])
+
+      local decorated_request, err = access_handler.execute(request_copy, injector_conf_both)
+
+      assert.is_nil(err)
+      assert.same(expected_request_copy, decorated_request)
+    end)
+
+  end)
+
+end)

--- a/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
@@ -86,7 +86,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
         local body = assert.res_status(400, r)
         local json = cjson.decode(body)
 
-        assert.same(json, { error = { message = "ai-prompt-decorator only supports llm/chat type requests" }})
+        assert.same(json, { error = { message = "this LLM route only supports llm/chat type requests" }})
       end)
 
       it("sends in an empty messages array", function()
@@ -105,7 +105,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
         local body = assert.res_status(400, r)
         local json = cjson.decode(body)
 
-        assert.same(json, { error = { message = "ai-prompt-decorator only supports llm/chat type requests" }})
+        assert.same(json, { error = { message = "this LLM route only supports llm/chat type requests" }})
       end)
     end)
 

--- a/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
@@ -1,0 +1,114 @@
+local helpers = require "spec.helpers"
+local cjson   = require "cjson"
+
+local PLUGIN_NAME = "ai-prompt-decorator"
+
+
+for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
+    local client
+
+    lazy_setup(function()
+
+      local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
+
+      local route1 = bp.routes:insert({
+        hosts = { "test1.com" },
+      })
+
+      bp.plugins:insert {
+        name = PLUGIN_NAME,
+        route = { id = route1.id },
+        config = {
+          prompts = {
+            prepend = {
+              [1] = {
+                role = "system",
+                content = "Prepend text 1 here.",
+              },
+              [2] = {
+                role = "system",
+                content = "Prepend text 2 here.",
+              },
+            },
+            append = {
+              [1] = {
+                role = "assistant",
+                content = "Append text 1 here.",
+              },
+              [2] = {
+                role = "user",
+                content = "Append text 2 here.",
+              },
+            },
+          },
+        },
+      }
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "bundled," .. PLUGIN_NAME,
+        declarative_config = strategy == "off" and helpers.make_yaml_file() or nil,
+      }))
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if client then client:close() end
+    end)
+
+    describe("request", function()
+      it("sends in a non-chat message", function()
+        local r = client:get("/request", {
+          headers = {
+            host = "test1.com",
+            ["Content-Type"] = "application/json",
+          },
+          body = [[
+            {
+              "anything": [
+                {
+                  "random": "data"
+                }
+              ]
+            }]],
+          method = "POST",
+        })
+        
+        local body = assert.res_status(400, r)
+        local json = cjson.decode(body)
+
+        assert.same(json, { error = { message = "ai-prompt-decorator only supports llm/chat type requests" }})
+      end)
+
+      it("sends in an empty messages array", function()
+        local r = client:get("/request", {
+          headers = {
+            host = "test1.com",
+            ["Content-Type"] = "application/json",
+          },
+          body = [[
+            {
+              "messages": []
+            }]],
+          method = "POST",
+        })
+        
+        local body = assert.res_status(400, r)
+        local json = cjson.decode(body)
+
+        assert.same(json, { error = { message = "ai-prompt-decorator only supports llm/chat type requests" }})
+      end)
+    end)
+
+  end)
+
+end end


### PR DESCRIPTION
### Summary

This commit offers another plugin that extends the functionality of "AI Proxy" in #12207.

It adds an array of "llm/v1/chat" messages to either the **front** or **end** of a caller's chat history.

This allows for complex prompt-engineering on behalf of the caller.

This reason for its development, is that many of our users would like to set up specific prompt history, words, phrases, or otherwise more tightly control how an AI / LLM model is used, if being called via Kong, and this applies especially with the `AI Proxy` plugin that will simplify this process.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - docs being discussed internally, as part of AI-Proxy plugin in #12207 
