### PR TITLE
chore(deps): bump lua-resty-aws from 1.3.5 to 1.3.6

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-aws-1.3.6.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-aws-1.3.6.yml
@@ -1,0 +1,3 @@
+message: Bumped lua-resty-aws from 1.3.5 to 1.3.6
+type: dependency
+scope: Core

--- a/kong-3.6.0-0.rockspec
+++ b/kong-3.6.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.0",
   "lua-resty-healthcheck == 3.0.1",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.3.5",
+  "lua-resty-aws == 1.3.6",
   "lua-resty-openssl == 1.2.0",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
### Summary

- fix: validator failure for some field types

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE