### PR TITLE
perf(router): remove NYI to be more JIT-friendly

### DIFF
--- a/changelog/unreleased/kong/speed_up_router.yml
+++ b/changelog/unreleased/kong/speed_up_router.yml
@@ -1,0 +1,3 @@
+message: Speed up the router matching when the `router_flavor` is `traditional_compatible` or `expressions`.
+type: performance
+scope: Performance

--- a/changelog/unreleased/kong/speed_up_router.yml
+++ b/changelog/unreleased/kong/speed_up_router.yml
@@ -1,3 +1,3 @@
-message: Speed up the router matching when the `router_flavor` is `traditional_compatible` or `expressions`.
+message: Speeded up the router matching when the `router_flavor` is `traditional_compatible` or `expressions`.
 type: performance
 scope: Performance

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -261,56 +261,29 @@ if is_http then
     return params
   end
 
+  local function gen_http_headers_field_accessor(name)
+    return function(params)
+      if not params.headers then
+        params.headers = get_http_params(get_headers, "headers", "lua_max_req_headers")
+      end
 
-  get_field_accessor = function(funcs, field)
-    local f = FIELDS_FUNCS[field] or funcs[field]
-    if f then
-      return f
+      return params.headers[name]
     end
+  end
 
-    local prefix = field:sub(1, PREFIX_LEN)
+  local function gen_http_queries_field_accessor(name)
+    return function(params)
+      if not params.queries then
+        params.queries = get_http_params(get_uri_args, "queries", "lua_max_uri_args")
+      end
 
-    -- generate for http.headers.*
+      return params.queries[name]
+    end
+  end
 
-    if prefix == HTTP_HEADERS_PREFIX then
-      local name = field:sub(PREFIX_LEN + 1)
-
-      f = function(params)
-        if not params.headers then
-          params.headers = get_http_params(get_headers, "headers", "lua_max_req_headers")
-        end
-
-        return params.headers[name]
-      end -- f
-
-      funcs[field] = f
-      return f
-    end -- if prefix == HTTP_HEADERS_PREFIX
-
-    -- generate for http.queries.*
-
-    if prefix == HTTP_QUERIES_PREFIX then
-      local name = field:sub(PREFIX_LEN + 1)
-
-      f = function(params)
-        if not params.queries then
-          params.queries = get_http_params(get_uri_args, "queries", "lua_max_uri_args")
-        end
-
-        return params.queries[name]
-      end -- f
-
-      funcs[field] = f
-      return f
-    end -- if prefix == HTTP_QUERIES_PREFIX
-
-    -- generate for http.path.segments.*
-
-    if field:sub(1, HTTP_SEGMENTS_PREFIX_LEN) == HTTP_SEGMENTS_PREFIX then
-      local range = field:sub(HTTP_SEGMENTS_PREFIX_LEN + 1)
-
-      f = function(params)
-        local segments = get_http_segments(params)
+  local function gen_http_segments_field_accessor(range)
+    return function(params)
+      local segments = get_http_segments(params)
 
         local value = segments[range]
 
@@ -359,9 +332,47 @@ if is_http then
         segments[range] = value
 
         return value
-      end -- f
+    end
+  end
 
+  get_field_accessor = function(funcs, field)
+    local f = FIELDS_FUNCS[field] or funcs[field]
+    if f then
+      return f
+    end
+
+    local prefix = field:sub(1, PREFIX_LEN)
+
+    -- generate for http.headers.*
+
+    if prefix == HTTP_HEADERS_PREFIX then
+      local name = field:sub(PREFIX_LEN + 1)
+
+      f = gen_http_headers_field_accessor(name)
       funcs[field] = f
+
+      return f
+    end -- if prefix == HTTP_HEADERS_PREFIX
+
+    -- generate for http.queries.*
+
+    if prefix == HTTP_QUERIES_PREFIX then
+      local name = field:sub(PREFIX_LEN + 1)
+
+      f = gen_http_queries_field_accessor(name)
+      funcs[field] = f
+
+      return f
+    end -- if prefix == HTTP_QUERIES_PREFIX
+
+    -- generate for http.path.segments.*
+
+    if field:sub(1, HTTP_SEGMENTS_PREFIX_LEN) == HTTP_SEGMENTS_PREFIX then
+      local range = field:sub(HTTP_SEGMENTS_PREFIX_LEN + 1)
+
+      f = gen_http_segments_field_accessor(range)
+      funcs[field] = f
+
       return f
     end -- if field:sub(1, HTTP_SEGMENTS_PREFIX_LEN)
 

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -261,6 +261,7 @@ if is_http then
     return params
   end
 
+
   local function gen_http_headers_field_accessor(name)
     return function(params)
       if not params.headers then
@@ -271,6 +272,7 @@ if is_http then
     end
   end
 
+
   local function gen_http_queries_field_accessor(name)
     return function(params)
       if not params.queries then
@@ -280,6 +282,7 @@ if is_http then
       return params.queries[name]
     end
   end
+
 
   local function gen_http_segments_field_accessor(range)
     return function(params)
@@ -334,6 +337,7 @@ if is_http then
         return value
     end
   end
+
 
   get_field_accessor = function(funcs, field)
     local f = FIELDS_FUNCS[field] or funcs[field]


### PR DESCRIPTION
## Please SQUASH AND MERGE

### Summary

```
---- TRACE 1772 start fields.lua:457
0001  UGET     4   0      ; FIELDS_FUNCS       (fields.lua:458)
0002  TGETV    4   4   1       (fields.lua:458)
0003  IST          4       (fields.lua:458)
0004  JMP      5 => 0009
0005  UGET     4   1      ; get_field_accessor       (fields.lua:459)
0006  TGETS    6   0   0  ; "funcs"       (fields.lua:459)
0007  MOV      7   1       (fields.lua:459)
0008  CALL     4   2   3       (fields.lua:459)
0000  . FUNCF    9          ; fields.lua:266
0001  . TGETV    2   0   1       (fields.lua:267)
0002  . ISF          2       (fields.lua:268)
0003  . JMP      3 => 0005
0004  . UCLO     0 => 0055       (fields.lua:269)
---- TRACE 1772 abort fields.lua:269 -- NYI: bytecode 50
```

Generating a field accessor in place in the `get_field_accessor()` is not JIT friendly, so let' generate accessor from the other function.

---

And tail call is not JIT-friendly in some cases, so rewrote it.


### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3653]_


[KAG-3653]: https://konghq.atlassian.net/browse/KAG-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ