### PR TITLE
feat(db/schema): add traditional fields to expressions flavor

### DIFF
--- a/changelog/unreleased/kong/flavor-expressions-supports-traditional-fields.yml
+++ b/changelog/unreleased/kong/flavor-expressions-supports-traditional-fields.yml
@@ -1,0 +1,4 @@
+message: |
+  The router flavor `expressions` now supports the definition of traditional routes.
+type: feature
+scope: Core

--- a/changelog/unreleased/kong/flavor-expressions-supports-traditional-fields.yml
+++ b/changelog/unreleased/kong/flavor-expressions-supports-traditional-fields.yml
@@ -1,4 +1,7 @@
 message: |
-  The router flavor `expressions` now supports the definition of traditional routes.
+  Supported fields `methods`, `hosts`, `paths`, `headers`,
+  `snis`, `sources`, `destinations` and `regex_priority`
+  for the `route` entity when the `router_flavor` is `expressions`.
+  The meaning of these fields are consistent with the traditional route entity.
 type: feature
 scope: Core

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -178,7 +178,7 @@ local routes = {
 if kong_router_flavor == "expressions" then
 
   local special_fields = {
-    { expression = { description = "The route expression.", type = "string", required = true }, },
+    { expression = { description = "The route expression.", type = "string" }, },
     { priority = { description = "A number used to choose which route resolves a given request when several routes match it using expression simultaneously.", type = "integer", required = true, default = 0 }, },
   }
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -189,7 +189,7 @@ if kong_router_flavor == "expressions" then
 
   local special_fields = {
     { expression = { description = "The route expression.", type = "string" }, },   -- not required now
-    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner an route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^46 }, required = true, default = 0 }, },
+    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner an route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^46 - 1 }, required = true, default = 0 }, },
   }
 
   for _, v in ipairs(special_fields) do

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -189,7 +189,7 @@ if kong_router_flavor == "expressions" then
 
   local special_fields = {
     { expression = { description = "The route expression.", type = "string" }, },   -- not required now
-    { priority = { description = "A number used to choose which route resolves a given request when several routes match it using expression simultaneously.", type = "integer", between = { 0, 2^53 - 1 }, required = true, default = 0 }, },
+    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner it a route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^53 - 1 }, required = true, default = 0 }, },
   }
 
   for _, v in ipairs(special_fields) do

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -57,15 +57,19 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
   local HTTP_PATH_SEGMENTS_SUFFIX_REG = [[^(0|[1-9]\d*)(_([1-9]\d*))?$]]
 
   validate_route = function(entity)
-    if is_empty_field(entity.snis) and
-       is_empty_field(entity.sources) and
-       is_empty_field(entity.destinations) and
-       is_empty_field(entity.methods) and
-       is_empty_field(entity.hosts) and
-       is_empty_field(entity.paths) and
-       is_empty_field(entity.headers) and
-       is_null(entity.expression)   -- expression is not a table
-    then
+    local is_expression_empty =
+      is_null(entity.expression)   -- expression is not a table
+
+    local is_others_empty =
+      is_empty_field(entity.snis) and
+      is_empty_field(entity.sources) and
+      is_empty_field(entity.destinations) and
+      is_empty_field(entity.methods) and
+      is_empty_field(entity.hosts) and
+      is_empty_field(entity.paths) and
+      is_empty_field(entity.headers)
+
+    if is_expression_empty and is_others_empty then
       return true
     end
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -2,8 +2,7 @@ local typedefs = require("kong.db.schema.typedefs")
 local deprecation = require("kong.deprecation")
 
 
-local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor or
-                           "traditional_compatible"
+local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
 
 
 local PATH_V1_DEPRECATION_MSG =

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -178,7 +178,7 @@ local routes = {
 if kong_router_flavor == "expressions" then
 
   local special_fields = {
-    { expression = { description = "The route expression.", type = "string" }, },
+    { expression = { description = "The route expression.", type = "string" }, },   -- not required now
     { priority = { description = "A number used to choose which route resolves a given request when several routes match it using expression simultaneously.", type = "integer", required = true, default = 0 }, },
   }
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -73,6 +73,11 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
       return true
     end
 
+    if not is_expression_empty and not is_others_empty then
+      return nil, "Router Expression failed validation: " ..
+                  "can not set 'expression' field with other fields simultaneously"
+    end
+
     local schema = get_schema(entity.protocols)
     local exp = get_expression(entity)
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -44,13 +44,14 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
   local re_match = ngx.re.match
 
   local router = require("resty.router.router")
+  local transform = require("kong.router.transform")
   local get_schema = require("kong.router.atc").schema
   local get_expression = kong_router_flavor == "traditional_compatible" and
                          require("kong.router.compat").get_expression or
                          require("kong.router.expressions").transform_expression
 
-  local is_null = require("kong.router.transform").is_null
-  local is_empty_field = require("kong.router.transform").is_empty_field
+  local is_null = transform.is_null
+  local is_empty_field = transform.is_empty_field
 
   local HTTP_PATH_SEGMENTS_PREFIX = "http.path.segments."
   local HTTP_PATH_SEGMENTS_SUFFIX_REG = [[^(0|[1-9]\d*)(_([1-9]\d*))?$]]

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -189,7 +189,7 @@ if kong_router_flavor == "expressions" then
 
   local special_fields = {
     { expression = { description = "The route expression.", type = "string" }, },   -- not required now
-    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner an route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^53 - 1 }, required = true, default = 0 }, },
+    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner an route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^46 }, required = true, default = 0 }, },
   }
 
   for _, v in ipairs(special_fields) do

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -75,7 +75,9 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
 
     if not is_expression_empty and not is_others_empty then
       return nil, "Router Expression failed validation: " ..
-                  "can not set 'expression' field with other fields simultaneously"
+                  "cannot set 'expression' with " ..
+                  "'methods', 'hosts', 'paths', 'headers', 'snis', 'sources' or 'destinations' " ..
+                  "simultaneously"
     end
 
     local schema = get_schema(entity.protocols)

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -189,7 +189,7 @@ if kong_router_flavor == "expressions" then
 
   local special_fields = {
     { expression = { description = "The route expression.", type = "string" }, },   -- not required now
-    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner it a route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^53 - 1 }, required = true, default = 0 }, },
+    { priority = { description = "A number used to specify the matching order for expression routes. The higher the `priority`, the sooner an route will be evaluated. This field is ignored unless `expression` field is set.", type = "integer", between = { 0, 2^53 - 1 }, required = true, default = 0 }, },
   }
 
   for _, v in ipairs(special_fields) do

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -68,14 +68,22 @@ local grpc_subschema = {
 
 if kong and kong.configuration and  kong.configuration.router_flavor == "expressions" then
 
+  -- now http route in flavor 'expressions' accepts 'sources' 'and destinations'
+
   http_subschema.fields[1] = nil  -- sources
   http_subschema.fields[2] = nil  -- destinations
+
+  -- the route should have the field 'expression' if no others
 
   table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
   table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.else_then_at_least_one_of, "expression")
 
+  -- now grpc route in flavor 'expressions' accepts 'sources' 'and destinations'
+
   grpc_subschema.fields[3] = nil  -- sources
   grpc_subschema.fields[4] = nil  -- destinations
+
+  -- the route should have the field 'expression' if no others
 
   table.insert(grpc_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
   table.insert(grpc_subschema.entity_checks[1].conditional_at_least_one_of.else_then_at_least_one_of, "expression")

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -67,17 +67,31 @@ local grpc_subschema = {
 
 
 if kong and kong.configuration and  kong.configuration.router_flavor == "expressions" then
-  return {}
 
-else
-  return {
-    http = http_subschema,  -- protocols is the subschema key, and the first
-    https = http_subschema, -- matching protocol name is selected as subschema name
-    tcp = stream_subschema,
-    tls = stream_subschema,
-    udp = stream_subschema,
-    tls_passthrough = stream_subschema,
-    grpc = grpc_subschema,
-    grpcs = grpc_subschema,
-  }
+  http_subschema.fields[1] = nil  -- sources
+  http_subschema.fields[2] = nil  -- destinations
+
+  table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
+  table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.else_then_at_least_one_of, "expression")
+
+  grpc_subschema.fields[3] = nil  -- sources
+  grpc_subschema.fields[4] = nil  -- destinations
+
+  table.insert(grpc_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
+  table.insert(grpc_subschema.entity_checks[1].conditional_at_least_one_of.else_then_at_least_one_of, "expression")
+
+  table.insert(stream_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
+  table.insert(stream_subschema.entity_checks[2].conditional_at_least_one_of.then_at_least_one_of, "expression")
+
 end
+
+return {
+  http = http_subschema,  -- protocols is the subschema key, and the first
+  https = http_subschema, -- matching protocol name is selected as subschema name
+  tcp = stream_subschema,
+  tls = stream_subschema,
+  udp = stream_subschema,
+  tls_passthrough = stream_subschema,
+  grpc = grpc_subschema,
+  grpcs = grpc_subschema,
+}

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -66,7 +66,7 @@ local grpc_subschema = {
 }
 
 
--- NOTICE: make sure we have correct scheam constraion for flavor 'expressions'
+-- NOTICE: make sure we have correct schema constraion for flavor 'expressions'
 if kong and kong.configuration and  kong.configuration.router_flavor == "expressions" then
 
   -- now http route in flavor 'expressions' accepts `sources` and `destinations`

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -71,7 +71,10 @@ if kong and kong.configuration and  kong.configuration.router_flavor == "express
 
   -- now http route in flavor 'expressions' accepts `sources` and `destinations`
 
+  assert(http_subschema.fields[1].sources)
   http_subschema.fields[1] = nil  -- sources
+
+  assert(http_subschema.fields[2].destinations)
   http_subschema.fields[2] = nil  -- destinations
 
   -- the route should have the field 'expression' if no others
@@ -81,7 +84,10 @@ if kong and kong.configuration and  kong.configuration.router_flavor == "express
 
   -- now grpc route in flavor 'expressions' accepts `sources` and `destinations`
 
+  assert(grpc_subschema.fields[3].sources)
   grpc_subschema.fields[3] = nil  -- sources
+
+  assert(grpc_subschema.fields[4].destinations)
   grpc_subschema.fields[4] = nil  -- destinations
 
   -- the route should have the field 'expression' if no others

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -66,9 +66,10 @@ local grpc_subschema = {
 }
 
 
+-- NOTICE: make sure we have correct scheam constraion for flavor 'expressions'
 if kong and kong.configuration and  kong.configuration.router_flavor == "expressions" then
 
-  -- now http route in flavor 'expressions' accepts 'sources' 'and destinations'
+  -- now http route in flavor 'expressions' accepts `sources` and `destinations`
 
   http_subschema.fields[1] = nil  -- sources
   http_subschema.fields[2] = nil  -- destinations
@@ -78,7 +79,7 @@ if kong and kong.configuration and  kong.configuration.router_flavor == "express
   table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.then_at_least_one_of, "expression")
   table.insert(http_subschema.entity_checks[1].conditional_at_least_one_of.else_then_at_least_one_of, "expression")
 
-  -- now grpc route in flavor 'expressions' accepts 'sources' 'and destinations'
+  -- now grpc route in flavor 'expressions' accepts `sources` and `destinations`
 
   grpc_subschema.fields[3] = nil  -- sources
   grpc_subschema.fields[4] = nil  -- destinations

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -30,6 +30,7 @@ local check_select_params  = utils.check_select_params
 local get_service_info     = utils.get_service_info
 local route_match_stat     = utils.route_match_stat
 local split_host_port      = transform.split_host_port
+local split_routes_and_services_by_path = transform.split_routes_and_services_by_path
 
 
 local DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
@@ -277,8 +278,13 @@ end
 
 
 function _M.new(routes, cache, cache_neg, old_router, get_exp_and_priority)
+  -- route_and_service argument is a table with [route] and [service]
   if type(routes) ~= "table" then
     return error("expected arg #1 routes to be a table")
+  end
+
+  if is_http then
+    routes = split_routes_and_services_by_path(routes)
   end
 
   local router, err

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -278,7 +278,7 @@ end
 
 
 function _M.new(routes, cache, cache_neg, old_router, get_exp_and_priority)
-  -- route_and_service argument is a table with [route] and [service]
+  -- routes argument is a table with [route] and [service]
   if type(routes) ~= "table" then
     return error("expected arg #1 routes to be a table")
   end

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -2,27 +2,28 @@ local _M = {}
 
 
 local atc = require("kong.router.atc")
-local utils = require("kong.router.utils")
+--local utils = require("kong.router.utils")
 local transform = require("kong.router.transform")
-local tb_new = require("table.new")
-local tb_nkeys = require("table.nkeys")
-local uuid = require("resty.jit-uuid")
+--local tb_new = require("table.new")
+--local tb_nkeys = require("table.nkeys")
+--local uuid = require("resty.jit-uuid")
 
 
-local shallow_copy    = require("kong.tools.utils").shallow_copy
+--local shallow_copy    = require("kong.tools.utils").shallow_copy
 
 
-local is_regex_magic  = utils.is_regex_magic
-local is_empty_field  = transform.is_empty_field
+--local is_regex_magic  = utils.is_regex_magic
+--local is_empty_field  = transform.is_empty_field
 local get_expression  = transform.get_expression
 local get_priority    = transform.get_priority
+local split_routes_and_services_by_path = transform.split_routes_and_services_by_path
 
 
 local type = type
-local pairs = pairs
-local ipairs = ipairs
-local assert = assert
-local tb_insert = table.insert
+--local pairs = pairs
+--local ipairs = ipairs
+--local assert = assert
+--local tb_insert = table.insert
 
 
 local is_http = ngx.config.subsystem == "http"
@@ -31,7 +32,7 @@ local is_http = ngx.config.subsystem == "http"
 -- When splitting routes, we need to assign new UUIDs to the split routes.  We use uuid v5 to generate them from
 -- the original route id and the path index so that incremental rebuilds see stable IDs for routes that have not
 -- changed.
-local uuid_generator = assert(uuid.factory_v5('7f145bf9-0dce-4f91-98eb-debbce4b9f6b'))
+--local uuid_generator = assert(uuid.factory_v5('7f145bf9-0dce-4f91-98eb-debbce4b9f6b'))
 
 
 local function get_exp_and_priority(route)
@@ -47,6 +48,7 @@ local function get_exp_and_priority(route)
 end
 
 
+--[[
 -- group array-like table t by the function f, returning a table mapping from
 -- the result of invoking f on one of the elements to the actual elements.
 local function group_by(t, f)
@@ -106,6 +108,7 @@ local function split_routes_and_services_by_path(routes_and_services)
 
   return routes_and_services_split
 end
+--]]
 
 
 function _M.new(routes_and_services, cache, cache_neg, old_router)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -16,17 +16,17 @@ local transform = require("kong.router.transform")
 --local is_empty_field  = transform.is_empty_field
 local get_expression  = transform.get_expression
 local get_priority    = transform.get_priority
-local split_routes_and_services_by_path = transform.split_routes_and_services_by_path
+--local split_routes_and_services_by_path = transform.split_routes_and_services_by_path
 
 
-local type = type
+--local type = type
 --local pairs = pairs
 --local ipairs = ipairs
 --local assert = assert
 --local tb_insert = table.insert
 
 
-local is_http = ngx.config.subsystem == "http"
+--local is_http = ngx.config.subsystem == "http"
 
 
 -- When splitting routes, we need to assign new UUIDs to the split routes.  We use uuid v5 to generate them from
@@ -113,6 +113,7 @@ end
 
 function _M.new(routes_and_services, cache, cache_neg, old_router)
   -- route_and_service argument is a table with [route] and [service]
+  --[[
   if type(routes_and_services) ~= "table" then
     return error("expected arg #1 routes to be a table", 2)
   end
@@ -120,6 +121,7 @@ function _M.new(routes_and_services, cache, cache_neg, old_router)
   if is_http then
     routes_and_services = split_routes_and_services_by_path(routes_and_services)
   end
+  --]]
 
   return atc.new(routes_and_services, cache, cache_neg, old_router, get_exp_and_priority)
 end

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -2,37 +2,11 @@ local _M = {}
 
 
 local atc = require("kong.router.atc")
---local utils = require("kong.router.utils")
 local transform = require("kong.router.transform")
---local tb_new = require("table.new")
---local tb_nkeys = require("table.nkeys")
---local uuid = require("resty.jit-uuid")
 
 
---local shallow_copy    = require("kong.tools.utils").shallow_copy
-
-
---local is_regex_magic  = utils.is_regex_magic
---local is_empty_field  = transform.is_empty_field
 local get_expression  = transform.get_expression
 local get_priority    = transform.get_priority
---local split_routes_and_services_by_path = transform.split_routes_and_services_by_path
-
-
---local type = type
---local pairs = pairs
---local ipairs = ipairs
---local assert = assert
---local tb_insert = table.insert
-
-
---local is_http = ngx.config.subsystem == "http"
-
-
--- When splitting routes, we need to assign new UUIDs to the split routes.  We use uuid v5 to generate them from
--- the original route id and the path index so that incremental rebuilds see stable IDs for routes that have not
--- changed.
---local uuid_generator = assert(uuid.factory_v5('7f145bf9-0dce-4f91-98eb-debbce4b9f6b'))
 
 
 local function get_exp_and_priority(route)
@@ -48,81 +22,7 @@ local function get_exp_and_priority(route)
 end
 
 
---[[
--- group array-like table t by the function f, returning a table mapping from
--- the result of invoking f on one of the elements to the actual elements.
-local function group_by(t, f)
-  local result = {}
-  for _, value in ipairs(t) do
-    local key = f(value)
-    if result[key] then
-      tb_insert(result[key], value)
-    else
-      result[key] = { value }
-    end
-  end
-  return result
-end
-
--- split routes into multiple routes, one for each prefix length and one for all
--- regular expressions
-local function split_route_by_path_into(route_and_service, routes_and_services_split)
-  local original_route = route_and_service.route
-
-  if is_empty_field(original_route.paths) or #original_route.paths == 1 then
-    tb_insert(routes_and_services_split, route_and_service)
-    return
-  end
-
-  -- make sure that route_and_service contains only the two expected entries, route and service
-  assert(tb_nkeys(route_and_service) == 1 or tb_nkeys(route_and_service) == 2)
-
-  local grouped_paths = group_by(
-    original_route.paths,
-    function(path)
-      return is_regex_magic(path) or #path
-    end
-  )
-  for index, paths in pairs(grouped_paths) do
-    local cloned_route = {
-      route = shallow_copy(original_route),
-      service = route_and_service.service,
-    }
-
-    cloned_route.route.original_route = original_route
-    cloned_route.route.paths = paths
-    cloned_route.route.id = uuid_generator(original_route.id .. "#" .. tostring(index))
-
-    tb_insert(routes_and_services_split, cloned_route)
-  end
-end
-
-
-local function split_routes_and_services_by_path(routes_and_services)
-  local count = #routes_and_services
-  local routes_and_services_split = tb_new(count, 0)
-
-  for i = 1, count do
-    split_route_by_path_into(routes_and_services[i], routes_and_services_split)
-  end
-
-  return routes_and_services_split
-end
---]]
-
-
 function _M.new(routes_and_services, cache, cache_neg, old_router)
-  -- route_and_service argument is a table with [route] and [service]
-  --[[
-  if type(routes_and_services) ~= "table" then
-    return error("expected arg #1 routes to be a table", 2)
-  end
-
-  if is_http then
-    routes_and_services = split_routes_and_services_by_path(routes_and_services)
-  end
-  --]]
-
   return atc.new(routes_and_services, cache, cache_neg, old_router, get_exp_and_priority)
 end
 

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -8,6 +8,10 @@ local atc = require("kong.router.atc")
 local transform = require("kong.router.transform")
 
 
+local get_expression = transform.get_expression
+local get_priority   = transform.get_priority
+
+
 local gen_for_field = transform.gen_for_field
 local OP_EQUAL      = transform.OP_EQUAL
 local LOGICAL_AND   = transform.LOGICAL_AND
@@ -27,7 +31,7 @@ local PROTOCOLS_OVERRIDE = {
 
 -- net.port => net.dst.port
 local function transform_expression(route)
-  local exp = route.expression
+  local exp = get_expression(route)
 
   if not exp then
     return nil
@@ -60,6 +64,8 @@ local function get_exp_and_priority(route)
     return
   end
 
+  local priority = get_priority(route)
+
   local protocols = route.protocols
 
   -- give the chance for http redirection (301/302/307/308/426)
@@ -69,7 +75,7 @@ local function get_exp_and_priority(route)
      protocols[1] == "tls" or
      protocols[1] == "tls_passthrough")
   then
-    return exp, route.priority
+    return exp, priority
   end
 
   local gen = gen_for_field("net.protocol", OP_EQUAL, protocols,
@@ -80,7 +86,7 @@ local function get_exp_and_priority(route)
     exp = exp .. LOGICAL_AND .. gen
   end
 
-  return exp, route.priority
+  return exp, priority
 end
 
 

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -305,6 +305,11 @@ end
 
 
 local function get_expression(route)
+  -- we perfer the field 'expression', ignore others
+  if not is_null(route.expression) then
+    return route.expression
+  end
+
   local methods = route.methods
   local hosts   = route.hosts
   local paths   = route.paths
@@ -512,6 +517,10 @@ local PLAIN_HOST_ONLY_BIT = lshift_uint64(0x01ULL, 60)
 local REGEX_URL_BIT       = lshift_uint64(0x01ULL, 51)
 
 
+-- expression only route has higher priority than traditional route
+local EXPRESSION_ONLY_BIT = lshift_uint64(0xFFULL, 55)
+
+
 -- convert a route to a priority value for use in the ATC router
 -- priority must be a 64-bit non negative integer
 -- format (big endian):
@@ -527,6 +536,11 @@ local REGEX_URL_BIT       = lshift_uint64(0x01ULL, 51)
 -- |                         |                                     |
 -- +-------------------------+-------------------------------------+
 local function get_priority(route)
+  -- we perfer the fields 'expression' and 'priority'
+  if not is_null(route.expression) then
+    return bor(EXPRESSION_ONLY_BIT, route.priority or 0)
+  end
+
   local snis = route.snis
   local srcs = route.sources
   local dsts = route.destinations

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -310,10 +310,12 @@ end
 
 
 local function get_expression(route)
-  -- we perfer the field 'expression', ignore others
+  -- we perfer the field 'expression', reject others
   if not is_null(route.expression) then
     return route.expression
   end
+
+  -- transform other fields (methods/hosts/paths/...) to expression
 
   local methods = route.methods
   local hosts   = route.hosts
@@ -545,6 +547,8 @@ local function get_priority(route)
   if not is_null(route.expression) then
     return bor(EXPRESSION_ONLY_BIT, route.priority or 0)
   end
+
+  -- transform other fields (methods/hosts/paths/...) to expression priority
 
   local snis = route.snis
   local srcs = route.sources

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -518,7 +518,7 @@ local REGEX_URL_BIT       = lshift_uint64(0x01ULL, 51)
 
 
 -- expression only route has higher priority than traditional route
-local EXPRESSION_ONLY_BIT = lshift_uint64(0xFFULL, 55)
+local EXPRESSION_ONLY_BIT = lshift_uint64(0xFFULL, 56)
 
 
 -- convert a route to a priority value for use in the ATC router
@@ -559,6 +559,14 @@ local function get_priority(route)
   local headers = route.headers
 
   local match_weight = 0  -- 0x0ULL
+
+  if not is_empty_field(srcs) then
+    match_weight = match_weight + 1
+  end
+
+  if not is_empty_field(dsts) then
+    match_weight = match_weight + 1
+  end
 
   if not is_empty_field(methods) then
     match_weight = match_weight + 1

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -665,6 +665,11 @@ end
 local uuid_generator = assert(uuid.factory_v5('7f145bf9-0dce-4f91-98eb-debbce4b9f6b'))
 
 
+local function sort_by_regex_or_length(path)
+  return is_regex_magic(path) or #path
+end
+
+
 -- group array-like table t by the function f, returning a table mapping from
 -- the result of invoking f on one of the elements to the actual elements.
 local function group_by(t, f)
@@ -696,10 +701,7 @@ local function split_route_by_path_into(route_and_service, routes_and_services_s
   assert(tb_nkeys(route_and_service) == 1 or tb_nkeys(route_and_service) == 2)
 
   local grouped_paths = group_by(
-    original_route.paths,
-    function(path)
-      return is_regex_magic(path) or #path
-    end
+    original_route.paths, sort_by_regex_or_length
   )
   for index, paths in pairs(grouped_paths) do
     local cloned_route = {

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -20,7 +20,7 @@ local bor, band, lshift, rshift = bit.bor, bit.band, bit.lshift, bit.rshift
 
 local is_regex_magic  = utils.is_regex_magic
 local replace_dashes_lower  = require("kong.tools.string").replace_dashes_lower
-local shallow_copy = require("kong.tools.utils").shallow_copy
+local shallow_copy = require("kong.tools.table").shallow_copy
 
 
 local is_null

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -643,6 +643,10 @@ local function get_priority(route)
     end
   end
 
+  -- Currently match_weight has only 3 bits
+  -- it can not be more than 7
+  assert(match_weight <= 7)
+
   local match_weight   = lshift_uint64(match_weight, 61)
   local headers_count  = lshift_uint64(headers_count, 52)
 

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -12,6 +12,7 @@ local type = type
 local assert = assert
 local pairs = pairs
 local ipairs = ipairs
+local tostring = tostring
 local tb_insert = table.insert
 local fmt = string.format
 local byte = string.byte

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -10,6 +10,7 @@ local utils = require("kong.router.utils")
 
 local type = type
 local assert = assert
+local pairs = pairs
 local ipairs = ipairs
 local tb_insert = table.insert
 local fmt = string.format

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -636,7 +636,9 @@ return {
 
   split_host_port = split_host_port,
 
+  is_null = is_null,
   is_empty_field = is_empty_field,
+
   gen_for_field = gen_for_field,
 
   get_expression = get_expression,

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -20,7 +20,7 @@ local bor, band, lshift, rshift = bit.bor, bit.band, bit.lshift, bit.rshift
 
 local is_regex_magic  = utils.is_regex_magic
 local replace_dashes_lower  = require("kong.tools.string").replace_dashes_lower
-local shallow_copy    = require("kong.tools.utils").shallow_copy
+local shallow_copy = require("kong.tools.utils").shallow_copy
 
 
 local is_null
@@ -682,7 +682,7 @@ local function split_route_by_path_into(route_and_service, routes_and_services_s
   local original_route = route_and_service.route
 
   if is_empty_field(original_route.paths) or #original_route.paths == 1 or
-     not is_null(original_route.expression)
+     not is_null(original_route.expression) -- expression will ignore paths
   then
     tb_insert(routes_and_services_split, route_and_service)
     return

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -688,7 +688,7 @@ end
 
 -- split routes into multiple routes, one for each prefix length and one for all
 -- regular expressions
-local function split_route_by_path_into(route_and_service, routes_and_services_split)
+local function split_route_by_path_info(route_and_service, routes_and_services_split)
   local original_route = route_and_service.route
 
   if is_empty_field(original_route.paths) or #original_route.paths == 1 or
@@ -724,7 +724,7 @@ local function split_routes_and_services_by_path(routes_and_services)
   local routes_and_services_split = tb_new(count, 0)
 
   for i = 1, count do
-    split_route_by_path_into(routes_and_services[i], routes_and_services_split)
+    split_route_by_path_info(routes_and_services[i], routes_and_services_split)
   end
 
   return routes_and_services_split

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -568,7 +568,7 @@ local function get_priority(route)
   local paths   = route.paths
   local headers = route.headers
 
-  local match_weight = 0  -- 0x0ULL
+  local match_weight = 0  -- 0x0ULL, *can not* exceed `7`
 
   if not is_empty_field(srcs) then
     match_weight = match_weight + 1

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -43,7 +43,8 @@ local function reload_flavor(flavor)
 end
 
 
-for _, flavor in ipairs({ "traditional", "traditional_compatible", }) do
+--for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
+for _, flavor in ipairs({  "expressions" }) do
 describe("routes schema (flavor = " .. flavor .. ")", function()
   local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
   local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
@@ -1074,7 +1075,8 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
         assert.falsy(ok)
         assert.same({
           ["@entity"] = {
-            "must set one of 'sources', 'destinations', 'snis' when 'protocols' is 'tcp', 'tls' or 'udp'"
+            "must set one of 'sources', 'destinations', 'snis'" ..
+            (flavor == "expressions" and ", 'expression'" or "") .. " when 'protocols' is 'tcp', 'tls' or 'udp'"
           }
         }, errs)
       end
@@ -1091,7 +1093,8 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'methods', 'hosts', 'headers', 'paths' when 'protocols' is 'http'"
+        "must set one of 'methods', 'hosts', 'headers', 'paths'" ..
+        (flavor == "expressions" and ", 'expression'" or "") .. " when 'protocols' is 'http'"
       }
     }, errs)
 
@@ -1103,7 +1106,8 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'methods', 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'https'"
+        "must set one of 'methods', 'hosts', 'headers', 'paths', 'snis'" ..
+        (flavor == "expressions" and ", 'expression'" or "") .. " when 'protocols' is 'https'"
       }
     }, errs)
   end)
@@ -1118,7 +1122,8 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'hosts', 'headers', 'paths' when 'protocols' is 'grpc'"
+        "must set one of 'hosts', 'headers', 'paths'" ..
+        (flavor == "expressions" and ", 'expression'" or "") .." when 'protocols' is 'grpc'"
       }
     }, errs)
 
@@ -1130,7 +1135,8 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs'"
+        "must set one of 'hosts', 'headers', 'paths', 'snis'" ..
+        (flavor == "expressions" and ", 'expression'" or "") .. " when 'protocols' is 'grpcs'"
       }
     }, errs)
   end)

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1343,11 +1343,12 @@ describe("routes schema (flavor = expressions)", function()
 end)
 
 
-describe("routes schema (flavor = traditional_compatible)", function()
+for _, flavor in ipairs({ "traditional_compatible", "expressions" }) do
+describe("routes schema (flavor = " .. flavor .. ")", function()
   local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
   local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
 
-  reload_flavor("traditional_compatible")
+  reload_flavor(flavor)
   setup_global_env()
 
   it("validates a valid http route", function()
@@ -1437,6 +1438,7 @@ describe("routes schema (flavor = traditional_compatible)", function()
     assert.is_nil(errs)
   end)
 end)
+end   -- flavor in ipairs({ "traditional_compatible", "expressions" })
 
 
 describe("routes schema (flavor = expressions)", function()

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -43,8 +43,7 @@ local function reload_flavor(flavor)
 end
 
 
---for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
-for _, flavor in ipairs({  "expressions" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
 describe("routes schema (flavor = " .. flavor .. ")", function()
   local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
   local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1369,6 +1369,14 @@ describe("routes schema (flavor = expressions)", function()
     assert.truthy(errs["priority"])
   end)
 
+  it("fails when priority is more than 2^53 - 1", function()
+    local route = { priority = 2^53 }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.falsy(ok)
+    assert.truthy(errs["priority"])
+  end)
+
   it("fails when all fields is missing", function()
     local route = { expression = ngx.null }
     route = Routes:process_auto_fields(route, "insert")

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -43,14 +43,17 @@ local function reload_flavor(flavor)
 end
 
 
-describe("routes schema (flavor = traditional/traditional_compatible)", function()
+for _, flavor in ipairs({ "traditional", "traditional_compatible", }) do
+describe("routes schema (flavor = " .. flavor .. ")", function()
   local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
   local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
   local uuid_pattern = "^" .. ("%x"):rep(8) .. "%-" .. ("%x"):rep(4) .. "%-"
                            .. ("%x"):rep(4) .. "%-" .. ("%x"):rep(4) .. "%-"
                            .. ("%x"):rep(12) .. "$"
 
-  reload_flavor("traditional")
+  local it_trad_only = (flavor == "traditional") and it or pending
+
+  reload_flavor(flavor)
   setup_global_env()
 
   it("validates a valid route", function()
@@ -354,7 +357,7 @@ describe("routes schema (flavor = traditional/traditional_compatible)", function
       assert.is_true(ok)
     end)
 
-    it("accepts properly percent-encoded values", function()
+    it_trad_only("accepts properly percent-encoded values", function()
       local valid_paths = { "/abcd\xaa\x10\xff\xAA\xFF" }
 
       for i = 1, #valid_paths do
@@ -1264,6 +1267,7 @@ describe("routes schema (flavor = traditional/traditional_compatible)", function
 
   end)
 end)
+end   -- for flavor
 
 
 describe("routes schema (flavor = expressions)", function()
@@ -1492,7 +1496,6 @@ describe("routes schema (flavor = expressions)", function()
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)
 
-    -- verified by `schema/typedefs.lua`
     assert.truthy(errs["@entity"])
   end)
 
@@ -1509,7 +1512,6 @@ describe("routes schema (flavor = expressions)", function()
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)
 
-    -- verified by `schema/typedefs.lua`
     assert.truthy(errs["@entity"])
   end)
 
@@ -1526,7 +1528,6 @@ describe("routes schema (flavor = expressions)", function()
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)
 
-    -- verified by `schema/typedefs.lua`
     assert.truthy(errs["@entity"])
   end)
 

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1369,8 +1369,8 @@ describe("routes schema (flavor = expressions)", function()
     assert.truthy(errs["priority"])
   end)
 
-  it("fails when priority is more than 2^46", function()
-    local route = { priority = 2^46 + 1 }
+  it("fails when priority is more than 2^46 - 1", function()
+    local route = { priority = 2^46 }
     route = Routes:process_auto_fields(route, "insert")
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1282,9 +1282,20 @@ describe("routes schema (flavor = expressions)", function()
     local route = {
       id             = a_valid_uuid,
       name           = "my_route",
-      protocols      = { "http" },
+      protocols      = { "https" },
+
+      methods        = { "GET", "POST" },
+      hosts          = { "example.com" },
+      headers        = { location = { "location-1" } },
+      paths          = { "/ovo" },
+
+      snis           = { "example.org" },
+      sources        = {{ ip = "127.0.0.1" }},
+      destinations   = {{ ip = "127.0.0.1" }},
+
       expression     = [[(http.method == "GET")]],
       priority       = 100,
+
       strip_path     = false,
       preserve_host  = true,
       service        = { id = another_uuid },

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1321,7 +1321,7 @@ describe("routes schema (flavor = expressions)", function()
     route = Routes:process_auto_fields(route, "insert")
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)
-    assert.truthy(errs["expression"])
+    assert.truthy(errs["@entity"])
   end)
 
   it("fails given an invalid expression", function()

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -357,6 +357,7 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
       assert.is_true(ok)
     end)
 
+    -- TODO: bump atc-router to fix it
     it_trad_only("accepts properly percent-encoded values", function()
       local valid_paths = { "/abcd\xaa\x10\xff\xAA\xFF" }
 

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1369,8 +1369,8 @@ describe("routes schema (flavor = expressions)", function()
     assert.truthy(errs["priority"])
   end)
 
-  it("fails when priority is more than 2^53 - 1", function()
-    local route = { priority = 2^53 }
+  it("fails when priority is more than 2^46", function()
+    local route = { priority = 2^46 + 1 }
     route = Routes:process_auto_fields(route, "insert")
     local ok, errs = Routes:validate_insert(route)
     assert.falsy(ok)

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1329,6 +1329,38 @@ describe("routes schema (flavor = expressions)", function()
     assert.falsy(route.strip_path)
   end)
 
+  it("fails when set 'expression' and others simultaneously", function()
+    local route = {
+      id             = a_valid_uuid,
+      name           = "my_route",
+      protocols      = { "http" },
+      expression     = [[(http.method == "GET")]],
+      service        = { id = another_uuid },
+    }
+
+    local others = {
+      methods        = { "GET", "POST" },
+      hosts          = { "example.com" },
+      headers        = { location = { "location-1" } },
+      paths          = { "/ovo" },
+
+      snis           = { "example.org" },
+      sources        = {{ ip = "127.0.0.1" }},
+      destinations   = {{ ip = "127.0.0.1" }},
+    }
+
+    for k, v in pairs(others) do
+      route[k] = v
+
+      local r = Routes:process_auto_fields(route, "insert")
+      local ok, errs = Routes:validate_insert(r)
+      assert.falsy(ok)
+      assert.truthy(errs["@entity"])
+
+      route[k] = nil
+    end
+  end)
+
   it("fails when priority is missing", function()
     local route = { priority = ngx.null }
     route = Routes:process_auto_fields(route, "insert")

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -23,6 +23,7 @@ end
 
 local function new_router(cases, old_router)
   -- add fields expression/priority only for flavor expressions
+  --[[
   if kong.configuration.router_flavor == "expressions" then
     for _, v in ipairs(cases) do
       local r = v.route
@@ -31,6 +32,7 @@ local function new_router(cases, old_router)
       r.priority = r.priority or atc_compat._get_priority(r)
     end
   end
+  --]]
 
   return Router.new(cases, nil, nil, old_router)
 end

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4868,7 +4868,7 @@ end)
 end -- for flavor
 
 
-for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
   describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5824,7 +5824,7 @@ do
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
             expression = [[http.path ^= r#"/foo"#]],
-            priority = 2^46 - 2,
+            priority = 2^46 - 3,
           },
         },
       }
@@ -5840,7 +5840,7 @@ do
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
             expression = [[http.path ^= r#"/foo"#]],
-            priority = 2^46 - 1,
+            priority = 2^46 - 2,
           },
       })
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5764,14 +5764,14 @@ do
   describe("Router (flavor = " .. flavor .. ") [http]", function()
     reload_router(flavor)
 
-    it("expression field has higher priority than other fields", function()
+    it("ignores other fields if expression field exists", function()
       local use_case = {
         {
           service = service,
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
-            paths = { "/foo" },
-            expression = [[http.path ^= r#"/bar"#]],
+            paths = { "/foo" },                       -- ignored
+            expression = [[http.path ^= r#"/bar"#]],  -- effective
           },
         },
       }

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -4985,8 +4985,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
   end)
 end
 
-do
-  local flavor = "traditional_compatible"
+for _, flavor in ipairs({ "traditional_compatible", "expressions" }) do
 
   describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
@@ -5129,7 +5128,8 @@ do
       assert.same(use_case[2].route, match_t.route)
     end)
   end)
-end   -- local flavor = "traditional_compatible"
+end   -- for flavor
+
 
 do
   local flavor = "expressions"

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5764,13 +5764,13 @@ do
   describe("Router (flavor = " .. flavor .. ") [http]", function()
     reload_router(flavor)
 
-    it("ignores other fields if expression field exists", function()
+    it("rejects other fields if expression field exists", function()
       local use_case = {
         {
           service = service,
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
-            paths = { "/foo" },                       -- ignored
+            paths = { "/foo" },                       -- rejected
             expression = [[http.path ^= r#"/bar"#]],  -- effective
           },
         },

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5760,5 +5760,41 @@ do
       assert.falsy(match_t)
     end)
   end)
+
+  describe("Router (flavor = " .. flavor .. ") [http]", function()
+    reload_router(flavor)
+
+    it("expression route has higher priority than traditional route", function()
+      local use_case = {
+        {
+          service = service,
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+            paths = { "/foo" },
+          },
+        },
+      }
+
+      local router = assert(new_router(use_case))
+
+      local match_t = router:select("GET", "/foo/bar")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+
+      table.insert(use_case, {
+          service = service,
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+            expression = [[http.path ^= r#"/foo"#]],
+          },
+      })
+
+      local router = assert(new_router(use_case))
+
+      local match_t = router:select("GET", "/foo/bar")
+      assert.truthy(match_t)
+      assert.same(use_case[2].route, match_t.route)
+    end)
+  end)
 end   -- local flavor = "expressions"
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5817,14 +5817,14 @@ do
       assert.same(use_case[2].route, match_t.route)
     end)
 
-    it("works when route.priority is near 2^53 - 1", function()
+    it("works when route.priority is near 2^46", function()
       local use_case = {
         {
           service = service,
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
             expression = [[http.path ^= r#"/foo"#]],
-            priority = 2^53 - 3,
+            priority = 2^46 - 2,
           },
         },
       }
@@ -5840,7 +5840,7 @@ do
           route   = {
             id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
             expression = [[http.path ^= r#"/foo"#]],
-            priority = 2^53 - 2,
+            priority = 2^46 - 1,
           },
       })
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5816,6 +5816,40 @@ do
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)
     end)
+
+    it("works when route.priority is near 2^53 - 1", function()
+      local use_case = {
+        {
+          service = service,
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+            expression = [[http.path ^= r#"/foo"#]],
+            priority = 2^53 - 3,
+          },
+        },
+      }
+
+      local router = assert(new_router(use_case))
+
+      local match_t = router:select("GET", "/foo/bar")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+
+      table.insert(use_case, {
+          service = service,
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+            expression = [[http.path ^= r#"/foo"#]],
+            priority = 2^53 - 2,
+          },
+      })
+
+      local router = assert(new_router(use_case))
+
+      local match_t = router:select("GET", "/foo/bar")
+      assert.truthy(match_t)
+      assert.same(use_case[2].route, match_t.route)
+    end)
   end)
 end   -- local flavor = "expressions"
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -22,18 +22,6 @@ local function reload_router(flavor, subsystem)
 end
 
 local function new_router(cases, old_router)
-  -- add fields expression/priority only for flavor expressions
-  --[[
-  if kong.configuration.router_flavor == "expressions" then
-    for _, v in ipairs(cases) do
-      local r = v.route
-
-      r.expression = r.expression or atc_compat.get_expression(r)
-      r.priority = r.priority or atc_compat._get_priority(r)
-    end
-  end
-  --]]
-
   return Router.new(cases, nil, nil, old_router)
 end
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5764,6 +5764,27 @@ do
   describe("Router (flavor = " .. flavor .. ") [http]", function()
     reload_router(flavor)
 
+    it("expression field has higher priority than other fields", function()
+      local use_case = {
+        {
+          service = service,
+          route   = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+            paths = { "/foo" },
+            expression = [[http.path ^= r#"/bar"#]],
+          },
+        },
+      }
+
+      local router = assert(new_router(use_case))
+
+      local match_t = router:select("GET", "/foo")
+      assert.falsy(match_t)
+
+      local match_t = router:select("GET", "/bar")
+      assert.truthy(match_t)
+    end)
+
     it("expression route has higher priority than traditional route", function()
       local use_case = {
         {

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -161,6 +161,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -2,7 +2,6 @@ local helpers = require "spec.helpers"
 local utils = require "pl.utils"
 local stringx = require "pl.stringx"
 local http = require "resty.http"
---local atc_compat = require "kong.router.compat"
 
 
 local function count_server_blocks(filename)
@@ -163,17 +162,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.destinations = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -163,6 +163,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -171,6 +172,7 @@ local function gen_route(flavor, r)
   r.priority = tonumber(atc_compat._get_priority(r))
 
   r.destinations = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 local utils = require "pl.utils"
 local stringx = require "pl.stringx"
 local http = require "resty.http"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local function count_server_blocks(filename)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -122,8 +122,7 @@ local function remove_routes(strategy, routes)
   admin_api.plugins:remove(enable_buffering_plugin)
 end
 
---for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
-for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
 for _, b in ipairs({ false, true }) do enable_buffering = b
 for _, strategy in helpers.each_strategy() do
   describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "] with buffering [" .. (b and "on]" or "off]") , function()

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2596,6 +2596,11 @@ do
     end)
 
     describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
+      -- yaml can not export a proper interger for huge priority
+      if strategy == "off" then
+        return
+      end
+
       local proxy_client
 
       reload_router(flavor)
@@ -2613,7 +2618,7 @@ do
         bp.routes:insert {
           protocols = { "http" },
           expression = [[http.path == "/foo/bar"]],
-          priority = 2^53 - 2,
+          priority = 2^53 - 1,
           service = service,
         }
 
@@ -2639,7 +2644,7 @@ do
         end
       end)
 
-      it("can set route.priority to 2^53 - 2", function()
+      it("can set route.priority to 2^53 - 1", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foo/bar",
@@ -2655,10 +2660,10 @@ do
           path    = "/routes/" .. route_id,
         })
         local body = assert.response(res).has_status(200)
-        assert(string.find(body, [["priority":9007199254740990]]))
+        assert(string.find(body, [["priority":9007199254740991]]))
 
         local json = cjson.decode(body)
-        assert.equal(2^53 - 2, json.priority)
+        assert.equal(2^53 - 1, json.priority)
 
         admin_client:close()
       end)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2613,7 +2613,7 @@ do
         bp.routes:insert {
           protocols = { "http" },
           expression = [[http.path == "/foo/bar"]],
-          priority = 2^46,
+          priority = 2^46 - 1,
           service = service,
         }
 
@@ -2639,7 +2639,7 @@ do
         end
       end)
 
-      it("can set route.priority to 2^46", function()
+      it("can set route.priority to 2^46 - 1", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foo/bar",
@@ -2655,10 +2655,10 @@ do
           path    = "/routes/" .. route_id,
         })
         local body = assert.response(res).has_status(200)
-        assert(string.find(body, [["priority":70368744177664]]))
+        assert(string.find(body, [["priority":70368744177663]]))
 
         local json = cjson.decode(body)
-        assert.equal(2^46, json.priority)
+        assert.equal(2^46 - 1, json.priority)
 
         admin_client:close()
       end)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2596,11 +2596,6 @@ do
     end)
 
     describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
-      -- yaml can not export a proper interger for huge priority
-      if strategy == "off" then
-        return
-      end
-
       local proxy_client
 
       reload_router(flavor)
@@ -2618,7 +2613,7 @@ do
         bp.routes:insert {
           protocols = { "http" },
           expression = [[http.path == "/foo/bar"]],
-          priority = 2^53 - 1,
+          priority = 2^46,
           service = service,
         }
 
@@ -2644,7 +2639,7 @@ do
         end
       end)
 
-      it("can set route.priority to 2^53 - 1", function()
+      it("can set route.priority to 2^46", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foo/bar",
@@ -2660,10 +2655,10 @@ do
           path    = "/routes/" .. route_id,
         })
         local body = assert.response(res).has_status(200)
-        assert(string.find(body, [["priority":9007199254740991]]))
+        assert(string.find(body, [["priority":70368744177664]]))
 
         local json = cjson.decode(body)
-        assert.equal(2^53 - 1, json.priority)
+        assert.equal(2^46, json.priority)
 
         admin_client:close()
       end)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2613,7 +2613,7 @@ do
         bp.routes:insert {
           protocols = { "http" },
           expression = [[http.path == "/foo/bar"]],
-          priority = 2^53 - 1,
+          priority = 2^53 - 2,
           service = service,
         }
 
@@ -2639,7 +2639,7 @@ do
         end
       end)
 
-      it("can set route.priority to 2^53 - 1", function()
+      it("can set route.priority to 2^53 - 2", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/foo/bar",
@@ -2655,10 +2655,10 @@ do
           path    = "/routes/" .. route_id,
         })
         local body = assert.response(res).has_status(200)
-        assert(string.find(body, [["priority":9007199254740991]]))
+        assert(string.find(body, [["priority":9007199254740990]]))
 
         local json = cjson.decode(body)
-        assert.equal(2^53 - 1, json.priority)
+        assert.equal(2^53 - 2, json.priority)
 
         admin_client:close()
       end)

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -63,6 +63,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -73,6 +74,7 @@ local function gen_route(flavor, r)
   r.hosts = nil
   r.paths = nil
   r.snis  = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -61,6 +61,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -2,7 +2,6 @@ local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers      = require "spec.helpers"
 local cjson        = require "cjson"
 local fmt          = string.format
---local atc_compat = require "kong.router.compat"
 
 
 local function get_cert(server_name)
@@ -63,19 +62,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.hosts = nil
-  r.paths = nil
-  r.snis  = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -2,7 +2,7 @@ local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers      = require "spec.helpers"
 local cjson        = require "cjson"
 local fmt          = string.format
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local function get_cert(server_name)

--- a/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
@@ -23,6 +23,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
@@ -25,6 +25,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -33,6 +34,7 @@ local function gen_route(flavor, r)
   r.priority = tonumber(atc_compat._get_priority(r))
 
   r.destinations = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require "spec.helpers"
---local atc_compat = require "kong.router.compat"
 
 
 local function reload_router(flavor)
@@ -25,17 +24,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.destinations = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
@@ -1,5 +1,5 @@
 local helpers = require "spec.helpers"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local function reload_router(flavor)

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -121,7 +121,7 @@ local function gen_plugin(route)
 end
 
 
-for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
 for _, strategy in helpers.each_strategy() do
   describe("overriding upstream TLS parameters for database [#" .. strategy .. ", flavor = " .. flavor .. "]", function()
     local admin_client

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require "spec.helpers"
 local ssl_fixtures = require "spec.fixtures.ssl"
---local atc_compat = require "kong.router.compat"
 
 
 local other_ca_cert = [[
@@ -104,21 +103,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.hosts = nil
-  r.paths = nil
-  r.snis  = nil
-
-  r.destinations = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local ssl_fixtures = require "spec.fixtures.ssl"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local other_ca_cert = [[

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -102,6 +102,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -104,6 +104,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -116,6 +117,7 @@ local function gen_route(flavor, r)
   r.snis  = nil
 
   r.destinations = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -29,6 +29,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -39,6 +40,7 @@ local function gen_route(flavor, r)
   r.hosts = nil
   r.paths = nil
   r.snis  = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -1,7 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local pl_path = require "pl.path"
---local atc_compat = require "kong.router.compat"
 
 local FILE_LOG_PATH = os.tmpname()
 
@@ -29,19 +28,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.hosts = nil
-  r.paths = nil
-  r.snis  = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -27,6 +27,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local pl_path = require "pl.path"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 local FILE_LOG_PATH = os.tmpname()
 

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require "spec.helpers"
 local pl_file = require "pl.file"
---local atc_compat = require "kong.router.compat"
 
 
 local TEST_CONF = helpers.test_conf
@@ -29,19 +28,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.hosts = nil
-  r.paths = nil
-  r.snis  = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -29,6 +29,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -39,6 +40,7 @@ local function gen_route(flavor, r)
   r.hosts = nil
   r.paths = nil
   r.snis  = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -27,6 +27,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local pl_file = require "pl.file"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local TEST_CONF = helpers.test_conf

--- a/spec/02-integration/05-proxy/23-context_spec.lua
+++ b/spec/02-integration/05-proxy/23-context_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local null = ngx.null
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local function reload_router(flavor)

--- a/spec/02-integration/05-proxy/23-context_spec.lua
+++ b/spec/02-integration/05-proxy/23-context_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require "spec.helpers"
 local null = ngx.null
---local atc_compat = require "kong.router.compat"
 
 
 local function reload_router(flavor)
@@ -26,18 +25,6 @@ end
 
 
 local function gen_route(flavor, r)
-  --[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.paths = nil
-  r.destinations = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/23-context_spec.lua
+++ b/spec/02-integration/05-proxy/23-context_spec.lua
@@ -24,6 +24,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/23-context_spec.lua
+++ b/spec/02-integration/05-proxy/23-context_spec.lua
@@ -26,6 +26,7 @@ end
 
 
 local function gen_route(flavor, r)
+  --[[
   if flavor ~= "expressions" then
     return r
   end
@@ -35,6 +36,7 @@ local function gen_route(flavor, r)
 
   r.paths = nil
   r.destinations = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/26-udp_spec.lua
+++ b/spec/02-integration/05-proxy/26-udp_spec.lua
@@ -1,5 +1,5 @@
 local helpers = require "spec.helpers"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local UDP_PROXY_PORT = 26001

--- a/spec/02-integration/05-proxy/26-udp_spec.lua
+++ b/spec/02-integration/05-proxy/26-udp_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require "spec.helpers"
---local atc_compat = require "kong.router.compat"
 
 
 local UDP_PROXY_PORT = 26001
@@ -28,17 +27,6 @@ end
 
 
 local function gen_route(flavor, r)
---[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.sources = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/26-udp_spec.lua
+++ b/spec/02-integration/05-proxy/26-udp_spec.lua
@@ -26,6 +26,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/26-udp_spec.lua
+++ b/spec/02-integration/05-proxy/26-udp_spec.lua
@@ -28,6 +28,7 @@ end
 
 
 local function gen_route(flavor, r)
+--[[
   if flavor ~= "expressions" then
     return r
   end
@@ -36,6 +37,7 @@ local function gen_route(flavor, r)
   r.priority = tonumber(atc_compat._get_priority(r))
 
   r.sources = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -96,6 +96,7 @@ local function reload_router(flavor)
 end
 
 
+-- TODO: remove it when we confirm it is not needed
 local function gen_route(flavor, r)
   return r
 end

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -1,7 +1,6 @@
 local helpers = require "spec.helpers"
 local pl_file = require "pl.file"
 local cjson = require "cjson"
---local atc_compat = require "kong.router.compat"
 
 
 local TEST_CONF = helpers.test_conf
@@ -98,17 +97,6 @@ end
 
 
 local function gen_route(flavor, r)
---[[
-  if flavor ~= "expressions" then
-    return r
-  end
-
-  r.expression = atc_compat.get_expression(r)
-  r.priority = tonumber(atc_compat._get_priority(r))
-
-  r.destinations = nil
-  --]]
-
   return r
 end
 

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local pl_file = require "pl.file"
 local cjson = require "cjson"
-local atc_compat = require "kong.router.compat"
+--local atc_compat = require "kong.router.compat"
 
 
 local TEST_CONF = helpers.test_conf

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -98,6 +98,7 @@ end
 
 
 local function gen_route(flavor, r)
+--[[
   if flavor ~= "expressions" then
     return r
   end
@@ -106,6 +107,7 @@ local function gen_route(flavor, r)
   r.priority = tonumber(atc_compat._get_priority(r))
 
   r.destinations = nil
+  --]]
 
   return r
 end

--- a/spec/02-integration/05-proxy/31-stream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/31-stream_tls_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 
-for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("#stream Proxying [#" .. strategy .. "] [#" .. flavor .. "]", function()
     local bp


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary



* now `expressions` flavor supports `methods` `hosts` `paths` `headers` `snis` and other fields
* now `expressions` flavor is a superset of `traditional_compatible`

NOTICE:
We will have additional work on `routes.lua ` and `routes_subschemas.lua` when cherry pick.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix: KAG-3805 KAG-3807
