### PR TITLE
[backport -> release/3.4.x] chore(cd): update file permission of kong.logrotate

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -38,6 +38,9 @@ contents:
   dst: /lib/systemd/system/kong.service
 - src: build/package/kong.logrotate
   dst: /etc/kong/kong.logrotate
+  file_info:
+    mode: 0644
+
 scripts:
   postinstall: ./build/package/postinstall.sh
 replaces:

--- a/changelog/unreleased/kong/fix-file-permission-of-logrotate.yml
+++ b/changelog/unreleased/kong/fix-file-permission-of-logrotate.yml
@@ -1,0 +1,3 @@
+message: update file permission of kong.logrotate to 644
+type: bugfix
+scope: Core

--- a/scripts/explain_manifest/explain.py
+++ b/scripts/explain_manifest/explain.py
@@ -64,12 +64,14 @@ class FileInfo():
 
         # use lstat to get the mode, uid, gid of the symlink itself
         self.mode = os.lstat(path).st_mode
+        # unix style mode
+        self.file_mode = '0' + oct(self.mode & 0o777)[2:]
         self.uid = os.lstat(path).st_uid
         self.gid = os.lstat(path).st_gid
 
         if not Path(path).is_symlink():
             self.size = os.stat(path).st_size
-        
+
         self._lazy_evaluate_attrs.update({
             "binary_content": lambda: open(path, "rb").read(),
             "text_content": lambda: open(path, "rb").read().decode('utf-8'),
@@ -129,7 +131,7 @@ class ElfFileInfo(FileInfo):
         binary = lief.parse(path)
         if not binary:  # not an ELF file, malformed, etc
             return
-    
+
         self.arch = binary.header.machine_type.name
 
         for d in binary.dynamic_entries:
@@ -152,7 +154,7 @@ class ElfFileInfo(FileInfo):
             self.version_requirement[f.name] = [LooseVersion(
                 a.name) for a in f.get_auxiliary_symbols()]
             self.version_requirement[f.name].sort()
-        
+
         self._lazy_evaluate_attrs.update({
             "exported_symbols": self.get_exported_symbols,
             "imported_symbols": self.get_imported_symbols,

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -19,6 +19,8 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False):
 
     expect("/etc/kong/kong.logrotate", "includes logrotate config").exists()
 
+    expect("/etc/kong/kong.logrotate", "logrotate config should have 0644 permissions").file_mode.equals("0644")
+
     expect("/usr/local/kong/include/openssl/**.h", "includes OpenSSL headers").exists()
 
     # binary correctness


### PR DESCRIPTION
origin PR: https://github.com/Kong/kong/pull/12629

---------

origin file permission of kong.logrotate is 664, but the correct file permission is 644

Fix: https://konghq.atlassian.net/browse/FTI-5756

---------

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
