### PR TITLE
fix(ai-proxy): do not double-gzip responses when status is not 200

### DIFF
--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -43,6 +43,8 @@ function _M:header_filter(conf)
 
         local new_response_string, err = ai_driver.from_format(response_body, conf.model, route_type)
         if err then
+          kong.ctx.plugin.ai_parser_error = true
+
           ngx.status = 500
           local message = {
             error = {
@@ -66,21 +68,24 @@ end
 
 function _M:body_filter(conf)
   if not kong.ctx.shared.skip_response_transformer then
-    -- all errors MUST be checked and returned in header_filter
-    -- we should receive a replacement response body from the same thread
-    
-    local original_request = kong.ctx.plugin.parsed_response or kong.response.get_raw_body()
-    local deflated_request = kong.ctx.plugin.parsed_response or kong.response.get_raw_body()
-    if deflated_request then
-      local is_gzip = kong.response.get_header("Content-Encoding") == "gzip"
-      if is_gzip then
-        deflated_request = kong_utils.deflate_gzip(deflated_request)
-      end
-      kong.response.set_raw_body(deflated_request)
-    end
+    if (kong.response.get_status() == 200) or (kong.ctx.plugin.ai_parser_error) then
+      -- all errors MUST be checked and returned in header_filter
+      -- we should receive a replacement response body from the same thread
 
-    -- call with replacement body, or original body if nothing changed
-    ai_shared.post_request(conf, original_request)
+      local original_request = kong.ctx.plugin.parsed_response
+      local deflated_request = kong.ctx.plugin.parsed_response
+      if deflated_request then
+        local is_gzip = kong.response.get_header("Content-Encoding") == "gzip"
+        if is_gzip then
+          deflated_request = kong_utils.deflate_gzip(deflated_request)
+        end
+
+        kong.response.set_raw_body(deflated_request)
+      end
+
+      -- call with replacement body, or original body if nothing changed
+      ai_shared.post_request(conf, original_request)
+    end
   end
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Logic error - with non-200 responses from the LLM, I was double-gzip'ing the response messages (if there was `content-encoding: gzip` header present).

This is a quick fix for it before 3.6.0 release, and this whole response phase can be refactored during the tech preview phase.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` N/A - part of new feature in 3.6.0, there is "no existing changelog" yet
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - N/A - part of new feature in 3.6.0, there are "no existing docs" yet

### Issue reference

Bug discovery during field testing.
