### PR TITLE
fix(build): ensure `$BUILD_NAME` is used during the building of WASM test filters

### DIFF
--- a/scripts/build-wasm-test-filters.sh
+++ b/scripts/build-wasm-test-filters.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 readonly BUILD_TARGET=wasm32-wasi
 readonly FIXTURE_PATH=${PWD}/spec/fixtures/proxy_wasm_filters
 
-readonly INSTALL_ROOT=${PWD}/bazel-bin/build/kong-dev
+readonly INSTALL_ROOT=${PWD}/bazel-bin/build/${BUILD_NAME:-kong-dev}
 readonly TARGET_DIR=${INSTALL_ROOT}/wasm-cargo-target
 
 readonly KONG_TEST_USER_CARGO_DISABLED=${KONG_TEST_USER_CARGO_DISABLED:-0}


### PR DESCRIPTION
when build kong with 
```make dev BUILD_NAME=35xx```
the last step throw an error:
```
./scripts/build-wasm-test-filters.sh
cargo not found, installing rust toolchain
ERROR: bazel install root not found (/Users/xxxx/Workspace/kong-ee/bazel-bin/build/kong-dev/wasm-cargo-target)
You must run bazel before running this script.
make: *** [wasm-test-filters] Error 1
```