### PR TITLE
chore(wasm): reuse kong.dns object for DNS bridge

### DIFF
--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -834,9 +834,11 @@ end
 local function enable(kong_config)
   set_available_filters(kong_config.wasm_modules_parsed)
 
-  proxy_wasm = proxy_wasm or require "resty.wasmx.proxy_wasm"
+  if not ngx.IS_CLI then
+    proxy_wasm = proxy_wasm or require "resty.wasmx.proxy_wasm"
 
-  register_property_handlers()
+    register_property_handlers()
+  end
 
   ENABLED = true
   STATUS = STATUS_ENABLED
@@ -885,10 +887,12 @@ function _M.init_worker()
     return true
   end
 
-  _G.dns_client = kong and kong.dns
+  if not ngx.IS_CLI then
+    _G.dns_client = kong and kong.dns
 
-  if not _G.dns_client then
-    return nil, "global kong.dns client is not initialized"
+    if not _G.dns_client then
+      return nil, "global kong.dns client is not initialized"
+    end
   end
 
   local ok, err = update_in_place()

--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -32,7 +32,6 @@ local _M = {
 
 
 local utils = require "kong.tools.utils"
-local dns = require "kong.tools.dns"
 local reports = require "kong.reports"
 local clear_tab = require "table.clear"
 local cjson = require "cjson.safe"
@@ -835,9 +834,6 @@ end
 local function enable(kong_config)
   set_available_filters(kong_config.wasm_modules_parsed)
 
-  -- setup a DNS client for ngx_wasm_module
-  _G.dns_client = _G.dns_client or dns(kong_config)
-
   proxy_wasm = proxy_wasm or require "resty.wasmx.proxy_wasm"
 
   register_property_handlers()
@@ -887,6 +883,12 @@ end
 function _M.init_worker()
   if not ENABLED then
     return true
+  end
+
+  _G.dns_client = kong and kong.dns
+
+  if not _G.dns_client then
+    return nil, "global kong.dns client is not initialized"
   end
 
   local ok, err = update_in_place()


### PR DESCRIPTION
The overall goal of this PR is to make the Wasm subsystem a better citizen of Kong.

### Summary

The original code used the `kong.tools.dns` module to attempt* to instantiate its own DNS client:

https://github.com/Kong/kong/blob/b7d50b01f4c69cbf7bbad5329f6d9947de61045b/kong/runloop/wasm.lua#L838-L839

This has not caused any problems that we are aware of, but it's not the correct behavior and could potentially lead to problems further down the line with the DNS client rewrite looming.

Reusing the global `kong.dns` object necessitates moving this initialization code to the `init_worker` phase to work around some order-of-operations challenges (`wasm.init()` needs to run _before_ core entity schemas are loaded, which is also before `kong.dns` is initialized).

Additionally, I have added some checks around our special `ngx.IS_CLI` flag to avoid setup steps in CLI mode. This means that test code that uses `kong.runloop.wasm` will not be expected to mock global objects that are effectively unused in this context.

*the DNS client code uses a singleton pattern with state kept at the module level, so it does not in fact create a "new" DNS client--it merely re-configures the existing one in-place.

### Checklist

- [x] The Pull Request has tests (there are existing tests for DNS queries within Wasm filters)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~

### Issue reference

KAG-3644