### PR TITLE
hotfix(deps): enable JIT support for pcre2

### DIFF
--- a/build/openresty/pcre/BUILD.pcre.bazel
+++ b/build/openresty/pcre/BUILD.pcre.bazel
@@ -18,6 +18,7 @@ cmake(
     ],
     cache_entries = {
         "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",
+        "PCRE2_SUPPORT_JIT": "ON",  # enable JIT support for pcre2_jit_compile
         "PCRE2_BUILD_PCRE2GREP": "OFF",  # we don't need the cli binary
         "PCRE2_BUILD_TESTS": "OFF",  # test doesn't compile on aarch64-linux-gnu (cross)
         "CMAKE_INSTALL_LIBDIR": "lib",  # force distros that uses lib64 (rhel family) to use lib


### PR DESCRIPTION
PCRE2 requires JIT support to be explicitly enabled during build. From https://pcre.org/current/doc/html/pcre2jit.html:

"JIT support is an optional feature of PCRE2. The "configure" option --enable-jit (or equivalent CMake option) must be set when PCRE2 is built if you want to use JIT."

Without the flag in this commit, Kong logs display several entries containing failures in `pcre2_jit_compile`, such as

```
2024/01/30 16:25:20 [info] 747309#0: pcre2_jit_compile() failed: -45 in "^\s*HTTP/1\.1\s+", ignored
```
