### PR TITLE
fix(clustering): restore immediate ping behavior on config update

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -253,7 +253,10 @@ function _M:communicate(premature)
       local err_t
       ok, err, err_t = config_helper.update(self.declarative_config, msg)
 
-      if not ok then
+      if ok then
+        ping_immediately = true
+
+      else
         if self.error_reporting then
           config_err_t = err_t
         end


### PR DESCRIPTION
This branch of logic was mistakenly removed in
0f95ffc0943da16e0588ae35b6054bb54a1fac51 / #12282.

No changelog entry is required because the defect fixed by this PR has never been released.