### PR TITLE
fix(wasm): do not call attach() on re-entrancy

### DIFF
--- a/changelog/unreleased/kong/wasm-attach.yml
+++ b/changelog/unreleased/kong/wasm-attach.yml
@@ -1,0 +1,5 @@
+message: >
+  **proxy-wasm**: Fixed "previous plan already attached" error thrown when a
+  filter triggers re-entrancy of the access handler.
+type: bugfix
+scope: Core

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -922,17 +922,22 @@ function _M.attach(ctx)
 
   ctx.ran_wasm = true
 
-  local ok, err = proxy_wasm.attach(chain.c_plan)
-  if not ok then
-    log(CRIT, "failed attaching ", chain.label, " filter chain to request: ", err)
-    return kong.response.error(500)
-  end
+  local ok, err
+  if not ctx.wasm_attached then
+    ctx.wasm_attached = true
 
-  ok, err = proxy_wasm.set_host_properties_handlers(properties.get,
-                                                    properties.set)
-  if not ok then
-    log(CRIT, "failed setting host property handlers: ", err)
-    return kong.response.error(500)
+    ok, err = proxy_wasm.attach(chain.c_plan)
+    if not ok then
+      log(CRIT, "failed attaching ", chain.label, " filter chain to request: ", err)
+      return kong.response.error(500)
+    end
+
+    ok, err = proxy_wasm.set_host_properties_handlers(properties.get,
+                                                      properties.set)
+    if not ok then
+      log(CRIT, "failed setting host property handlers: ", err)
+      return kong.response.error(500)
+    end
   end
 
   jit.off(proxy_wasm.start)


### PR DESCRIPTION
### Summary

`kong.runloop.wasm.attach()` may be called more than once when filters utilize the `dispatch_http_call` proxy-wasm SDK function. Previously this was assumed to be false, which can yield errors like this one:

> 2024-01-22 16:39:16 2024/01/22 22:39:16 [crit] 2464#0: *340 [lua] wasm.lua:790: attach(): failed attaching service(6bc44ccb-30c9-5f3d-acfa-017fa1b2ef82) filter chain to request: previous plan already attached, client: 172.17.0.1, server: kong, request: "GET /anything HTTP/1.1", host: "localhost:8000", request_id: "112ec236dcf487391a579a6f6f63fc0b"

This adds a `ngx.ctx` check and avoids calling `proxy_wasm.attach()` in this case.

Unfortunately it is incredibly non-trivial to add a test case for this at the moment, but the behavior change/correctness has been validated by hand.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] ~There is a user-facing docs PR~

### Issue reference

KAG-3603
