### PR TITLE
fix(core): fix an issue where Kong do not handle properly when Python and Javascript plugin server crashes

### DIFF
--- a/changelog/unreleased/kong/plugin_server_restart.yml
+++ b/changelog/unreleased/kong/plugin_server_restart.yml
@@ -1,0 +1,3 @@
+message: "**Plugin Server**: fix an issue where Kong fails to properly restart MessagePack-based pluginservers (used in Python and Javascript plugins, for example)"
+type: bugfix
+scope: Core

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -392,8 +392,8 @@ end
 
 
 function Rpc:handle_event(plugin_name, conf, phase)
-  local instance_id, res, err
-  instance_id, err = self.get_instance_id(plugin_name, conf)
+  local instance_id, err = self.get_instance_id(plugin_name, conf)
+  local res
   if not err then
     res, err = self:call("cmd_handle_event", {
       instance_id = instance_id,
@@ -402,20 +402,16 @@ function Rpc:handle_event(plugin_name, conf, phase)
   end
 
   if not res or res == "" then
-    if err then
-      local err_lowered = err and err:lower() or ""
+    local err_lowered = err and err:lower() or "unknown error"
 
-      kong.log.err(err_lowered)
-
-      if err_lowered == "not ready" then
-        self.reset_instance(plugin_name, conf)
-      end
-      if str_find(err_lowered, "no plugin instance")
-        or str_find(err_lowered, "closed")  then
-        self.reset_instance(plugin_name, conf)
-        return self:handle_event(plugin_name, conf, phase)
-      end
+    if str_find(err_lowered, "no plugin instance", nil, true)
+      or str_find(err_lowered, "closed", nil, true) then
+      self.reset_instance(plugin_name, conf)
+      kong.log.warn(err)
+      return self:handle_event(plugin_name, conf, phase)
     end
+
+    kong.log.err(err)
   end
 end
 


### PR DESCRIPTION
### Summary

The bug was introduced when refactoring/cherry-picking. We missed the `mp_rpc.lua`. The PR also syncs the changes made to EE branches.

**DO NOT CHEERY-PICK THIS TO EE**.

### Checklist

- [N/A] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #12364
Fix KAG-3765