### PR TITLE
refactor(router/atc): move assert to unlikely path

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -197,8 +197,10 @@ else  -- stream
 end -- is_http
 
 
--- stream subsystem need not to generate func
-local get_field_accessor = function(funcs, field) end
+-- stream subsystem needs not to generate func
+local function get_field_accessor(funcs, field)
+  error("unknown router matching schema field: " .. field)
+end
 
 
 if is_http then
@@ -359,7 +361,8 @@ if is_http then
       return f
     end -- if field:sub(1, HTTP_SEGMENTS_PREFIX_LEN)
 
-    -- others return nil
+    -- others are error
+    error("unknown router matching schema field: " .. field)
   end
 
 end -- is_http
@@ -450,8 +453,6 @@ end
 function _M:get_value(field, params, ctx)
   local func = FIELDS_FUNCS[field] or
                get_field_accessor(self.funcs, field)
-
-  assert(func, "unknown router matching schema field: " .. field)
 
   return func(params, ctx)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR changes `assert` to `error` and moves it into the function `get_field_accessor()`, 
which is a non-hot path,
so we will remove this cost when finding the func in hash table. 

KAG-3634

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
