### PR TITLE
fix(tracing): eliminate aws service request time from latencies.kong

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1158,6 +1158,9 @@ function Kong.access()
     ctx.KONG_ACCESS_ENDED_AT = get_updated_now_ms()
     ctx.KONG_ACCESS_TIME = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_ACCESS_START
     ctx.KONG_RESPONSE_LATENCY = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_PROCESSING_START
+    if ctx.KONG_THIRDPARTY_ACCESS_TIME then
+      ctx.KONG_RESPONSE_LATENCY = ctx.KONG_RESPONSE_LATENCY - ctx.KONG_THIRDPARTY_ACCESS_TIME
+    end
 
     if has_timing then
       req_dyn_hook_run_hooks(ctx, "timing", "after:access")

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -71,6 +71,9 @@ local AWSLambdaHandler = {
 
 
 function AWSLambdaHandler:access(conf)
+  -- TRACING: set KONG_WAITING_TIME start
+  local kong_wait_time_start = get_now()
+
   if initialize then
     initialize()
   end
@@ -164,9 +167,6 @@ function AWSLambdaHandler:access(conf)
 
   local upstream_body_json = build_request_payload(conf)
 
-  -- TRACING: set KONG_WAITING_TIME start
-  local kong_wait_time_start = get_now()
-
   local res, err = lambda_service:invoke({
     FunctionName = conf.function_name,
     InvocationType = conf.invocation_type,
@@ -186,9 +186,11 @@ function AWSLambdaHandler:access(conf)
 
   -- TRACING: set KONG_WAITING_TIME stop
   local ctx = ngx.ctx
+  local lambda_wait_time_total = get_now() - kong_wait_time_start
   -- setting the latency here is a bit tricky, but because we are not
   -- actually proxying, it will not be overwritten
-  ctx.KONG_WAITING_TIME = get_now() - kong_wait_time_start
+  ctx.KONG_WAITING_TIME = lambda_wait_time_total
+  ctx.KONG_THIRDPARTY_ACCESS_TIME = lambda_wait_time_total
 
   local headers = res.headers
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
As per FTI-5261's report, it is unexpected that the external request time of AWS lambda service is also being added to `latencies.kong` latency number which is part of our serialized log data and being used by some of our monitoring plugins, such as datadog.

This PR tries to eliminate the AWS related request time from `latencies.kong`, by adding a new ctx variable `ctx.KONG_THIRDPARTY_ACCESS_TIME`. Since this problem is not a special one, we have a similar situation in many other plugins/vaults that requires external access(such as external IdP, secret management service, etc.). We can also add those things into `ctx.KONG_THIRDPARTY_ACCESS_TIME` so that we can tracking external 3rd-party service's latency, as well as subtracting them from Kong's latency number. 

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-5261
