### PR TITLE
fix(timer-ng): decrease the minimum/maximum threads

### DIFF
--- a/changelog/unreleased/kong/decrease-cocurrency-limit-of-timer-ng.yml
+++ b/changelog/unreleased/kong/decrease-cocurrency-limit-of-timer-ng.yml
@@ -1,0 +1,3 @@
+message: |
+    Fix a bug where the ulimit setting (open files) is low Kong will fail to start as the lua-resty-timer-ng exhausts the available worker_connections. Decrease the concurrency range of the lua-resty-timer-ng library from [512, 2048] to [256, 1024] to fix this bug.
+type: bugfix

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -99,8 +99,8 @@ return function(options)
 
     else
       _timerng = require("resty.timerng").new({
-        min_threads = 512,
-        max_threads = 2048,
+        min_threads = 256,
+        max_threads = 1024,
       })
     end
 


### PR DESCRIPTION
### Summary

Too high concurrency setting might make Kong throws error at the runtime.

### Checklist

- [N/A] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3779], [FTI-5780]_


[KAG-3779]: https://konghq.atlassian.net/browse/KAG-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-5780]: https://konghq.atlassian.net/browse/FTI-5780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ