### PR TITLE
chore(ci): revert upload/download-artifact version bump to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         luarocks config
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: bazel-outputs

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -106,7 +106,7 @@ jobs:
           $TEST_CMD
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
@@ -237,7 +237,7 @@ jobs:
 
 
     - name: Download test rerun information
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       continue-on-error: true
       with:
         name: ${{ env.FAILED_TEST_FILES_FILE }}
@@ -259,14 +259,14 @@ jobs:
 
     - name: Upload test rerun information
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.FAILED_TEST_FILES_FILE }}
         path: ${{ env.FAILED_TEST_FILES_FILE }}
         retention-days: 2
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}-${{ matrix.suite }}-${{ contains(matrix.split, 'first') && '1' || '2' }}
@@ -339,7 +339,7 @@ jobs:
           .ci/run_tests.sh
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
@@ -391,7 +391,7 @@ jobs:
           .ci/run_tests.sh
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
@@ -421,7 +421,7 @@ jobs:
         sudo luarocks install luafilesystem
 
     # Download all archived coverage stats files
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v3
 
     - name: Stats aggregation
       shell: bash

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -65,7 +65,7 @@ jobs:
         luarocks
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: bazel-outputs
@@ -267,7 +267,7 @@ jobs:
         done
 
     - name: Save results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: perf-results
@@ -278,7 +278,7 @@ jobs:
         retention-days: 31
 
     - name: Save error logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: error_logs


### PR DESCRIPTION
### Summary

The v4 version causes issues in EE, so we decided to stay on v3 for now.

Reverts 9cf81aba64

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
