### PR TITLE
fix(kong.conf.default): fix the default value of `upstream_keepalive_max_requests`

### DIFF
--- a/changelog/unreleased/kong/fix-default-value-of-upstream-keepalive-max-requests.yml
+++ b/changelog/unreleased/kong/fix-default-value-of-upstream-keepalive-max-requests.yml
@@ -1,0 +1,5 @@
+message: |
+    Fixed default value in kong.conf.default documentation from 1000 to 10000
+    for upstream_keepalive_max_requests option.
+type: bugfix
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1020,7 +1020,7 @@
                                      # each upstream request to open a new
                                      # connection.
 
-#upstream_keepalive_max_requests = 1000  # Sets the default maximum number of
+#upstream_keepalive_max_requests = 10000 # Sets the default maximum number of
                                          # requests than can be proxied upstream
                                          # through one keepalive connection.
                                          # After the maximum number of requests


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

 This commit fixes the discrepancy between the default value `1000` of upstream_keepalive_max_requests in the Kong.conf comments and the actual value `10000` in kong/templates/kong_defaults.lua.

### Checklist

- [x] N/A ~~The Pull Request has tests~~
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

