### PR TITLE
bump(deps): bump ngx_brotli version to master branch

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -38,7 +38,7 @@ build-packages:
   image: centos:7
   package: rpm
   package-type: el7
-  bazel-args: --//:wasmx_el7_workaround=true
+  bazel-args: --//:wasmx_el7_workaround=true --//:brotli=False
   check-manifest-suite: el7-amd64
 - label: rhel-8
   image: rockylinux:8
@@ -53,7 +53,7 @@ build-packages:
 - label: rhel-9-arm64
   package: rpm
   package-type: el9
-  bazel-args: --platforms=//:rhel9-crossbuild-aarch64
+  bazel-args: --platforms=//:rhel9-crossbuild-aarch64 --//:brotli=False
   check-manifest-suite: el9-arm64
 
   # Amazon Linux
@@ -70,7 +70,7 @@ build-packages:
 - label: amazonlinux-2023-arm64
   package: rpm
   package-type: aws2023
-  bazel-args: --platforms=//:aws2023-crossbuild-aarch64
+  bazel-args: --platforms=//:aws2023-crossbuild-aarch64 --//:brotli=False
   check-manifest-suite: amazonlinux-2023-arm64
 
 build-images:

--- a/.requirements
+++ b/.requirements
@@ -18,4 +18,5 @@ WASMER=3.1.1
 WASMTIME=14.0.3
 V8=10.5.18
 
-NGX_BROTLI=25f86f0bac1101b6512135eac5f93c49c63609e3 # v1.0.0rc
+NGX_BROTLI=a71f9312c2deb28875acc7bacfdd5695a111aa53 # master branch of Jan 23, 2024
+BROTLI=ed738e842d2fbdf2d6459e39267a633c4a9b2f5d # master branch of brotli deps submodule of Jan 23, 2024

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -123,6 +123,19 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "brotli",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "brotli_flag",
+    flag_values = {
+        ":brotli": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "debug_linux_flag",
     constraint_values = [

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -149,6 +149,7 @@ CONFIGURE_OPTIONS = [
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/pcre/lib\"",
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/openssl/lib\"",
     "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/luajit/lib\"",
+    "--with-ld-opt=\"-L$$EXT_BUILD_DEPS$$/lib\"",
     # Here let's try not having --disable-new-dtags; --disable-new-dtags creates rpath instead of runpath
     # note rpath can't handle indirect dependency (nginx -> luajit -> dlopen("other")), so each indirect
     # dependency should have its rpath set (luajit, libxslt etc); on the other side, rpath is not
@@ -168,7 +169,6 @@ CONFIGURE_OPTIONS = [
     "--add-module=$$EXT_BUILD_ROOT$$/external/lua-kong-nginx-module/stream",
     "--add-module=$$EXT_BUILD_ROOT$$/external/lua-resty-lmdb",
     "--add-module=$$EXT_BUILD_ROOT$$/external/lua-resty-events",
-    "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_brotli",
 ] + select({
     "@kong//:aarch64-linux-anylibc-cross": [
         "--crossbuild=Linux:aarch64",
@@ -230,6 +230,11 @@ CONFIGURE_OPTIONS = [
         "--group=nobody",
     ],
     "//conditions:default": [],
+}) + select({
+    "@kong//:brotli_flag": [
+        "--add-module=$$EXT_BUILD_ROOT$$/external/ngx_brotli",
+    ],
+    "//conditions:default": [],
 }) + wasmx_configure_options
 
 # TODO: set prefix to populate pid_path, conf_path, log_path etc
@@ -259,10 +264,10 @@ configure_make(
     configure_options = CONFIGURE_OPTIONS,
     data = [
         "@lua-kong-nginx-module//:all_srcs",
-        "@lua-resty-lmdb//:all_srcs",
         "@lua-resty-events//:all_srcs",
-        "@openresty_binding//:all_srcs",
+        "@lua-resty-lmdb//:all_srcs",
         "@ngx_brotli//:all_srcs",
+        "@openresty_binding//:all_srcs",
     ] + select({
         "@kong//:wasmx_flag": [
             "@ngx_wasm_module//:all_srcs",
@@ -284,9 +289,9 @@ configure_make(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@pcre",
         "@openresty//:luajit",
-        "@openssl//:openssl",
+        "@openssl",
+        "@pcre",
     ] + select({
         "@kong//:any-cross": [
             "@cross_deps_zlib//:zlib",
@@ -297,6 +302,12 @@ configure_make(
         # alpine uses different libc so doesn't need it
         ":needs-xcrypt2": [
             "@cross_deps_libxcrypt//:libxcrypt",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@kong//:brotli_flag": [
+            "@brotli//:brotlicommon",
+            "@brotli//:brotlienc",
         ],
         "//conditions:default": [],
     }),

--- a/build/openresty/brotli/brotli_repositories.bzl
+++ b/build/openresty/brotli/brotli_repositories.bzl
@@ -1,0 +1,14 @@
+"""A module defining the dependency """
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@kong_bindings//:variables.bzl", "KONG_VAR")
+
+def brotli_repositories():
+    maybe(
+        git_repository,
+        name = "brotli",
+        branch = KONG_VAR["BROTLI"],
+        remote = "https://github.com/google/brotli",
+        visibility = ["//visibility:public"],  # let this to be referenced by openresty build
+    )

--- a/build/openresty/repositories.bzl
+++ b/build/openresty/repositories.bzl
@@ -8,6 +8,7 @@ load("//build/openresty/pcre:pcre_repositories.bzl", "pcre_repositories")
 load("//build/openresty/openssl:openssl_repositories.bzl", "openssl_repositories")
 load("//build/openresty/atc_router:atc_router_repositories.bzl", "atc_router_repositories")
 load("//build/openresty/wasmx:wasmx_repositories.bzl", "wasmx_repositories")
+load("//build/openresty/brotli:brotli_repositories.bzl", "brotli_repositories")
 
 # This is a dummy file to export the module's repository.
 _NGINX_MODULE_DUMMY_FILE = """
@@ -23,6 +24,7 @@ def openresty_repositories():
     openssl_repositories()
     atc_router_repositories()
     wasmx_repositories()
+    brotli_repositories()
 
     openresty_version = KONG_VAR["OPENRESTY"]
 

--- a/changelog/unreleased/kong/bump_ngx_brotli.yml
+++ b/changelog/unreleased/kong/bump_ngx_brotli.yml
@@ -1,0 +1,3 @@
+message: Bumped ngx_brotli to master branch, and disabled it on rhel7 rhel9-arm64 and amazonlinux-2023-arm64 due to toolchain issues
+type: dependency
+scope: Core

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
@@ -169,7 +169,6 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
-  - ngx_brotli
   - ngx_wasm_module
   OpenSSL   : OpenSSL 3.2.0 23 Nov 2023
   DWARF     : True

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -201,7 +201,6 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
-  - ngx_brotli
   - ngx_wasm_module
   OpenSSL   : OpenSSL 3.2.0 23 Nov 2023
   DWARF     : True

--- a/scripts/explain_manifest/fixtures/el9-arm64.txt
+++ b/scripts/explain_manifest/fixtures/el9-arm64.txt
@@ -169,7 +169,6 @@
   - lua-kong-nginx-module/stream
   - lua-resty-events
   - lua-resty-lmdb
-  - ngx_brotli
   - ngx_wasm_module
   OpenSSL   : OpenSSL 3.2.0 23 Nov 2023
   DWARF     : True


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. bump `ngx_brotli` version to master branch https://github.com/google/ngx_brotli
2. disable `ngx_brotli` feature in rhel7 rhel9-arm64 and amazonlinux-2023-arm64 regarding to toolchain error.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference
FTI-5706

