### PR TITLE
fix(pdk): get the first http header value after bumping to OpenResty 1.25.3.1

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -80,7 +80,7 @@ local function new(self)
     end
   end
 
-  local replace_dashes = require("kong.tools.string").replace_dashes
+  local http_get_header = require("kong.tools.http").get_header
 
 
   ---
@@ -163,12 +163,6 @@ local function new(self)
     if is_trusted_ip() then
       local scheme = _REQUEST.get_header(X_FORWARDED_PROTO)
       if scheme then
-        local p = find(scheme, ",", 1, true)
-
-        if p then
-          scheme = sub(scheme, 1, p - 1)
-        end
-
         return lower(scheme)
       end
     end
@@ -249,16 +243,7 @@ local function new(self)
     check_phase(PHASES.request)
 
     if is_trusted_ip() then
-      local port = _REQUEST.get_header(X_FORWARDED_PORT)
-      if port then
-        local p = find(port, ",", 1, true)
-
-        if p then
-          port = sub(port, 1, p - 1)
-        end
-      end
-
-      port = tonumber(port or "", 10)
+      local port = tonumber(_REQUEST.get_header(X_FORWARDED_PORT), 10)
       if port and port >= MIN_PORT and port <= MAX_PORT then
         return port
       end
@@ -315,12 +300,6 @@ local function new(self)
     if is_trusted_ip() then
       local path = _REQUEST.get_header(X_FORWARDED_PATH)
       if path then
-        local p = find(path, ",", 1, true)
-
-        if p then
-          path = sub(path, 1, p - 1)
-        end
-
         return path
       end
     end
@@ -364,12 +343,6 @@ local function new(self)
     if is_trusted_ip() then
       prefix = _REQUEST.get_header(X_FORWARDED_PREFIX)
       if prefix then
-        local p = find(prefix, ",", 1, true)
-
-        if p then
-          prefix = sub(prefix, 1, p - 1)
-        end
-
         return prefix
       end
     end
@@ -652,7 +625,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    return var["http_" .. replace_dashes(name)]
+    return http_get_header(ngx.ctx, name)
   end
 
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -625,7 +625,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    return http_get_header(ngx.ctx, name)
+    return http_get_header(name, ngx.ctx)
   end
 
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -625,7 +625,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    return http_get_header(name, ngx.ctx)
+    return http_get_header(name)
   end
 
 

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -844,11 +844,6 @@ local function parse_access_token(conf)
 
   local access_token = kong.request.get_header(conf.auth_header_name)
   if access_token then
-    local p = access_token:find(",", 1, true)
-    if p then
-      access_token = access_token:sub(1, p - 1)
-    end
-
     local parts = {}
     for v in access_token:gmatch("%S+") do -- Split by space
       table.insert(parts, v)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1210,11 +1210,11 @@ return {
 
       local trusted_ip = kong.ip.is_trusted(realip_remote_addr)
       if trusted_ip then
-        forwarded_proto  = get_header(ctx, "x_forwarded_proto")  or ctx.scheme
-        forwarded_host   = get_header(ctx, "x_forwarded_host")   or host
-        forwarded_port   = get_header(ctx, "x_forwarded_port")   or port
-        forwarded_path   = get_header(ctx, "x_forwarded_path")
-        forwarded_prefix = get_header(ctx, "x_forwarded_prefix")
+        forwarded_proto  = get_header("x_forwarded_proto", ctx)  or ctx.scheme
+        forwarded_host   = get_header("x_forwarded_host", ctx)   or host
+        forwarded_port   = get_header("x_forwarded_port", ctx)   or port
+        forwarded_path   = get_header("x_forwarded_path", ctx)
+        forwarded_prefix = get_header("x_forwarded_prefix", ctx)
 
       else
         forwarded_proto  = ctx.scheme
@@ -1304,7 +1304,7 @@ return {
       end
 
       -- Keep-Alive and WebSocket Protocol Upgrade Headers
-      local upgrade = get_header(ctx, "upgrade")
+      local upgrade = get_header("upgrade", ctx)
       if upgrade and lower(upgrade) == "websocket" then
         var.upstream_connection = "keep-alive, Upgrade"
         var.upstream_upgrade    = "websocket"
@@ -1314,7 +1314,7 @@ return {
       end
 
       -- X-Forwarded-* Headers
-      local http_x_forwarded_for = get_header(ctx, "x_forwarded_for")
+      local http_x_forwarded_for = get_header("x_forwarded_for", ctx)
       if http_x_forwarded_for then
         var.upstream_x_forwarded_for = http_x_forwarded_for .. ", " ..
                                        realip_remote_addr
@@ -1401,7 +1401,7 @@ return {
       end
 
       -- clear hop-by-hop request headers:
-      local http_connection = get_header(ctx, "connection")
+      local http_connection = get_header("connection", ctx)
       if http_connection ~= "keep-alive" and
          http_connection ~= "close"      and
          http_connection ~= "upgrade"
@@ -1422,7 +1422,7 @@ return {
       end
 
       -- add te header only when client requests trailers (proxy removes it)
-      local http_te = get_header(ctx, "te")
+      local http_te = get_header("te", ctx)
       if http_te then
         if http_te == "trailers" then
           var.upstream_te = "trailers"

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -528,19 +528,17 @@ end
 
 
 do
-  local var = ngx.var
-  local get_headers = ngx.req.get_headers
   local replace_dashes = require("kong.tools.string").replace_dashes
 
   function _M.get_header(ctx, name)
-    local value = var["http_" .. replace_dashes(name)]
+    local value = ngx.var["http_" .. replace_dashes(name)]
 
     if not value or not value:find(", ", 1, true) then
       return value
     end
 
     if not ctx.headers then
-      ctx.headers = get_headers()
+      ctx.headers = ngx.req.get_headers()
     end
 
     value = ctx.headers[name]

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -12,8 +12,6 @@ local setmetatable  = setmetatable
 local sort          = table.sort
 local concat        = table.concat
 local fmt           = string.format
-local var           = ngx.var
-local get_headers   = ngx.req.get_headers
 local re_match      = ngx.re.match
 local join          = tools_str.join
 local split         = tools_str.split
@@ -200,7 +198,7 @@ end
 -- @param allow_terminated if truthy, the `X-Forwarded-Proto` header will be checked as well.
 -- @return boolean or nil+error in case the header exists multiple times
 _M.check_https = function(trusted_ip, allow_terminated)
-  if var.scheme:lower() == "https" then
+  if ngx.var.scheme:lower() == "https" then
     return true
   end
 
@@ -212,7 +210,7 @@ _M.check_https = function(trusted_ip, allow_terminated)
   -- otherwise, we fall back to relying on the client scheme
   -- (which was either validated earlier, or we fall through this block)
   if trusted_ip then
-    local scheme = get_headers()["x-forwarded-proto"]
+    local scheme = ngx.req.get_headers()["x-forwarded-proto"]
 
     -- we could use the first entry (lower security), or check the contents of
     -- each of them (slow). So for now defensive, and error
@@ -530,6 +528,8 @@ end
 
 
 do
+  local var = ngx.var
+  local get_headers = ngx.req.get_headers
   local replace_dashes = require("kong.tools.string").replace_dashes
 
   function _M.get_header(ctx, name)

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -527,4 +527,28 @@ do
 end
 
 
+do
+  local get_headers = ngx.req.get_headers
+
+  function _M.get_header(ctx, name)
+    if type(ctx) ~= "table" then
+      return nil, "ctx must be a table"
+    end
+
+    if type(name) ~= "string" then
+      return nil, "header name must be a string"
+    end
+
+    if not ctx.headers then
+      ctx.headers = get_headers()
+    end
+
+    local value = ctx.headers[name]
+
+    return type(value) == "table" and
+           value[1] or value
+  end
+end
+
+
 return _M

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -531,14 +531,6 @@ do
   local get_headers = ngx.req.get_headers
 
   function _M.get_header(ctx, name)
-    if type(ctx) ~= "table" then
-      return nil, "ctx must be a table"
-    end
-
-    if type(name) ~= "string" then
-      return nil, "header name must be a string"
-    end
-
     if not ctx.headers then
       ctx.headers = get_headers()
     end

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -530,7 +530,7 @@ end
 do
   local replace_dashes = require("kong.tools.string").replace_dashes
 
-  function _M.get_header(ctx, name)
+  function _M.get_header(name, ctx)
     local value = ngx.var["http_" .. replace_dashes(name)]
 
     if not value or not value:find(", ", 1, true) then

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -12,6 +12,8 @@ local setmetatable  = setmetatable
 local sort          = table.sort
 local concat        = table.concat
 local fmt           = string.format
+local var           = ngx.var
+local get_headers   = ngx.req.get_headers
 local re_match      = ngx.re.match
 local join          = tools_str.join
 local split         = tools_str.split
@@ -198,7 +200,7 @@ end
 -- @param allow_terminated if truthy, the `X-Forwarded-Proto` header will be checked as well.
 -- @return boolean or nil+error in case the header exists multiple times
 _M.check_https = function(trusted_ip, allow_terminated)
-  if ngx.var.scheme:lower() == "https" then
+  if var.scheme:lower() == "https" then
     return true
   end
 
@@ -210,7 +212,7 @@ _M.check_https = function(trusted_ip, allow_terminated)
   -- otherwise, we fall back to relying on the client scheme
   -- (which was either validated earlier, or we fall through this block)
   if trusted_ip then
-    local scheme = ngx.req.get_headers()["x-forwarded-proto"]
+    local scheme = get_headers()["x-forwarded-proto"]
 
     -- we could use the first entry (lower security), or check the contents of
     -- each of them (slow). So for now defensive, and error
@@ -528,14 +530,20 @@ end
 
 
 do
-  local get_headers = ngx.req.get_headers
+  local replace_dashes = require("kong.tools.string").replace_dashes
 
   function _M.get_header(ctx, name)
+    local value = var["http_" .. replace_dashes(name)]
+
+    if not value or not value:find(", ", 1, true) then
+      return value
+    end
+
     if not ctx.headers then
       ctx.headers = get_headers()
     end
 
-    local value = ctx.headers[name]
+    value = ctx.headers[name]
 
     return type(value) == "table" and
            value[1] or value

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -537,11 +537,20 @@ do
       return value
     end
 
-    if not ctx.headers then
-      ctx.headers = ngx.req.get_headers()
+    local headers
+
+    if ctx then
+      if not ctx.headers then
+        ctx.headers = ngx.req.get_headers()
+      end
+
+      headers = ctx.headers
+
+    else
+      headers = ngx.req.get_headers()
     end
 
-    value = ctx.headers[name]
+    value = headers[name]
 
     return type(value) == "table" and
            value[1] or value

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -540,11 +540,11 @@ do
     local headers
 
     if ctx then
-      if not ctx.headers then
-        ctx.headers = ngx.req.get_headers()
+      if not ctx.cached_request_headers then
+        ctx.cached_request_headers = ngx.req.get_headers()
       end
 
-      headers = ctx.headers
+      headers = ctx.cached_request_headers
 
     else
       headers = ngx.req.get_headers()

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -104,7 +104,7 @@ X-Foo-Header: ''
 
 
 
-=== TEST 5: request.get_header() have a limit on header numbers
+=== TEST 5: request.get_header() have no limit on header numbers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -133,7 +133,7 @@ X-Foo-Header: ''
 --- request
 GET /t
 --- response_body
-accept header value: nil
+accept header value: text/html
 --- no_error_log
 [error]
 

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -9,7 +9,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: request.get_header() returns all headers when multiple is given with same name
+=== TEST 1: request.get_header() returns first header when multiple is given with same name
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -26,7 +26,7 @@ GET /t
 Accept: application/json
 Accept: text/html
 --- response_body
-accept header value: application/json, text/html
+accept header value: application/json
 --- no_error_log
 [error]
 

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -104,7 +104,7 @@ X-Foo-Header: ''
 
 
 
-=== TEST 5: request.get_header() have no limit on header numbers
+=== TEST 5: request.get_header() have a limit on header numbers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -133,7 +133,7 @@ X-Foo-Header: ''
 --- request
 GET /t
 --- response_body
-accept header value: text/html
+accept header value: nil
 --- no_error_log
 [error]
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It is a fixing PR for #12327.
KAG-3570

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
