### PR TITLE
refactor(router/atc): simplify searching for field accessor function

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -199,6 +199,11 @@ end -- is_http
 
 -- stream subsystem needs not to generate func
 local function get_field_accessor(funcs, field)
+  local f = FIELDS_FUNCS[field]
+  if f then
+    return f
+  end
+
   error("unknown router matching schema field: " .. field)
 end
 
@@ -259,7 +264,7 @@ if is_http then
 
 
   get_field_accessor = function(funcs, field)
-    local f = funcs[field]
+    local f = FIELDS_FUNCS[field] or funcs[field]
     if f then
       return f
     end
@@ -447,8 +452,7 @@ end
 
 
 function _M:get_value(field, params, ctx)
-  local func = FIELDS_FUNCS[field] or
-               get_field_accessor(self.funcs, field)
+  local func = get_field_accessor(self.funcs, field)
 
   return func(params, ctx)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Move the `FIELDS_FUNCS` searching into function `get_field_accessor()`,
this will make code easy to understand.

KAG-3634

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
