### PR TITLE
perf(router/atc): simplify cache key calculation

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -375,7 +375,7 @@ local function visit_for_cache_key(field, value, str_buf)
     value = tb_concat(value, ",")
   end
 
-  str_buf:putf("%s=%s|", field, value or "")
+  str_buf:put(value or "", "|")
 
   return true
 end

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -8,7 +8,6 @@ local tonumber = tonumber
 local setmetatable = setmetatable
 local tb_sort = table.sort
 local tb_concat = table.concat
-local replace_dashes_lower = require("kong.tools.string").replace_dashes_lower
 
 
 local var           = ngx.var
@@ -371,30 +370,12 @@ local function visit_for_cache_key(field, value, str_buf)
     return true
   end
 
-  local headers_or_queries = field:sub(1, PREFIX_LEN)
-
-  if headers_or_queries == HTTP_HEADERS_PREFIX then
-    headers_or_queries = true
-    field = replace_dashes_lower(field)
-
-  elseif headers_or_queries == HTTP_QUERIES_PREFIX then
-    headers_or_queries = true
-
-  else
-    headers_or_queries = false
+  if type(value) == "table" then
+    tb_sort(value)
+    value = tb_concat(value, ",")
   end
 
-  if not headers_or_queries then
-    str_buf:put(value or "", "|")
-
-  else  -- headers or queries
-    if type(value) == "table" then
-      tb_sort(value)
-      value = tb_concat(value, ",")
-    end
-
-    str_buf:putf("%s=%s|", field, value or "")
-  end
+  str_buf:putf("%s=%s|", field, value or "")
 
   return true
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

simplify cache key algorithm:
* the field names of "http.header.*" are constants, lowercase is unnecessary
* the order of atc fields is fixed, need not to put field's name into cache key

Now the cache key is the collection of all fields' values with the given order.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
