### PR TITLE
chore(tests): remove redis code duplication in specs

### DIFF
--- a/spec/02-integration/01-helpers/04-redis_helper_spec.lua
+++ b/spec/02-integration/01-helpers/04-redis_helper_spec.lua
@@ -1,0 +1,60 @@
+local redis_helper = require "spec.helpers.redis_helper"
+local helpers = require "spec.helpers"
+
+local REDIS_HOST = helpers.redis_host
+local REDIS_PORT = helpers.redis_port
+local REDIS_DATABASE1 = 1
+local REDIS_DATABASE2 = 2
+
+describe("redis_helper tests", function()
+  describe("connect", function ()
+    describe("when connection info is correct", function()
+      it("connects to redis", function()
+        local red, version = redis_helper.connect(REDIS_HOST, REDIS_PORT)
+        assert.is_truthy(version)
+        assert.is_not_nil(red)
+      end)
+    end)
+
+    describe("when connection info is invalid", function ()
+      it("does not connect to redis", function()
+        assert.has_error(function()
+          redis_helper.connect(REDIS_HOST, 5123)
+        end)
+      end)
+    end)
+  end)
+
+  describe("reset_redis", function ()
+    it("clears redis database", function()
+      -- given - redis with some values in 2 databases
+      local red = redis_helper.connect(REDIS_HOST, REDIS_PORT)
+      red:select(REDIS_DATABASE1)
+      red:set("dog", "an animal")
+      local ok, err = red:get("dog")
+      assert.falsy(err)
+      assert.same("an animal", ok)
+
+      red:select(REDIS_DATABASE2)
+      red:set("cat", "also animal")
+      local ok, err = red:get("cat")
+      assert.falsy(err)
+      assert.same("also animal", ok)
+
+      -- when - resetting redis
+      redis_helper.reset_redis(REDIS_HOST, REDIS_PORT)
+
+      -- then - clears everything
+      red:select(REDIS_DATABASE1)
+      local ok, err = red:get("dog")
+      assert.falsy(err)
+      assert.same(ngx.null, ok)
+
+      red:select(REDIS_DATABASE2)
+      local ok, err = red:get("cat")
+      assert.falsy(err)
+      assert.same(ngx.null, ok)
+    end)
+  end)
+end)
+

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
-local redis = require "resty.redis"
 local version = require "version"
 local cjson = require "cjson"
+local redis_helper = require "spec.helpers.redis_helper"
 
 
 local REDIS_HOST      = helpers.redis_host
@@ -19,29 +19,6 @@ local REDIS_PASSWORD = "secret"
 
 local SLEEP_TIME = 1
 
-local function redis_connect()
-  local red = redis:new()
-  red:set_timeout(2000)
-  assert(red:connect(REDIS_HOST, REDIS_PORT))
-  local red_version = string.match(red:info(), 'redis_version:([%g]+)\r\n')
-  return red, assert(version(red_version))
-end
-
-local function flush_redis(red, db)
-  assert(red:select(db))
-  red:flushall()
-end
-
-local function add_redis_user(red)
-  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "allcommands", ">" .. REDIS_PASSWORD))
-  assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
-end
-
-local function remove_redis_user(red)
-  assert(red:acl("deluser", REDIS_USER_VALID))
-  assert(red:acl("deluser", REDIS_USER_INVALID))
-end
-
 describe("Plugin: rate-limiting (integration)", function()
   local client
   local bp
@@ -56,7 +33,7 @@ describe("Plugin: rate-limiting (integration)", function()
     }, {
       "rate-limiting"
     })
-    red, red_version = redis_connect()
+    red, red_version = redis_helper.connect(REDIS_HOST, REDIS_PORT)
   end)
 
   lazy_teardown(function()
@@ -98,11 +75,11 @@ describe("Plugin: rate-limiting (integration)", function()
         -- https://github.com/Kong/kong/issues/3292
 
         lazy_setup(function()
-          flush_redis(red, REDIS_DB_1)
-          flush_redis(red, REDIS_DB_2)
-          flush_redis(red, REDIS_DB_3)
+          red:flushall()
+
           if red_version >= version("6.0.0") then
-            add_redis_user(red)
+            redis_helper.add_admin_user(red, REDIS_USER_VALID, REDIS_PASSWORD)
+            redis_helper.add_basic_user(red, REDIS_USER_INVALID, REDIS_PASSWORD)
           end
 
           bp = helpers.get_db_utils(nil, {
@@ -219,7 +196,8 @@ describe("Plugin: rate-limiting (integration)", function()
         lazy_teardown(function()
           helpers.stop_kong()
           if red_version >= version("6.0.0") then
-            remove_redis_user(red)
+            redis_helper.remove_user(red, REDIS_USER_VALID)
+            redis_helper.remove_user(red, REDIS_USER_INVALID)
           end
         end)
 

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -1,6 +1,6 @@
 local cjson          = require "cjson"
 local helpers        = require "spec.helpers"
-
+local redis_helper   = require "spec.helpers.redis_helper"
 
 local REDIS_HOST      = helpers.redis_host
 local REDIS_PORT      = helpers.redis_port
@@ -24,33 +24,6 @@ local function wait()
   local millis = (now - math.floor(now))
   ngx.sleep(1 - millis)
 end
-
-
-local function flush_redis()
-  local redis = require "resty.redis"
-  local red = redis:new()
-  red:set_timeout(2000)
-  local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
-  if not ok then
-    error("failed to connect to Redis: " .. err)
-  end
-
-  if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
-    local ok, err = red:auth(REDIS_PASSWORD)
-    if not ok then
-      error("failed to connect to Redis: " .. err)
-    end
-  end
-
-  local ok, err = red:select(REDIS_DATABASE)
-  if not ok then
-    error("failed to change Redis database: " .. err)
-  end
-
-  red:flushall()
-  red:close()
-end
-
 
 local redis_confs = {
   no_ssl = {
@@ -102,7 +75,7 @@ local function init_db(strategy, policy)
   })
 
   if policy == "redis" then
-    flush_redis()
+    redis_helper.reset_redis(REDIS_HOST, REDIS_PORT)
   end
 
   return bp

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -1,7 +1,8 @@
 local helpers = require "spec.helpers"
-local redis = require "resty.redis"
 local version = require "version"
 local cjson = require "cjson"
+local redis_helper = require "spec.helpers.redis_helper"
+
 local tostring = tostring
 
 
@@ -21,28 +22,6 @@ local REDIS_PASSWORD = "secret"
 
 local SLEEP_TIME = 1
 
-local function redis_connect()
-  local red = redis:new()
-  red:set_timeout(2000)
-  assert(red:connect(REDIS_HOST, REDIS_PORT))
-  local red_version = string.match(red:info(), 'redis_version:([%g]+)\r\n')
-  return red, assert(version(red_version))
-end
-
-local function flush_redis(red, db)
-  assert(red:select(db))
-  red:flushall()
-end
-
-local function add_redis_user(red)
-  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", "+exists", ">" .. REDIS_PASSWORD))
-  assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
-end
-
-local function remove_redis_user(red)
-  assert(red:acl("deluser", REDIS_USER_VALID))
-  assert(red:acl("deluser", REDIS_USER_INVALID))
-end
 
 describe("Plugin: rate-limiting (integration)", function()
   local client
@@ -59,8 +38,7 @@ describe("Plugin: rate-limiting (integration)", function()
     }, {
       "response-ratelimiting",
     })
-    red, red_version = redis_connect()
-
+    red, red_version = redis_helper.connect(REDIS_HOST, REDIS_PORT)
   end)
 
   lazy_teardown(function()
@@ -100,11 +78,11 @@ describe("Plugin: rate-limiting (integration)", function()
       -- https://github.com/Kong/kong/issues/3292
 
       lazy_setup(function()
-        flush_redis(red, REDIS_DB_1)
-        flush_redis(red, REDIS_DB_2)
-        flush_redis(red, REDIS_DB_3)
+        red:flushall()
+
         if red_version >= version("6.0.0") then
-          add_redis_user(red)
+          redis_helper.add_admin_user(red, REDIS_USER_VALID, REDIS_PASSWORD)
+          redis_helper.add_basic_user(red, REDIS_USER_INVALID, REDIS_PASSWORD)
         end
 
         bp = helpers.get_db_utils(nil, {
@@ -219,7 +197,8 @@ describe("Plugin: rate-limiting (integration)", function()
       lazy_teardown(function()
         helpers.stop_kong()
         if red_version >= version("6.0.0") then
-          remove_redis_user(red)
+          redis_helper.remove_user(red, REDIS_USER_VALID)
+          redis_helper.remove_user(red, REDIS_USER_INVALID)
         end
       end)
 

--- a/spec/helpers/redis_helper.lua
+++ b/spec/helpers/redis_helper.lua
@@ -1,0 +1,40 @@
+local redis = require "resty.redis"
+local version = require "version"
+
+local DEFAULT_TIMEOUT = 2000
+
+
+local function connect(host, port)
+  local redis_client = redis:new()
+  redis_client:set_timeout(DEFAULT_TIMEOUT)
+  assert(redis_client:connect(host, port))
+  local red_version = string.match(redis_client:info(), 'redis_version:([%g]+)\r\n')
+  return redis_client, assert(version(red_version))
+end
+
+local function reset_redis(host, port)
+  local redis_client = connect(host, port)
+  redis_client:flushall()
+  redis_client:close()
+end
+
+local function add_admin_user(redis_client, username, password)
+  assert(redis_client:acl("setuser", username, "on", "allkeys", "allcommands", ">" .. password))
+end
+
+local function add_basic_user(redis_client, username, password)
+  assert(redis_client:acl("setuser", username, "on", "allkeys", "+get", ">" .. password))
+end
+
+local function remove_user(redis_client, username)
+  assert(redis_client:acl("deluser", username))
+end
+
+
+return {
+  connect = connect,
+  add_admin_user = add_admin_user,
+  add_basic_user = add_basic_user,
+  remove_user = remove_user,
+  reset_redis = reset_redis,
+}


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In tests there was a lot of code duplication related to redis connection, user adding, removing and db flushing. This commits extracts all of this code to redis_helper

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] **N/A - tests change** ~~_A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)_~~
- [x] **N/A - tests change** ~~_There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE_~~

### Issue reference

KAG-2130