### PR TITLE
refactor(db/schema): do not generate validator of router expression for non-traditional flavors

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -3,7 +3,7 @@ local deprecation = require("kong.deprecation")
 
 local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
 
--- works with both `traditional_compatible` and `expressions` routes`
+-- works with both `traditional_compatible` and `expressions` routes
 local validate_route
 if kong_router_flavor ~= "traditional" then
   local ipairs = ipairs

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -1,24 +1,27 @@
 local typedefs = require("kong.db.schema.typedefs")
-local router = require("resty.router.router")
 local deprecation = require("kong.deprecation")
 
+local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
+
+-- works with both `traditional_compatible` and `expressions` routes`
 local validate_route
-do
+if kong_router_flavor ~= "traditional" then
   local ipairs = ipairs
   local tonumber = tonumber
   local re_match = ngx.re.match
 
+  local router = require("resty.router.router")
   local get_schema = require("kong.router.atc").schema
-  local get_expression = require("kong.router.compat").get_expression
-  local transform_expression = require("kong.router.expressions").transform_expression
+  local get_expression = kong_router_flavor == "traditional_compatible" and
+                         require("kong.router.compat").get_expression or
+                         require("kong.router.expressions").transform_expression
 
   local HTTP_PATH_SEGMENTS_PREFIX = "http.path.segments."
   local HTTP_PATH_SEGMENTS_SUFFIX_REG = [[^(0|[1-9]\d*)(_([1-9]\d*))?$]]
 
-  -- works with both `traditional_compatiable` and `expressions` routes`
   validate_route = function(entity)
     local schema = get_schema(entity.protocols)
-    local exp = transform_expression(entity) or get_expression(entity)
+    local exp = get_expression(entity)
 
     local fields, err = router.validate(schema, exp)
     if not fields then
@@ -40,9 +43,7 @@ do
 
     return true
   end
-end
-
-local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
+end   -- if kong_router_flavor ~= "traditional"
 
 if kong_router_flavor == "expressions" then
   return {

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -38,8 +38,8 @@ if kong_router_flavor ~= "traditional" then
           return nil, "Router Expression failed validation: " ..
                       "illformed http.path.segments.* field"
         end
-      end
-    end
+      end -- if f:find
+    end -- for fields
 
     return true
   end


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`validate_route()` only works with `traditional_compatible` and `expressions` routes

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
