### PR TITLE
refactor(router/atc): remove tail calls to avoid NYIs

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -130,7 +130,9 @@ local function gen_for_field(name, op, vals, val_transform)
   end
 
   -- consume the whole buffer
-  return values_buf:put(")"):get()
+  local str = values_buf:put(")"):get()
+
+  return str
 end
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -130,6 +130,8 @@ local function gen_for_field(name, op, vals, val_transform)
   end
 
   -- consume the whole buffer
+  -- returns a local variable instead uses a tail call
+  -- to avoid NYI
   local str = values_buf:put(")"):get()
 
   return str

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -130,7 +130,7 @@ local function gen_for_field(name, op, vals, val_transform)
   end
 
   -- consume the whole buffer
-  -- returns a local variable instead uses a tail call
+  -- returns a local variable instead of using a tail call
   -- to avoid NYI
   local str = values_buf:put(")"):get()
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -139,6 +139,8 @@ local function gen_for_nets(ip_field, port_field, vals)
 
   local str = nets_buf:put(")"):get()
 
+  -- returns a local variable instead uses a tail call
+  -- to avoid NYI
   return str
 end
 
@@ -190,6 +192,8 @@ local function get_expression(route)
     end
 
     if src_gen or dst_gen then
+      -- returns a local variable instead uses a tail call
+      -- to avoid NYI
       local str = expr_buf:get()
       return str
     end
@@ -277,6 +281,8 @@ local function get_expression(route)
 
   local str = expr_buf:get()
 
+  -- returns a local variable instead uses a tail call
+  -- to avoid NYI
   return str
 end
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -137,7 +137,9 @@ local function gen_for_nets(ip_field, port_field, vals)
     ::continue::
   end   -- for
 
-  return nets_buf:put(")"):get()
+  local str = nets_buf:put(")"):get()
+
+  return str
 end
 
 
@@ -188,7 +190,8 @@ local function get_expression(route)
     end
 
     if src_gen or dst_gen then
-      return expr_buf:get()
+      local str = expr_buf:get()
+      return str
     end
   end
 
@@ -272,7 +275,9 @@ local function get_expression(route)
     expression_append(expr_buf, LOGICAL_AND, headers_buf:get())
   end
 
-  return expr_buf:get()
+  local str = expr_buf:get()
+
+  return str
 end
 
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -139,7 +139,7 @@ local function gen_for_nets(ip_field, port_field, vals)
 
   local str = nets_buf:put(")"):get()
 
-  -- returns a local variable instead uses a tail call
+  -- returns a local variable instead of using a tail call
   -- to avoid NYI
   return str
 end
@@ -192,7 +192,7 @@ local function get_expression(route)
     end
 
     if src_gen or dst_gen then
-      -- returns a local variable instead uses a tail call
+      -- returns a local variable instead of using a tail call
       -- to avoid NYI
       local str = expr_buf:get()
       return str
@@ -281,7 +281,7 @@ local function get_expression(route)
 
   local str = expr_buf:get()
 
-  -- returns a local variable instead uses a tail call
+  -- returns a local variable instead of using a tail call
   -- to avoid NYI
   return str
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

As #12467 did, remove some tail return NYI to be more JIT-friendly.

KAG-3634

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
