### PR TITLE
fix(plugins): fix competing redis configs

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1670,7 +1670,11 @@ function Schema:process_auto_fields(data, context, nulls, opts)
           local new_values = sdata.func(value)
           if new_values then
             for k, v in pairs(new_values) do
-              data[k] = v
+              if type(v) == "table" then
+                data[k] = tablex.merge(data[k] or {}, v, true)
+              else
+                data[k] = v
+              end
             end
           end
         end

--- a/kong/plugins/acme/storage/config_adapters/redis.lua
+++ b/kong/plugins/acme/storage/config_adapters/redis.lua
@@ -3,13 +3,13 @@ local function redis_config_adapter(conf)
         host = conf.host,
         port = conf.port,
         database = conf.database,
-        auth = conf.password or conf.auth, -- allow conf.auth until 4.0 version
+        auth = conf.password,
         ssl = conf.ssl,
         ssl_verify = conf.ssl_verify,
-        ssl_server_name = conf.server_name or conf.ssl_server_name, -- allow conf.ssl_server_name until 4.0 version
+        ssl_server_name = conf.server_name,
 
-        namespace = conf.extra_options.namespace or conf.namespace, -- allow conf.namespace until 4.0 version
-        scan_count = conf.extra_options.scan_count or conf.scan_count, -- allow conf.scan_count until 4.0 version
+        namespace = conf.extra_options.namespace,
+        scan_count = conf.extra_options.scan_count,
     }
 end
 

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -80,15 +80,15 @@ local EXPIRATION = require "kong.plugins.rate-limiting.expiration"
 
 local function get_redis_configuration(plugin_conf)
   return {
-     host = plugin_conf.redis.host or plugin_conf.redis_host,
-     port = plugin_conf.redis.port or plugin_conf.redis_port,
-     username = plugin_conf.redis.username or plugin_conf.redis_username,
-     password = plugin_conf.redis.password or plugin_conf.redis_password,
-     database = plugin_conf.redis.database or plugin_conf.redis_database,
-     timeout = plugin_conf.redis.timeout or plugin_conf.redis_timeout,
-     ssl = plugin_conf.redis.ssl or plugin_conf.redis_ssl,
-     ssl_verify = plugin_conf.redis.ssl_verify or plugin_conf.redis_ssl_verify,
-     server_name = plugin_conf.redis.server_name or plugin_conf.redis_server_name,
+     host = plugin_conf.redis.host,
+     port = plugin_conf.redis.port,
+     username = plugin_conf.redis.username,
+     password = plugin_conf.redis.password,
+     database = plugin_conf.redis.database,
+     timeout = plugin_conf.redis.timeout,
+     ssl = plugin_conf.redis.ssl,
+     ssl_verify = plugin_conf.redis.ssl_verify,
+     server_name = plugin_conf.redis.server_name,
   }
 end
 

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -93,40 +93,103 @@ return {
           { policy = policy },
           { fault_tolerant = { description = "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors.", type = "boolean", required = true, default = true }, },
           { redis = redis_schema.config_schema },
-          { redis_host = typedefs.host },
-          { redis_port = typedefs.port({ default = 6379 }), },
-          { redis_password = { description = "When using the `redis` policy, this property specifies the password to connect to the Redis server.", type = "string", len_min = 0, referenceable = true }, },
-          { redis_username = { description = "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.", type = "string", referenceable = true }, },
-          { redis_ssl = { description = "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.", type = "boolean", required = true, default = false, }, },
-          { redis_ssl_verify = { description = "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.", type = "boolean", required = true, default = false }, },
-          { redis_server_name = typedefs.sni },
-          { redis_timeout = { description = "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.", type = "number", default = 2000, }, },
-          { redis_database = { description = "When using the `redis` policy, this property specifies the Redis database to use.", type = "integer", default = 0 }, },
           { hide_client_headers = { description = "Optionally hide informative response headers.", type = "boolean", required = true, default = false }, },
           { error_code = { description = "Set a custom error code to return when the rate limit is exceeded.", type = "number", default = 429, gt = 0 }, },
           { error_message = { description = "Set a custom error message to return when the rate limit is exceeded.", type = "string", default = "API rate limit exceeded" }, },
           { sync_rate = { description = "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior.", type = "number", required = true, default = -1 }, },
         },
         custom_validator = validate_periods_order,
+        shorthand_fields = {
+          -- TODO: deprecated forms, to be removed in Kong 4.0
+          { redis_host = {
+            type = "string",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
+                { after = "4.0", })
+              return { redis = { host = value } }
+            end
+          } },
+          { redis_port = {
+            type = "integer",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
+                { after = "4.0", })
+              return { redis = { port = value } }
+            end
+          } },
+          { redis_password = {
+            type = "string",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
+                { after = "4.0", })
+              return { redis = { password = value } }
+            end
+          } },
+          { redis_username = {
+            type = "string",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
+                { after = "4.0", })
+              return { redis = { username = value } }
+            end
+          } },
+          { redis_ssl = {
+            type = "boolean",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
+                { after = "4.0", })
+              return { redis = { ssl = value } }
+            end
+          } },
+          { redis_ssl_verify = {
+            type = "boolean",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
+                { after = "4.0", })
+              return { redis = { ssl_verify = value } }
+            end
+          } },
+          { redis_server_name = {
+            type = "string",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
+                { after = "4.0", })
+              return { redis = { server_name = value } }
+            end
+          } },
+          { redis_timeout = {
+            type = "integer",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
+                { after = "4.0", })
+              return { redis = { timeout = value } }
+            end
+          } },
+          { redis_database = {
+            type = "integer",
+            func = function(value)
+              deprecation("rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
+                { after = "4.0", })
+              return { redis = { database = value } }
+            end
+          } },
+        },
       },
     },
   },
   entity_checks = {
     { at_least_one_of = { "config.second", "config.minute", "config.hour", "config.day", "config.month", "config.year" } },
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.host", "config.redis_host" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.host", then_match = { required = true },
     } },
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.port", "config.redis_port" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.port", then_match = { required = true },
     } },
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.timeout", "config.redis_timeout" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.timeout", then_match = { required = true },
     } },
     { conditional = {
       if_field = "config.limit_by", if_match = { eq = "header" },
@@ -136,59 +199,5 @@ return {
       if_field = "config.limit_by", if_match = { eq = "path" },
       then_field = "config.path", then_match = { required = true },
     } },
-    { custom_entity_check = {
-      field_sources = {
-        "config.redis_host",
-        "config.redis_port",
-        "config.redis_password",
-        "config.redis_username",
-        "config.redis_ssl",
-        "config.redis_ssl_verify",
-        "config.redis_server_name",
-        "config.redis_timeout",
-        "config.redis_database"
-      },
-      fn = function(entity)
-
-        if (entity.config.redis_host or ngx.null) ~= ngx.null then
-          deprecation("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_port or ngx.null) ~= ngx.null and entity.config.redis_port ~= 6379 then
-          deprecation("rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_password or ngx.null) ~= ngx.null then
-          deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_username or ngx.null) ~= ngx.null then
-          deprecation("rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_ssl or ngx.null) ~= ngx.null and entity.config.redis_ssl ~= false then
-          deprecation("rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_ssl_verify or ngx.null) ~= ngx.null and entity.config.redis_ssl_verify ~= false then
-          deprecation("rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_server_name or ngx.null) ~= ngx.null then
-          deprecation("rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_timeout or ngx.null) ~= ngx.null and entity.config.redis_timeout ~= 2000 then
-          deprecation("rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_database or ngx.null) ~= ngx.null and entity.config.redis_database ~= 0 then
-          deprecation("rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
-            { after = "4.0", })
-        end
-
-        return true
-      end
-    } }
   },
 }

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -27,15 +27,15 @@ end
 
 local function get_redis_configuration(plugin_conf)
   return {
-     host = plugin_conf.redis.host or plugin_conf.redis_host,
-     port = plugin_conf.redis.port or plugin_conf.redis_port,
-     username = plugin_conf.redis.username or plugin_conf.redis_username,
-     password = plugin_conf.redis.password or plugin_conf.redis_password,
-     database = plugin_conf.redis.database or plugin_conf.redis_database,
-     timeout = plugin_conf.redis.timeout or plugin_conf.redis_timeout,
-     ssl = plugin_conf.redis.ssl or plugin_conf.redis_ssl,
-     ssl_verify = plugin_conf.redis.ssl_verify or plugin_conf.redis_ssl_verify,
-     server_name = plugin_conf.redis.server_name or plugin_conf.redis_server_name,
+     host = plugin_conf.redis.host,
+     port = plugin_conf.redis.port,
+     username = plugin_conf.redis.username,
+     password = plugin_conf.redis.password,
+     database = plugin_conf.redis.database,
+     timeout = plugin_conf.redis.timeout,
+     ssl = plugin_conf.redis.ssl,
+     ssl_verify = plugin_conf.redis.ssl_verify,
+     server_name = plugin_conf.redis.server_name,
   }
 end
 

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -60,7 +60,6 @@ else
   }
 end
 
-
 return {
   name = "response-ratelimiting",
   fields = {
@@ -96,67 +95,6 @@ return {
             },
           },
           { redis = redis_schema.config_schema },
-          {
-            redis_host = typedefs.redis_host,
-          },
-          {
-            redis_port = typedefs.port({
-              default = 6379,
-              description = "When using the `redis` policy, this property specifies the port of the Redis server."
-            }),
-          },
-          {
-            redis_password = {
-              description =
-              "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
-              type = "string",
-              len_min = 0,
-              referenceable = true
-            },
-          },
-          {
-            redis_username = {
-              description =
-              "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              type = "string",
-              referenceable = true
-            },
-          },
-          {
-            redis_ssl = {
-              description =
-              "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
-              type = "boolean",
-              required = true,
-              default = false,
-            },
-          },
-          {
-            redis_ssl_verify = {
-              description =
-              "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
-              type = "boolean",
-              required = true,
-              default = false
-            },
-          },
-          {
-            redis_server_name = typedefs.redis_server_name
-          },
-          {
-            redis_timeout = {
-              description = "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.",
-              type = "number",
-              default = 2000
-            },
-          },
-          {
-            redis_database = {
-              description = "When using the `redis` policy, this property specifies Redis database to use.",
-              type = "number",
-              default = 0
-            },
-          },
           {
             block_on_first_violation = {
               description =
@@ -200,77 +138,96 @@ return {
             },
           },
         },
+        shorthand_fields = {
+          -- TODO: deprecated forms, to be removed in Kong 4.0
+          { redis_host = {
+            type = "string",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
+                { after = "4.0", })
+              return { redis = { host = value } }
+            end
+          } },
+          { redis_port = {
+            type = "integer",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
+                { after = "4.0", })
+              return { redis = { port = value } }
+            end
+          } },
+          { redis_password = {
+            type = "string",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
+                { after = "4.0", })
+              return { redis = { password = value } }
+            end
+          } },
+          { redis_username = {
+            type = "string",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
+                { after = "4.0", })
+              return { redis = { username = value } }
+            end
+          } },
+          { redis_ssl = {
+            type = "boolean",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
+                { after = "4.0", })
+              return { redis = { ssl = value } }
+            end
+          } },
+          { redis_ssl_verify = {
+            type = "boolean",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
+                { after = "4.0", })
+              return { redis = { ssl_verify = value } }
+            end
+          } },
+          { redis_server_name = {
+            type = "string",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
+                { after = "4.0", })
+              return { redis = { server_name = value } }
+            end
+          } },
+          { redis_timeout = {
+            type = "integer",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
+                { after = "4.0", })
+              return { redis = { timeout = value } }
+            end
+          } },
+          { redis_database = {
+            type = "integer",
+            func = function(value)
+              deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
+                { after = "4.0", })
+              return { redis = { database = value } }
+            end
+          } },
+        },
       },
     },
   },
   entity_checks = {
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.host", "config.redis_host" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.host", then_match = { required = true },
     } },
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.port", "config.redis_port" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.port", then_match = { required = true },
     } },
-    { conditional_at_least_one_of = {
+    { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
-      then_at_least_one_of = { "config.redis.timeout", "config.redis_timeout" },
-      then_err = "must set one of %s when 'policy' is 'redis'",
+      then_field = "config.redis.timeout", then_match = { required = true },
     } },
-    { custom_entity_check = {
-      field_sources = {
-        "config.redis_host",
-        "config.redis_port",
-        "config.redis_password",
-        "config.redis_username",
-        "config.redis_ssl",
-        "config.redis_ssl_verify",
-        "config.redis_server_name",
-        "config.redis_timeout",
-        "config.redis_database"
-      },
-      fn = function(entity)
-        if (entity.config.redis_host or ngx.null) ~= ngx.null then
-          deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_port or ngx.null) ~= ngx.null and entity.config.redis_port ~= 6379 then
-          deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_password or ngx.null) ~= ngx.null then
-          deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_username or ngx.null) ~= ngx.null then
-          deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_ssl or ngx.null) ~= ngx.null and entity.config.redis_ssl ~= false then
-          deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_ssl_verify or ngx.null) ~= ngx.null and entity.config.redis_ssl_verify ~= false then
-          deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_server_name or ngx.null) ~= ngx.null then
-          deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_timeout or ngx.null) ~= ngx.null and entity.config.redis_timeout ~= 2000 then
-          deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-            { after = "4.0", })
-        end
-        if (entity.config.redis_database or ngx.null) ~= ngx.null and entity.config.redis_database ~= 0 then
-          deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
-            { after = "4.0", })
-        end
-
-        return true
-      end
-    } }
   },
 }

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -131,7 +131,7 @@ describe("Plugin: rate-limiting (schema)", function()
       } }
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
-      assert.contains("must set one of 'config.redis.host', 'config.redis_host' when 'policy' is 'redis'", err["@entity"])
+      assert.equal("required field missing", err.config.redis.host)
     end)
   end)
 end)

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -129,7 +129,7 @@ describe("Plugin: response-rate-limiting (schema)", function()
       } }
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
-      assert.contains("must set one of 'config.redis.host', 'config.redis_host' when 'policy' is 'redis'", err["@entity"])
+      assert.equal("required field missing", err.config.redis.host)
     end)
   end)
 end)

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -408,6 +408,17 @@ describe("Plugin: rate-limiting (integration)", function()
     end
 
     it("allows to create a plugin with new redis configuration", function()
+      local redis_config = {
+        host = helpers.redis_host,
+        port = helpers.redis_port,
+        username = "test1",
+        password = "testX",
+        database = 1,
+        timeout = 1100,
+        ssl = true,
+        ssl_verify = true,
+        server_name = "example.test",
+      }
       local res = assert(admin_client:send {
         method = "POST",
         route = {
@@ -424,23 +435,26 @@ describe("Plugin: rate-limiting (integration)", function()
               }
             },
             policy = "redis",
-            redis = {
-              host = helpers.redis_host,
-              port = helpers.redis_port,
-              username = "test1",
-              password = "testX",
-              database = 1,
-              timeout = 1100,
-              ssl = true,
-              ssl_verify = true,
-              server_name = "example.test",
-            },
+            redis = redis_config,
           },
         },
       })
 
       local json = cjson.decode(assert.res_status(201, res))
+
+      -- verify that legacy defaults don't ovewrite new structure when they were not defined
+      assert.same(redis_config.host, json.config.redis.host)
+      assert.same(redis_config.port, json.config.redis.port)
+      assert.same(redis_config.username, json.config.redis.username)
+      assert.same(redis_config.password, json.config.redis.password)
+      assert.same(redis_config.database, json.config.redis.database)
+      assert.same(redis_config.timeout, json.config.redis.timeout)
+      assert.same(redis_config.ssl, json.config.redis.ssl)
+      assert.same(redis_config.ssl_verify, json.config.redis.ssl_verify)
+      assert.same(redis_config.server_name, json.config.redis.server_name)
+
       delete_plugin(admin_client, json)
+
       assert.logfile().has.no.line("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)
       assert.logfile().has.no.line("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead (deprecated after 4.0)", true)
       assert.logfile().has.no.line("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead (deprecated after 4.0)", true)
@@ -453,6 +467,23 @@ describe("Plugin: rate-limiting (integration)", function()
     end)
 
     it("allows to create a plugin with legacy redis configuration", function()
+      local plugin_config = {
+        limits = {
+          video = {
+            minute = 100,
+          }
+        },
+        policy = "redis",
+        redis_host = "custom-host.example.test",
+        redis_port = 55000,
+        redis_username = "test1",
+        redis_password = "testX",
+        redis_database = 1,
+        redis_timeout = 3400,
+        redis_ssl = true,
+        redis_ssl_verify = true,
+        redis_server_name = "example.test",
+      }
       local res = assert(admin_client:send {
         method = "POST",
         route = {
@@ -462,28 +493,25 @@ describe("Plugin: rate-limiting (integration)", function()
         headers = { ["Content-Type"] = "application/json" },
         body = {
           name = "response-ratelimiting",
-          config = {
-            limits = {
-              video = {
-                minute = 100,
-              }
-            },
-            policy = "redis",
-            redis_host = "custom-host.example.test",
-            redis_port = 55000,
-            redis_username = "test1",
-            redis_password = "testX",
-            redis_database = 1,
-            redis_timeout = 1100,
-            redis_ssl = true,
-            redis_ssl_verify = true,
-            redis_server_name = "example.test",
-          },
+          config = plugin_config,
         },
       })
 
       local json = cjson.decode(assert.res_status(201, res))
+
+      -- verify that legacy config got written into new structure
+      assert.same(plugin_config.redis_host, json.config.redis.host)
+      assert.same(plugin_config.redis_port, json.config.redis.port)
+      assert.same(plugin_config.redis_username, json.config.redis.username)
+      assert.same(plugin_config.redis_password, json.config.redis.password)
+      assert.same(plugin_config.redis_database, json.config.redis.database)
+      assert.same(plugin_config.redis_timeout, json.config.redis.timeout)
+      assert.same(plugin_config.redis_ssl, json.config.redis.ssl)
+      assert.same(plugin_config.redis_ssl_verify, json.config.redis.ssl_verify)
+      assert.same(plugin_config.redis_server_name, json.config.redis.server_name)
+
       delete_plugin(admin_client, json)
+
       assert.logfile().has.line("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)
       assert.logfile().has.line("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead (deprecated after 4.0)", true)
       assert.logfile().has.line("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead (deprecated after 4.0)", true)


### PR DESCRIPTION




<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

ACME, RateLimiting and Response-RateLimiting now use the same redis configuration structure. The olds fields were left in place to maintain backwards compatibility. When resolving the configuration we looked into new fields and if they were empty then fallback to legacy fields. Unfortunately the new fields have their defaults as well which get written into db - so at the time of plugin resolution we'd have to implement complex logic to figure out if the new value came from user or from defualt.

This approach removes the olds fields and uses shorthands to maintain backwards compatibility.

### Checklist

- [x] The Pull Request has tests
- [x] N/A - ~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3388
