### PR TITLE
chore(ci): add commit linter workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,12 @@
+name: commit-lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ahmadnassri/action-commit-lint@v2
+        with:
+          config: conventional


### PR DESCRIPTION
### Summary

Enforce commit message format.

Docs: https://github.com/ahmadnassri/action-commit-lint?tab=readme-ov-file#built-in-configs

Feel free to add new commits testing the linter.