### PR TITLE
[backport -> release/2.8.x] perf(proxy): use more reasonable keepalive default value for Nginx tuning

### DIFF
--- a/CHANGELOG/unreleased/kong/11515.yaml
+++ b/CHANGELOG/unreleased/kong/11515.yaml
@@ -1,0 +1,7 @@
+message: Bumped the default value of `upstream_keepalive_pool_size` to `512` and `upstream_keepalive_max_requests` to `1000`
+type: performance
+scope: Configuration
+prs:
+  - 11515
+jiras:
+  - "FTI-4868"

--- a/CHANGELOG/unreleased/kong/optimize_keepalive_parameters.yml
+++ b/CHANGELOG/unreleased/kong/optimize_keepalive_parameters.yml
@@ -1,0 +1,3 @@
+message: Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to `10000`.
+type: performance
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -939,7 +939,7 @@
                                             # at worst any regex Kong executes could finish within
                                             # roughly 2 seconds.
 
-#nginx_http_keepalive_requests = 1000  # Sets the maximum number of client requests that can be served through one
+#nginx_http_keepalive_requests = 10000 # Sets the maximum number of client requests that can be served through one
                                        # keep-alive connection. After the maximum number of requests are made,
                                        # the connection is closed.
                                        # Closing connections periodically is necessary to free per-connection

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -784,26 +784,26 @@
                                   # `text/html`, `application/json`, and
                                   # `application/xml`.
 
-#upstream_keepalive_pool_size = 60  # Sets the default size of the upstream
-                                    # keepalive connection pools.
-                                    # Upstream keepalive connection pools
-                                    # are segmented by the `dst ip/dst
-                                    # port/SNI` attributes of a connection.
-                                    # A value of `0` will disable upstream
-                                    # keepalive connections by default, forcing
-                                    # each upstream request to open a new
-                                    # connection.
+#upstream_keepalive_pool_size = 512  # Sets the default size of the upstream
+                                     # keepalive connection pools.
+                                     # Upstream keepalive connection pools
+                                     # are segmented by the `dst ip/dst
+                                     # port/SNI` attributes of a connection.
+                                     # A value of `0` will disable upstream
+                                     # keepalive connections by default, forcing
+                                     # each upstream request to open a new
+                                     # connection.
 
-#upstream_keepalive_max_requests = 100  # Sets the default maximum number of
-                                        # requests than can be proxied upstream
-                                        # through one keepalive connection.
-                                        # After the maximum number of requests
-                                        # is reached, the connection will be
-                                        # closed.
-                                        # A value of `0` will disable this
-                                        # behavior, and a keepalive connection
-                                        # can be used to proxy an indefinite
-                                        # number of requests.
+#upstream_keepalive_max_requests = 1000  # Sets the default maximum number of
+                                         # requests than can be proxied upstream
+                                         # through one keepalive connection.
+                                         # After the maximum number of requests
+                                         # is reached, the connection will be
+                                         # closed.
+                                         # A value of `0` will disable this
+                                         # behavior, and a keepalive connection
+                                         # can be used to proxy an indefinite
+                                         # number of requests.
 
 #upstream_keepalive_idle_timeout = 60   # Sets the default timeout (in seconds)
                                         # for which an upstream keepalive
@@ -938,6 +938,16 @@
                                             # regex matching. The default of `100000` should ensure
                                             # at worst any regex Kong executes could finish within
                                             # roughly 2 seconds.
+
+#nginx_http_keepalive_requests = 1000  # Sets the maximum number of client requests that can be served through one
+                                       # keep-alive connection. After the maximum number of requests are made,
+                                       # the connection is closed.
+                                       # Closing connections periodically is necessary to free per-connection
+                                       # memory allocations. Therefore, using too high maximum number of requests
+                                       # could result in excessive memory usage and not recommended.
+                                       # See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests
+
+
 
 #------------------------------------------------------------------------------
 # DATASTORE

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -55,7 +55,7 @@ trusted_ips = NONE
 error_default_type = text/plain
 upstream_keepalive = NONE
 upstream_keepalive_pool_size = 512
-upstream_keepalive_max_requests = 1000
+upstream_keepalive_max_requests = 10000
 upstream_keepalive_idle_timeout = 60
 
 nginx_user = kong kong
@@ -76,7 +76,7 @@ nginx_http_ssl_dhparam = NONE
 nginx_http_ssl_session_tickets = NONE
 nginx_http_ssl_session_timeout = NONE
 nginx_http_lua_regex_match_limit = 100000
-nginx_http_keepalive_requests = 1000
+nginx_http_keepalive_requests = 10000
 nginx_stream_ssl_protocols = NONE
 nginx_stream_ssl_prefer_server_ciphers = NONE
 nginx_stream_ssl_dhparam = NONE

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -54,8 +54,8 @@ headers_upstream = x-kong-request-id
 trusted_ips = NONE
 error_default_type = text/plain
 upstream_keepalive = NONE
-upstream_keepalive_pool_size = 60
-upstream_keepalive_max_requests = 100
+upstream_keepalive_pool_size = 512
+upstream_keepalive_max_requests = 1000
 upstream_keepalive_idle_timeout = 60
 
 nginx_user = kong kong
@@ -75,6 +75,8 @@ nginx_http_ssl_prefer_server_ciphers = NONE
 nginx_http_ssl_dhparam = NONE
 nginx_http_ssl_session_tickets = NONE
 nginx_http_ssl_session_timeout = NONE
+nginx_http_lua_regex_match_limit = 100000
+nginx_http_keepalive_requests = 1000
 nginx_stream_ssl_protocols = NONE
 nginx_stream_ssl_prefer_server_ciphers = NONE
 nginx_stream_ssl_dhparam = NONE
@@ -90,7 +92,6 @@ nginx_upstream_keepalive_timeout = NONE
 nginx_http_upstream_keepalive = NONE
 nginx_http_upstream_keepalive_requests = NONE
 nginx_http_upstream_keepalive_timeout = NONE
-nginx_http_lua_regex_match_limit = 100000
 
 client_max_body_size = 0
 client_body_buffer_size = 8k

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -1002,7 +1002,7 @@ describe("NGINX conf compiler", function()
                            nil, true)
             assert.matches("daemon on;", contents, nil, true)
             assert.matches("listen 0.0.0.0:9000;", contents, nil, true)
-            assert.not_matches("keepalive", contents, nil, true)
+            assert.not_matches("keepalive%s+%d+", contents)
           end)
 
           it("'upstream_keepalive = 0' disables keepalive", function()


### PR DESCRIPTION
backport https://github.com/Kong/kong/pull/12223
also backport this PR: https://github.com/Kong/kong-ee/pull/6507


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Bumped default values of `nginx_http_keepalive_requests` and `upstream_keepalive_max_requests` to `10000`.
### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3360
