### PR TITLE
[backport -> release/3.3.x] tests(helpers): wait_for_all_config_update support pass custom headers and https_server support disable listen ipv6 (#11718)

### DIFF
--- a/spec/fixtures/https_server.lua
+++ b/spec/fixtures/https_server.lua
@@ -183,6 +183,7 @@ function https_server.start(self)
     http_port = self.http_port,
     protocol = self.protocol,
     worker_num = self.worker_num,
+    disable_ipv6 = self.disable_ipv6,
   }
 
   local file, err = create_conf(conf_params)
@@ -245,8 +246,8 @@ function https_server.shutdown(self)
   return count
 end
 
-
-function https_server.new(port, hostname, protocol, check_hostname, workers, delay)
+-- **DEPRECATED**: please use `spec.helpers.http_mock` instead.
+function https_server.new(port, hostname, protocol, check_hostname, workers, delay, disable_ipv6)
   local self = setmetatable({}, https_server)
   local host
   local hosts
@@ -270,6 +271,7 @@ function https_server.new(port, hostname, protocol, check_hostname, workers, del
   self.logs_dir = "logs"
   self.protocol = protocol or "http"
   self.worker_num = workers or 2
+  self.disable_ipv6 = disable_ipv6
 
   return self
 end

--- a/spec/fixtures/mock_webserver_tpl.lua
+++ b/spec/fixtures/mock_webserver_tpl.lua
@@ -73,10 +73,14 @@ http {
   server {
 # if protocol ~= 'https' then
     listen 127.0.0.1:${http_port};
+# if not disable_ipv6 then
     listen [::1]:${http_port};
+#end
 # else
     listen 127.0.0.1:${http_port} ssl http2;
+# if not disable_ipv6 then
     listen [::1]:${http_port} ssl http2;
+#end
     ssl_certificate     ${cert_path}/kong_spec.crt;
     ssl_certificate_key ${cert_path}/kong_spec.key;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1847,20 +1847,24 @@ local function wait_for_all_config_update(opts)
   local stream_enabled = opts.stream_enabled or false
   local override_rl = opts.override_global_rate_limiting_plugin or false
   local override_auth = opts.override_global_key_auth_plugin or false
+  local headers = opts.override_default_headers or { ["Content-Type"] = "application/json" }
+  local disable_ipv6 = opts.disable_ipv6 or false
 
-  local function call_admin_api(method, path, body, expected_status)
+  local function call_admin_api(method, path, body, expected_status, headers)
     local client = admin_client(admin_client_timeout, forced_admin_port)
 
     local res
 
     if string.upper(method) == "POST" then
       res = client:post(path, {
-        headers = {["Content-Type"] = "application/json"},
+        headers = headers,
         body = body,
       })
 
     elseif string.upper(method) == "DELETE" then
-      res = client:delete(path)
+      res = client:delete(path, {
+        headers = headers
+      })
     end
 
     local ok, json_or_nil_or_err = pcall(function ()
@@ -1897,7 +1901,7 @@ local function wait_for_all_config_update(opts)
   local host = "localhost"
   local port = get_available_port()
 
-  local server = https_server.new(port, host, "http", nil, 1)
+  local server = https_server.new(port, host, "http", nil, 1, nil, disable_ipv6)
 
   server:start()
 
@@ -1905,28 +1909,28 @@ local function wait_for_all_config_update(opts)
   local res = assert(call_admin_api("POST",
                              "/upstreams",
                              { name = upstream_name },
-                             201))
+                             201, headers))
   upstream_id = res.id
 
   -- create mocking target to mocking upstream
   res = assert(call_admin_api("POST",
                        string.format("/upstreams/%s/targets", upstream_id),
                        { target = host .. ":" .. port },
-                       201))
+                       201, headers))
   target_id = res.id
 
   -- create mocking service to mocking upstream
   res = assert(call_admin_api("POST",
                        "/services",
                        { name = service_name, url = "http://" .. upstream_name .. "/always_200" },
-                       201))
+                       201, headers))
   service_id = res.id
 
   -- create mocking route to mocking service
   res = assert(call_admin_api("POST",
                        string.format("/services/%s/routes", service_id),
                        { paths = { route_path }, strip_path = true, path_handling = "v0",},
-                       201))
+                       201, headers))
   route_id = res.id
 
   if override_rl then
@@ -1934,7 +1938,7 @@ local function wait_for_all_config_update(opts)
     res = assert(call_admin_api("POST",
                                 string.format("/services/%s/plugins", service_id),
                                 { name = "rate-limiting", config = { minute = 999999, policy = "local" } },
-                                201))
+                                201, headers))
     rl_plugin_id = res.id
   end
 
@@ -1943,21 +1947,21 @@ local function wait_for_all_config_update(opts)
     res = assert(call_admin_api("POST",
                                 string.format("/services/%s/plugins", service_id),
                                 { name = "key-auth", config = { key_names = { key_header_name } } },
-                                201))
+                                201, headers))
     key_auth_plugin_id = res.id
 
     -- create consumer
     res = assert(call_admin_api("POST",
                                 "/consumers",
                                 { username = consumer_name },
-                                201))
+                                201, headers))
       consumer_id = res.id
 
     -- create credential to key-auth plugin
     res = assert(call_admin_api("POST",
                                 string.format("/consumers/%s/key-auth", consumer_id),
                                 { key = test_credentials },
-                                201))
+                                201, headers))
     credential_id = res.id
   end
 
@@ -1966,28 +1970,28 @@ local function wait_for_all_config_update(opts)
     local res = assert(call_admin_api("POST",
                               "/upstreams",
                               { name = stream_upstream_name },
-                              201))
+                              201, headers))
     stream_upstream_id = res.id
 
     -- create mocking target to mocking upstream
     res = assert(call_admin_api("POST",
                         string.format("/upstreams/%s/targets", stream_upstream_id),
                         { target = host .. ":" .. port },
-                        201))
+                        201, headers))
     stream_target_id = res.id
 
     -- create mocking service to mocking upstream
     res = assert(call_admin_api("POST",
                         "/services",
                         { name = stream_service_name, url = "tcp://" .. stream_upstream_name },
-                        201))
+                        201, headers))
     stream_service_id = res.id
 
     -- create mocking route to mocking service
     res = assert(call_admin_api("POST",
                         string.format("/services/%s/routes", stream_service_id),
                         { destinations = { { port = stream_port }, }, protocols = { "tcp" },},
-                        201))
+                        201, headers))
     stream_route_id = res.id
   end
 
@@ -2026,25 +2030,25 @@ local function wait_for_all_config_update(opts)
 
   -- delete mocking configurations
   if override_auth then
-    call_admin_api("DELETE", string.format("/consumers/%s/key-auth/%s", consumer_id, credential_id), nil, 204)
-    call_admin_api("DELETE", string.format("/consumers/%s", consumer_id), nil, 204)
-    call_admin_api("DELETE", "/plugins/" .. key_auth_plugin_id, nil, 204)
+    call_admin_api("DELETE", string.format("/consumers/%s/key-auth/%s", consumer_id, credential_id), nil, 204, headers)
+    call_admin_api("DELETE", string.format("/consumers/%s", consumer_id), nil, 204, headers)
+    call_admin_api("DELETE", "/plugins/" .. key_auth_plugin_id, nil, 204, headers)
   end
 
   if override_rl then
-    call_admin_api("DELETE", "/plugins/" .. rl_plugin_id, nil, 204)
+    call_admin_api("DELETE", "/plugins/" .. rl_plugin_id, nil, 204, headers)
   end
 
-  call_admin_api("DELETE", "/routes/" .. route_id, nil, 204)
-  call_admin_api("DELETE", "/services/" .. service_id, nil, 204)
-  call_admin_api("DELETE", string.format("/upstreams/%s/targets/%s", upstream_id, target_id), nil, 204)
-  call_admin_api("DELETE", "/upstreams/" .. upstream_id, nil, 204)
+  call_admin_api("DELETE", "/routes/" .. route_id, nil, 204, headers)
+  call_admin_api("DELETE", "/services/" .. service_id, nil, 204, headers)
+  call_admin_api("DELETE", string.format("/upstreams/%s/targets/%s", upstream_id, target_id), nil, 204, headers)
+  call_admin_api("DELETE", "/upstreams/" .. upstream_id, nil, 204, headers)
 
   if stream_enabled then
-    call_admin_api("DELETE", "/routes/" .. stream_route_id, nil, 204)
-    call_admin_api("DELETE", "/services/" .. stream_service_id, nil, 204)
-    call_admin_api("DELETE", string.format("/upstreams/%s/targets/%s", stream_upstream_id, stream_target_id), nil, 204)
-    call_admin_api("DELETE", "/upstreams/" .. stream_upstream_id, nil, 204)
+    call_admin_api("DELETE", "/routes/" .. stream_route_id, nil, 204, headers)
+    call_admin_api("DELETE", "/services/" .. stream_service_id, nil, 204, headers)
+    call_admin_api("DELETE", string.format("/upstreams/%s/targets/%s", stream_upstream_id, stream_target_id), nil, 204, headers)
+    call_admin_api("DELETE", "/upstreams/" .. stream_upstream_id, nil, 204, headers)
   end
 
   ok, err = pcall(function ()


### PR DESCRIPTION
backport #11718.

## Original description

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Migrate the changes related to helpers from [6734](https://github.com/Kong/kong-ee/pull/6734) to ce.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [na] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* `wait_for_all_config_update` support pass custom headers
* `https_server support disable` listen ipv6

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
