### PR TITLE
fix(core): Regex header values in traditional router are now validated

### DIFF
--- a/changelog/unreleased/kong/traditional_router_header_validation.yml
+++ b/changelog/unreleased/kong/traditional_router_header_validation.yml
@@ -1,0 +1,3 @@
+message: Regex header values in traditional router are now validated.
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/traditional_router_header_validation.yml
+++ b/changelog/unreleased/kong/traditional_router_header_validation.yml
@@ -1,3 +1,3 @@
-message: Fix issue where a regex header value would not be validated if the `traditional` or `traditional_compatible` router flavors were in use.
+message: Fixed an issue where the `route` entity would accept an invalid regex pattern if the `router_flavor` is `traditional` or `traditional_compatible`. Now, the invalid regex pattern for matching the value of request headers will not be accepted when creating the `route` entity.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/traditional_router_header_validation.yml
+++ b/changelog/unreleased/kong/traditional_router_header_validation.yml
@@ -1,3 +1,3 @@
-message: Regex header values in traditional router are now validated.
+message: Fix issue where a regex header value would not be validated if the `traditional` or `traditional_compatible` router flavors were in use.
 type: bugfix
 scope: Core

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -196,6 +196,10 @@ local routes = {
             },
           },
         },
+        values = {
+          type = "array",
+          elements = typedefs.regex_or_plain_pattern,
+        }
       } },
 
       { regex_priority = { description = "A number used to choose which route resolves a given request when several routes match it using regexes simultaneously.", type = "integer", default = 0 }, },

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -621,6 +621,17 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
       assert.falsy(ok)
       assert.equal("length must be at least 1", err.headers[1])
     end)
+
+    it("value must be a plain pattern or a valid regex pattern", function()
+      local route = {
+        headers = { location = { "~[" } },
+        protocols = { "http" },
+      }
+
+      local ok, err = Routes:validate(route)
+      assert.falsy(ok)
+      assert.match("invalid regex", err.headers[1])
+    end)
   end)
 
   describe("methods attribute", function()


### PR DESCRIPTION
### Summary

ATT

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)

### Issue reference

Fix FTI-5403
