### PR TITLE
fix(plugins): add len_min=0 for string fields

### DIFF
--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -41,6 +41,7 @@ local KONG_STORAGE_SCHEMA = {
 local LEGACY_SCHEMA_TRANSLATIONS = {
   { auth = {
     type = "string",
+    len_min = 0,
     func = function(value)
       deprecation("acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
         { after = "4.0", })
@@ -57,6 +58,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { namespace = {
     type = "string",
+    len_min = 0,
     func = function(value)
       deprecation("acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
         { after = "4.0", })

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -119,6 +119,7 @@ return {
           } },
           { redis_password = {
             type = "string",
+            len_min = 0,
             func = function(value)
               deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -158,6 +158,7 @@ return {
           } },
           { redis_password = {
             type = "string",
+            len_min = 0,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Shorthand fields even though are transient still use validation. For a string field if it's minimum length is not defined then the default is 1 to disallow empty strings.

However for some of the fields underneath shorthand fields we wanted to allow empty strings therefore we need to add this `len_min=0` to those string fields that can be empty.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] N/A (fix for a feature not released yet) ~~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~~
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-3388
