### PR TITLE
fix(ci): re enable off tests with the scheduler

### DIFF
--- a/.ci/test_suites.json
+++ b/.ci/test_suites.json
@@ -17,6 +17,9 @@
   {
     "name": "dbless",
     "exclude_tags": "flaky,ipv6,postgres,db",
+    "environment": {
+      "KONG_TEST_DATABASE": "off"
+    },
     "venv_script": "kong-dev-venv.sh",
     "specs": [
       "spec/02-integration/02-cmd/",


### PR DESCRIPTION
### Summary

 re enable off tests with the scheduler

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
