### PR TITLE
fix(core): set worker ID of privileged agent to -1

### DIFF
--- a/changelog/unreleased/kong/fix_privileged_agent_id_1.yml
+++ b/changelog/unreleased/kong/fix_privileged_agent_id_1.yml
@@ -1,4 +1,4 @@
 message: |
-  Consistently set worker ID of privileged agent to `-1`.
+  Use `-1` as the worker ID of privileged agent to avoid access issues.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix_privileged_agent_id_1.yml
+++ b/changelog/unreleased/kong/fix_privileged_agent_id_1.yml
@@ -1,0 +1,4 @@
+message: |
+  Consistently set worker ID of privileged agent to `-1`.
+type: bugfix
+scope: Core

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -254,7 +254,7 @@ return {
     GET = function (self, db, helpers)
       local body = {
         worker = {
-          id = ngx.worker.id(),
+          id = ngx.worker.id() or -1,
           count = ngx.worker.count(),
         },
         stats = kong.timer:stats({

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -120,7 +120,7 @@ function _M:export_deflated_reconfigure_payload()
   end
 
   -- store serialized plugins map for troubleshooting purposes
-  local shm_key_name = "clustering:cp_plugins_configured:worker_" .. worker_id()
+  local shm_key_name = "clustering:cp_plugins_configured:worker_" .. (worker_id() or -1)
   kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured))
   ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
 

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -83,7 +83,7 @@ end
 
 
 function ACMEHandler:init_worker()
-  local worker_id = ngx.worker.id()
+  local worker_id = ngx.worker.id() or -1
   kong.log.info("acme renew timer started on worker ", worker_id)
   ngx.timer.every(86400, renew)
 end

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -441,7 +441,7 @@ function _M.execute(conf)
   kong.log.debug("Status code is within given status code ranges")
 
   if not worker_id then
-    worker_id = ngx.worker.id()
+    worker_id = ngx.worker.id() or -1
   end
 
   conf._prefix = conf.prefix

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -635,7 +635,7 @@ do
   local CURRENT_BALANCER_HASH = 0
 
   reconfigure_handler = function(data)
-    local worker_id = ngx_worker_id()
+    local worker_id = ngx_worker_id() or -1
 
     if exiting() then
       log(NOTICE, "declarative reconfigure was canceled on worker #", worker_id,

--- a/kong/runloop/log_level.lua
+++ b/kong/runloop/log_level.lua
@@ -41,7 +41,7 @@ local function init_handler()
                   - ngx.time()
 
   if shm_log_level and cur_log_level ~= shm_log_level and timeout > 0 then
-    set_log_level(ngx.worker.id(), shm_log_level, timeout)
+    set_log_level(ngx.worker.id() or -1, shm_log_level, timeout)
   end
 end
 
@@ -68,7 +68,7 @@ end
 
 -- log level worker event updates
 local function worker_handler(data)
-  local worker = ngx.worker.id()
+  local worker = ngx.worker.id() or -1
 
   log(NOTICE, "log level worker event received for worker ", worker)
 

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -371,7 +371,7 @@ function Rpc:call_start_instance(plugin_name, conf)
     return nil, err
   end
 
-  kong.log.debug("started plugin server: seq ", conf.__seq__, ", worker ", ngx.worker.id(), ", instance id ",
+  kong.log.debug("started plugin server: seq ", conf.__seq__, ", worker ", ngx.worker.id() or -1, ", instance id ",
     status.instance_status.instance_id)
 
   return {

--- a/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
+++ b/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
@@ -188,7 +188,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
         rewrite = {[[
           kong.response.set_header(
             "]] .. WORKER_ID_HEADER .. [[",
-            ngx.worker.id()
+            ngx.worker.id() or -1
           )
         ]]}
       }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

By default, `ngx.worker.id()` returns `nil` for the privileged agent. Now Fall back to -1 as the worker ID of privileged agent worker to avoid error. Keep consistent with code like https://github.com/Kong/kong/blob/0ff50d5237d16b7f3535d57e9ef63dfd603ac62a/kong/globalpatches.lua#L427

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5707]_


[FTI-5707]: https://konghq.atlassian.net/browse/FTI-5707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ