### PR TITLE
refactor(tools): rework `is_not_debug_mode` flag of  request aware table

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -10,6 +10,7 @@ local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
 local fields = require("kong.router.fields")
 local utils = require("kong.router.utils")
+local rat = require("kong.tools.request_aware_table")
 local yield = require("kong.tools.yield").yield
 
 
@@ -506,8 +507,7 @@ function _M:exec(ctx)
   -- cache key calculation
 
   if not CACHE_PARAMS then
-    -- access `kong.configuration.log_level` here
-    CACHE_PARAMS = require("kong.tools.request_aware_table").new()
+    CACHE_PARAMS = rat.new()
   end
 
   CACHE_PARAMS:clear()
@@ -631,8 +631,7 @@ function _M:exec(ctx)
   -- cache key calculation
 
   if not CACHE_PARAMS then
-    -- access `kong.configuration.log_level` here
-    CACHE_PARAMS = require("kong.tools.request_aware_table").new()
+    CACHE_PARAMS = rat.new()
   end
 
   CACHE_PARAMS:clear()

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -12,6 +12,7 @@ local is_not_debug_mode
 
 local error        = error
 local rawset       = rawset
+local rawget       = rawget
 local setmetatable = setmetatable
 
 

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -6,7 +6,8 @@ local table_clear = require("table.clear")
 local get_request_id = require("kong.tracing.request_id").get
 
 
-local is_not_debug_mode = (kong.configuration.log_level ~= "debug")
+-- set in new()
+local is_not_debug_mode
 
 
 local error        = error
@@ -98,6 +99,10 @@ local __direct_mt = {
 -- @return The newly created table with request-aware access
 local function new(narr, nrec)
   local data = table_new(narr or 0, nrec or 0)
+
+  if is_not_debug_mode == nil then
+    is_not_debug_mode = (kong.configuration.log_level ~= "debug")
+  end
 
   -- return table without proxy when debug_mode is disabled
   if is_not_debug_mode then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The value of `is_not_debug_mode` depends on `kong.configuration.log_level`,
which may be unavailable when the module is required.

This PR sets the value of `is_not_debug_mode` in the first call of `new()`.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
