### PR TITLE
Allow models to specifiy conflict keys

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -758,6 +758,13 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      unique_key = {
+        type = "array",
+        elements = { type = "string" },
+        nilable = true,
+      },
+    },
+    {
       generate_admin_api = {
         type = "boolean",
         nilable = true,

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -825,6 +825,8 @@ function _M.new(connector, schema, errors)
 
   local unique_fields                 = {}
 
+  local unique_key                    = schema.unique_key
+
 
   for field_name, field in schema:each_field() do
     if field.type == "foreign" then
@@ -1005,6 +1007,7 @@ function _M.new(connector, schema, errors)
   insert(page_next_names, LIMIT)
 
   local pk_escaped = concat(primary_key_escaped, ", ")
+  local unique_escaped = concat(unique_key or primary_key_escaped, ", ")
 
   select_expressions       = concat(select_expressions, ", ")
   primary_key_placeholders = concat(primary_key_placeholders, ", ")
@@ -1153,7 +1156,7 @@ function _M.new(connector, schema, errors)
     code =  {
       "INSERT INTO ",  table_name_escaped, " (", insert_columns, ")\n",
       "     VALUES (", insert_expressions, ")\n",
-      "ON CONFLICT (", pk_escaped, ") DO UPDATE\n",
+     "ON CONFLICT (", unique_escaped, ") DO UPDATE\n",
       "        SET ",  upsert_expressions, "\n",
       "  RETURNING ", select_expressions, ";",
     }

--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -8,6 +8,7 @@ return {
     endpoint_key = "key",
     cache_key = { "key" },
     workspaceable = true,
+    unique_key = { "ws_id", "key" },
     admin_api_name = "key-auths",
     admin_api_nested_name = "key-auth",
     fields = {


### PR DESCRIPTION
### Summary

The upsert DAO function generated uses the primary key as an "ON CONFLICT" match. This might not be the case if a field uses a unique flag or if that field is also workgroupable. Postgresql requires an index to be specified.

I tried autodetecting the correct behavior but it failed on other models. Changing the primary key also did not work. I added a way to specify the conflict index.
It defaults to the primary key.


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #12288
