### PR TITLE
fix(plugins): consistent error responses upon Admin API auth failures

### DIFF
--- a/changelog/unreleased/kong/enhance_admin_api_auth_error_response.yml
+++ b/changelog/unreleased/kong/enhance_admin_api_auth_error_response.yml
@@ -1,0 +1,3 @@
+message: "Enhance error responses for authentication failures in the Admin API"
+type: bugfix
+scope: Plugin

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -176,12 +176,12 @@ local function do_authentication(conf)
     if given_username and given_password then
       credential = load_credential_from_db(given_username)
     else
-      return false, unauthorized("Invalid authentication credentials", www_authenticate)
+      return false, unauthorized("Unauthorized", www_authenticate)
     end
   end
 
   if not credential or not validate_credentials(credential, given_password) then
-    return false, unauthorized("Invalid authentication credentials", www_authenticate)
+    return false, unauthorized("Unauthorized", www_authenticate)
   end
 
   -- Retrieve consumer

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -30,7 +30,7 @@ local _realm = 'Key realm="' .. _KONG._NAME .. '"'
 
 local ERR_DUPLICATE_API_KEY   = { status = 401, message = "Duplicate API key found" }
 local ERR_NO_API_KEY          = { status = 401, message = "No API key found in request" }
-local ERR_INVALID_AUTH_CRED   = { status = 401, message = "Invalid authentication credentials" }
+local ERR_INVALID_AUTH_CRED   = { status = 401, message = "Unauthorized" }
 local ERR_INVALID_PLUGIN_CONF = { status = 500, message = "Invalid plugin configuration" }
 local ERR_UNEXPECTED          = { status = 500, message = "An unexpected error occurred" }
 

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -263,7 +263,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = "Invalid authentication credentials" }
+    return false, {status = 401, message = "Unauthorized" }
   end
 
   if conf.hide_credentials then

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -697,7 +697,7 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
       })
       local body = res:read_body()
       proxy_client:close()
-      return body ~= [[{"message":"Invalid authentication credentials"}]]
+      return body ~= [[{"message":"Unauthorized"}]]
     end, 5)
 
     admin_client = assert(helpers.admin_client())

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -291,7 +291,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
       end)
       it("handles duplicated key in querystring", function()
         local res = assert(proxy_client:send {
@@ -365,7 +365,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(401, res)
             local json = cjson.decode(body)
             assert.not_nil(json)
-            assert.matches("Invalid authentication credentials", json.message)
+            assert.matches("Unauthorized", json.message)
           end)
 
           -- lua-multipart doesn't currently handle duplicates at all.
@@ -461,7 +461,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
       end)
     end)
 
@@ -521,7 +521,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
 
         res = assert(proxy_client:send {
           method  = "GET",
@@ -534,7 +534,7 @@ for _, strategy in helpers.each_strategy() do
         body = assert.res_status(401, res)
         json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
       end)
     end)
 

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -184,7 +184,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
         assert.equal('Basic realm="test-realm"', res.headers["WWW-Authenticate"])
       end)
 
@@ -200,7 +200,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
         assert.equal('Basic realm="test-realm"', res.headers["WWW-Authenticate"])
       end)
 
@@ -216,7 +216,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
         assert.equal('Basic realm="test-realm"', res.headers["WWW-Authenticate"])
       end)
 
@@ -232,7 +232,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
         assert.equal('Basic realm="test-realm"', res.headers["WWW-Authenticate"])
       end)
 
@@ -308,7 +308,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.not_nil(json)
-        assert.matches("Invalid authentication credentials", json.message)
+        assert.matches("Unauthorized", json.message)
         assert.equal('Basic realm="test-realm"', res.headers["WWW-Authenticate"])
       end)
 

--- a/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
+++ b/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
@@ -179,7 +179,7 @@ for _, strategy in helpers.each_strategy() do
           local body = assert.res_status(401, res)
           local json = cjson.decode(body)
           assert.not_nil(json)
-          assert.matches("Invalid authentication credentials", json.message)
+          assert.matches("Unauthorized", json.message)
         end)
       end)
 

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -237,7 +237,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           })
           assert.response(res).has.status(401)
           local json = assert.response(res).has.jsonbody()
-          assert.equal("Invalid authentication credentials", json.message)
+          assert.equal("Unauthorized", json.message)
         end)
         it("returns 'invalid credentials' when credential value is in wrong format in proxy-authorization header", function()
           local res = assert(proxy_client:send {
@@ -250,7 +250,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           })
           assert.response(res).has.status(401)
           local json = assert.response(res).has.jsonbody()
-          assert.equal("Invalid authentication credentials", json.message)
+          assert.equal("Unauthorized", json.message)
         end)
         it("returns 'invalid credentials' when credential value is missing in authorization header", function()
           local res = assert(proxy_client:send {
@@ -263,7 +263,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           })
           assert.response(res).has.status(401)
           local json = assert.response(res).has.jsonbody()
-          assert.equal("Invalid authentication credentials", json.message)
+          assert.equal("Unauthorized", json.message)
         end)
         it("passes if credential is valid in post request", function()
           local res = assert(proxy_client:send {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Unifying error responses when admin authentication via Admin/Portal API is failed. 

Cherry-picks: https://github.com/Kong/kong-ee/pull/6552

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] **n/a** There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix SEC-912 / KAG-1672
