### PR TITLE
docs(kong.conf.default): add proxy_protocol to status_listen property

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -695,6 +695,7 @@
                          #   enabled.
                          # - `http2` will allow for clients to open HTTP/2
                          #   connections to Kong's proxy server.
+                         # - `proxy_protocol` will enable usage of the PROXY protocol.
                          #
                          # This value can be set to `off`, disabling
                          # the Status API for this node.


### PR DESCRIPTION
### Summary

It seems that proxy_protocol is another value that can be added to the status_listen property, however it was unlisted earlier. Adding it here so customers know status_listen can utilize the proxy protocol. This stems from a support case.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Support case 00040675.