### PR TITLE
chore(conf): enable grpc_ssl_conf_command too

### DIFF
--- a/kong/conf_loader/parse.lua
+++ b/kong/conf_loader/parse.lua
@@ -438,6 +438,7 @@ local function check_and_parse(conf, opts)
           "nginx_http_ssl_conf_command",
           "nginx_http_proxy_ssl_conf_command",
           "nginx_http_lua_ssl_conf_command",
+          "nginx_http_grpc_ssl_conf_command",
           "nginx_stream_ssl_conf_command",
           "nginx_stream_proxy_ssl_conf_command",
           "nginx_stream_lua_ssl_conf_command"}) do

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -94,6 +94,7 @@ nginx_http_ssl_session_timeout = NONE
 nginx_http_ssl_conf_command = NONE
 nginx_http_proxy_ssl_conf_command = NONE
 nginx_http_lua_ssl_conf_command = NONE
+nginx_http_grpc_ssl_conf_command = NONE
 nginx_http_lua_regex_match_limit = 100000
 nginx_http_lua_regex_cache_max_entries = 8192
 nginx_http_keepalive_requests = 10000

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -28,6 +28,7 @@ underscores_in_headers on;
 lua_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 proxy_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
+grpc_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 > end
 > if ssl_ciphers then
 ssl_ciphers ${{SSL_CIPHERS}};


### PR DESCRIPTION
### Summary

The #12420 by @Water-Melon forgot to add `grpc_ssl_conf_command`. This commit adds that.

[KAG-3259](https://konghq.atlassian.net/browse/KAG-3259)

[KAG-3259]: https://konghq.atlassian.net/browse/KAG-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ