### PR TITLE
fix(redis): add default port for standardized Redis config

### DIFF
--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -271,6 +271,14 @@ local schema = {
         then_err = "terms of service must be accepted, see https://letsencrypt.org/repository/",
       }
     },
+    { conditional = {
+      if_field = "config.storage", if_match = { eq = "redis" },
+      then_field = "config.storage_config.redis.host", then_match = { required = true },
+    } },
+    { conditional = {
+      if_field = "config.storage", if_match = { eq = "redis" },
+      then_field = "config.storage_config.redis.port", then_match = { required = true },
+    } },
     {
       custom_entity_check = {
         field_sources = { "config.storage", },

--- a/kong/tools/redis/schema.lua
+++ b/kong/tools/redis/schema.lua
@@ -7,7 +7,7 @@ return {
         description = "Redis configuration",
         fields = {
             { host = typedefs.host },
-            { port = typedefs.port },
+            { port = typedefs.port({ default = 6379 }), },
             { timeout = typedefs.timeout { default = DEFAULT_TIMEOUT } },
             { username = { description = "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. To be compatible with Redis v5.x.y, you can set it to `default`.", type = "string",
                 referenceable = true
@@ -31,9 +31,6 @@ return {
                 default = false
                 } },
             { server_name = typedefs.sni { required = false } }
-        },
-        entity_checks = {
-            { mutually_required = { "host", "port" }, },
-        },
+        }
     }
 }

--- a/spec/01-unit/30-standardized_redis_config_spec.lua
+++ b/spec/01-unit/30-standardized_redis_config_spec.lua
@@ -1,0 +1,106 @@
+local schema_def = require "spec.fixtures.custom_plugins.kong.plugins.redis-dummy.schema"
+local v = require("spec.helpers").validate_plugin_config_schema
+
+
+describe("Validate standardized redis config schema", function()
+  describe("valid  config", function()
+    it("accepts minimal redis config (populates defaults)", function()
+      local config = {
+        redis = {
+          host = "localhost"
+        }
+      }
+      local ok, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.same({
+        host = "localhost",
+        port = 6379,
+        timeout = 2000,
+        username = ngx.null,
+        password = ngx.null,
+        database = 0,
+        ssl = false,
+        ssl_verify = false,
+        server_name = ngx.null,
+      }, ok.config.redis)
+      assert.is_nil(err)
+    end)
+
+    it("full redis config", function()
+      local config = {
+        redis = {
+          host = "localhost",
+          port = 9900,
+          timeout = 3333,
+          username = "test",
+          password = "testXXX",
+          database = 5,
+          ssl = true,
+          ssl_verify = true,
+          server_name = "example.test"
+        }
+      }
+      local ok, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.same(config.redis, ok.config.redis)
+      assert.is_nil(err)
+    end)
+
+    it("allows empty strings on password", function()
+      local config = {
+        redis = {
+          host = "localhost",
+          password = "",
+        }
+      }
+      local ok, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.same({
+        host = "localhost",
+        port = 6379,
+        timeout = 2000,
+        username = ngx.null,
+        password = "",
+        database = 0,
+        ssl = false,
+        ssl_verify = false,
+        server_name = ngx.null,
+      }, ok.config.redis)
+      assert.is_nil(err)
+    end)
+  end)
+
+  describe("invalid config", function()
+    it("rejects invalid config", function()
+      local config = {
+        redis = {
+          host = "",
+          port = -5,
+          timeout = -5,
+          username = 1,
+          password = 4,
+          database = "abc",
+          ssl = "abc",
+          ssl_verify = "xyz",
+          server_name = "test-test"
+        }
+      }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        config = {
+          redis = {
+            database = 'expected an integer',
+            host = 'length must be at least 1',
+            password = 'expected a string',
+            port = 'value should be between 0 and 65535',
+            ssl = 'expected a boolean',
+            ssl_verify = 'expected a boolean',
+            timeout = 'value should be between 0 and 2147483646',
+            username = 'expected a string',
+          }
+        }
+      }, err)
+    end)
+  end)
+end)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -81,6 +81,12 @@ describe("kong config", function()
           config:
             port: 10000
             host: 127.0.0.1
+        - name: rate-limiting
+          config:
+            minute: 200
+            policy: redis
+            redis:
+              host: 127.0.0.1
       plugins:
       - name: correlation-id
         id: 467f719f-a544-4a8f-bc4b-7cd12913a9d4
@@ -130,7 +136,7 @@ describe("kong config", function()
     local res = client:get("/services/bar/plugins")
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
-    assert.equals(2, #json.data)
+    assert.equals(3, #json.data)
 
     local res = client:get("/plugins/467f719f-a544-4a8f-bc4b-7cd12913a9d4")
     local body = assert.res_status(200, res)
@@ -532,7 +538,17 @@ describe("kong config", function()
 
     local service2 = bp.services:insert({ name = "service2" }, { nulls = true })
     local route2 = bp.routes:insert({ service = service2, methods = { "GET" }, name = "b" }, { nulls = true })
-    local plugin3 = bp.tcp_log_plugins:insert({
+    local plugin3 = bp.rate_limiting_plugins:insert({
+      service = service2,
+      config = {
+        minute = 100,
+        policy = "redis",
+        redis = {
+          host = "localhost"
+        }
+      }
+    }, { nulls = true })
+    local plugin4 = bp.tcp_log_plugins:insert({
       service = service2,
     }, { nulls = true })
     local consumer = bp.consumers:insert(nil, { nulls = true })
@@ -603,7 +619,7 @@ describe("kong config", function()
     assert.equals(route2.name, yaml.routes[2].name)
     assert.equals(service2.id, yaml.routes[2].service)
 
-    assert.equals(3, #yaml.plugins)
+    assert.equals(4, #yaml.plugins)
     table.sort(yaml.plugins, sort_by_name)
     assert.equals(plugin1.id, yaml.plugins[1].id)
     assert.equals(plugin1.name, yaml.plugins[1].name)
@@ -615,6 +631,8 @@ describe("kong config", function()
 
     assert.equals(plugin3.id, yaml.plugins[3].id)
     assert.equals(plugin3.name, yaml.plugins[3].name)
+    assert.equals(plugin4.id, yaml.plugins[4].id)
+    assert.equals(plugin4.name, yaml.plugins[4].name)
     assert.equals(service2.id, yaml.plugins[3].service)
 
     assert.equals(1, #yaml.consumers)

--- a/spec/03-plugins/29-acme/04-schema_spec.lua
+++ b/spec/03-plugins/29-acme/04-schema_spec.lua
@@ -89,6 +89,40 @@ describe("Plugin: acme (schema)", function()
           }
         },
     },
+    ----------------------------------------
+    {
+      name = "accepts valid redis config",
+      input = {
+        account_email = "example@example.com",
+        storage = "redis",
+        storage_config = {
+          redis = {
+            host = "localhost"
+          },
+        }
+      },
+    },
+    ----------------------------------------
+    {
+      name = "rejects invalid redis config",
+      input = {
+        account_email = "example@example.com",
+        storage = "redis",
+        storage_config = {
+          redis = { },
+        }
+      },
+      error = {
+        ["@entity"] = { "failed conditional validation given value of field 'config.storage'" },
+        config = {
+          storage_config = {
+            redis = {
+              host = "required field missing",
+            }
+          }
+        },
+      },
+    },
   }
 
   for _, t in ipairs(tests) do

--- a/spec/fixtures/custom_plugins/kong/plugins/redis-dummy/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/redis-dummy/handler.lua
@@ -1,0 +1,12 @@
+local kong = kong
+
+local RedisDummy = {
+  PRIORITY = 1000,
+  VERSION = "0.1.0",
+}
+
+function RedisDummy:access(conf)
+    kong.log("access phase")
+end
+
+return RedisDummy

--- a/spec/fixtures/custom_plugins/kong/plugins/redis-dummy/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/redis-dummy/schema.lua
@@ -1,0 +1,15 @@
+local redis_schema = require "kong.tools.redis.schema"
+
+return {
+  name = "redis-dummy",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+          { redis = redis_schema.config_schema },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The default port should be 6379. This was how `rate-limiting` and `response-ratelimiting` worked before Redis config standardization. The bug was introduced because `acme` Redis configuration was used as reference which did not have default for Redis port.


### Checklist

- [x] The Pull Request has tests
- [x] N/A (new feature) ~~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~~
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

KAG-3618
