### PR TITLE
chore(changelog): update changelog for gRPC TLS seclevel change

### DIFF
--- a/changelog/unreleased/kong/set_grpc_tls_seclevel.yml
+++ b/changelog/unreleased/kong/set_grpc_tls_seclevel.yml
@@ -1,0 +1,3 @@
+message: Set security level of gRPC's TLS to 0 when ssl_cipher_suite is set to old
+type: bugfix
+scope: Configuration


### PR DESCRIPTION
Update changelog for gRPC TLS seclevel change. The original PR is #12548.

Set security level of gRPC's TLS to `0` when `ssl_cipher_suite` is set to `old`.

KAG-3259