### PR TITLE
fix(router/atc): reset rebuilding flag if route has no id

### DIFF
--- a/changelog/unreleased/kong/fix-router-rebuing-flag.yml
+++ b/changelog/unreleased/kong/fix-router-rebuing-flag.yml
@@ -1,5 +1,5 @@
 message: |
-  Fix an issue where router's rebuilding flag is not reset correctly
-  if a route has no proper id
+  Fix an issue where router may not work correctly
+  when the routes configuration changed.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-router-rebuing-flag.yml
+++ b/changelog/unreleased/kong/fix-router-rebuing-flag.yml
@@ -1,0 +1,5 @@
+message: |
+  Fix an issue where router's rebuilding flag is not reset correctly
+  if a route has no proper id
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix-router-rebuing-flag.yml
+++ b/changelog/unreleased/kong/fix-router-rebuing-flag.yml
@@ -1,5 +1,5 @@
 message: |
-  Fix an issue where router may not work correctly
+  Fixed an issue where router may not work correctly
   when the routes configuration changed.
 type: bugfix
 scope: Core

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -285,6 +285,7 @@ local function new_from_previous(routes, get_exp_and_priority, old_router)
     local route_id = route.id
 
     if not route_id then
+      old_router.rebuilding = false
       return nil, "could not categorize route"
     end
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2131,6 +2131,46 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             assert.spy(add_matcher).was_called(2)
             assert.spy(remove_matcher).was_called(2)
           end)
+
+          it("works well if route has no proper id", function()
+            local wrong_use_case = {
+              {
+                service = service,
+                route = {
+                  id = nil,   -- no id here
+                  paths = { "/foo", },
+                  updated_at = 100,
+                },
+              },
+            }
+
+            local nrouter = new_router(wrong_use_case, router)
+            assert.is_nil(nrouter)
+            assert.falsy(router.rebuilding)
+
+            local use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = { "/foo1", },
+                  updated_at = 100,
+                },
+              },
+            }
+
+            local nrouter = assert(new_router(use_case, router))
+
+            assert.equal(nrouter, router)
+            assert.falsy(router.rebuilding)
+
+            local match_t = nrouter:select("GET", "/foo1")
+            assert.truthy(match_t)
+            assert.same(use_case[1].route, match_t.route)
+
+            match_t = nrouter:select("GET", "/bar")
+            assert.falsy(match_t)
+          end)
         end)
 
         describe("check empty route fields", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The variable `rebuilding` is a flag to prevent duplicate router building action,
if any error occurs it should be set to `false`,
or else the router will never be rebuilt again.

KAG-3857

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
