### PR TITLE
refactor(pdk/request): need not to call `replace_dashes` for get_header()

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -80,9 +80,6 @@ local function new(self)
     end
   end
 
-  local replace_dashes = require("kong.tools.string").replace_dashes
-
-
   ---
   -- Returns the scheme component of the request's URL. The returned value is
   -- normalized to lowercase form.
@@ -625,7 +622,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    return var["http_" .. replace_dashes(name)]
+    return var["http_" .. name]
   end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In nginx's C code `ngx_http_variable_unknown_header()` (https://github.com/nginx/nginx/blob/master/src/http/ngx_http_variables.c#L961-L969),
we already lowercased and replaced `-` to `_`,
so need not to call `replace_dashes()` in Lua land

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
