### PR TITLE
fix(dao): allow shorthand fields to be in response

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -1011,6 +1011,10 @@ function DAO:select(pk_or_entity, options)
   end
 
   local err
+  if options == nil or options.expand_shorthands == nil then
+    options = options or {}
+    options.expand_shorthands = true
+  end
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1064,6 +1068,10 @@ function DAO:page(size, offset, options)
   end
 
   local entities, err
+  if options == nil or options.expand_shorthands == nil then
+    options = options or {}
+    options.expand_shorthands = true
+  end
   entities, err, err_t = self:rows_to_entities(rows, options)
   if not entities then
     return nil, err, err_t
@@ -1148,6 +1156,8 @@ function DAO:insert(entity, options)
   end
 
   local ws_id = row.ws_id
+  options = options or {}
+  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1201,6 +1211,8 @@ function DAO:update(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
+  options = options or {}
+  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1254,6 +1266,8 @@ function DAO:upsert(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
+  options = options or {}
+  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1443,7 +1457,7 @@ function DAO:row_to_entity(row, options)
     end
   end
 
-  local entity, errors = self.schema:process_auto_fields(transformed_entity or row, "select", nulls)
+  local entity, errors = self.schema:process_auto_fields(transformed_entity or row, "select", nulls, options)
   if not entity then
     local err_t = self.errors:schema_violation(errors)
     return nil, tostring(err_t), err_t

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -89,6 +89,8 @@ end
 
 
 function Plugins:update(primary_key, entity, options)
+  options = options or {}
+  options.expand_shorthands = false
   local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
   if rbw_entity then
     entity = self.schema:merge_values(entity, rbw_entity)

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1680,6 +1680,10 @@ function Schema:process_auto_fields(data, context, nulls, opts)
           end
         end
       end
+
+      if is_select and sdata.include_in_output and opts.expand_shorthands then
+        data[sname] = sdata.translate_backwards(data)
+      end
     end
     if has_errs then
       return nil, errs
@@ -1908,7 +1912,20 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
     elseif not ((key == "ttl"   and self.ttl) or
                 (key == "ws_id" and show_ws)) then
-      data[key] = nil
+
+      local should_be_in_ouput = false
+
+      if self.shorthand_fields then
+        for _, shorthand_field in ipairs(self.shorthand_fields) do
+          if shorthand_field[key] and shorthand_field[key].include_in_output then
+            should_be_in_ouput = is_select
+          end
+        end
+      end
+
+      if not should_be_in_ouput then
+        data[key] = nil
+      end
     end
   end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1681,8 +1681,8 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.include_in_output and opts.expand_shorthands then
-        data[sname] = sdata.translate_backwards(data)
+      if is_select and sdata.translate_backwards and opts.expand_shorthands then
+        data[sname] = utils.table_path(data, sdata.translate_backwards)
       end
     end
     if has_errs then
@@ -1917,7 +1917,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
       if self.shorthand_fields then
         for _, shorthand_field in ipairs(self.shorthand_fields) do
-          if shorthand_field[key] and shorthand_field[key].include_in_output then
+          if shorthand_field[key] and shorthand_field[key].translate_backwards then
             should_be_in_ouput = is_select
           end
         end

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -683,6 +683,8 @@ local function make_shorthand_field_schema()
   shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
 
   insert(shorthand_field_schema, { func = { type = "function", required = true } })
+  insert(shorthand_field_schema, { translate_backwards = { type = "function", required = false } })
+  insert(shorthand_field_schema, { include_in_output = { type = "boolean", required = false, default = false } })
   return shorthand_field_schema
 end
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -683,8 +683,7 @@ local function make_shorthand_field_schema()
   shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
 
   insert(shorthand_field_schema, { func = { type = "function", required = true } })
-  insert(shorthand_field_schema, { translate_backwards = { type = "function", required = false } })
-  insert(shorthand_field_schema, { include_in_output = { type = "boolean", required = false, default = false } })
+  insert(shorthand_field_schema, { translate_backwards = { type = "array", elements = { type = "string" }, required = false } })
   return shorthand_field_schema
 end
 

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -42,10 +42,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { auth = {
     type = "string",
     len_min = 0,
-    include_in_output = true,
-    translate_backwards = function(instance)
-      return instance.password
-    end,
+    translate_backwards = {'password'},
     func = function(value)
       deprecation("acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
         { after = "4.0", })
@@ -54,10 +51,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { ssl_server_name = {
     type = "string",
-    include_in_output = true,
-    translate_backwards = function(instance)
-      return instance.server_name
-    end,
+    translate_backwards = {'server_name'},
     func = function(value)
       deprecation("acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
         { after = "4.0", })
@@ -67,10 +61,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { namespace = {
     type = "string",
     len_min = 0,
-    include_in_output = true,
-    translate_backwards = function(instance)
-      return instance.extra_options.namespace
-    end,
+    translate_backwards = {'extra_options', 'namespace'},
     func = function(value)
       deprecation("acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
         { after = "4.0", })
@@ -79,10 +70,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { scan_count = {
     type = "integer",
-    include_in_output = true,
-    translate_backwards = function(instance)
-      return instance.extra_options.scan_count
-    end,
+    translate_backwards = {'extra_options', 'scan_count'},
     func = function(value)
       deprecation("acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",
         { after = "4.0", })

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -42,6 +42,10 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { auth = {
     type = "string",
     len_min = 0,
+    include_in_output = true,
+    translate_backwards = function(instance)
+      return instance.password
+    end,
     func = function(value)
       deprecation("acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
         { after = "4.0", })
@@ -50,6 +54,10 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { ssl_server_name = {
     type = "string",
+    include_in_output = true,
+    translate_backwards = function(instance)
+      return instance.server_name
+    end,
     func = function(value)
       deprecation("acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
         { after = "4.0", })
@@ -59,6 +67,10 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { namespace = {
     type = "string",
     len_min = 0,
+    include_in_output = true,
+    translate_backwards = function(instance)
+      return instance.extra_options.namespace
+    end,
     func = function(value)
       deprecation("acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
         { after = "4.0", })
@@ -67,6 +79,10 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { scan_count = {
     type = "integer",
+    include_in_output = true,
+    translate_backwards = function(instance)
+      return instance.extra_options.scan_count
+    end,
     func = function(value)
       deprecation("acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",
         { after = "4.0", })

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -103,10 +103,7 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.host
-            end,
+            translate_backwards = {'redis', 'host'},
             func = function(value)
               deprecation("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
                 { after = "4.0", })
@@ -115,10 +112,7 @@ return {
           } },
           { redis_port = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.port
-            end,
+            translate_backwards = {'redis', 'port'},
             func = function(value)
               deprecation("rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
                 { after = "4.0", })
@@ -128,10 +122,7 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.password
-            end,
+            translate_backwards = {'redis', 'password'},
             func = function(value)
               deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })
@@ -140,10 +131,7 @@ return {
           } },
           { redis_username = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.username
-            end,
+            translate_backwards = {'redis', 'username'},
             func = function(value)
               deprecation("rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
                 { after = "4.0", })
@@ -152,10 +140,7 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.ssl
-            end,
+            translate_backwards = {'redis', 'ssl'},
             func = function(value)
               deprecation("rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
                 { after = "4.0", })
@@ -164,10 +149,7 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.ssl_verify
-            end,
+            translate_backwards = {'redis', 'ssl_verify'},
             func = function(value)
               deprecation("rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
                 { after = "4.0", })
@@ -176,10 +158,7 @@ return {
           } },
           { redis_server_name = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.server_name
-            end,
+            translate_backwards = {'redis', 'server_name'},
             func = function(value)
               deprecation("rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
                 { after = "4.0", })
@@ -188,10 +167,7 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.timeout
-            end,
+            translate_backwards = {'redis', 'timeout'},
             func = function(value)
               deprecation("rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
                 { after = "4.0", })
@@ -200,10 +176,7 @@ return {
           } },
           { redis_database = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.database
-            end,
+            translate_backwards = {'redis', 'database'},
             func = function(value)
               deprecation("rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
                 { after = "4.0", })

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -103,6 +103,10 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.host
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
                 { after = "4.0", })
@@ -111,6 +115,10 @@ return {
           } },
           { redis_port = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.port
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
                 { after = "4.0", })
@@ -120,6 +128,10 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.password
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })
@@ -128,6 +140,10 @@ return {
           } },
           { redis_username = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.username
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
                 { after = "4.0", })
@@ -136,6 +152,10 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.ssl
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
                 { after = "4.0", })
@@ -144,6 +164,10 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.ssl_verify
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
                 { after = "4.0", })
@@ -152,6 +176,10 @@ return {
           } },
           { redis_server_name = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.server_name
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
                 { after = "4.0", })
@@ -160,6 +188,10 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.timeout
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
                 { after = "4.0", })
@@ -168,6 +200,10 @@ return {
           } },
           { redis_database = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.database
+            end,
             func = function(value)
               deprecation("rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
                 { after = "4.0", })

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -142,6 +142,10 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.host
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
                 { after = "4.0", })
@@ -150,6 +154,10 @@ return {
           } },
           { redis_port = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.port
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
                 { after = "4.0", })
@@ -159,6 +167,10 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.password
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })
@@ -167,6 +179,10 @@ return {
           } },
           { redis_username = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.username
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
                 { after = "4.0", })
@@ -175,6 +191,10 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.ssl
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
                 { after = "4.0", })
@@ -183,6 +203,10 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.ssl_verify
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
                 { after = "4.0", })
@@ -191,6 +215,10 @@ return {
           } },
           { redis_server_name = {
             type = "string",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.server_name
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
                 { after = "4.0", })
@@ -199,6 +227,10 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.timeout
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
                 { after = "4.0", })
@@ -207,6 +239,10 @@ return {
           } },
           { redis_database = {
             type = "integer",
+            include_in_output = true,
+            translate_backwards = function(instance)
+              return instance.redis.database
+            end,
             func = function(value)
               deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
                 { after = "4.0", })

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -142,10 +142,7 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.host
-            end,
+            translate_backwards = {'redis', 'host'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
                 { after = "4.0", })
@@ -154,10 +151,7 @@ return {
           } },
           { redis_port = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.port
-            end,
+            translate_backwards = {'redis', 'port'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
                 { after = "4.0", })
@@ -167,10 +161,7 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.password
-            end,
+            translate_backwards = {'redis', 'password'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
                 { after = "4.0", })
@@ -179,10 +170,7 @@ return {
           } },
           { redis_username = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.username
-            end,
+            translate_backwards = {'redis', 'username'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
                 { after = "4.0", })
@@ -191,10 +179,7 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.ssl
-            end,
+            translate_backwards = {'redis', 'ssl'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
                 { after = "4.0", })
@@ -203,10 +188,7 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.ssl_verify
-            end,
+            translate_backwards = {'redis', 'ssl_verify'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
                 { after = "4.0", })
@@ -215,10 +197,7 @@ return {
           } },
           { redis_server_name = {
             type = "string",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.server_name
-            end,
+            translate_backwards = {'redis', 'server_name'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
                 { after = "4.0", })
@@ -227,10 +206,7 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.timeout
-            end,
+            translate_backwards = {'redis', 'timeout'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
                 { after = "4.0", })
@@ -239,10 +215,7 @@ return {
           } },
           { redis_database = {
             type = "integer",
-            include_in_output = true,
-            translate_backwards = function(instance)
-              return instance.redis.database
-            end,
+            translate_backwards = {'redis', 'database'},
             func = function(value)
               deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
                 { after = "4.0", })

--- a/kong/tools/table.lua
+++ b/kong/tools/table.lua
@@ -307,5 +307,22 @@ function _M.add_error(errors, k, v)
   return errors
 end
 
+--- Retrieves a value from table using path.
+-- @param t The source table to retrieve the value from.
+-- @param path Path table containing keys
+-- @param v Value of the error
+-- @return Returns `value` if something was found and `nil` otherwise
+function _M.table_path(t, path)
+  local current_value = t
+  for _, path_element in ipairs(path) do
+    if current_value[path_element] == nil then
+      return nil
+    end
+
+    current_value = current_value[path_element]
+  end
+
+  return current_value
+end
 
 return _M

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -1648,4 +1648,40 @@ describe("Utils", function()
       assert.equal(meta, getmetatable(t3.b.a))
     end)
   end)
+
+  describe("table_path(t, path)", function()
+    local t = {
+      x = 1,
+      a = {
+        b = {
+          c = 200
+        },
+      },
+      z = 2
+    }
+
+    it("retrieves value from table based on path - single level", function()
+      local path = { "x" }
+
+      assert.equal(1, utils.table_path(t, path))
+    end)
+
+    it("retrieves value from table based on path - deep value", function()
+      local path = { "a", "b", "c" }
+
+      assert.equal(200, utils.table_path(t, path))
+    end)
+
+    it("returns nil if element is not found - leaf not found", function()
+      local path = { "a", "b", "x" }
+
+      assert.equal(nil, utils.table_path(t, path))
+    end)
+
+    it("returns nil if element is not found - root branch not found", function()
+      local path = { "o", "j", "k" }
+
+      assert.equal(nil, utils.table_path(t, path))
+    end)
+  end)
 end)

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -120,7 +120,10 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         enabled = true,
         config = {
           second = 1,
-          policy = "local",
+          policy = "redis",
+          redis = {
+            host = "localhost"
+          },
 
           -- [[ new fields
           error_code = 403,
@@ -134,6 +137,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         should not have: error_code, error_message, sync_rate
       --]]
       local expected = utils.cycle_aware_deep_copy(rate_limit)
+      expected.config.redis = nil
       expected.config.error_code = nil
       expected.config.error_message = nil
       expected.config.sync_rate = nil
@@ -146,6 +150,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         should not have: sync_rate
       --]]
       expected = utils.cycle_aware_deep_copy(rate_limit)
+      expected.config.redis = nil
       expected.config.sync_rate = nil
       do_assert(utils.uuid(), "3.2.0", expected)
 
@@ -156,6 +161,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         should not have: sync_rate
       --]]
       expected = utils.cycle_aware_deep_copy(rate_limit)
+      expected.config.redis = nil
       expected.config.sync_rate = nil
       do_assert(utils.uuid(), "3.3.0", expected)
 
@@ -169,7 +175,10 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         enabled = true,
         config = {
           second = 1,
-          policy = "local",
+          policy = "redis",
+          redis = {
+            host = "localhost"
+          },
 
           -- [[ new fields
           error_code = 403,
@@ -179,7 +188,9 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         },
       }
 
-      do_assert(utils.uuid(), "3.4.0", rate_limit)
+      local expected = utils.cycle_aware_deep_copy(rate_limit)
+      expected.config.redis = nil
+      do_assert(utils.uuid(), "3.4.0", expected)
 
       -- cleanup
       admin.plugins:remove({ id = rate_limit.id })

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -497,6 +497,17 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.same(plugin_config.redis_ssl_verify, json.config.redis.ssl_verify)
       assert.same(plugin_config.redis_server_name, json.config.redis.server_name)
 
+      -- verify that legacy fields are present for backwards compatibility
+      assert.same(plugin_config.redis_host, json.config.redis_host)
+      assert.same(plugin_config.redis_port, json.config.redis_port)
+      assert.same(plugin_config.redis_username, json.config.redis_username)
+      assert.same(plugin_config.redis_password, json.config.redis_password)
+      assert.same(plugin_config.redis_database, json.config.redis_database)
+      assert.same(plugin_config.redis_timeout, json.config.redis_timeout)
+      assert.same(plugin_config.redis_ssl, json.config.redis_ssl)
+      assert.same(plugin_config.redis_ssl_verify, json.config.redis_ssl_verify)
+      assert.same(plugin_config.redis_server_name, json.config.redis_server_name)
+
       delete_plugin(admin_client, json)
 
       assert.logfile().has.line("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)

--- a/spec/03-plugins/23-rate-limiting/06-shorthand_fields_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/06-shorthand_fields_spec.lua
@@ -1,0 +1,225 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+
+describe("Plugin: rate-limiting (shorthand fields)", function()
+  local bp, route, admin_client
+  local plugin_id = utils.uuid()
+
+  lazy_setup(function()
+    bp = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+      "plugins",
+    }, {
+      "rate-limiting"
+    })
+
+    route = assert(bp.routes:insert {
+      hosts = { "redis.test" },
+    })
+
+    assert(helpers.start_kong())
+    admin_client = helpers.admin_client()
+  end)
+
+  lazy_teardown(function()
+    if admin_client then
+      admin_client:close()
+    end
+
+    helpers.stop_kong()
+  end)
+
+  local function assert_redis_config_same(expected_config, received_config)
+  -- verify that legacy config got written into new structure
+    assert.same(expected_config.redis_host, received_config.redis.host)
+    assert.same(expected_config.redis_port, received_config.redis.port)
+    assert.same(expected_config.redis_username, received_config.redis.username)
+    assert.same(expected_config.redis_password, received_config.redis.password)
+    assert.same(expected_config.redis_database, received_config.redis.database)
+    assert.same(expected_config.redis_timeout, received_config.redis.timeout)
+    assert.same(expected_config.redis_ssl, received_config.redis.ssl)
+    assert.same(expected_config.redis_ssl_verify, received_config.redis.ssl_verify)
+    assert.same(expected_config.redis_server_name, received_config.redis.server_name)
+
+    -- verify that legacy fields are present for backwards compatibility
+    assert.same(expected_config.redis_host, received_config.redis_host)
+    assert.same(expected_config.redis_port, received_config.redis_port)
+    assert.same(expected_config.redis_username, received_config.redis_username)
+    assert.same(expected_config.redis_password, received_config.redis_password)
+    assert.same(expected_config.redis_database, received_config.redis_database)
+    assert.same(expected_config.redis_timeout, received_config.redis_timeout)
+    assert.same(expected_config.redis_ssl, received_config.redis_ssl)
+    assert.same(expected_config.redis_ssl_verify, received_config.redis_ssl_verify)
+    assert.same(expected_config.redis_server_name, received_config.redis_server_name)
+  end
+
+  describe("single plugin tests", function()
+    local plugin_config = {
+      minute = 100,
+      policy = "redis",
+      redis_host = "custom-host.example.test",
+      redis_port = 55000,
+      redis_username = "test1",
+      redis_password = "testX",
+      redis_database = 1,
+      redis_timeout = 1100,
+      redis_ssl = true,
+      redis_ssl_verify = true,
+      redis_server_name = "example.test",
+    }
+
+    after_each(function ()
+      local res = assert(admin_client:send({
+        method = "DELETE",
+        path = "/plugins/" .. plugin_id,
+      }))
+
+      assert.res_status(204, res)
+    end)
+
+    it("POST/PATCH/GET request returns legacy fields", function()
+      -- POST
+      local res = assert(admin_client:send {
+        method = "POST",
+        route = {
+          id = route.id
+        },
+        path = "/plugins",
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          id = plugin_id,
+          name = "rate-limiting",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(201, res))
+      assert_redis_config_same(plugin_config, json.config)
+
+      -- PATCH
+      local updated_host = 'testhost'
+      res = assert(admin_client:send {
+        method = "PATCH",
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "rate-limiting",
+          config = {
+            redis_host = updated_host
+          },
+        },
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      local patched_config = utils.cycle_aware_deep_copy(plugin_config)
+      patched_config.redis_host = updated_host
+      assert_redis_config_same(patched_config, json.config)
+
+      -- GET
+      res = assert(admin_client:send {
+        method = "GET",
+        path = "/plugins/" .. plugin_id
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(patched_config, json.config)
+    end)
+
+    it("successful PUT request returns legacy fields", function()
+      local res = assert(admin_client:send {
+        method = "PUT",
+        route = {
+          id = route.id
+        },
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "rate-limiting",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(plugin_config, json.config)
+    end)
+  end)
+
+  describe('mutliple instances', function()
+    local redis1_port = 55000
+    lazy_setup(function()
+      local routes_count = 100
+      for i=1,routes_count do
+        local route = assert(bp.routes:insert {
+          hosts = { "redis" .. tostring(i) .. ".test" },
+        })
+        assert(bp.plugins:insert {
+          name = "rate-limiting",
+          route = { id = route.id },
+          config = {
+            minute = 100 + i,
+            policy = "redis",
+            redis_host = "custom-host" .. tostring(i) .. ".example.test",
+            redis_port = redis1_port + i,
+            redis_username = "test1",
+            redis_password = "testX",
+            redis_database = 1,
+            redis_timeout = 1100,
+            redis_ssl = true,
+            redis_ssl_verify = true,
+            redis_server_name = "example" .. tostring(i) .. ".test",
+          },
+        })
+      end
+    end)
+
+    it('get collection', function ()
+      local res = assert(admin_client:send {
+        path = "/plugins"
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+
+    it('get paginated collection', function ()
+      local res = assert(admin_client:send {
+        path = "/plugins",
+        query = { size = 50 }
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+  end)
+end)

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -510,6 +510,17 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.same(plugin_config.redis_ssl_verify, json.config.redis.ssl_verify)
       assert.same(plugin_config.redis_server_name, json.config.redis.server_name)
 
+      -- verify that legacy fields are present for backwards compatibility
+      assert.same(plugin_config.redis_host, json.config.redis_host)
+      assert.same(plugin_config.redis_port, json.config.redis_port)
+      assert.same(plugin_config.redis_username, json.config.redis_username)
+      assert.same(plugin_config.redis_password, json.config.redis_password)
+      assert.same(plugin_config.redis_database, json.config.redis_database)
+      assert.same(plugin_config.redis_timeout, json.config.redis_timeout)
+      assert.same(plugin_config.redis_ssl, json.config.redis_ssl)
+      assert.same(plugin_config.redis_ssl_verify, json.config.redis_ssl_verify)
+      assert.same(plugin_config.redis_server_name, json.config.redis_server_name)
+
       delete_plugin(admin_client, json)
 
       assert.logfile().has.line("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead (deprecated after 4.0)", true)

--- a/spec/03-plugins/24-response-rate-limiting/06-shorthand_fields_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/06-shorthand_fields_spec.lua
@@ -1,0 +1,233 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+
+describe("Plugin: response-ratelimiting (shorthand fields)", function()
+  local bp, route, admin_client
+  local plugin_id = utils.uuid()
+
+  lazy_setup(function()
+    bp = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+      "plugins",
+    }, {
+      "response-ratelimiting"
+    })
+
+    route = assert(bp.routes:insert {
+      hosts = { "redis.test" },
+    })
+
+    assert(helpers.start_kong())
+    admin_client = helpers.admin_client()
+  end)
+
+  lazy_teardown(function()
+    if admin_client then
+      admin_client:close()
+    end
+
+    helpers.stop_kong()
+  end)
+
+  local function assert_redis_config_same(expected_config, received_config)
+  -- verify that legacy config got written into new structure
+    assert.same(expected_config.redis_host, received_config.redis.host)
+    assert.same(expected_config.redis_port, received_config.redis.port)
+    assert.same(expected_config.redis_username, received_config.redis.username)
+    assert.same(expected_config.redis_password, received_config.redis.password)
+    assert.same(expected_config.redis_database, received_config.redis.database)
+    assert.same(expected_config.redis_timeout, received_config.redis.timeout)
+    assert.same(expected_config.redis_ssl, received_config.redis.ssl)
+    assert.same(expected_config.redis_ssl_verify, received_config.redis.ssl_verify)
+    assert.same(expected_config.redis_server_name, received_config.redis.server_name)
+
+    -- verify that legacy fields are present for backwards compatibility
+    assert.same(expected_config.redis_host, received_config.redis_host)
+    assert.same(expected_config.redis_port, received_config.redis_port)
+    assert.same(expected_config.redis_username, received_config.redis_username)
+    assert.same(expected_config.redis_password, received_config.redis_password)
+    assert.same(expected_config.redis_database, received_config.redis_database)
+    assert.same(expected_config.redis_timeout, received_config.redis_timeout)
+    assert.same(expected_config.redis_ssl, received_config.redis_ssl)
+    assert.same(expected_config.redis_ssl_verify, received_config.redis_ssl_verify)
+    assert.same(expected_config.redis_server_name, received_config.redis_server_name)
+  end
+
+  describe("single plugin tests", function()
+    local plugin_config = {
+      limits = {
+        video = {
+          minute = 100,
+        }
+      },
+      policy = "redis",
+      redis_host = "custom-host.example.test",
+      redis_port = 55000,
+      redis_username = "test1",
+      redis_password = "testX",
+      redis_database = 1,
+      redis_timeout = 1100,
+      redis_ssl = true,
+      redis_ssl_verify = true,
+      redis_server_name = "example.test",
+    }
+
+    after_each(function ()
+      local res = assert(admin_client:send({
+        method = "DELETE",
+        path = "/plugins/" .. plugin_id,
+      }))
+
+      assert.res_status(204, res)
+    end)
+
+    it("POST/PATCH/GET request returns legacy fields", function()
+      -- POST
+      local res = assert(admin_client:send {
+        method = "POST",
+        route = {
+          id = route.id
+        },
+        path = "/plugins",
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          id = plugin_id,
+          name = "response-ratelimiting",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(201, res))
+      assert_redis_config_same(plugin_config, json.config)
+
+      -- PATCH
+      local updated_host = 'testhost'
+      res = assert(admin_client:send {
+        method = "PATCH",
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "response-ratelimiting",
+          config = {
+            redis_host = updated_host
+          },
+        },
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      local patched_config = utils.cycle_aware_deep_copy(plugin_config)
+      patched_config.redis_host = updated_host
+      assert_redis_config_same(patched_config, json.config)
+
+      -- GET
+      res = assert(admin_client:send {
+        method = "GET",
+        path = "/plugins/" .. plugin_id
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(patched_config, json.config)
+    end)
+
+    it("successful PUT request returns legacy fields", function()
+      local res = assert(admin_client:send {
+        method = "PUT",
+        route = {
+          id = route.id
+        },
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "response-ratelimiting",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(plugin_config, json.config)
+    end)
+  end)
+
+  describe('mutliple instances', function()
+    local redis1_port = 55000
+    lazy_setup(function()
+      local routes_count = 100
+      for i=1,routes_count do
+        local route = assert(bp.routes:insert {
+          hosts = { "redis" .. tostring(i) .. ".test" },
+        })
+        assert(bp.plugins:insert {
+          name = "response-ratelimiting",
+          route = { id = route.id },
+          config = {
+            limits = {
+              video = {
+                minute = 100 + i,
+              }
+            },
+            policy = "redis",
+            redis_host = "custom-host" .. tostring(i) .. ".example.test",
+            redis_port = redis1_port + i,
+            redis_username = "test1",
+            redis_password = "testX",
+            redis_database = 1,
+            redis_timeout = 1100,
+            redis_ssl = true,
+            redis_ssl_verify = true,
+            redis_server_name = "example" .. tostring(i) .. ".test",
+          },
+        })
+      end
+    end)
+
+    it('get collection', function ()
+      local res = assert(admin_client:send {
+        path = "/plugins"
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+
+    it('get paginated collection', function ()
+      local res = assert(admin_client:send {
+        path = "/plugins",
+        query = { size = 50 }
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+  end)
+end)

--- a/spec/03-plugins/29-acme/05-redis_storage_spec.lua
+++ b/spec/03-plugins/29-acme/05-redis_storage_spec.lua
@@ -380,6 +380,12 @@ describe("Plugin: acme (storage.redis)", function()
         assert.same(redis_config.scan_count, json.config.storage_config.redis.extra_options.scan_count)
         assert.same(redis_config.namespace, json.config.storage_config.redis.extra_options.namespace)
 
+        -- verify that legacy fields are present for backwards compatibility
+        assert.same(redis_config.auth, json.config.storage_config.redis.auth)
+        assert.same(redis_config.ssl_server_name, json.config.storage_config.redis.ssl_server_name)
+        assert.same(redis_config.scan_count, json.config.storage_config.redis.scan_count)
+        assert.same(redis_config.namespace, json.config.storage_config.redis.namespace)
+
         delete_plugin(client, json)
 
         assert.logfile().has.line("acme: config.storage_config.redis.namespace is deprecated, " ..

--- a/spec/03-plugins/29-acme/07-shorthand_fields_spec.lua
+++ b/spec/03-plugins/29-acme/07-shorthand_fields_spec.lua
@@ -1,0 +1,156 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+
+describe("Plugin: acme (shorthand fields)", function()
+  local bp, route, admin_client
+  local plugin_id = utils.uuid()
+
+  lazy_setup(function()
+    bp = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+      "plugins",
+    }, {
+      "acme"
+    })
+
+    route = assert(bp.routes:insert {
+      hosts = { "redis.test" },
+    })
+
+    assert(helpers.start_kong())
+    admin_client = helpers.admin_client()
+  end)
+
+  lazy_teardown(function()
+    if admin_client then
+      admin_client:close()
+    end
+
+    helpers.stop_kong()
+  end)
+
+  local function assert_redis_config_same(expected_config, received_config)
+    -- verify that legacy config got written into new structure
+    assert.same(expected_config.host, received_config.storage_config.redis.host)
+    assert.same(expected_config.port, received_config.storage_config.redis.port)
+    assert.same(expected_config.auth, received_config.storage_config.redis.password)
+    assert.same(expected_config.database, received_config.storage_config.redis.database)
+    assert.same(expected_config.timeout, received_config.storage_config.redis.timeout)
+    assert.same(expected_config.ssl, received_config.storage_config.redis.ssl)
+    assert.same(expected_config.ssl_verify, received_config.storage_config.redis.ssl_verify)
+    assert.same(expected_config.ssl_server_name, received_config.storage_config.redis.server_name)
+    assert.same(expected_config.scan_count, received_config.storage_config.redis.extra_options.scan_count)
+    assert.same(expected_config.namespace, received_config.storage_config.redis.extra_options.namespace)
+
+    -- verify that legacy fields are present for backwards compatibility
+    assert.same(expected_config.auth, received_config.storage_config.redis.auth)
+    assert.same(expected_config.ssl_server_name, received_config.storage_config.redis.ssl_server_name)
+    assert.same(expected_config.scan_count, received_config.storage_config.redis.scan_count)
+    assert.same(expected_config.namespace, received_config.storage_config.redis.namespace)
+  end
+
+  describe("single plugin tests", function()
+    local redis_config = {
+      host = helpers.redis_host,
+      port = helpers.redis_port,
+      auth = "test",
+      database = 1,
+      timeout = 3500,
+      ssl = true,
+      ssl_verify = true,
+      ssl_server_name = "example.test",
+      scan_count = 13,
+      namespace = "namespace2:",
+    }
+
+    local plugin_config = {
+      account_email = "test@test.com",
+      storage = "redis",
+      storage_config = {
+        redis = redis_config,
+      },
+    }
+
+    after_each(function ()
+      local res = assert(admin_client:send({
+        method = "DELETE",
+        path = "/plugins/" .. plugin_id,
+      }))
+
+      assert.res_status(204, res)
+    end)
+
+    it("POST/PATCH/GET request returns legacy fields", function()
+      -- POST
+      local res = assert(admin_client:send {
+        method = "POST",
+        route = {
+          id = route.id
+        },
+        path = "/plugins",
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          id = plugin_id,
+          name = "acme",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(201, res))
+      assert_redis_config_same(redis_config, json.config)
+
+      -- PATCH
+      local updated_host = 'testhost'
+      res = assert(admin_client:send {
+        method = "PATCH",
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "acme",
+          config = {
+            storage_config = {
+              redis = {
+                host = updated_host
+              }
+            }
+          },
+        },
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      local patched_config = utils.cycle_aware_deep_copy(redis_config)
+      patched_config.host = updated_host
+      assert_redis_config_same(patched_config, json.config)
+
+      -- GET
+      res = assert(admin_client:send {
+        method = "GET",
+        path = "/plugins/" .. plugin_id
+      })
+
+      json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(patched_config, json.config)
+    end)
+
+    it("successful PUT request returns legacy fields", function()
+      local res = assert(admin_client:send {
+        method = "PUT",
+        route = {
+          id = route.id
+        },
+        path = "/plugins/" .. plugin_id,
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "acme",
+          config = plugin_config,
+        },
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      assert_redis_config_same(redis_config, json.config)
+    end)
+  end)
+end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Shorthand fields are stripped out of response but we're using them when we want to rename some of the fields. This commit adds an option `expand_shortfields` as well as some some options to `shorthand_fields` schema that would allow us to include them back in the schema while using the latest data

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] N/A ~~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)~~
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

KAG-3677