### PR TITLE
fix(api): avoid returning 405 on /schemas/vaults/:name

### DIFF
--- a/changelog/unreleased/kong/fix_api_405_vaults_validate_endpoint.yml
+++ b/changelog/unreleased/kong/fix_api_405_vaults_validate_endpoint.yml
@@ -1,0 +1,3 @@
+message: "**Admin API**: fixed an issue where calling the endpoint `POST /schemas/vaults/validate` was conflicting with the endpoint `/schemas/vaults/:name` which only has GET implemented, hence resulting in a 405."
+type: bugfix
+scope: Admin API

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -200,6 +200,11 @@ return {
       return validate_schema("plugins", self.params)
     end
   },
+  ["/schemas/vaults/validate"] = {
+    POST = function(self, db, helpers)
+      return validate_schema("vaults", self.params)
+    end
+  },
   ["/schemas/:db_entity_name/validate"] = {
     POST = function(self, db, helpers)
       local db_entity_name = self.params.db_entity_name

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -485,6 +485,16 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local json = cjson.decode(body)
       assert.same({ message = "No vault named 'not-present'" }, json)
     end)
+
+    it("does not return 405 on /schemas/vaults/validate", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/schemas/vaults/validate",
+      })
+      local body = assert.res_status(400, res)
+      local json = cjson.decode(body)
+      assert.same("schema violation (name: required field missing)", json.message)
+    end)
   end)
 
   describe("/schemas/:entity", function()


### PR DESCRIPTION
This fixes an issue where calling the endpoint `POST /schemas/vaults/validate`
was conflicting with the endpoint `/schemas/vaults/:name` which only
has GET implemented, hence resulting in a 405.

By explicting defining a new endpoint `/schemas/vaults/validate`, Lapis
framework should take care of always choosing it over `/schemas/vaults/:name`.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-3699
