### PR TITLE
perf(opentelemetry): increase queue max batch size

### DIFF
--- a/changelog/unreleased/kong/otel-increase-queue-max-batch-size.yml
+++ b/changelog/unreleased/kong/otel-increase-queue-max-batch-size.yml
@@ -1,0 +1,3 @@
+message: "**Opentelemetry**: increase queue max batch size to 200"
+type: performance
+scope: Plugin

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -45,7 +45,11 @@ return {
           },
         } },
         { resource_attributes = resource_attributes },
-        { queue = typedefs.queue },
+        { queue = typedefs.queue {
+          default = {
+            max_batch_size = 200,
+          },
+        } },
         { batch_span_count = { description = "The number of spans to be sent in a single batch.", type = "integer" } },
         { batch_flush_delay = { description = "The delay, in seconds, between two consecutive batches.", type = "integer" } },
         { connect_timeout = typedefs.timeout { default = 1000 } },


### PR DESCRIPTION
### Summary

The max batch size for Opentelemetry was set to the default value: 1 the value actually refers to the number of spans in a batch, so we are increasing the default value to 200 which corresponds to what the default value used to be with the "old" queue implementation.

### Checklist

- [x] (no) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/KAG-3173
