### PR TITLE
fix(vault): use global query when finding a vault by prefix

### DIFF
--- a/changelog/unreleased/kong/fix-vault-workspaces.yml
+++ b/changelog/unreleased/kong/fix-vault-workspaces.yml
@@ -1,0 +1,3 @@
+message: "**Vault**: do not use incorrect (default) workspace identifier when retrieving vault entity by prefix"
+type: bugfix
+scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -60,6 +60,9 @@ local COLON = byte(":")
 local SLASH = byte("/")
 
 
+local VAULT_QUERY_OPTS = { workspace = ngx.null }
+
+
 ---
 -- Checks if the passed in reference looks like a reference.
 -- Valid references start with '{vault://' and end with '}'.
@@ -607,10 +610,10 @@ local function new(self)
 
     if cache then
       local vault_cache_key = vaults:cache_key(prefix)
-      vault, err = cache:get(vault_cache_key, nil, vaults.select_by_prefix, vaults, prefix)
+      vault, err = cache:get(vault_cache_key, nil, vaults.select_by_prefix, vaults, prefix, VAULT_QUERY_OPTS)
 
     else
-      vault, err = vaults:select_by_prefix(prefix)
+      vault, err = vaults:select_by_prefix(prefix, VAULT_QUERY_OPTS)
     end
 
     if not vault then


### PR DESCRIPTION
### Summary

In FTI-5762 it was reported that there is a problem with secret rotation when vaults are stored inside a workspace. This commit will fix it by passing `workspace = null` aka making a call a global call which will not then use the possibly incorrect workspace (default) to find vault entity (the vault config). The vault entity prefix is unique across workspaces.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix FTI-5762
