### PR TITLE
feat(wasm): support directive for general shm_kv entry

### DIFF
--- a/changelog/unreleased/kong/feat-wasm-general-shm-kv.yml
+++ b/changelog/unreleased/kong/feat-wasm-general-shm-kv.yml
@@ -1,0 +1,6 @@
+message: |
+   Introduce `nginx_wasm_main_shm_kv` configuration entry, which enables
+   Wasm filters to use the Proxy-Wasm operations `get_shared_data` and
+   `set_shared_data` without namespaced keys.
+type: feature
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -732,7 +732,7 @@
 
 #mem_cache_size = 128m           # Size of each of the two shared memory caches
                                  # for traditional mode database entities
-                                 # and runtime data, `kong_core_cache` and 
+                                 # and runtime data, `kong_core_cache` and
                                  # `kong_cache`.
                                  #
                                  # The accepted units are `k` and `m`, with a minimum
@@ -2065,9 +2065,16 @@
 # The following namespaces are supported:
 #
 # - `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.
+# - `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,
+#   allowing operators to define a general memory zone which is usable by
+#   the `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as
+#   an in-memory key-value store of data shareable across filters.
 # - `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,
 #   allowing operators to define custom shared memory zones which are usable by
-#   the `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions.
+#   the `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as
+#   separate namespaces in the `"<name>/<key>"` format.
+#   For using these functions with non-namespaced keys, the Nginx template needs
+#   a `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.
 # - `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`
 #   block, allowing various Wasmtime-specific flags to be set.
 # - `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -305,6 +305,8 @@ local CONF_PARSERS = {
     },
   },
 
+  nginx_wasm_main_shm_kv = { typ = "string" },
+
   worker_events_max_payload = { typ = "number" },
 
   upstream_keepalive_pool_size = { typ = "number" },

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -31,7 +31,11 @@ wasm {
 > end
 
 > for _, el in ipairs(nginx_wasm_main_directives) do
+> if el.name == "shm_kv" then
+  shm_kv * $(el.value);
+> else
   $(el.name) $(el.value);
+> end
 > end
 
 > if #nginx_wasm_wasmtime_directives > 0 then

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -911,10 +911,18 @@ describe("NGINX conf compiler", function()
       it("injects a shm_kv", function()
         assert.matches("wasm {.+shm_kv counters 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_kv_counters="10m" }, debug))
       end)
+      it("injects a general shm_kv", function()
+        assert.matches("wasm {.+shm_kv %* 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_kv="10m" }, debug))
+      end)
       it("injects multiple shm_kvs", function()
         assert.matches(
-          "wasm {.+shm_kv cache 10m.+shm_kv counters 10m;.+}",
-          ngx_cfg({ wasm = true, nginx_wasm_shm_kv_cache="10m", nginx_wasm_shm_kv_counters="10m"}, debug)
+          "wasm {.+shm_kv cache 10m.+shm_kv counters 10m;.+shm_kv %* 5m;.+}",
+          ngx_cfg({
+            wasm = true,
+            nginx_wasm_shm_kv_cache="10m",
+            nginx_wasm_shm_kv_counters="10m",
+            nginx_wasm_shm_kv="5m",
+          }, debug)
         )
       end)
       it("injects default configurations if wasm=on", function()

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -912,16 +912,16 @@ describe("NGINX conf compiler", function()
         assert.matches("wasm {.+shm_kv counters 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_kv_counters="10m" }, debug))
       end)
       it("injects a general shm_kv", function()
-        assert.matches("wasm {.+shm_kv %* 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_kv="10m" }, debug))
+        assert.matches("wasm {.+shm_kv %* 10m;.+}", ngx_cfg({ wasm = true, nginx_wasm_shm_kv = "10m" }, debug))
       end)
       it("injects multiple shm_kvs", function()
         assert.matches(
           "wasm {.+shm_kv cache 10m.+shm_kv counters 10m;.+shm_kv %* 5m;.+}",
           ngx_cfg({
             wasm = true,
-            nginx_wasm_shm_kv_cache="10m",
-            nginx_wasm_shm_kv_counters="10m",
-            nginx_wasm_shm_kv="5m",
+            nginx_wasm_shm_kv_cache = "10m",
+            nginx_wasm_shm_kv_counters = "10m",
+            nginx_wasm_shm_kv = "5m",
           }, debug)
         )
       end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -41,7 +41,11 @@ wasm {
 > end
 
 > for _, el in ipairs(nginx_wasm_main_directives) do
+> if el.name == "shm_kv" then
+  shm_kv * $(el.value);
+> else
   $(el.name) $(el.value);
+> end
 > end
 
 > if #nginx_wasm_wasmtime_directives > 0 then


### PR DESCRIPTION
### Summary

WasmX supports using non-namespaced entries in proxy-wasm `get_shared_data` and `set_shared_data`. For this, one needs to define a no-namespaced shm_kv using the `shm_kv * <size>` directive. This commit adds `nginx_wasm_main_shm_kv` as a supported option alongside the existing `nginx_wasm_main_shm_kv_<namespace>` entries, for definition of the non-namespaced `shm_kv`.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~ - this PR updates `kong.conf.default` with documentation on the new directive, from which the Docs site generates configuration documentation.
