### PR TITLE
refactor(router/atc): simplify the code of atc router schema

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -5,6 +5,7 @@ local _MT = { __index = _M, }
 local buffer = require("string.buffer")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
+local fields = require("kong.router.fields")
 local utils = require("kong.router.utils")
 local rat = require("kong.tools.request_aware_table")
 local yield = require("kong.tools.yield").yield
@@ -55,7 +56,6 @@ do
   local schema = require("resty.router.schema")
   local context = require("resty.router.context")
   local router = require("resty.router.router")
-  local fields = require("kong.router.fields")
 
   local function generate_schema(fields)
     local s = schema.new()

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -5,7 +5,6 @@ local _MT = { __index = _M, }
 local buffer = require("string.buffer")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
-local fields = require("kong.router.fields")
 local utils = require("kong.router.utils")
 local rat = require("kong.tools.request_aware_table")
 local yield = require("kong.tools.yield").yield
@@ -56,6 +55,7 @@ do
   local schema = require("resty.router.schema")
   local context = require("resty.router.context")
   local router = require("resty.router.router")
+  local fields = require("kong.router.fields")
 
   local function generate_schema(fields)
     local s = schema.new()
@@ -104,6 +104,27 @@ do
   -- for db schema validation
   function _M.schema(protocols)
     return assert(protocol_to_schema[protocols[1]])
+  end
+
+  -- for unit testing
+  function _M._set_ngx(mock_ngx)
+    if type(mock_ngx) ~= "table" then
+      return
+    end
+
+    if mock_ngx.header then
+      header = mock_ngx.header
+    end
+
+    if mock_ngx.var then
+      var = mock_ngx.var
+    end
+
+    if mock_ngx.log then
+      ngx_log = mock_ngx.log
+    end
+
+    fields._set_ngx(mock_ngx)
   end
 end
 
@@ -684,28 +705,6 @@ function _M:exec(ctx)
 end
 
 end   -- if is_http
-
-
-function _M._set_ngx(mock_ngx)
-  if type(mock_ngx) ~= "table" then
-    return
-  end
-
-  if mock_ngx.header then
-    header = mock_ngx.header
-  end
-
-  if mock_ngx.var then
-    var = mock_ngx.var
-  end
-
-  if mock_ngx.log then
-    ngx_log = mock_ngx.log
-  end
-
-  -- unit testing
-  fields._set_ngx(mock_ngx)
-end
 
 
 _M.LOGICAL_OR      = LOGICAL_OR


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-3634

* move atc-router related modules into `do end` block
* some wrapper functions for atc objects created.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
