### PR TITLE
chore(deps): bump bazelisk from 1.18.0 to 1.19.0 (dev dep)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
 GRPCURL_VERSION ?= 1.8.5
-BAZLISK_VERSION ?= 1.18.0
+BAZLISK_VERSION ?= 1.19.0
 H2CLIENT_VERSION ?= 0.4.0
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built


### PR DESCRIPTION
### Summary

Bazelisk v1.19.0 comes with two significant changes:

- MODULE.bazel and REPO.bazel files are now obeyed
- Users will see a progress bar during binary downloads