### PR TITLE
chore(gha): Rollup Default Timeout PRs

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -6,6 +6,7 @@ permissions:
   pull-requests: write
 jobs:
   assign-author:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: assign-author

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -13,6 +13,7 @@ on:
         description: "Target Branch in kong/docs.konghq.com (e.g. release/2.4)"
         required: true
       force_build:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
         description: "Ignore the build cache and build dependencies from scratch"
         type: boolean
         default: false
@@ -70,6 +71,7 @@ jobs:
           source .ci/setup_env_github.sh
           make dev
   autodoc:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-22.04
     needs: [build]
     steps:

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -13,7 +13,6 @@ on:
         description: "Target Branch in kong/docs.konghq.com (e.g. release/2.4)"
         required: true
       force_build:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
         description: "Ignore the build cache and build dependencies from scratch"
         type: boolean
         default: false

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check_comment:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request != null && contains(github.event.comment.body, 'cherry-pick the changes locally and resolve any conflicts')
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,7 @@ permissions:
   actions: write
 jobs:
   backport:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Backport
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Build dependencies
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,12 +37,14 @@ env:
 
 jobs:
   build:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     uses: ./.github/workflows/build.yml
     with:
       relative-build-root: bazel-bin/build
 
   lint-and-doc-tests:
     name: Lint and Doc tests
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-22.04
     needs: build
 
@@ -92,6 +94,7 @@ jobs:
 
   schedule:
     name: Schedule busted tests to run
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-22.04
     needs: build
 
@@ -136,6 +139,7 @@ jobs:
 
   busted-tests:
     name: Busted test runner ${{ matrix.runner }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-22.04
     needs: [build,schedule]
 
@@ -328,6 +332,7 @@ jobs:
         sudo dmesg -T
 
   pdk-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: PDK tests
     runs-on: ubuntu-22.04
     needs: build
@@ -389,6 +394,7 @@ jobs:
   cleanup-and-aggregate-stats:
     needs: [lint-and-doc-tests,pdk-tests,busted-tests]
     name: Cleanup and Luacov stats aggregator
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -20,6 +20,7 @@ on:
 jobs:
 
   autoformat:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Auto-format and Check
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   require-changelog:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}
     name: Requires changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   validate-changelog:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Validate changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -6,6 +6,7 @@ on:
     types: [created]
 jobs:
   cross-repo-cherrypick:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Cherry pick to remote repository
     runs-on: ubuntu-latest
     # Only run when pull request is merged, or labeled

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   close-issues:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, edited, synchronize, labeled, unlabeled]
 jobs:
   check-labels:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: prevent merge labels
     runs-on: ubuntu-latest
 

--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   check_author:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, edited, synchronize, labeled, unlabeled]
 jobs:
   schema-change-labels:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   create-pr:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the workflow

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build-packages:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Build dependencies
     runs-on: ubuntu-22.04
     if: |
@@ -79,6 +80,7 @@ jobs:
         make install-dev-rocks
 
   perf:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: RPS, latency and flamegraphs
     runs-on: ubuntu-22.04
     needs: build-packages

--- a/.github/workflows/release-and-tests-fail-bot.yml
+++ b/.github/workflows/release-and-tests-fail-bot.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   notify_failure:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'schedule' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ env:
 
 jobs:
   metadata:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Metadata
     runs-on: ubuntu-22.04
     outputs:
@@ -101,6 +102,7 @@ jobs:
         echo '```' >> $GITHUB_STEP_SUMMARY
 
   build-packages:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: metadata
     name: Build & Package - ${{ matrix.label }}
     environment: ${{ needs.metadata.outputs.deploy-environment }}
@@ -277,6 +279,7 @@ jobs:
         retention-days: 3
 
   verify-manifest-packages:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: [metadata, build-packages]
     name: Verify Manifest - Package ${{ matrix.label }}
     runs-on: ubuntu-22.04
@@ -309,6 +312,7 @@ jobs:
         python ./main.py -f filelist.txt -p $pkg -o test.txt -s ${{ matrix.check-manifest-suite }}
 
   build-images:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Build Images - ${{ matrix.label }}
     needs: [metadata, build-packages]
     runs-on: ubuntu-22.04
@@ -410,6 +414,7 @@ jobs:
           Artifacts available https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   verify-manifest-images:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: [metadata, build-images]
     name: Verify Manifest - Image ${{ matrix.label }}
     runs-on: ubuntu-22.04
@@ -444,6 +449,7 @@ jobs:
         fi
 
   scan-images:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Scan Images - ${{ matrix.label }}
     needs: [metadata, build-images]
     runs-on: ubuntu-22.04
@@ -578,6 +584,7 @@ jobs:
         scripts/release-kong.sh
 
   release-images:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Release Images - ${{ matrix.label }} - ${{ needs.metadata.outputs.release-desc }}
     needs: [metadata, build-images]
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -34,6 +34,7 @@ jobs:
       relative-build-root: bazel-bin/build
 
   upgrade-test:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Run migration tests
     runs-on: ubuntu-22.04
     needs: build


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR combines all the recent GHA default timeout changes into a single branch/PR, which will simplify backporting.

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] The Pull Request has backports to all the versions it needs to cover
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

Sister PR to: https://github.com/Kong/kong-ee/pull/8223
