### PR TITLE
fix(ci): build and test use github token

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Download runtimes file
       uses: Kong/gh-storage/download@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         repo-path: Kong/gateway-action-storage/main/.ci/runtimes.json
 


### PR DESCRIPTION
### Summary

replace PAT with github_token

background: when I opened this PR PAT had expired and it was making some tests fail on CI. It has since been rotated and things are green again now. 

We can still merge this and use github_token for this workflow instead to avoid this problem in the future.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
