### PR TITLE
docs(*): CE changelog automation and verification

### DIFF
--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,10 +1,10 @@
-.PHONY: generate_changelog push_changelog
+.PHONY: generate push_changelog
 
 VERSION = 3.x.y.z
 UNRELEASED_DIR = unreleased
 DEBUG = false
 
-generate_changelog:
+generate:
 	@rm -f $(VERSION).md
 	@touch $(VERSION).md
 

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all create_branch generate push_changelog
 
-VERSION ?= 3.6.0.0
-BASE_BRANCH ?= origin/next/3.6.x.x
+VERSION ?= 3.6.0
+BASE_BRANCH ?= origin/release/3.6.x
 DEBUG ?= false
 UNRELEASED_DIR := unreleased
 
@@ -24,7 +24,7 @@ generate:
 				--changelog-paths $(VERSION)/kong,$(UNRELEASED_DIR)/kong \
 				--title Kong \
 				--github-issue-repo Kong/kong \
-				--github-api-repo Kong/kong-ee \
+				--github-api-repo Kong/kong \
 				--with-jiras \
 				>> $(VERSION).md; \
 		else \
@@ -33,70 +33,28 @@ generate:
 				--changelog-paths $(UNRELEASED_DIR)/kong \
 				--title Kong \
 				--github-issue-repo Kong/kong \
-				--github-api-repo Kong/kong-ee \
+				--github-api-repo Kong/kong \
 				--with-jiras \
 				>> $(VERSION).md; \
 		fi \
 	fi
-	@if [ -d "$(UNRELEASED_DIR)/kong-ee" ]; then \
+	@if [ -d "$(UNRELEASED_DIR)/kong-manager" ]; then \
 		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(VERSION)/kong-ee,$(UNRELEASED_DIR)/kong-ee \
-				--title Kong-Enterprise \
-				--github-issue-repo Kong/kong-ee \
-				--github-api-repo Kong/kong-ee \
+				--changelog-paths $(VERSION)/kong-manager,$(UNRELEASED_DIR)/kong-manager \
+				--title Kong-Manager \
+				--github-issue-repo Kong/kong-manager \
+				--github-api-repo Kong/kong \
 				--with-jiras \
 				>> $(VERSION).md; \
 		else \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(UNRELEASED_DIR)/kong-ee \
-				--title Kong-Enterprise \
-				--github-issue-repo Kong/kong-ee \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		fi \
-    fi
-	@if [ -d "$(UNRELEASED_DIR)/kong-manager-ee" ]; then \
-		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(VERSION)/kong-manager-ee,$(UNRELEASED_DIR)/kong-manager-ee \
-				--title Kong-Manager-Enterprise \
-				--github-issue-repo Kong/kong-admin \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		else \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(UNRELEASED_DIR)/kong-manager-ee \
-				--title Kong-Manager-Enterprise \
-				--github-issue-repo Kong/kong-admin \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		fi \
-    fi
-	@if [ -d "$(UNRELEASED_DIR)/kong-portal-ee" ]; then \
-		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(VERSION)/kong-portal-ee,$(UNRELEASED_DIR)/kong-portal-ee \
-				--title Kong-Portal \
-				--github-issue-repo Kong/kong-portal-templates \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		else \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(UNRELEASED_DIR)/kong-portal-ee \
-				--title Kong-Portal \
-				--github-issue-repo Kong/kong-portal-templates \
-				--github-api-repo Kong/kong-ee \
+				--changelog-paths $(UNRELEASED_DIR)/kong-manager \
+				--title Kong-Manager \
+				--github-issue-repo Kong/kong-manager \
+				--github-api-repo Kong/kong \
 				--with-jiras \
 				>> $(VERSION).md; \
 		fi \
@@ -104,8 +62,8 @@ generate:
 
 	@mv $(VERSION).md $(UNRELEASED_DIR)/
 	@git mv $(UNRELEASED_DIR) $(VERSION)
-	@mkdir -p $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}
-	@touch $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}/.gitkeep
+	@mkdir -p $(UNRELEASED_DIR)/{kong,kong-manager}
+	@touch $(UNRELEASED_DIR)/{kong,kong-manager}/.gitkeep
 
 	@echo
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
@@ -116,4 +74,4 @@ push_changelog:
 	@git push -fu origin HEAD
 
 	@echo
-	@echo "Successfully pushed to Github. Please create changelog PR overthere."
+	@echo "Successfully pushed $(BRANCH_NAME) to Github. Please create changelog PR overthere."

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -101,7 +101,7 @@ generate_changelog:
 	@echo
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
 
-BRANCH_BASE = next/3.x.x.x
+BRANCH_BASE = origin/next/3.x.x.x
 push_changelog:
 	@git checkout -b generate-$(VERSION)-changelog $(BRANCH_BASE)
 	@git add .

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,8 +1,16 @@
-.PHONY: generate push_changelog
+.PHONY: all create_branch generate push_changelog
 
-VERSION = 3.x.y.z
-UNRELEASED_DIR = unreleased
-DEBUG = false
+VERSION := 3.x.y.z
+BASE_BRANCH := origin/next/3.x.x.x
+UNRELEASED_DIR := unreleased
+DEBUG := false
+
+all: create_branch generate push_changelog
+
+BRANCH_NAME := generate-$(VERSION)-changelog
+create_branch:
+	@git fetch
+	@git checkout -b $(BRANCH_NAME) $(BASE_BRANCH)
 
 generate:
 	@rm -f $(VERSION).md
@@ -101,12 +109,10 @@ generate:
 	@echo
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
 
-BRANCH_BASE = origin/next/3.x.x.x
 push_changelog:
-	@git checkout -b generate-$(VERSION)-changelog $(BRANCH_BASE)
 	@git add .
 	@git commit -m "docs(release): genereate $(VERSION) changelog"
 	@git push -u origin HEAD
 
 	@echo
-	@echo "Successfully push changelog Github. Please create PR overthere."
+	@echo "Successfully pushed to Github. Please create changelog PR overthere."

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,0 +1,99 @@
+CHANGELOG_VERSION=3.x.y.z
+CHANGELOG_FOLDER=unreleased
+DEBUG=false
+
+generate:
+	@rm -f changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md
+	@touch changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md
+	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong \
+			--title Kong \
+			--github-issue-repo Kong/kong \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+    fi
+	# EE only
+	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-ee" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-ee \
+			--title Kong-Enterprise \
+			--github-issue-repo Kong/kong-ee \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+    fi
+	# CE inspects 'kong-manager' but EE inspects 'kong-manager-ee'
+	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-manager-ee" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-manager-ee \
+			--title Kong-Manager-Enterprise \
+			--github-issue-repo Kong/kong-admin \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+    fi
+	# EE only
+	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-portal" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-portal \
+			--title Kong-Portal \
+			--github-issue-repo Kong/kong-portal-templates \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+    fi
+	@echo "Successfully genreate changelog changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md"
+
+regenerate:
+	@rm -f changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md
+	@touch changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md
+	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong,changelog/$(CHANGELOG_FOLDER)/kong \
+			--title Kong \
+			--github-issue-repo Kong/kong \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
+    fi
+	# EE only
+	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-ee" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-ee,changelog/$(CHANGELOG_FOLDER)/kong-ee \
+			--title Kong-Enterprise \
+			--github-issue-repo Kong/kong-ee \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
+    fi
+	# CE inspects 'kong-manager' but EE inspects 'kong-manager-ee'
+	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-manager-ee" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-manager-ee,changelog/$(CHANGELOG_FOLDER)/kong-manager-ee \
+			--title Kong-Manager-Enterprise \
+			--github-issue-repo Kong/kong-admin \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
+    fi
+	# EE only
+	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-portal" ]; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-portal,changelog/$(CHANGELOG_FOLDER)/kong-portal \
+			--title Kong-Portal \
+			--github-issue-repo Kong/kong-portal-templates \
+			--github-api-repo Kong/kong-ee \
+			--with-jiras \
+			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
+    fi
+	@echo "Successfully regenreate changelog changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md"

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,99 +1,116 @@
-CHANGELOG_VERSION=3.x.y.z
-CHANGELOG_FOLDER=unreleased
+.PHONY: generate
+
+VERSION=3.x.y.z
+FOLDER=unreleased
 DEBUG=false
+INCLUDE_UNRELEASED=false
 
 generate:
-	@rm -f changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md
-	@touch changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md
-	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong \
-			--title Kong \
-			--github-issue-repo Kong/kong \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+	@rm -f $(VERSION).md
+	@touch $(VERSION).md
+	@if [ -d "$(FOLDER)/kong" ]; then \
+		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong,unreleased/kong \
+				--title Kong \
+				--github-issue-repo Kong/kong \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		else \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong \
+				--title Kong \
+				--github-issue-repo Kong/kong \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		fi \
+	fi
+	@if [ -d "$(FOLDER)/kong-manager" ]; then \
+		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-manager,unreleased/manager \
+				--title Kong-Manager \
+				--github-issue-repo Kong/kong-manager \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		else \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-manager \
+				--title Kong-Manager \
+				--github-issue-repo Kong/kong-manager \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		fi \
+	fi
+	@if [ -d "$(FOLDER)/kong-ee" ]; then \
+		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-ee,unreleased/kong-ee \
+				--title Kong-Enterprise \
+				--github-issue-repo Kong/kong-ee \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		else \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-ee \
+				--title Kong-Enterprise \
+				--github-issue-repo Kong/kong-ee \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		fi \
     fi
-	# EE only
-	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-ee" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-ee \
-			--title Kong-Enterprise \
-			--github-issue-repo Kong/kong-ee \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+	@if [ -d "$(FOLDER)/kong-manager-ee" ]; then \
+		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-manager-ee,unreleased/kong-manager-ee \
+				--title Kong-Manager-Enterprise \
+				--github-issue-repo Kong/kong-admin \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		else \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-manager-ee \
+				--title Kong-Manager-Enterprise \
+				--github-issue-repo Kong/kong-admin \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		fi \
     fi
-	# CE inspects 'kong-manager' but EE inspects 'kong-manager-ee'
-	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-manager-ee" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-manager-ee \
-			--title Kong-Manager-Enterprise \
-			--github-issue-repo Kong/kong-admin \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
+	@if [ -d "$(FOLDER)/kong-portal-ee" ]; then \
+		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-portal-ee,unreleased/kong-portal-ee \
+				--title Kong-Portal \
+				--github-issue-repo Kong/kong-portal-templates \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		else \
+			changelog --debug=$(DEBUG) generate \
+				--repo-path . \
+				--changelog-paths $(FOLDER)/kong-portal-ee \
+				--title Kong-Portal \
+				--github-issue-repo Kong/kong-portal-templates \
+				--github-api-repo Kong/kong-ee \
+				--with-jiras \
+				>> $(VERSION).md; \
+		fi \
     fi
-	# EE only
-	@if [ -d "changelog/$(CHANGELOG_FOLDER)/kong-portal" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_FOLDER)/kong-portal \
-			--title Kong-Portal \
-			--github-issue-repo Kong/kong-portal-templates \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md; \
-    fi
-	@echo "Successfully genreate changelog changelog/$(CHANGELOG_FOLDER)/$(CHANGELOG_VERSION).md"
-
-regenerate:
-	@rm -f changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md
-	@touch changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md
-	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong,changelog/$(CHANGELOG_FOLDER)/kong \
-			--title Kong \
-			--github-issue-repo Kong/kong \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
-    fi
-	# EE only
-	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-ee" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-ee,changelog/$(CHANGELOG_FOLDER)/kong-ee \
-			--title Kong-Enterprise \
-			--github-issue-repo Kong/kong-ee \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
-    fi
-	# CE inspects 'kong-manager' but EE inspects 'kong-manager-ee'
-	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-manager-ee" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-manager-ee,changelog/$(CHANGELOG_FOLDER)/kong-manager-ee \
-			--title Kong-Manager-Enterprise \
-			--github-issue-repo Kong/kong-admin \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
-    fi
-	# EE only
-	@if [ -d "changelog/$(CHANGELOG_VERSION)/kong-portal" ]; then \
-		changelog --debug=$(DEBUG) generate \
-			--repo-path . \
-			--changelog-paths changelog/$(CHANGELOG_VERSION)/kong-portal,changelog/$(CHANGELOG_FOLDER)/kong-portal \
-			--title Kong-Portal \
-			--github-issue-repo Kong/kong-portal-templates \
-			--github-api-repo Kong/kong-ee \
-			--with-jiras \
-			>> changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md; \
-    fi
-	@echo "Successfully regenreate changelog changelog/$(CHANGELOG_VERSION)/$(CHANGELOG_VERSION).md"
+	@echo "Successfully genreate changelog $(VERSION).md"

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -97,12 +97,16 @@ generate:
 	@git mv $(UNRELEASED_DIR) $(VERSION)
 	@mkdir -p $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}
 	@touch $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}/.gitkeep
+
+	@echo
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
 
-PR_BASE = origin/master
+PR_BASE = next/3.x.x.x
 github_pr:
 	@git checkout -b geneerate-$(VERSION)-changelog $(PR_BASE)
 	@git add .
 	@git commit -m "docs(release): genereate $(VERSION) changelog"
 	@git push -u origin HEAD
-	@echo "Changelog branch pushed to Github. Please create PR overthere."
+
+	@echo
+	@echo "Successfully push changelog Github. Please create PR overthere."

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,10 +1,10 @@
-.PHONY: generate github_pr
+.PHONY: generate_changelog push_changelog
 
 VERSION = 3.x.y.z
 UNRELEASED_DIR = unreleased
 DEBUG = false
 
-generate:
+generate_changelog:
 	@rm -f $(VERSION).md
 	@touch $(VERSION).md
 
@@ -101,9 +101,9 @@ generate:
 	@echo
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
 
-PR_BASE = next/3.x.x.x
-github_pr:
-	@git checkout -b geneerate-$(VERSION)-changelog $(PR_BASE)
+BRANCH_BASE = next/3.x.x.x
+push_changelog:
+	@git checkout -b generate-$(VERSION)-changelog $(BRANCH_BASE)
 	@git add .
 	@git commit -m "docs(release): genereate $(VERSION) changelog"
 	@git push -u origin HEAD

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,8 +1,8 @@
-.PHONY: generate
+.PHONY: generate github_pr
 
-VERSION=3.x.y.z
-UNRELEASED_DIR=unreleased
-DEBUG=false
+VERSION = 3.x.y.z
+UNRELEASED_DIR = unreleased
+DEBUG = false
 
 generate:
 	@rm -f $(VERSION).md
@@ -98,3 +98,11 @@ generate:
 	@mkdir -p $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}
 	@touch $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}/.gitkeep
 	@echo "Done! Please check $(VERSION)/$(VERSION).md"
+
+PR_BASE = origin/master
+github_pr:
+	@git checkout -b geneerate-$(VERSION)-changelog $(PR_BASE)
+	@git add .
+	@git commit -m "docs(release): genereate $(VERSION) changelog"
+	@git push -u origin HEAD
+	@echo "Changelog branch pushed to Github. Please create PR overthere."

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -10,7 +10,7 @@ all: create_branch generate push_changelog
 BRANCH_NAME := generate-$(VERSION)-changelog
 create_branch:
 	@git fetch
-	@git checkout -b $(BRANCH_NAME) $(BASE_BRANCH)
+	@git checkout -B $(BRANCH_NAME) $(BASE_BRANCH)
 
 generate:
 	@rm -f $(VERSION).md

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,13 +1,14 @@
 .PHONY: all create_branch generate push_changelog
 
-VERSION := 3.x.y.z
-BASE_BRANCH := origin/next/3.x.x.x
+VERSION ?= 3.6.0.0
+BASE_BRANCH ?= origin/next/3.6.x.x
+DEBUG ?= false
 UNRELEASED_DIR := unreleased
-DEBUG := false
+
+BRANCH_NAME := generate-$(VERSION)-changelog
 
 all: create_branch generate push_changelog
 
-BRANCH_NAME := generate-$(VERSION)-changelog
 create_branch:
 	@git fetch
 	@git checkout -B $(BRANCH_NAME) $(BASE_BRANCH)

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -112,7 +112,7 @@ generate:
 push_changelog:
 	@git add .
 	@git commit -m "docs(release): genereate $(VERSION) changelog"
-	@git push -u origin HEAD
+	@git push -fu origin HEAD
 
 	@echo
 	@echo "Successfully pushed to Github. Please create changelog PR overthere."

--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -1,18 +1,18 @@
 .PHONY: generate
 
 VERSION=3.x.y.z
-FOLDER=unreleased
+UNRELEASED_DIR=unreleased
 DEBUG=false
-INCLUDE_UNRELEASED=false
 
 generate:
 	@rm -f $(VERSION).md
 	@touch $(VERSION).md
-	@if [ -d "$(FOLDER)/kong" ]; then \
-		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+
+	@if [ -d "$(UNRELEASED_DIR)/kong" ]; then \
+		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong,unreleased/kong \
+				--changelog-paths $(VERSION)/kong,$(UNRELEASED_DIR)/kong \
 				--title Kong \
 				--github-issue-repo Kong/kong \
 				--github-api-repo Kong/kong-ee \
@@ -21,7 +21,7 @@ generate:
 		else \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong \
+				--changelog-paths $(UNRELEASED_DIR)/kong \
 				--title Kong \
 				--github-issue-repo Kong/kong \
 				--github-api-repo Kong/kong-ee \
@@ -29,32 +29,11 @@ generate:
 				>> $(VERSION).md; \
 		fi \
 	fi
-	@if [ -d "$(FOLDER)/kong-manager" ]; then \
-		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+	@if [ -d "$(UNRELEASED_DIR)/kong-ee" ]; then \
+		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-manager,unreleased/manager \
-				--title Kong-Manager \
-				--github-issue-repo Kong/kong-manager \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		else \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-manager \
-				--title Kong-Manager \
-				--github-issue-repo Kong/kong-manager \
-				--github-api-repo Kong/kong-ee \
-				--with-jiras \
-				>> $(VERSION).md; \
-		fi \
-	fi
-	@if [ -d "$(FOLDER)/kong-ee" ]; then \
-		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-ee,unreleased/kong-ee \
+				--changelog-paths $(VERSION)/kong-ee,$(UNRELEASED_DIR)/kong-ee \
 				--title Kong-Enterprise \
 				--github-issue-repo Kong/kong-ee \
 				--github-api-repo Kong/kong-ee \
@@ -63,7 +42,7 @@ generate:
 		else \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-ee \
+				--changelog-paths $(UNRELEASED_DIR)/kong-ee \
 				--title Kong-Enterprise \
 				--github-issue-repo Kong/kong-ee \
 				--github-api-repo Kong/kong-ee \
@@ -71,11 +50,11 @@ generate:
 				>> $(VERSION).md; \
 		fi \
     fi
-	@if [ -d "$(FOLDER)/kong-manager-ee" ]; then \
-		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+	@if [ -d "$(UNRELEASED_DIR)/kong-manager-ee" ]; then \
+		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-manager-ee,unreleased/kong-manager-ee \
+				--changelog-paths $(VERSION)/kong-manager-ee,$(UNRELEASED_DIR)/kong-manager-ee \
 				--title Kong-Manager-Enterprise \
 				--github-issue-repo Kong/kong-admin \
 				--github-api-repo Kong/kong-ee \
@@ -84,7 +63,7 @@ generate:
 		else \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-manager-ee \
+				--changelog-paths $(UNRELEASED_DIR)/kong-manager-ee \
 				--title Kong-Manager-Enterprise \
 				--github-issue-repo Kong/kong-admin \
 				--github-api-repo Kong/kong-ee \
@@ -92,11 +71,11 @@ generate:
 				>> $(VERSION).md; \
 		fi \
     fi
-	@if [ -d "$(FOLDER)/kong-portal-ee" ]; then \
-		if [ "$(INCLUDE_UNRELEASED)" = "true" ]; then \
+	@if [ -d "$(UNRELEASED_DIR)/kong-portal-ee" ]; then \
+		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-portal-ee,unreleased/kong-portal-ee \
+				--changelog-paths $(VERSION)/kong-portal-ee,$(UNRELEASED_DIR)/kong-portal-ee \
 				--title Kong-Portal \
 				--github-issue-repo Kong/kong-portal-templates \
 				--github-api-repo Kong/kong-ee \
@@ -105,7 +84,7 @@ generate:
 		else \
 			changelog --debug=$(DEBUG) generate \
 				--repo-path . \
-				--changelog-paths $(FOLDER)/kong-portal-ee \
+				--changelog-paths $(UNRELEASED_DIR)/kong-portal-ee \
 				--title Kong-Portal \
 				--github-issue-repo Kong/kong-portal-templates \
 				--github-api-repo Kong/kong-ee \
@@ -113,4 +92,9 @@ generate:
 				>> $(VERSION).md; \
 		fi \
     fi
-	@echo "Successfully genreate changelog $(VERSION).md"
+
+	@mv $(VERSION).md $(UNRELEASED_DIR)/
+	@git mv $(UNRELEASED_DIR) $(VERSION)
+	@mkdir -p $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}
+	@touch $(UNRELEASED_DIR)/{kong,kong-ee,kong-manager-ee,kong-portal-ee}/.gitkeep
+	@echo "Done! Please check $(VERSION)/$(VERSION).md"

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,17 +19,16 @@ Ensure `GITHUB_TOKEN` is set in your environment.
 
 # Generate changelog
 
-The section takes EE repo and `3.6.0.0` for example, please change
-`VERSION` and `BASE_BRANCH` accordingly. Add `DEBUG=true` to show
-debug output.
+The section takes `Kong/kong` and `3.6.0` for demo, please change arguments
+`VERSION` and `BASE_BRANCH` accordingly. Add `DEBUG=true` to show debug output.
 
 ```bash
 ~ $ pwd
-/Users/zachary/workspace/kong-ee
+/Users/zachary/workspace/kong
 
 ~ $ cd changelog
 
-~ $ make VERSION=3.6.0.0 BASE_BRANCH=origin/next/3.6.x.x
+~ $ make VERSION=3.6.0 BASE_BRANCH=origin/release/3.6.x
 ```
 
 If a functional PR with changelog is merged after the changelog PR is created
@@ -47,7 +46,7 @@ Show the usage.
 
 ```bash
 ~ $ pwd
-/Users/zachary/workspace/kong-ee
+/Users/zachary/workspace/kong
 
 ~ $ changelog/verify-prs -h
 Version: 0.1
@@ -86,7 +85,7 @@ Run the script. Both `--base-commit` and `--head-commit` can be set to branch na
 
 ```bash
 ~ $ pwd
-/Users/zachary/workspace/kong-ee
+/Users/zachary/workspace/kong
 
 ~ $ changelog/verify-prs --org-repo kong/kong --base-commit 3.4.0 --head-commit 3.5.0
 Org Repo: kong/kong

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Setup
 
-Ensure binary `changelog` is available and executable.
+Ensure binary `changelog` is available and executable on your local system.
 
 ```bash
 ~ $ changelog
@@ -18,8 +18,8 @@ Prepare branch.
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
 
-~ $ git fetch --all
-~ $ git checkout -b geneerate-3.6.0.0-changelog origin/master
+~ $ git fetch
+~ $ git checkout -b geneerate-3.6.0.0-changelog origin/next/3.6.x.x
 ```
 
 Generate changelog. Add option `DEBUG=true` to enable debug.
@@ -37,8 +37,10 @@ please repeat the next two parts.
 Push changelog.
 
 ```bash
-~ $ make VERSION=3.6.0.0 BRANCH_BASE=origin/master push_changelog
+~ $ make VERSION=3.6.0.0 BRANCH_BASE=origin/next/3.6.x.x push_changelog
 ```
+
+Please go to GitHub creating changelog PR.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,7 @@
 # Setup
 
-Download binary `changelog 0.0.2` from [Kong/gateway-changelog](https://github.com/Kong/gateway-changelog),
+Download binary `changelog 0.0.2` from [Kong/gateway-changelog](https://github.com/Kong/gateway-changelog/releases),
+or [release-helper](https://github.com/outsinre/release-helper/blob/main/changelog),
 and add it to environment variable `PATH`.
 
 ```bash

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -32,7 +32,8 @@ Add `DEBUG=true` to show more detailed output.
 ```
 
 If a PR with changelog is merged after the changelog PR is created
-or merged, please repeat this section.
+or merged, please repeat this section. You might need to delete local
+PR branch first.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -31,7 +31,7 @@ please repeat the next two parts.
 /Users/zachary/workspace/kong-ee
 ~ $ cd changelog
 
-~ $ make VERSION=3.6.0.0 generate_changelog
+~ $ make VERSION=3.6.0.0 generate
 ```
 
 Push changelog.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 # Setup
 
-Download binary `changelog` from [Kong/gateway-changelog](https://github.com/Kong/gateway-changelog),
+Download binary `changelog 0.0.2` from [Kong/gateway-changelog](https://github.com/Kong/gateway-changelog),
 and add it to environment variable `PATH`.
 
 ```bash

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,35 +1,18 @@
 # Setup
 
-Add the `changelog` directory to your environment variable `PATH`.
+Ensure binary `changelog` is available and executable.
 
 ```bash
-~ $ pwd
-/Users/zachary/workspace/kong-ee
-
-~ $ cd changelog
-~ $ PATH="$(realpath .):$PATH"
-```
-
-Enure `golang` is available on your local system.
-
-```bash
-~ $ go env
-```
-
-Ensure binaries are executable.
-
-```bash
-~ $ chmod +x ./changelog
-
-~ $ chmod +x ./verify-prs
+~ $ changelog
+changelog version 0.0.2
 ```
 
 # Generate changelog
 
-Take EE repo and `3.6.0.0` for example, check the operations below. To enable debug,
-add option `DEBUG=true`.
+Take EE repo and `3.6.0.0` for example, check the operations below.
+Please change the version number and the base branch accordinly.
 
-Prepare changelog branch.
+Prepare branch.
 
 ```bash
 ~ $ pwd
@@ -39,23 +22,22 @@ Prepare changelog branch.
 ~ $ git checkout -b geneerate-3.6.0.0-changelog origin/master
 ```
 
-Generate changelog. Suppose a new PR is merged after the changelog PR is created,
-please repeat this part.
+Generate changelog. Add option `DEBUG=true` to enable debug.
+Suppose a new PR is merged after the changelog PR is created,
+please repeat the next two parts.
 
 ```bash
+~ $ pwd
+/Users/zachary/workspace/kong-ee
 ~ $ cd changelog
-~ $ make VERSION=3.6.0.0
+
+~ $ make VERSION=3.6.0.0 generate_changelog
 ```
 
-Commit changelog updates.
+Push changelog.
 
 ```bash
-~ $ git status
-~ $ ls 3.6.0.0/3.6.0.0.md
-
-~ $ git add .
-~ $ git commit -m "docs(release): genereate 3.6.0.0 changelog"
-~ $ git push -u origin HEAD
+~ $ make VERSION=3.6.0.0 BRANCH_BASE=origin/master push_changelog
 ```
 
 # Verify PRs
@@ -72,16 +54,19 @@ Ensure `GITHUB_TOKEN` is set in your environment.
 ~ $ echo $GITHUB_TOKEN
 ```
 
-Run the script. Both `--base-commit` and `--head-commit` can be set to branch names.
+Show the usage.
 
 ```bash
-~ $ verify-prs -h
+~ $ pwd
+/Users/zachary/workspace/kong-ee
+
+~ $ changelog/verify-prs -h
 Version: 0.1
  Author: Zachary Hu (zhucac AT outlook.com)
  Script: Compare between two revisions (e.g. tags and branches), and output
          commits, PRs, PRs without changelog and CE PRs without CE2EE (experimental).
 
-         A PR should have an associated YML file under 'unreleased', otherwise
+         A PR should have an associated YML file under 'changelog/unreleased', otherwise
          it is printed for verification.
 
          Regarding CE2EE, if a CE PR has any cross-referenced EE PRs, it is regarded synced
@@ -89,7 +74,7 @@ Version: 0.1
          in the title. If a CE PR is labelled with 'cherry-pick kong-ee', it is regarded synced
          to EE. If a CE PR is not synced to EE, it is printed for verification.
 
-  Usage: verify-prs -h
+  Usage: changelog/verify-prs -h
 
          -v, --verbose       Print debug info.
 
@@ -102,11 +87,19 @@ Version: 0.1
          --bulk N            Number of jobs ran concurrency. Default is '5'.
                              Adjust this value to your CPU cores.
 
-         verify-prs --org-repo kong/kong-ee --base-commit 3.4.2.0 --head-commit 3.4.2.1 [--strict-filter] [--bulk 5] [--safe-mode] [-v]
+Example:
+         changelog/verify-prs --org-repo kong/kong-ee --base-commit 3.4.2.0 --head-commit 3.4.2.1 [--strict-filter] [--bulk 5] [--safe-mode] [-v]
 
-         ORG_REPO=kong/kong-ee BASE_COMMIT=3.4.2.0 HEAD_COMMIT=3.4.2.1 verify-prs
+         ORG_REPO=kong/kong-ee BASE_COMMIT=3.4.2.0 HEAD_COMMIT=3.4.2.1 changelog/verify-prs
+```
 
-~ $ verify-prs --org-repo kong/kong --base-commit 3.4.0 --head-commit 3.5.0
+Run the script. Both `--base-commit` and `--head-commit` can be set to branch names.
+
+```bash
+~ $ pwd
+/Users/zachary/workspace/kong-ee
+
+~ $ changelog/verify-prs --org-repo kong/kong --base-commit 3.4.0 --head-commit 3.5.0
 Org Repo: kong/kong
 Base Commit: 3.4.0
 Head Commit: 3.5.0

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -18,9 +18,9 @@ Ensure `GITHUB_TOKEN` is set in your environment.
 
 # Generate changelog
 
-Take EE repo and `3.6.0.0` for example, check the operations below.
-Please change the version number and the base branch accordinly.
-Add `DEBUG=true` to show more detailed output.
+The section takes EE repo and `3.6.0.0` for example, please change
+`VERSION` and `BASE_BRANCH` accordingly. Add `DEBUG=true` to show
+debug output.
 
 ```bash
 ~ $ pwd
@@ -31,9 +31,8 @@ Add `DEBUG=true` to show more detailed output.
 ~ $ make VERSION=3.6.0.0 BASE_BRANCH=origin/next/3.6.x.x
 ```
 
-If a PR with changelog is merged after the changelog PR is created
-or merged, please repeat this section. You might need to delete local
-PR branch first.
+If a functional PR with changelog is merged after the changelog PR is created
+or merged, please repeat the commands.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,7 +6,7 @@ Add the `changelog` directory to your environment variable `PATH`.
 ~ $ pwd
 /Users/zachary/workspace/kong-ee/changelog
 
-~ $ PATH="$(realpath ./changelog):$PATH"
+~ $ PATH="$(realpath .):$PATH"
 ```
 
 Enure `golang` is available on your local system.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,143 @@
+# Setup
+
+Add the `changelog` directory to your environment variable `PATH`.
+
+```bash
+~ $ pwd
+/Users/zachary/workspace/kong-ee
+
+~ $ PATH="$(realpath ./changelog):$PATH"
+```
+
+Enure `golang` is available on your local system.
+
+```bash
+~ $ go env
+```
+
+Ensure binaries are executable.
+
+```bash
+~ $ chmod +x ./changelog/changelog
+
+~ $ chmod +x ./changelog/verify-prs
+```
+
+# Generate changelog
+
+Take EE repo for example, check operations below. To enable debug, please add `DEBUG=true`.
+
+```bash
+~ $ pwd
+/Users/zachary/workspace/kong-ee
+
+~ $ make -f changelog/Makefile CHANGELOG_VERSION=3.6.0.0 generate
+
+~ $ git mv changelog/unreleased changelog/3.6.0.0
+~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
+~ $ touch changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
+
+~ $ git add .
+~ $ git commit -m "docs(release): genereate 3.6.0.0 changelog"
+~ $ git push -u origin HEAD
+```
+
+Suppose a new PR is merged after the changelog PR is created, we can regenerate changelog as follows.
+
+```bash
+~ $ pwd
+/Users/zachary/workspace/kong-ee
+
+~ $ make -f changelog/Makefile CHANGELOG_VERSION=3.6.0.0 regenerate
+
+~ $ git mv changelog/unreleased/* changelog/3.6.0.0/
+~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
+~ $ touch changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
+
+~ $ git add .
+~ $ git commit --amend --no-edit
+~ $ git push -f origin head
+```
+
+# Verify PRs
+
+Given two arbitrary revisions, list commits, PRs, PRs without changelog and PRs without CE2EE.
+
+If a CE PR has neither the 'cherry-pick kong-ee' label nor has cross-referenced EE PRs with 'cherry'
+in the title, it is HIGHLY PROBABLY not synced to EE. This is only experimental as developers may not
+follow the CE2EE guideline. However, it is a quick shortcut for us to validate the majority of CE PRs.
+
+Ensure `GITHUB_TOKEN` is set in your environment.
+
+```bash
+~ $ echo $GITHUB_TOKEN
+```
+
+Run the script. Both `--base-commit` and `--head-commit` can be set to branch names.
+
+```bash
+~ $ verify-prs -h
+Version: 0.1
+ Author: Zachary Hu (zhucac AT outlook.com)
+ Script: Compare between two revisions (e.g. tags and branches), and output
+         commits, PRs, PRs without changelog and CE PRs without CE2EE (experimental).
+
+         A PR should have an associated YML file under 'changelog/unreleased', otherwise
+         it is printed for verification.
+
+         Regarding CE2EE, if a CE PR has any cross-referenced EE PRs, it is regarded synced
+         to EE. If strict mode is enabled, associated EE PRs must contain keyword 'cherry'
+         in the title. If a CE PR is labelled with 'cherry-pick kong-ee', it is regarded synced
+         to EE. If a CE PR is not synced to EE, it is printed for verification.
+
+  Usage: verify-prs -h
+
+         -v, --verbose       Print debug info.
+
+         --strict-filter     When checking if a CE PR is synced to EE,
+                             more strict filters are applied.
+
+         --safe-mode         When checking if a CE PR is synced to EE,
+                             check one by one. This overrides '--bulk'.
+
+         --bulk N            Number of jobs ran concurrency. Default is '5'.
+                             Adjust this value to your CPU cores.
+
+         verify-prs --org-repo kong/kong-ee --base-commit 3.4.2.0 --head-commit 3.4.2.1 [--strict-filter] [--bulk 5] [--safe-mode] [-v]
+
+         ORG_REPO=kong/kong-ee BASE_COMMIT=3.4.2.0 HEAD_COMMIT=3.4.2.1 verify-prs
+
+~ $ verify-prs --org-repo kong/kong --base-commit 3.4.0 --head-commit 3.5.0
+Org Repo: kong/kong
+Base Commit: 3.4.0
+Head Commit: 3.5.0
+
+comparing between '3.4.0' and '3.5.0'
+number of commits: 280
+number of pages: 6
+commits per page: 50
+
+PRs:
+https://github.com/Kong/kong/pull/7414
+...
+
+PRs without changelog:
+https://github.com/Kong/kong/pull/7413
+...
+
+PRs without 'cherry-pick kong-ee' label:
+https://github.com/Kong/kong/pull/11721
+...
+
+PRs without cross-referenced EE PRs:
+https://github.com/Kong/kong/pull/11304
+...
+
+Commits: /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO/commits.txt
+PRs: /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO/prs.txt
+PRs without changelog: /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO/prs_no_changelog.txt
+CE PRs without cherry-pick label: /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO/prs_no_cherrypick_label.txt
+CE PRs without referenced EE cherry-pick PRs: /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO/prs_no_cross_reference.txt
+
+Remeber to remove /var/folders/wc/fnkx5qmx61l_wx5shysmql5r0000gn/T/outputXXX.JEkGD8AO
+```

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,7 @@ Add the `changelog` directory to your environment variable `PATH`.
 
 ```bash
 ~ $ pwd
-/Users/zachary/workspace/kong-ee
+/Users/zachary/workspace/kong-ee/changelog
 
 ~ $ PATH="$(realpath ./changelog):$PATH"
 ```
@@ -18,9 +18,9 @@ Enure `golang` is available on your local system.
 Ensure binaries are executable.
 
 ```bash
-~ $ chmod +x ./changelog/changelog
+~ $ chmod +x ./changelog
 
-~ $ chmod +x ./changelog/verify-prs
+~ $ chmod +x ./verify-prs
 ```
 
 # Generate changelog
@@ -34,9 +34,11 @@ Take EE repo for example, check operations below. To enable debug, please add `D
 ~ $ cd changelog
 ~ $ make generate VERSION=3.6.0.0
 
-~ $ git mv changelog/unreleased changelog/3.6.0.0
-~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
-~ $ touch changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
+~ $ mv 3.6.0.0.md unreleased/3.6.0.0.md
+~ $ git add unreleased/3.6.0.0.md
+~ $ git mv unreleased 3.6.0.0
+~ $ mkdir -p unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
+~ $ touch unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
 
 ~ $ git add .
 ~ $ git commit -m "docs(release): genereate 3.6.0.0 changelog"
@@ -51,9 +53,9 @@ Suppose a new PR is merged after the changelog PR is created, we can regenerate 
 ~ $ cd changelog
 ~ $ make generate FOLDER=3.6.0.0 INCLUDE_UNRELEASED=true  VERSION=3.6.0.0
 
-~ $ git mv changelog/unreleased/* changelog/3.6.0.0/
-~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
-~ $ touch changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
+~ $ git mv unreleased/* 3.6.0.0/
+~ $ mkdir -p unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
+~ $ touch unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
 
 ~ $ git add .
 ~ $ git commit --amend --no-edit
@@ -83,7 +85,7 @@ Version: 0.1
  Script: Compare between two revisions (e.g. tags and branches), and output
          commits, PRs, PRs without changelog and CE PRs without CE2EE (experimental).
 
-         A PR should have an associated YML file under 'changelog/unreleased', otherwise
+         A PR should have an associated YML file under 'unreleased', otherwise
          it is printed for verification.
 
          Regarding CE2EE, if a CE PR has any cross-referenced EE PRs, it is regarded synced

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -37,7 +37,7 @@ please repeat the next two parts.
 Push changelog.
 
 ```bash
-~ $ make VERSION=3.6.0.0 BRANCH_BASE=origin/next/3.6.x.x push_changelog
+~ $ make VERSION=3.6.0.0 push_changelog
 ```
 
 Please go to GitHub creating changelog PR.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -31,7 +31,8 @@ Take EE repo for example, check operations below. To enable debug, please add `D
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
 
-~ $ make -f changelog/Makefile CHANGELOG_VERSION=3.6.0.0 generate
+~ $ cd changelog
+~ $ make generate VERSION=3.6.0.0
 
 ~ $ git mv changelog/unreleased changelog/3.6.0.0
 ~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
@@ -47,8 +48,8 @@ Suppose a new PR is merged after the changelog PR is created, we can regenerate 
 ```bash
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
-
-~ $ make -f changelog/Makefile CHANGELOG_VERSION=3.6.0.0 regenerate
+~ $ cd changelog
+~ $ make generate FOLDER=3.6.0.0 INCLUDE_UNRELEASED=true  VERSION=3.6.0.0
 
 ~ $ git mv changelog/unreleased/* changelog/3.6.0.0/
 ~ $ mkdir -p changelog/unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,8 +5,8 @@ Add the `changelog` directory to your environment variable `PATH`.
 ```bash
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
-~ $ cd changelog
 
+~ $ cd changelog
 ~ $ PATH="$(realpath .):$PATH"
 ```
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -10,6 +10,12 @@ and add it to environment variable `PATH`.
 changelog version 0.0.2
 ```
 
+Ensure `GITHUB_TOKEN` is set in your environment.
+
+```bash
+~ $ echo $GITHUB_TOKEN
+```
+
 # Generate changelog
 
 Take EE repo and `3.6.0.0` for example, check the operations below.
@@ -35,12 +41,6 @@ Given two arbitrary revisions, list commits, PRs, PRs without changelog and PRs 
 If a CE PR has neither the 'cherry-pick kong-ee' label nor has cross-referenced EE PRs with 'cherry'
 in the title, it is HIGHLY PROBABLY not synced to EE. This is only experimental as developers may not
 follow the CE2EE guideline. However, it is a quick shortcut for us to validate the majority of CE PRs.
-
-Ensure `GITHUB_TOKEN` is set in your environment.
-
-```bash
-~ $ echo $GITHUB_TOKEN
-```
 
 Show the usage.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -29,16 +29,27 @@ Ensure binaries are executable.
 Take EE repo and `3.6.0.0` for example, check the operations below. To enable debug,
 add option `DEBUG=true`.
 
+Prepare changelog branch.
+
 ```bash
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
 
 ~ $ git fetch --all
 ~ $ git checkout -b geneerate-3.6.0.0-changelog origin/master
+```
 
+Generate changelog. Suppose a new PR is merged after the changelog PR is created,
+please repeat this part.
+
+```bash
 ~ $ cd changelog
 ~ $ make VERSION=3.6.0.0
+```
 
+Commit changelog updates.
+
+```bash
 ~ $ git status
 ~ $ ls 3.6.0.0/3.6.0.0.md
 
@@ -46,9 +57,6 @@ add option `DEBUG=true`.
 ~ $ git commit -m "docs(release): genereate 3.6.0.0 changelog"
 ~ $ git push -u origin HEAD
 ```
-
-Suppose a new PR is merged after the changelog PR is created, please rerun
-`make VERSION=3.6.0.0` to update changelog.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -14,8 +14,7 @@ changelog version 0.0.2
 
 Take EE repo and `3.6.0.0` for example, check the operations below.
 Please change the version number and the base branch accordinly.
-
-Prepare branch.
+Add `DEBUG=true` to show more detailed output.
 
 ```bash
 ~ $ pwd
@@ -26,7 +25,8 @@ Prepare branch.
 ~ $ make VERSION=3.6.0.0 BASE_BRANCH=origin/next/3.6.x.x
 ```
 
-Please go to GitHub creating changelog PR.
+If a PR is merged after the changelog PR is created or merged,
+please repeat this section.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,8 +1,11 @@
 # Setup
 
-Ensure binary `changelog` is available and executable on your local system.
+Download binary `changelog` from [Kong/gateway-changelog](https://github.com/Kong/gateway-changelog),
+and add it to environment variable `PATH`.
 
 ```bash
+~ $ PATH="/path/to/changelog:$PATH"
+
 ~ $ changelog
 changelog version 0.0.2
 ```
@@ -18,26 +21,9 @@ Prepare branch.
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
 
-~ $ git fetch
-~ $ git checkout -b geneerate-3.6.0.0-changelog origin/next/3.6.x.x
-```
-
-Generate changelog. Add option `DEBUG=true` to enable debug.
-Suppose a new PR is merged after the changelog PR is created,
-please repeat the next two parts.
-
-```bash
-~ $ pwd
-/Users/zachary/workspace/kong-ee
 ~ $ cd changelog
 
-~ $ make VERSION=3.6.0.0 generate
-```
-
-Push changelog.
-
-```bash
-~ $ make VERSION=3.6.0.0 push_changelog
+~ $ make VERSION=3.6.0.0 BASE_BRANCH=origin/next/3.6.x.x
 ```
 
 Please go to GitHub creating changelog PR.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,8 @@ Add the `changelog` directory to your environment variable `PATH`.
 
 ```bash
 ~ $ pwd
-/Users/zachary/workspace/kong-ee/changelog
+/Users/zachary/workspace/kong-ee
+~ $ cd changelog
 
 ~ $ PATH="$(realpath .):$PATH"
 ```
@@ -25,42 +26,29 @@ Ensure binaries are executable.
 
 # Generate changelog
 
-Take EE repo for example, check operations below. To enable debug, please add `DEBUG=true`.
+Take EE repo and `3.6.0.0` for example, check the operations below. To enable debug,
+add option `DEBUG=true`.
 
 ```bash
 ~ $ pwd
 /Users/zachary/workspace/kong-ee
 
-~ $ cd changelog
-~ $ make generate VERSION=3.6.0.0
+~ $ git fetch --all
+~ $ git checkout -b geneerate-3.6.0.0-changelog origin/master
 
-~ $ mv 3.6.0.0.md unreleased/3.6.0.0.md
-~ $ git add unreleased/3.6.0.0.md
-~ $ git mv unreleased 3.6.0.0
-~ $ mkdir -p unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
-~ $ touch unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
+~ $ cd changelog
+~ $ make VERSION=3.6.0.0
+
+~ $ git status
+~ $ ls 3.6.0.0/3.6.0.0.md
 
 ~ $ git add .
 ~ $ git commit -m "docs(release): genereate 3.6.0.0 changelog"
 ~ $ git push -u origin HEAD
 ```
 
-Suppose a new PR is merged after the changelog PR is created, we can regenerate changelog as follows.
-
-```bash
-~ $ pwd
-/Users/zachary/workspace/kong-ee
-~ $ cd changelog
-~ $ make generate FOLDER=3.6.0.0 INCLUDE_UNRELEASED=true  VERSION=3.6.0.0
-
-~ $ git mv unreleased/* 3.6.0.0/
-~ $ mkdir -p unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}
-~ $ touch unreleased/{kong,kong-ee,kong-manager-ee,kong-portal}/.gitkeep
-
-~ $ git add .
-~ $ git commit --amend --no-edit
-~ $ git push -f origin head
-```
+Suppose a new PR is merged after the changelog PR is created, please rerun
+`make VERSION=3.6.0.0` to update changelog.
 
 # Verify PRs
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -25,8 +25,8 @@ Add `DEBUG=true` to show more detailed output.
 ~ $ make VERSION=3.6.0.0 BASE_BRANCH=origin/next/3.6.x.x
 ```
 
-If a PR is merged after the changelog PR is created or merged,
-please repeat this section.
+If a PR with changelog is merged after the changelog PR is created
+or merged, please repeat this section.
 
 # Verify PRs
 

--- a/changelog/verify-prs
+++ b/changelog/verify-prs
@@ -1,0 +1,464 @@
+#!/usr/bin/env bash
+
+function warn () {
+    >&2 printf '%s\n' "$@"
+}
+
+function die () {
+    local st
+    st="$?"
+    case $2 in
+        (*[^0-9]*|'') : ;;
+        (*) st=$2 ;;
+    esac
+
+    if [[ -n "$1" ]] ; then warn "$1" ; fi
+
+    warn "WARNING: $0 is terminated" "output dir $out_dir removed"
+    rm -rf "$out_dir"
+
+    exit "$st"
+}
+
+function show_help () {
+    local prg
+    prg=$(basename "$0")
+    cat <<-EOF
+Version: 0.1
+ Author: Zachary Hu (zhucac AT outlook.com)
+ Script: Compare between two revisions (e.g. tags and branches), and output
+         commits, PRs, PRs without changelog and CE PRs without CE2EE (experimental).
+
+         A PR should have an associated YML file under 'changelog/unreleased', otherwise
+         it is printed for verification.
+
+         Regarding CE2EE, if a CE PR has any cross-referenced EE PRs, it is regarded synced
+         to EE. If strict mode is enabled, associated EE PRs must contain keyword 'cherry'
+         in the title. If a CE PR is labelled with 'cherry-pick kong-ee', it is regarded synced
+         to EE. If a CE PR is not synced to EE, it is printed for verification.
+
+  Usage: ${prg} -h
+
+         -v, --verbose       Print debug info.
+
+         --strict-filter     When checking if a CE PR is synced to EE,
+                             more strict filters are applied.
+
+         --safe-mode         When checking if a CE PR is synced to EE,
+                             check one by one. This overrides '--bulk'.
+
+         --bulk N            Number of jobs ran concurrency. Default is '5'.
+                             Adjust this value to your CPU cores.
+
+         ${prg} --org-repo kong/kong-ee --base-commit 3.4.2.0 --head-commit 3.4.2.1 [--strict-filter] [--bulk 5] [--safe-mode] [-v]
+
+         ORG_REPO=kong/kong-ee BASE_COMMIT=3.4.2.0 HEAD_COMMIT=3.4.2.1 $prg
+EOF
+}
+
+function set_globals () {
+    ORG_REPO="${ORG_REPO:-kong/kong-ee}"
+    BASE_COMMIT="${BASE_COMMIT:-3.4.2.0}"
+    HEAD_COMMIT="${HEAD_COMMIT:-3.4.2.1}"
+
+    verbose=0
+    STRICT_FILTER=0
+    SAFE_MODE=0
+
+    BULK=5
+    USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+
+    out_dir=$(mktemp -dt outputXXX)
+    commits_file="${out_dir}/commits.txt" ; touch "$commits_file"
+    prs_file="${out_dir}/prs.txt" ; touch "$prs_file"
+    prs_no_changelog_file="${out_dir}/prs_no_changelog.txt" ; touch "$prs_no_changelog_file"
+    prs_no_cherrypick_label_file="${out_dir}/prs_no_cherrypick_label.txt" ; touch "$prs_no_cherrypick_label_file"
+    prs_no_cross_reference_file="${out_dir}/prs_no_cross_reference.txt" ; touch "$prs_no_cross_reference_file"
+
+    num_of_commits=0
+
+    per_page=100
+    num_of_pages=1
+}
+
+function parse_args () {
+    while : ; do
+        case "$1" in
+            (-h|--help)
+                show_help
+                exit
+                ;;
+            (-v|--verbose)
+                set -x
+                verbose=$(( verbose + 1 ))
+                ;;
+            (--org-repo)
+                if [[ -n "$2" ]] ; then
+                    ORG_REPO="$2"
+                else
+                    die 'ERROR: "--org-repo" requires a non-empty option argument.' 2
+                fi
+                shift
+                ;;
+            (--org-repo=*)
+                ORG_REPO="${1#--org-repo=}"
+                if [[ -z "$ORG_REPO" ]] ; then
+                    die 'ERROR: "--org-repo=" requires a non-empty option argument followed immediately.' 2
+                fi
+                ;;
+            (--base-commit)
+                if [[ -n "$2" ]] ; then
+                    BASE_COMMIT="$2"
+                else
+                    die 'ERROR: "--base-commit" requires a non-empty option argument.' 2
+                fi
+                shift
+                ;;
+            (--base-commit=*)
+                BASE_COMMIT="${1#--base-commit=}"
+                if [[ -z "$BASE_COMMIT" ]] ; then
+                    die 'ERROR: "--base-commit=" requires a non-empty option argument followed immediately.' 2
+                fi
+                ;;
+            (--head-commit)
+                if [[ -n "$2" ]] ; then
+                    HEAD_COMMIT="$2"
+                else
+                    die 'ERROR: "--head-commit" requires a non-empty option argument.' 2
+                fi
+                shift
+                ;;
+            (--head-commit=*)
+                HEAD_COMMIT="${1#--base-commit=}"
+                if [[ -z "$HEAD_COMMIT" ]] ; then
+                    die 'ERROR: "--head-commit=" requires a non-empty option argument followed immediately.' 2
+                fi
+                ;;
+            (--bulk)
+                if [[ -n "$2" ]] ; then
+                    BULK="$2"
+                else
+                    die 'ERROR: "--bulk" requires a non-empty option argument.' 2
+                fi
+                shift
+                ;;
+            (--bulk=*)
+                BULK="${1#--bulk=}"
+                if [[ -z "$BULK" ]] ; then
+                    die 'ERROR: "--bulk=" requires a non-empty option argument followed immediately.' 2
+                fi
+                ;;
+            (--strict-filter)
+                STRICT_FILTER=1
+                ;;
+            (--safe-mode)
+                SAFE_MODE=1
+                ;;
+            (--)
+                shift
+                break
+                ;;
+            (-?*)
+                warn "WARNING: unknown option (ignored): $1"
+                ;;
+            (*)
+                break
+                ;;
+        esac
+
+        shift
+    done
+}
+
+function prepare_args () {
+    parse_args "$@"
+
+    if [[ -z "${ORG_REPO:+x}" ]] ; then
+        warn "WARNING: ORG_REPO must be provided"
+    fi
+    if [[ -z "${BASE_COMMIT:+x}" ]] ; then
+        warn "WARNING: BASE_COMMIT must be provided"
+    fi
+    if [[ -z "${HEAD_COMMIT:+x}" ]] ; then
+        warn "WARNING: HEAD_COMMIT must be provided"
+    fi
+    if [[ -z "${GITHUB_TOKEN:+x}" ]] ; then
+        warn "WARNING: GITHUB_TOKEN must be provided"
+    fi
+    if (( BULK >= 8 )) ; then
+        warn "WARNING: job concurrency $BULK is too high. May reach the rate limit of GitHub API."
+    fi
+    if (( SAFE_MODE )) ; then
+        warn "WARNING: safe mode enabled. Jobs takes longer time. Take a cup of coffee!"
+    fi
+
+    printf '%s\n' \
+           "Org Repo: ${ORG_REPO}" \
+           "Base Commit: ${BASE_COMMIT}" \
+           "Head Commit: ${HEAD_COMMIT}"
+}
+
+function get_num_pages_commits () {
+    local first_paged_response
+    first_paged_response=$( curl -i -sSL \
+                           -H "User-Agent: ${USER_AGENT}" \
+                           -H "Accept: application/vnd.github+json" \
+                           -H "X-GitHub-Api-Version: 2022-11-28" \
+                           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                           "https://api.github.com/repos/${ORG_REPO}/compare/${BASE_COMMIT}...${HEAD_COMMIT}?page=1&per_page=${per_page}" )
+
+    local status_line
+    status_line=$( sed -n 1p <<< "$first_paged_response" )
+    if ! [[ "$status_line" =~ 200 ]] ; then
+        die 'ERROR: cannot request GitHub API. Please check arguments or try option "-v"' 2
+    fi
+
+    local link_header
+    link_header=$( awk '/^link:/ { print; exit }' <<< "$first_paged_response" )
+    IFS="," read -ra links <<< "$link_header"
+
+    local regex='[^_](page=([0-9]+)).*rel="last"'
+    for link in "${links[@]}" ; do
+        if [[ "$link" =~ $regex ]] ; then
+            num_of_pages="${BASH_REMATCH[2]}"
+            break
+        fi
+    done
+
+    num_of_commits=$( awk 'BEGIN { FS="[[:space:]]+|," } /total_commits/ { print $3; exit }' <<< "$first_paged_response" )
+    printf 'number of commits: %s\n' "$num_of_commits"
+
+}
+
+function get_commits_prs () {
+    get_num_pages_commits
+    printf 'number of pages: %s\n' "$num_of_pages"
+    printf 'commits per page: %s\n' "$per_page"
+
+    printf '%s\n' "" "PRs:"
+    for i in $( seq 1 "${num_of_pages}" ) ; do
+        mapfile -t < <( curl -sSL \
+                             -H "User-Agent: ${USER_AGENT}" \
+                             -H "Accept: application/vnd.github+json" \
+                             -H "X-GitHub-Api-Version: 2022-11-28" \
+                             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                             "https://api.github.com/repos/${ORG_REPO}/compare/${BASE_COMMIT}...${HEAD_COMMIT}?page=${i}&per_page=${per_page}" | \
+                            jq -r '.commits[].sha' )
+
+        local max_per_request=17
+        local BASE_Q="repo:${ORG_REPO}%20type:pr%20is:merged"
+        local full_q="$BASE_Q"
+        local count=0
+        for commit in "${MAPFILE[@]}" ; do
+            printf '%s\n' "${commit:0:9}" >> "$commits_file"
+
+            full_q="${full_q}%20${commit:0:9}"
+            count=$(( count+1 ))
+
+            if ! (( count % max_per_request )) || test "$count" -eq "$per_page" || test "$count" -eq "$num_of_commits" ; then
+                curl -sSL \
+                     -H "User-Agent: ${USER_AGENT}" \
+                     -H "Accept: application/vnd.github+json" \
+                     -H "X-GitHub-Api-Version: 2022-11-28" \
+                     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                     "https://api.github.com/search/issues?q=$full_q" | jq -r '.items[].html_url' | tee -a "$prs_file"
+
+                full_q="$BASE_Q"
+            fi
+        done
+    done
+
+    sort -uo "$prs_file" "$prs_file"
+}
+
+function check_pr_changelog () {
+    if [[ -z "${1:+x}" ]] ; then return ; fi
+
+    local changelog_pattern="changelog/unreleased/kong*/*.yml"
+    local req_url="https://api.github.com/repos/${ORG_REPO}/pulls/PR_NUMBER/files"
+    local pr_number="${1##https*/}"
+    req_url="${req_url/PR_NUMBER/$pr_number}"
+    mapfile -t < <( curl -sSL \
+                         -H "User-Agent: ${USER_AGENT}" \
+                         -H "Accept: application/vnd.github+json" \
+                         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                         -H "X-GitHub-Api-Version: 2022-11-28" \
+                         "$req_url" | jq -r '.[].filename' )
+
+    local has_changelog=0
+    for f in "${MAPFILE[@]}" ; do
+        if [[ "$f" == ${changelog_pattern} ]] ; then has_changelog=1; break; fi
+    done
+    if ! (( has_changelog )) ; then echo "$1" | tee -a "$prs_no_changelog_file" ; fi
+}
+
+function check_changelog () {
+    echo -e "\nPRs without changelog:"
+    export ORG_REPO="$ORG_REPO" USER_AGENT="$USER_AGENT" prs_no_changelog_file="$prs_no_changelog_file"
+    export -f check_pr_changelog
+    if type parallel >/dev/null 2>&1 ; then
+        parallel -j "$BULK" check_pr_changelog <"$1"
+    else
+        warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
+        <"$1" xargs -P "$BULK" -n1 bash -c 'check_pr_changelog "$@"' _
+    fi
+    sort -uo "$prs_no_changelog_file" "$prs_no_changelog_file"
+}
+
+function check_cherrypick_label () {
+    if [[ -z "${1:+x}" ]] ; then return ; fi
+
+    local label_pattern="cherry-pick kong-ee"
+    local req_url="https://api.github.com/repos/${ORG_REPO}/issues/PR_NUMBER/labels"
+    local pr_number="${1##https://*/}"
+    req_url="${req_url/PR_NUMBER/$pr_number}"
+    mapfile -t < <( curl -sSL \
+                         -H "User-Agent: ${USER_AGENT}" \
+                         -H "Accept: application/vnd.github+json" \
+                         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                         -H "X-GitHub-Api-Version: 2022-11-28" \
+                         "$req_url" | jq -r '.[].name' )
+
+    local has_label=0
+    for l in "${MAPFILE[@]}" ; do
+        if [[ "$l" == ${label_pattern} ]] ; then has_label=1; break; fi
+    done
+    if ! (( has_label )) ; then echo "$1" | tee -a "$prs_no_cherrypick_label_file" ; fi
+}
+
+function check_cross_reference () {
+    if [[ -z "${1:+x}" ]] ; then return ; fi
+
+    local req_url="https://api.github.com/repos/${ORG_REPO}/issues/PR_NUMBER/timeline"
+    local pr_number="${1##https://*/}"
+    req_url="${req_url/PR_NUMBER/$pr_number}"
+
+    local first_paged_response
+    first_paged_response=$( curl -i -sSL \
+                                 -H "User-Agent: ${USER_AGENT}" \
+                                 -H "Accept: application/vnd.github+json" \
+                                 -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                                 "${req_url}?page=1&per_page=${per_page}" )
+
+    local link_header
+    link_header=$( awk '/^link:/ { print; exit }' <<< "$first_paged_response" )
+    IFS="," read -ra links <<< "$link_header"
+
+    local count=1
+    local regex='[^_](page=([0-9]+)).*rel="last"'
+    for link in "${links[@]}" ; do
+        if [[ "$link" =~ $regex ]] ; then
+            count="${BASH_REMATCH[2]}"
+            break
+        fi
+    done
+
+    local jq_filter
+    if (( STRICT_FILTER )) ; then
+        jq_filter='.[].source.issue | select( (.pull_request != null) and
+                                              (.pull_request.html_url | ascii_downcase | contains("kong/kong-ee")) and
+                                              (.pull_request.merged_at != null) and
+                                              (.title | ascii_downcase | contains("cherry")) )
+                                    | [.pull_request.html_url, .title]
+                                    | @tsv'
+    else
+        jq_filter='.[].source.issue | select( (.pull_request != null) and
+                                              (.pull_request.html_url | ascii_downcase | contains("kong/kong-ee")) and
+                                              (.pull_request.merged_at != null) )
+                                    | [.pull_request.html_url, .title]
+                                    | @tsv'
+    fi
+
+    local has_ref=0
+    local json_response
+    for i in $( seq 1 "${count}" ) ; do
+        json_response=$( curl -sSL \
+                              -H "User-Agent: ${USER_AGENT}" \
+                              -H "Accept: application/vnd.github+json" \
+                              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                              -H "X-GitHub-Api-Version: 2022-11-28" \
+                              "${req_url}?page=${i}&per_page=${per_page}" )
+
+        if jq -er "$jq_filter" <<< "$json_response" >/dev/null
+        then
+            has_ref=1
+            break
+        fi
+    done
+
+    if ! (( has_ref )) ; then echo "$1" | tee -a "$prs_no_cross_reference_file" ; fi
+}
+
+function check_ce2ee () {
+    if [[ "$ORG_REPO" != "kong/kong" && "$ORG_REPO" != "Kong/kong" ]] ; then
+        warn "WARNING: only check CE2EE for CE repo. Skip $ORG_REPO"
+        return
+    fi
+
+    echo -e "\nPRs without 'cherry-pick kong-ee' label:"
+    export ORG_REPO="$ORG_REPO" USER_AGENT="$USER_AGENT" prs_no_cherrypick_label_file="$prs_no_cherrypick_label_file"
+    export -f check_cherrypick_label
+    if type parallel >/dev/null 2>&1 ; then
+        parallel -j "$BULK" check_cherrypick_label <"$1"
+    else
+        warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
+        <"$1" xargs -P "$BULK" -n1 bash -c 'check_cherrypick_label "$@"' _
+    fi
+    sort -uo "$prs_no_cherrypick_label_file" "$prs_no_cherrypick_label_file"
+
+    echo -e "\nPRs without cross-referenced EE PRs:"
+    if (( SAFE_MODE )) ; then
+        local in_fd
+        if [[ -f "$1" ]] ; then
+            : {in_fd}<"$1"
+        else
+            : {in_fd}<&0
+            warn "WARNING: $1 not a valid file. Read from stdin -"
+        fi
+
+        while read -r -u "$in_fd" ; do
+            check_cross_reference "$REPLY"
+        done
+
+        : ${in_fd}<&-
+    else
+        export ORG_REPO="$ORG_REPO" USER_AGENT="$USER_AGENT" STRICT_FILTER="$STRICT_FILTER" prs_no_cross_reference_file="$prs_no_cross_reference_file"
+        export -f check_cross_reference
+        if type parallel >/dev/null 2>&1 ; then
+            parallel -j "$BULK" check_cross_reference <"$1"
+        else
+            warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
+            <"$1" xargs -P "$BULK" -n1 bash -c 'check_cross_reference "$@"' _
+        fi
+    fi
+    sort -uo "$prs_no_cross_reference_file" "$prs_no_cross_reference_file"
+}
+
+function main () {
+    set -Eeo pipefail
+    trap die ERR SIGABRT SIGQUIT SIGHUP SIGINT
+
+    set_globals
+    prepare_args "$@"
+
+    printf '%s\n' "" "comparing between '${BASE_COMMIT}' and '${HEAD_COMMIT}'"
+
+    get_commits_prs
+
+    check_changelog "$prs_file"
+
+    check_ce2ee "$prs_file"
+
+    printf '%s\n' "" \
+           "Commits: $commits_file" \
+           "PRs: $prs_file" \
+           "PRs without changelog: $prs_no_changelog_file" \
+           "CE PRs without cherry-pick label: $prs_no_cherrypick_label_file" \
+           "CE PRs without referenced EE cherry-pick PRs: $prs_no_cross_reference_file" \
+           "" "Remeber to remove $out_dir"
+
+    trap '' EXIT
+}
+
+if (( "$#" )) ; then main "$@" ; else show_help ; fi

--- a/changelog/verify-prs
+++ b/changelog/verify-prs
@@ -22,7 +22,7 @@ function die () {
 
 function show_help () {
     local prg
-    prg=$(basename "$0")
+    prg="${BASH_SOURCE[0]}"
     cat <<-EOF
 Version: 0.1
  Author: Zachary Hu (zhucac AT outlook.com)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

docs(*): CE changelog automation and verification. Please read: https://github.com/Kong/kong/blob/FTI-5723/ce-changelog-automation/changelog/README.md

From now on, to generate changelog, just 1 command is enough.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
