### PR TITLE
[backport -> release/3.5.x] Backport 12548 to release/3.5.x

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -989,6 +989,7 @@ local function check_and_parse(conf, opts)
           "nginx_http_ssl_conf_command",
           "nginx_http_proxy_ssl_conf_command",
           "nginx_http_lua_ssl_conf_command",
+          "nginx_http_grpc_ssl_conf_command",
           "nginx_stream_ssl_conf_command",
           "nginx_stream_proxy_ssl_conf_command",
           "nginx_stream_lua_ssl_conf_command"}) do

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -94,6 +94,7 @@ nginx_http_ssl_session_timeout = NONE
 nginx_http_ssl_conf_command = NONE
 nginx_http_proxy_ssl_conf_command = NONE
 nginx_http_lua_ssl_conf_command = NONE
+nginx_http_grpc_ssl_conf_command = NONE
 nginx_http_lua_regex_match_limit = 100000
 nginx_http_lua_regex_cache_max_entries = 8192
 nginx_http_keepalive_requests = 10000

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -28,6 +28,7 @@ underscores_in_headers on;
 lua_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 proxy_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
+grpc_ssl_conf_command CipherString DEFAULT:@SECLEVEL=0;
 > end
 > if ssl_ciphers then
 ssl_ciphers ${{SSL_CIPHERS}};


### PR DESCRIPTION
#12548 

The #12420 by @Water-Melon forgot to add `grpc_ssl_conf_command`. This commit adds that.

Signed-off-by: Aapo Talvensaari <aapo.talvensaari@gmail.com>
(cherry picked from commit 84cb1be01d8e9a241e8a2b3afd6d55bb184e605b)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
