### PR TITLE
chore: apply label on failed cherry-pick

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -27,6 +27,7 @@ jobs:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
       - name: Create backport pull requests
         uses: jschmid1/cross-repo-cherrypick-action@2d2a475d31b060ac21521b5eda0a78876bbae94e #v1.1.0
+        id: cherry_pick
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
           pull_title: '[cherry-pick -> ${target_branch}] ${pull_title}'
@@ -43,3 +44,8 @@ jobs:
             {
               "master": "master"
             }
+      - name: add label
+        if: steps.cherry_pick.outputs.was_successful == 'false'
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.0
+        with:
+          labels: incomplete-cherry-pick


### PR DESCRIPTION


### Summary

Applies an `incomplete-cherry-pick` label to the original PR if a cherry-pick fails to be created.

Fix: [konghq.atlassian.net/browse/KAG-3590](https://konghq.atlassian.net/browse/KAG-3590)


