### PR TITLE
fix(dao): add missing shorthand fields expansions

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -503,6 +503,8 @@ local function check_update(self, key, entity, options, name)
     return nil, nil, tostring(err_t), err_t
   end
 
+  options = options or {}
+  options.expand_shorthands = false
   local rbw_entity
   local err, err_t
   if name then

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -502,17 +502,21 @@ local function check_update(self, key, entity, options, name)
     return nil, nil, tostring(err_t), err_t
   end
 
-  options.expand_shorthands = false
   local rbw_entity
   local err, err_t
   if name then
-     rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
+    options.hide_shorthands = true
+    rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
+    options.hide_shorthands = false
   else
-     rbw_entity, err, err_t = self:select(key, options)
+    options.hide_shorthands = true
+    rbw_entity, err, err_t = self:select(key, options)
+    options.hide_shorthands = false
   end
   if err then
     return nil, nil, err, err_t
   end
+
 
   if rbw_entity and check_immutable_fields then
     local ok, errors = self.schema:validate_immutable_fields(entity_to_update, rbw_entity)
@@ -711,9 +715,6 @@ local function generate_foreign_key_methods(schema)
         end
 
         local entities, err
-        if options.expand_shorthands ~= false then
-          options.expand_shorthands = true
-        end
         entities, err, err_t = self:rows_to_entities(rows, options)
         if err then
           return nil, err, err_t
@@ -773,9 +774,6 @@ local function generate_foreign_key_methods(schema)
         end
 
         local err
-        if options.expand_shorthands ~= false then
-          options.expand_shorthands = true
-        end
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -821,7 +819,6 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
-        options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -873,7 +870,6 @@ local function generate_foreign_key_methods(schema)
         end
 
         local ws_id = row.ws_id
-        options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -1021,9 +1017,6 @@ function DAO:select(pk_or_entity, options)
   end
 
   local err
-  if options.expand_shorthands ~= false then
-    options.expand_shorthands = true
-  end
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1077,9 +1070,6 @@ function DAO:page(size, offset, options)
   end
 
   local entities, err
-  if options.expand_shorthands ~= false then
-    options.expand_shorthands = true
-  end
   entities, err, err_t = self:rows_to_entities(rows, options)
   if not entities then
     return nil, err, err_t
@@ -1162,7 +1152,6 @@ function DAO:insert(entity, options)
   end
 
   local ws_id = row.ws_id
-  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1214,7 +1203,6 @@ function DAO:update(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
-  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1266,7 +1254,6 @@ function DAO:upsert(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
-  options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t
@@ -1389,9 +1376,6 @@ function DAO:select_by_cache_key(cache_key, options)
 
   local err
   local ws_id = row.ws_id
-  if options.expand_shorthands ~= false then
-    options.expand_shorthands = true
-  end
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -710,6 +710,10 @@ local function generate_foreign_key_methods(schema)
         end
 
         local entities, err
+        if options == nil or options.expand_shorthands == nil then
+          options = options or {}
+          options.expand_shorthands = true
+        end
         entities, err, err_t = self:rows_to_entities(rows, options)
         if err then
           return nil, err, err_t
@@ -768,6 +772,10 @@ local function generate_foreign_key_methods(schema)
         end
 
         local err
+        if options == nil or options.expand_shorthands == nil then
+          options = options or {}
+          options.expand_shorthands = true
+        end
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -812,6 +820,8 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
+        options = options or {}
+        options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -862,6 +872,8 @@ local function generate_foreign_key_methods(schema)
         end
 
         local ws_id = row.ws_id
+        options = options or {}
+        options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
           return nil, err, err_t
@@ -1389,6 +1401,10 @@ function DAO:select_by_cache_key(cache_key, options)
 
   local err
   local ws_id = row.ws_id
+  if options == nil or options.expand_shorthands == nil then
+    options = options or {}
+    options.expand_shorthands = true
+  end
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
     return nil, err, err_t

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -482,15 +482,14 @@ end
 
 
 local function check_update(self, key, entity, options, name)
-  local transform
-  if options ~= nil then
-    local ok, errors = validate_options_value(self, options)
-    if not ok then
-      local err_t = self.errors:invalid_options(errors)
-      return nil, nil, tostring(err_t), err_t
-    end
-    transform = options.transform
+  options = options or {}
+  local ok, errors = validate_options_value(self, options)
+  if not ok then
+    local err_t = self.errors:invalid_options(errors)
+    return nil, nil, tostring(err_t), err_t
   end
+  local transform = options.transform
+
 
   if transform == nil then
     transform = true
@@ -503,7 +502,6 @@ local function check_update(self, key, entity, options, name)
     return nil, nil, tostring(err_t), err_t
   end
 
-  options = options or {}
   options.expand_shorthands = false
   local rbw_entity
   local err, err_t
@@ -686,6 +684,7 @@ local function generate_foreign_key_methods(schema)
 
       local page_method_name = "page_for_" .. name
       methods[page_method_name] = function(self, foreign_key, size, offset, options)
+        options = options or {}
         local size, err, err_t = validate_pagination_method(self, field,
                                    foreign_key, size, offset, options)
         if not size then
@@ -712,8 +711,7 @@ local function generate_foreign_key_methods(schema)
         end
 
         local entities, err
-        if options == nil or options.expand_shorthands ~= false then
-          options = options or {}
+        if options.expand_shorthands ~= false then
           options.expand_shorthands = true
         end
         entities, err, err_t = self:rows_to_entities(rows, options)
@@ -751,6 +749,7 @@ local function generate_foreign_key_methods(schema)
 
     if field.unique or schema.endpoint_key == name then
       methods["select_by_" .. name] = function(self, unique_value, options)
+        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -774,8 +773,7 @@ local function generate_foreign_key_methods(schema)
         end
 
         local err
-        if options == nil or options.expand_shorthands ~= false then
-          options = options or {}
+        if options.expand_shorthands ~= false then
           options.expand_shorthands = true
         end
         row, err, err_t = self:row_to_entity(row, options)
@@ -795,6 +793,7 @@ local function generate_foreign_key_methods(schema)
       end
 
       methods["update_by_" .. name] = function(self, unique_value, entity, options)
+        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -822,7 +821,6 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
-        options = options or {}
         options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
@@ -843,6 +841,7 @@ local function generate_foreign_key_methods(schema)
       end
 
       methods["upsert_by_" .. name] = function(self, unique_value, entity, options)
+        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -874,7 +873,6 @@ local function generate_foreign_key_methods(schema)
         end
 
         local ws_id = row.ws_id
-        options = options or {}
         options.expand_shorthands = true
         row, err, err_t = self:row_to_entity(row, options)
         if not row then
@@ -988,11 +986,9 @@ end
 
 
 function DAO:select(pk_or_entity, options)
+  options = options or {}
   validate_primary_key_type(pk_or_entity)
-
-  if options ~= nil then
-    validate_options_type(options)
-  end
+  validate_options_type(options)
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1025,8 +1021,7 @@ function DAO:select(pk_or_entity, options)
   end
 
   local err
-  if options == nil or options.expand_shorthands ~= false then
-    options = options or {}
+  if options.expand_shorthands ~= false then
     options.expand_shorthands = true
   end
   row, err, err_t = self:row_to_entity(row, options)
@@ -1082,8 +1077,7 @@ function DAO:page(size, offset, options)
   end
 
   local entities, err
-  if options == nil or options.expand_shorthands ~= false then
-    options = options or {}
+  if options.expand_shorthands ~= false then
     options.expand_shorthands = true
   end
   entities, err, err_t = self:rows_to_entities(rows, options)
@@ -1148,11 +1142,9 @@ end
 
 
 function DAO:insert(entity, options)
+  options = options or {}
   validate_entity_type(entity)
-
-  if options ~= nil then
-    validate_options_type(options)
-  end
+  validate_options_type(options)
 
   local entity_to_insert, err, err_t = check_insert(self, entity, options)
   if not entity_to_insert then
@@ -1170,7 +1162,6 @@ function DAO:insert(entity, options)
   end
 
   local ws_id = row.ws_id
-  options = options or {}
   options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
@@ -1189,12 +1180,10 @@ end
 
 
 function DAO:update(pk_or_entity, entity, options)
+  options = options or {}
   validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
-
-  if options ~= nil then
-    validate_options_type(options)
-  end
+  validate_options_type(options)
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1225,7 +1214,6 @@ function DAO:update(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
-  options = options or {}
   options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
@@ -1244,12 +1232,10 @@ end
 
 
 function DAO:upsert(pk_or_entity, entity, options)
+  options = options or {}
   validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
-
-  if options ~= nil then
-    validate_options_type(options)
-  end
+  validate_options_type(options)
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1280,7 +1266,6 @@ function DAO:upsert(pk_or_entity, entity, options)
   end
 
   local ws_id = row.ws_id
-  options = options or {}
   options.expand_shorthands = true
   row, err, err_t = self:row_to_entity(row, options)
   if not row then
@@ -1371,6 +1356,7 @@ end
 
 
 function DAO:select_by_cache_key(cache_key, options)
+  options = options or {}
   local ck_definition = self.schema.cache_key
   if not ck_definition then
     error("entity does not have a cache_key defined", 2)
@@ -1403,8 +1389,7 @@ function DAO:select_by_cache_key(cache_key, options)
 
   local err
   local ws_id = row.ws_id
-  if options == nil or options.expand_shorthands ~= false then
-    options = options or {}
+  if options.expand_shorthands ~= false then
     options.expand_shorthands = true
   end
   row, err, err_t = self:row_to_entity(row, options)

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -517,7 +517,6 @@ local function check_update(self, key, entity, options, name)
     return nil, nil, err, err_t
   end
 
-
   if rbw_entity and check_immutable_fields then
     local ok, errors = self.schema:validate_immutable_fields(entity_to_update, rbw_entity)
     if not ok then
@@ -688,7 +687,6 @@ local function generate_foreign_key_methods(schema)
 
       local page_method_name = "page_for_" .. name
       methods[page_method_name] = function(self, foreign_key, size, offset, options)
-        options = options or {}
         local size, err, err_t = validate_pagination_method(self, field,
                                    foreign_key, size, offset, options)
         if not size then
@@ -750,7 +748,6 @@ local function generate_foreign_key_methods(schema)
 
     if field.unique or schema.endpoint_key == name then
       methods["select_by_" .. name] = function(self, unique_value, options)
-        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -791,7 +788,6 @@ local function generate_foreign_key_methods(schema)
       end
 
       methods["update_by_" .. name] = function(self, unique_value, entity, options)
-        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -838,7 +834,6 @@ local function generate_foreign_key_methods(schema)
       end
 
       methods["upsert_by_" .. name] = function(self, unique_value, entity, options)
-        options = options or {}
         local ok, err, err_t = validate_unique_row_method(self, name, field, unique_value, options)
         if not ok then
           return nil, err, err_t
@@ -982,9 +977,11 @@ end
 
 
 function DAO:select(pk_or_entity, options)
-  options = options or {}
   validate_primary_key_type(pk_or_entity)
-  validate_options_type(options)
+
+  if options ~= nil then
+    validate_options_type(options)
+  end
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1132,9 +1129,11 @@ end
 
 
 function DAO:insert(entity, options)
-  options = options or {}
   validate_entity_type(entity)
-  validate_options_type(options)
+
+  if options ~= nil then
+    validate_options_type(options)
+  end
 
   local entity_to_insert, err, err_t = check_insert(self, entity, options)
   if not entity_to_insert then
@@ -1169,10 +1168,12 @@ end
 
 
 function DAO:update(pk_or_entity, entity, options)
-  options = options or {}
   validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
-  validate_options_type(options)
+
+  if options ~= nil then
+    validate_options_type(options)
+  end
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1220,10 +1221,12 @@ end
 
 
 function DAO:upsert(pk_or_entity, entity, options)
-  options = options or {}
   validate_primary_key_type(pk_or_entity)
   validate_entity_type(entity)
-  validate_options_type(options)
+
+  if options ~= nil then
+    validate_options_type(options)
+  end
 
   local primary_key = self.schema:extract_pk_values(pk_or_entity)
   local ok, errors = self.schema:validate_primary_key(primary_key)
@@ -1343,7 +1346,6 @@ end
 
 
 function DAO:select_by_cache_key(cache_key, options)
-  options = options or {}
   local ck_definition = self.schema.cache_key
   if not ck_definition then
     error("entity does not have a cache_key defined", 2)

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -712,7 +712,7 @@ local function generate_foreign_key_methods(schema)
         end
 
         local entities, err
-        if options == nil or options.expand_shorthands == nil then
+        if options == nil or options.expand_shorthands ~= false then
           options = options or {}
           options.expand_shorthands = true
         end
@@ -774,7 +774,7 @@ local function generate_foreign_key_methods(schema)
         end
 
         local err
-        if options == nil or options.expand_shorthands == nil then
+        if options == nil or options.expand_shorthands ~= false then
           options = options or {}
           options.expand_shorthands = true
         end
@@ -1025,7 +1025,7 @@ function DAO:select(pk_or_entity, options)
   end
 
   local err
-  if options == nil or options.expand_shorthands == nil then
+  if options == nil or options.expand_shorthands ~= false then
     options = options or {}
     options.expand_shorthands = true
   end
@@ -1082,7 +1082,7 @@ function DAO:page(size, offset, options)
   end
 
   local entities, err
-  if options == nil or options.expand_shorthands == nil then
+  if options == nil or options.expand_shorthands ~= false then
     options = options or {}
     options.expand_shorthands = true
   end
@@ -1403,7 +1403,7 @@ function DAO:select_by_cache_key(cache_key, options)
 
   local err
   local ws_id = row.ws_id
-  if options == nil or options.expand_shorthands == nil then
+  if options == nil or options.expand_shorthands ~= false then
     options = options or {}
     options.expand_shorthands = true
   end

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -90,7 +90,7 @@ end
 
 function Plugins:update(primary_key, entity, options)
   options = options or {}
-  options.expand_shorthands = false
+  options.hide_shorthands = true
   local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
   if rbw_entity then
     entity = self.schema:merge_values(entity, rbw_entity)
@@ -100,6 +100,7 @@ function Plugins:update(primary_key, entity, options)
     return nil, err, err_t
   end
 
+  options.hide_shorthands = false
   return self.super.update(self, primary_key, entity, options)
 end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1681,7 +1681,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.translate_backwards and opts.expand_shorthands then
+      if is_select and sdata.translate_backwards and opts and opts.expand_shorthands then
         data[sname] = utils.table_path(data, sdata.translate_backwards)
       end
     end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1681,7 +1681,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.translate_backwards and opts and not(opts.hide_shorthands) then
+      if is_select and sdata.translate_backwards and not(opts and opts.hide_shorthands) then
         data[sname] = utils.table_path(data, sdata.translate_backwards)
       end
     end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1681,7 +1681,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.translate_backwards and opts and opts.expand_shorthands then
+      if is_select and sdata.translate_backwards and opts and not(opts.hide_shorthands) then
         data[sname] = utils.table_path(data, sdata.translate_backwards)
       end
     end

--- a/spec/02-integration/03-db/14-dao_spec.lua
+++ b/spec/02-integration/03-db/14-dao_spec.lua
@@ -1,11 +1,12 @@
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 local declarative = require "kong.db.declarative"
 
 -- Note: include "off" strategy here as well
 for _, strategy in helpers.all_strategies() do
   describe("db.dao #" .. strategy, function()
     local bp, db
-    local consumer, service, plugin, acl
+    local consumer, service, service2, plugin, plugin2, acl
     local group = "The A Team"
 
     lazy_setup(function()
@@ -26,13 +27,32 @@ for _, strategy in helpers.all_strategies() do
         name = "abc",
         url = "http://localhost",
       }
-  
+
+      service2 = bp.services:insert {
+        name = "def",
+        url = "http://2-localhost",
+      }
+
       plugin = bp.plugins:insert {
         enabled = true,
         name = "acl",
         service = service,
         config = {
           allow = { "*" },
+        },
+      }
+
+      plugin2 = bp.plugins:insert {
+        enabled = true,
+        name = "rate-limiting",
+        instance_name = 'rate-limiting-instance-1',
+        service = service,
+        config = {
+          minute = 100,
+          policy = "redis",
+          redis = {
+            host = "localhost"
+          }
         },
       }
       -- Note: bp in off strategy returns service=id instead of a table
@@ -81,7 +101,7 @@ for _, strategy in helpers.all_strategies() do
 
     it("select_by_cache_key()", function()
       local cache_key = kong.db.acls:cache_key(consumer.id, group)
-      
+
       local read_acl, err = kong.db.acls:select_by_cache_key(cache_key)
       assert.is_nil(err)
       assert.same(acl, read_acl)
@@ -91,6 +111,78 @@ for _, strategy in helpers.all_strategies() do
       local read_plugin, err = kong.db.plugins:select_by_cache_key(cache_key)
       assert.is_nil(err)
       assert.same(plugin, read_plugin)
+
+      cache_key = kong.db.plugins:cache_key("rate-limiting", nil, service.id, nil)
+      read_plugin, err = kong.db.plugins:select_by_cache_key(cache_key)
+      assert.is_nil(err)
+      assert.same(plugin2, read_plugin)
+    end)
+
+    it("page_for_route", function()
+      local plugins_for_service, err = kong.db.plugins:page_for_service(service)
+      assert.is_nil(err)
+      assert.equal(2, #plugins_for_service)
+      for _, read_plugin in ipairs(plugins_for_service) do
+        if read_plugin.name == 'acl' then
+          assert.same(plugin, read_plugin)
+        elseif read_plugin.name == 'rate-limiting' then
+          assert.same(plugin2, read_plugin)
+        end
+      end
+    end)
+
+    it("select_by_instance_name", function()
+      local read_plugin, err = kong.db.plugins:select_by_instance_name(plugin2.instance_name)
+      assert.is_nil(err)
+      assert.same(plugin2, read_plugin)
+    end)
+
+    it("update_by_instance_name", function()
+      local newhost = "newhost"
+      local updated_plugin = utils.cycle_aware_deep_copy(plugin2)
+      updated_plugin.config.redis.host = newhost
+      updated_plugin.config.redis_host = newhost
+
+      local read_plugin, err = kong.db.plugins:update_by_instance_name(plugin2.instance_name, updated_plugin)
+      assert.is_nil(err)
+      assert.same(updated_plugin, read_plugin)
+    end)
+
+    it("upsert_by_instance_name", function()
+      -- existing plugin upsert (update part of upsert)
+      local newhost = "newhost"
+      local updated_plugin = utils.cycle_aware_deep_copy(plugin2)
+      updated_plugin.config.redis.host = newhost
+      updated_plugin.config.redis_host = newhost
+
+      local read_plugin, err = kong.db.plugins:upsert_by_instance_name(plugin2.instance_name, updated_plugin)
+      assert.is_nil(err)
+      assert.same(updated_plugin, read_plugin)
+
+      -- new plugin upsert (insert part of upsert)
+      local new_plugin_config = {
+        id = utils.uuid(),
+        enabled = true,
+        name = "rate-limiting",
+        instance_name = 'rate-limiting-instance-2',
+        service = service2,
+        config = {
+          minute = 200,
+          policy = "redis",
+          redis = {
+            host = "new-host-2"
+          }
+        },
+      }
+
+      local read_plugin, err = kong.db.plugins:upsert_by_instance_name(new_plugin_config.instance_name, new_plugin_config)
+      assert.is_nil(err)
+      assert.same(new_plugin_config.id, read_plugin.id)
+      assert.same(new_plugin_config.instance_name, read_plugin.instance_name)
+      assert.same(new_plugin_config.service.id, read_plugin.service.id)
+      assert.same(new_plugin_config.config.minute, read_plugin.config.minute)
+      assert.same(new_plugin_config.config.redis.host, read_plugin.config.redis.host)
+      assert.same(new_plugin_config.config.redis.host, read_plugin.config.redis_host) -- legacy field is included
     end)
   end)
 end

--- a/spec/03-plugins/23-rate-limiting/06-shorthand_fields_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/06-shorthand_fields_spec.lua
@@ -153,6 +153,7 @@ describe("Plugin: rate-limiting (shorthand fields)", function()
       local routes_count = 100
       for i=1,routes_count do
         local route = assert(bp.routes:insert {
+          name = "route-" .. tostring(i),
           hosts = { "redis" .. tostring(i) .. ".test" },
         })
         assert(bp.plugins:insert {
@@ -201,6 +202,30 @@ describe("Plugin: rate-limiting (shorthand fields)", function()
     it('get paginated collection', function ()
       local res = assert(admin_client:send {
         path = "/plugins",
+        query = { size = 50 }
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+
+    it('get plugins by route', function ()
+      local res = assert(admin_client:send {
+        path = "/routes/route-1/plugins",
         query = { size = 50 }
       })
 

--- a/spec/03-plugins/24-response-rate-limiting/06-shorthand_fields_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/06-shorthand_fields_spec.lua
@@ -157,6 +157,7 @@ describe("Plugin: response-ratelimiting (shorthand fields)", function()
       local routes_count = 100
       for i=1,routes_count do
         local route = assert(bp.routes:insert {
+          name = "route-" .. tostring(i),
           hosts = { "redis" .. tostring(i) .. ".test" },
         })
         assert(bp.plugins:insert {
@@ -209,6 +210,31 @@ describe("Plugin: response-ratelimiting (shorthand fields)", function()
     it('get paginated collection', function ()
       local res = assert(admin_client:send {
         path = "/plugins",
+        query = { size = 50 }
+      })
+
+      local json = cjson.decode(assert.res_status(200, res))
+      for _,plugin in ipairs(json.data) do
+        local i = plugin.config.redis.port - redis1_port
+        local expected_config = {
+          redis_host = "custom-host" .. tostring(i) .. ".example.test",
+          redis_port =  redis1_port + i,
+          redis_username =  "test1",
+          redis_password =  "testX",
+          redis_database =  1,
+          redis_timeout =  1100,
+          redis_ssl =  true,
+          redis_ssl_verify =  true,
+          redis_server_name =  "example" .. tostring(i) .. ".test",
+        }
+        assert_redis_config_same(expected_config, plugin.config)
+      end
+    end)
+
+
+    it('get plugins by route', function ()
+      local res = assert(admin_client:send {
+        path = "/routes/route-1/plugins",
         query = { size = 50 }
       })
 


### PR DESCRIPTION



<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
This commits adds shorthand expansions for `select_by_` / `update_by_` etc. methods

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] N/A ~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md]~(https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-3686
