### PR TITLE
tests: fix flakiness

### DIFF
--- a/spec/02-integration/07-sdk/03-cluster_spec.lua
+++ b/spec/02-integration/07-sdk/03-cluster_spec.lua
@@ -1,4 +1,6 @@
 local helpers = require("spec.helpers")
+local CP_MOCK_PORT = helpers.get_available_port()
+local DP_MOCK_PORT = helpers.get_available_port()
 
 local uuid_pattern = "^" .. ("%x"):rep(8) .. "%-" .. ("%x"):rep(4) .. "%-"
                          .. ("%x"):rep(4) .. "%-" .. ("%x"):rep(4) .. "%-"
@@ -10,7 +12,7 @@ local fixtures_dp = {
 fixtures_dp.http_mock.my_server_block = [[
   server {
       server_name my_server;
-      listen 62349;
+      listen ]] .. DP_MOCK_PORT .. [[;
 
       location = "/hello" {
         content_by_lua_block {
@@ -28,7 +30,7 @@ local fixtures_cp = {
 fixtures_cp.http_mock.my_server_block = [[
   server {
       server_name my_server;
-      listen 62350;
+      listen ]] .. CP_MOCK_PORT .. [[;
 
       location = "/hello" {
         content_by_lua_block {
@@ -83,7 +85,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("kong.cluster.get_id() in Hybrid mode", function()
-      proxy_client = helpers.http_client(helpers.get_proxy_ip(false), 62350)
+      proxy_client = helpers.http_client(helpers.get_proxy_ip(false), CP_MOCK_PORT)
 
       local res = proxy_client:get("/hello")
       local cp_cluster_id = assert.response(res).has_status(200)
@@ -93,7 +95,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client:close()
 
       helpers.wait_until(function()
-        proxy_client = helpers.http_client(helpers.get_proxy_ip(false), 62349)
+        proxy_client = helpers.http_client(helpers.get_proxy_ip(false), DP_MOCK_PORT)
         local res = proxy_client:get("/hello")
         local body = assert.response(res).has_status(200)
         proxy_client:close()

--- a/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
@@ -154,7 +154,10 @@ end)
 describe("when CP exits before DP", function()
   local need_exit = true
 
-  setup(function()
+  lazy_setup(function()
+    -- reset and bootstrap DB before starting CP
+    helpers.get_db_utils(nil)
+
     assert(helpers.start_kong({
       role = "control_plane",
       prefix = "servroot1",
@@ -179,7 +182,7 @@ describe("when CP exits before DP", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if need_exit then
       helpers.stop_kong("servroot1")
     end

--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()

--- a/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local inflate_gzip = require("kong.tools.gzip").inflate_gzip
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 
 local openai_driver = require("kong.llm.drivers.openai")
 

--- a/spec/03-plugins/39-ai-request-transformer/01-transformer_spec.lua
+++ b/spec/03-plugins/39-ai-request-transformer/01-transformer_spec.lua
@@ -2,7 +2,7 @@ local llm_class = require("kong.llm")
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-request-transformer"
 
 local FORMATS = {

--- a/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-request-transformer"
 
 local OPENAI_FLAT_RESPONSE = {

--- a/spec/03-plugins/40-ai-response-transformer/01-transformer_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/01-transformer_spec.lua
@@ -1,8 +1,10 @@
 local llm_class = require("kong.llm")
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local http_mock = require "spec.helpers.http_mock"
+local pl_path = require "pl.path"
 
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-response-transformer"
 
 local OPENAI_INSTRUCTIONAL_RESPONSE = {
@@ -13,7 +15,7 @@ local OPENAI_INSTRUCTIONAL_RESPONSE = {
     options = {
       max_tokens = 512,
       temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/instructions"
+      upstream_url = "http://" .. helpers.mock_upstream_host .. ":" .. MOCK_PORT .. "/instructions"
     },
   },
   auth = {
@@ -55,98 +57,67 @@ local EXPECTED_RESULT = {
 }
 
 local SYSTEM_PROMPT = "You are a mathematician. "
-                   .. "Multiply all numbers in my JSON request, by 2. Return me this message: "
-                   .. "{\"status\": 400, \"headers: {\"content-type\": \"application/xml\"}, \"body\": \"OUTPUT\"} "
-                   .. "where 'OUTPUT' is the result but transformed into XML format."
+    .. "Multiply all numbers in my JSON request, by 2. Return me this message: "
+    .. "{\"status\": 400, \"headers: {\"content-type\": \"application/xml\"}, \"body\": \"OUTPUT\"} "
+    .. "where 'OUTPUT' is the result but transformed into XML format."
 
 
-local client
+describe(PLUGIN_NAME .. ": (unit)", function()
+  local mock
+  local mock_response_file = pl_path.abspath(
+    "spec/fixtures/ai-proxy/openai/request-transformer/response-with-instructions.json")
 
+  lazy_setup(function()
+    mock = http_mock.new(tostring(MOCK_PORT), {
+      ["/instructions"] = {
+        content = string.format([[
+            local pl_file = require "pl.file"
+            ngx.header["Content-Type"] = "application/json"
+            ngx.say(pl_file.read("%s"))
+          ]], mock_response_file),
+      },
+    }, {
+      hostname = "llm",
+    })
 
-for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
+    assert(mock:start())
+  end)
 
-  describe(PLUGIN_NAME .. ": (unit)", function()
+  lazy_teardown(function()
+    assert(mock:stop())
+  end)
 
-    lazy_setup(function()
-      -- set up provider fixtures
-      local fixtures = {
-        http_mock = {},
-      }
+  describe("openai transformer tests, specific response", function()
+    it("transforms request based on LLM instructions, with response transformation instructions format", function()
+      local llm = llm_class:new(OPENAI_INSTRUCTIONAL_RESPONSE, {})
+      assert.truthy(llm)
 
-      fixtures.http_mock.openai = [[
-        server {
-            server_name llm;
-            listen ]]..MOCK_PORT..[[;
-            
-            default_type 'application/json';
+      local result, err = llm:ai_introspect_body(
+        REQUEST_BODY,      -- request body
+        SYSTEM_PROMPT,     -- conf.prompt
+        {},                -- http opts
+        nil                -- transformation extraction pattern (loose json)
+      )
 
-            location ~/instructions {
-              content_by_lua_block {
-                local pl_file = require "pl.file"
-                ngx.print(pl_file.read("spec/fixtures/ai-proxy/openai/request-transformer/response-with-instructions.json"))
-              }
-            }
-        }
-      ]]
+      assert.is_nil(err)
 
-      -- start kong
-      assert(helpers.start_kong({
-        -- set the strategy
-        database   = strategy,
-        -- use the custom test template to create a local mock server
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-        -- make sure our plugin gets loaded
-        plugins = "bundled," .. PLUGIN_NAME,
-        -- write & load declarative config, only if 'strategy=off'
-        declarative_config = strategy == "off" and helpers.make_yaml_file() or nil,
-      }, nil, nil, fixtures))
-    end)
-    
-    lazy_teardown(function()
-      helpers.stop_kong(nil, true)
-    end)
+      local table_result, err = cjson.decode(result)
+      assert.is_nil(err)
+      assert.same(EXPECTED_RESULT, table_result)
 
-    before_each(function()
-      client = helpers.proxy_client()
-    end)
+      -- parse in response string format
+      local headers, body, status, err = llm:parse_json_instructions(result)
+      assert.is_nil(err)
+      assert.same({ ["content-type"] = "application/xml" }, headers)
+      assert.same(209, status)
+      assert.same(EXPECTED_RESULT.body, body)
 
-    after_each(function()
-      if client then client:close() end
-    end)
-
-    describe("openai transformer tests, specific response", function()
-      it("transforms request based on LLM instructions, with response transformation instructions format", function()
-        local llm = llm_class:new(OPENAI_INSTRUCTIONAL_RESPONSE, {})
-        assert.truthy(llm)
-
-        local result, err = llm:ai_introspect_body(
-          REQUEST_BODY,  -- request body
-          SYSTEM_PROMPT, -- conf.prompt
-          {},            -- http opts
-          nil            -- transformation extraction pattern (loose json)
-        )
-
-        assert.is_nil(err)
-
-        local table_result, err = cjson.decode(result)
-        assert.is_nil(err)
-        assert.same(EXPECTED_RESULT, table_result)
-
-        -- parse in response string format
-        local headers, body, status, err = llm:parse_json_instructions(result)
-        assert.is_nil(err)
-        assert.same({ ["content-type"] = "application/xml"}, headers)
-        assert.same(209, status)
-        assert.same(EXPECTED_RESULT.body, body)
-
-        -- parse in response table format
-        headers, body, status, err = llm:parse_json_instructions(table_result)
-        assert.is_nil(err)
-        assert.same({ ["content-type"] = "application/xml"}, headers)
-        assert.same(209, status)
-        assert.same(EXPECTED_RESULT.body, body)
-      end)
-
+      -- parse in response table format
+      headers, body, status, err = llm:parse_json_instructions(table_result)
+      assert.is_nil(err)
+      assert.same({ ["content-type"] = "application/xml" }, headers)
+      assert.same(209, status)
+      assert.same(EXPECTED_RESULT.body, body)
     end)
   end)
-end end
+end)

--- a/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-local MOCK_PORT = 62349
+local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-response-transformer"
 
 local OPENAI_INSTRUCTIONAL_RESPONSE = {


### PR DESCRIPTION
## Please REBASE and MERGE

### Summary

The [dynamic test scheduler](https://github.com/Kong/kong/pull/12286) exposed some issues by disrupting the order of the tests, some of which did not initialize the database or wrote incompatible data to the database, causing the Gateway instance to fail to start and causing the following test to fail.

### Starting a Gateway instance even if it's not needed

* `spec/03-plugins/39-ai-request-transformer/01-transformer_spec.lua`
* `spec/03-plugins/40-ai-response-transformer/01-transformer_spec.lua`

These two test sets start a Gateway instance to launch a mocking server, which can be replaced by the `spec.helpers.http_mock`.

### The database was not initialized before starting the Gateway instance

* `spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua`

### Starting a service using a fixed port instead of a random port

Since the test sequence is disrupted and the port release is not real-time, this may cause the port to be occupied to the point where the test fails.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3746]_


[KAG-3746]: https://konghq.atlassian.net/browse/KAG-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ