### PR TITLE
feat(schema): add deprecation field attribute

### DIFF
--- a/changelog/unreleased/kong/plugin-schema-deprecation-record.yml
+++ b/changelog/unreleased/kong/plugin-schema-deprecation-record.yml
@@ -1,0 +1,3 @@
+message: "**Schema**: Added a deprecation field attribute to identify deprecated fields"
+type: feature
+scope: Configuration

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -7,6 +7,8 @@ local nkeys        = require "table.nkeys"
 local is_reference = require "kong.pdk.vault".is_reference
 local json         = require "kong.db.schema.json"
 local cjson_safe   = require "cjson.safe"
+local deprecation  = require "kong.deprecation"
+local deepcompare  = require "pl.tablex".deepcompare
 
 
 local setmetatable = setmetatable
@@ -880,6 +882,16 @@ function Schema:validate_field(field, value)
 
   if field.abstract then
     return nil, validation_errors.SUBSCHEMA_ABSTRACT_FIELD
+  end
+
+  if field.deprecation then
+    local old_default = field.deprecation.old_default
+    local should_warn = old_default == nil
+                        or not deepcompare(value, old_default)
+    if should_warn then
+      deprecation(field.deprecation.message,
+          { after = field.deprecation.removal_in_version, })
+    end
   end
 
   if field.type == "array" then

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -192,6 +192,20 @@ local field_schema = {
   { encrypted = { type = "boolean" }, },
   { referenceable = { type = "boolean" }, },
   { json_schema = json_metaschema },
+  -- Deprecation attribute: used to mark a field as deprecated
+  -- Results in `message` and `removal_in_version` to be printed in a warning
+  -- (via kong.deprecation) when the field is used.
+  -- If `old_default` is not set, the warning message is always printed.
+  -- If `old_default` is set, the warning message is only printed when the
+  -- field's value is different from the value of `old_default`.
+  { deprecation = {
+    type = "record",
+    fields = {
+      { message = { type = "string", required = true } },
+      { removal_in_version = { type = "string", required = true } },
+      { old_default = { type = "any", required = false } },
+    },
+  } },
 }
 
 

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -1,7 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 local reserved_words = require "kong.plugins.acme.reserved_words"
 local redis_schema = require "kong.tools.redis.schema"
-local deprecation = require("kong.deprecation")
 
 local tablex = require "pl.tablex"
 
@@ -43,18 +42,20 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     type = "string",
     len_min = 0,
     translate_backwards = {'password'},
+    deprecation = {
+      message = "acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
+      removal_in_version = "4.0", },
     func = function(value)
-      deprecation("acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
-        { after = "4.0", })
       return { password = value }
     end
   }},
   { ssl_server_name = {
     type = "string",
     translate_backwards = {'server_name'},
+    deprecation = {
+      message = "acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
+      removal_in_version = "4.0", },
     func = function(value)
-      deprecation("acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
-        { after = "4.0", })
       return { server_name = value }
     end
   }},
@@ -62,18 +63,20 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     type = "string",
     len_min = 0,
     translate_backwards = {'extra_options', 'namespace'},
+    deprecation = {
+      message = "acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
+      removal_in_version = "4.0", },
     func = function(value)
-      deprecation("acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
-        { after = "4.0", })
       return { extra_options = { namespace = value } }
     end
   }},
   { scan_count = {
     type = "integer",
     translate_backwards = {'extra_options', 'scan_count'},
+    deprecation = {
+      message = "acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",
+      removal_in_version = "4.0", },
     func = function(value)
-      deprecation("acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",
-        { after = "4.0", })
       return { extra_options = { scan_count = value } }
     end
   }},

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -1,5 +1,4 @@
 local typedefs = require "kong.db.schema.typedefs"
-local deprecation = require("kong.deprecation")
 
 local STAT_NAMES = {
   "kong_latency",
@@ -89,17 +88,30 @@ return {
               consumer_tag = { description = "String to be attached as tag of the consumer.", type = "string",
               default = "consumer" }, },
           {
-              retry_count = { description = "Number of times to retry when sending data to the upstream server.",
-              type = "integer" }, },
+              retry_count = {
+                description = "Number of times to retry when sending data to the upstream server.",
+                type = "integer",
+                deprecation = {
+                  message = "datadog: config.retry_count no longer works, please use config.queue.max_retry_time instead",
+                  removal_in_version = "4.0",
+                  old_default = 10 }, }, },
           {
               queue_size = {
-              description = "Maximum number of log entries to be sent on each message to the upstream server.",
-              type = "integer" }, },
+                description = "Maximum number of log entries to be sent on each message to the upstream server.",
+                type = "integer",
+                deprecation = {
+                  message = "datadog: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
+                  removal_in_version = "4.0",
+                  old_default = 1 }, }, },
           {
               flush_timeout = {
-              description =
-              "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.",
-              type = "number" }, },
+                description =
+                  "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.",
+                type = "number",
+                deprecation = {
+                  message = "datadog: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
+                  removal_in_version = "4.0",
+                  old_default = 2 }, }, },
           { queue = typedefs.queue },
           {
             metrics = {
@@ -133,29 +145,6 @@ return {
                   }, },
               },
             },
-          },
-        },
-
-        entity_checks = {
-          {
-            custom_entity_check = {
-              field_sources = { "retry_count", "queue_size", "flush_timeout" },
-              fn = function(entity)
-                if (entity.retry_count or ngx.null) ~= ngx.null and entity.retry_count ~= 10 then
-                  deprecation("datadog: config.retry_count no longer works, please use config.queue.max_retry_time instead",
-                    { after = "4.0", })
-                end
-                if (entity.queue_size or ngx.null) ~= ngx.null and entity.queue_size ~= 1 then
-                  deprecation("datadog: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
-                    { after = "4.0", })
-                end
-                if (entity.flush_timeout or ngx.null) ~= ngx.null and entity.flush_timeout ~= 2 then
-                  deprecation("datadog: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
-                    { after = "4.0", })
-                end
-                return true
-              end
-            }
           },
         },
       },

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -1,6 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 local Schema = require "kong.db.schema"
-local deprecation = require("kong.deprecation")
 
 local function custom_validator(attributes)
   for _, v in pairs(attributes) do
@@ -50,8 +49,20 @@ return {
             max_batch_size = 200,
           },
         } },
-        { batch_span_count = { description = "The number of spans to be sent in a single batch.", type = "integer" } },
-        { batch_flush_delay = { description = "The delay, in seconds, between two consecutive batches.", type = "integer" } },
+        { batch_span_count = {
+            description = "The number of spans to be sent in a single batch.",
+            type = "integer",
+            deprecation = {
+              message = "opentelemetry: config.batch_span_count is deprecated, please use config.queue.max_batch_size instead",
+              removal_in_version = "4.0",
+              old_default = 200 }, }, },
+        { batch_flush_delay = {
+            description = "The delay, in seconds, between two consecutive batches.",
+            type = "integer",
+            deprecation = {
+              message = "opentelemetry: config.batch_flush_delay is deprecated, please use config.queue.max_coalescing_delay instead",
+              removal_in_version = "4.0",
+              old_default = 3, }, }, },
         { connect_timeout = typedefs.timeout { default = 1000 } },
         { send_timeout = typedefs.timeout { default = 5000 } },
         { read_timeout = typedefs.timeout { default = 5000 } },
@@ -69,22 +80,6 @@ return {
           between = {0, 1},
           required = false,
           default = nil,
-        } },
-      },
-      entity_checks = {
-        { custom_entity_check = {
-          field_sources = { "batch_span_count", "batch_flush_delay" },
-          fn = function(entity)
-            if (entity.batch_span_count or ngx.null) ~= ngx.null and entity.batch_span_count ~= 200 then
-              deprecation("opentelemetry: config.batch_span_count is deprecated, please use config.queue.max_batch_size instead",
-                          { after = "4.0", })
-            end
-            if (entity.batch_flush_delay or ngx.null) ~= ngx.null and entity.batch_flush_delay ~= 3 then
-              deprecation("opentelemetry: config.batch_flush_delay is deprecated, please use config.queue.max_coalescing_delay instead",
-                          { after = "4.0", })
-            end
-            return true
-          end
         } },
       },
     }, },

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -1,6 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 local redis_schema = require "kong.tools.redis.schema"
-local deprecation = require "kong.deprecation"
 
 local SYNC_RATE_REALTIME = -1
 
@@ -104,18 +103,20 @@ return {
           { redis_host = {
             type = "string",
             translate_backwards = {'redis', 'host'},
+            deprecation = {
+              message = "rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
-                { after = "4.0", })
               return { redis = { host = value } }
             end
           } },
           { redis_port = {
             type = "integer",
             translate_backwards = {'redis', 'port'},
+            deprecation = {
+              message = "rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
-                { after = "4.0", })
               return { redis = { port = value } }
             end
           } },
@@ -123,63 +124,70 @@ return {
             type = "string",
             len_min = 0,
             translate_backwards = {'redis', 'password'},
+            deprecation = {
+              message = "rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
-                { after = "4.0", })
               return { redis = { password = value } }
             end
           } },
           { redis_username = {
             type = "string",
             translate_backwards = {'redis', 'username'},
+            deprecation = {
+              message = "rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
-                { after = "4.0", })
               return { redis = { username = value } }
             end
           } },
           { redis_ssl = {
             type = "boolean",
             translate_backwards = {'redis', 'ssl'},
+            deprecation = {
+              message = "rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-                { after = "4.0", })
               return { redis = { ssl = value } }
             end
           } },
           { redis_ssl_verify = {
             type = "boolean",
             translate_backwards = {'redis', 'ssl_verify'},
+            deprecation = {
+              message = "rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-                { after = "4.0", })
               return { redis = { ssl_verify = value } }
             end
           } },
           { redis_server_name = {
             type = "string",
             translate_backwards = {'redis', 'server_name'},
+            deprecation = {
+              message = "rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
-                { after = "4.0", })
               return { redis = { server_name = value } }
             end
           } },
           { redis_timeout = {
             type = "integer",
             translate_backwards = {'redis', 'timeout'},
+            deprecation = {
+              message = "rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-                { after = "4.0", })
               return { redis = { timeout = value } }
             end
           } },
           { redis_database = {
             type = "integer",
             translate_backwards = {'redis', 'database'},
+            deprecation = {
+              message = "rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
-                { after = "4.0", })
               return { redis = { database = value } }
             end
           } },

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -1,6 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 local redis_schema = require "kong.tools.redis.schema"
-local deprecation = require "kong.deprecation"
 
 local ORDERED_PERIODS = { "second", "minute", "hour", "day", "month", "year" }
 
@@ -143,18 +142,20 @@ return {
           { redis_host = {
             type = "string",
             translate_backwards = {'redis', 'host'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
-                { after = "4.0", })
               return { redis = { host = value } }
             end
           } },
           { redis_port = {
             type = "integer",
             translate_backwards = {'redis', 'port'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
-                { after = "4.0", })
               return { redis = { port = value } }
             end
           } },
@@ -162,63 +163,70 @@ return {
             type = "string",
             len_min = 0,
             translate_backwards = {'redis', 'password'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
-                { after = "4.0", })
               return { redis = { password = value } }
             end
           } },
           { redis_username = {
             type = "string",
             translate_backwards = {'redis', 'username'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
-                { after = "4.0", })
               return { redis = { username = value } }
             end
           } },
           { redis_ssl = {
             type = "boolean",
             translate_backwards = {'redis', 'ssl'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-                { after = "4.0", })
               return { redis = { ssl = value } }
             end
           } },
           { redis_ssl_verify = {
             type = "boolean",
             translate_backwards = {'redis', 'ssl_verify'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-                { after = "4.0", })
               return { redis = { ssl_verify = value } }
             end
           } },
           { redis_server_name = {
             type = "string",
             translate_backwards = {'redis', 'server_name'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
-                { after = "4.0", })
               return { redis = { server_name = value } }
             end
           } },
           { redis_timeout = {
             type = "integer",
             translate_backwards = {'redis', 'timeout'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-                { after = "4.0", })
               return { redis = { timeout = value } }
             end
           } },
           { redis_database = {
             type = "integer",
             translate_backwards = {'redis', 'database'},
+            deprecation = {
+              message = "response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
+              removal_in_version = "4.0", },
             func = function(value)
-              deprecation("response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
-                { after = "4.0", })
               return { redis = { database = value } }
             end
           } },

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -1,6 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 local constants = require "kong.plugins.statsd.constants"
-local deprecation = require("kong.deprecation")
 
 
 local METRIC_NAMES = {
@@ -196,31 +195,26 @@ return {
           { consumer_identifier_default = { type = "string", required = true, default = "custom_id", one_of = CONSUMER_IDENTIFIERS }, },
           { service_identifier_default = { type = "string", required = true, default = "service_name_or_host", one_of = SERVICE_IDENTIFIERS }, },
           { workspace_identifier_default = { type = "string", required = true, default = "workspace_id", one_of = WORKSPACE_IDENTIFIERS }, },
-          { retry_count = { type = "integer" }, },
-          { queue_size = { type = "integer" }, },
-          { flush_timeout = { type = "number" }, },
+          { retry_count = {
+              type = "integer",
+              deprecation = {
+                message = "statsd: config.retry_count no longer works, please use config.queue.max_retry_time instead",
+                removal_in_version = "4.0",
+                old_default = 10 }, }, },
+          { queue_size = {
+              type = "integer",
+              deprecation = {
+                message = "statsd: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
+                removal_in_version = "4.0",
+                old_default = 1 }, }, },
+          { flush_timeout = {
+              type = "number",
+              deprecation = {
+                message = "statsd: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
+                removal_in_version = "4.0",
+                old_default = 2 }, }, },
           { tag_style = { type = "string", required = false, one_of = TAG_TYPE }, },
           { queue = typedefs.queue },
-        },
-        entity_checks = {
-          { custom_entity_check = {
-            field_sources = { "retry_count", "queue_size", "flush_timeout" },
-            fn = function(entity)
-              if (entity.retry_count or ngx.null) ~= ngx.null and entity.retry_count ~= 10 then
-                deprecation("statsd: config.retry_count no longer works, please use config.queue.max_retry_time instead",
-                            { after = "4.0", })
-              end
-              if (entity.queue_size or ngx.null) ~= ngx.null and entity.queue_size ~= 1 then
-                deprecation("statsd: config.queue_size is deprecated, please use config.queue.max_batch_size instead",
-                            { after = "4.0", })
-              end
-              if (entity.flush_timeout or ngx.null) ~= ngx.null and entity.flush_timeout ~= 2 then
-                deprecation("statsd: config.flush_timeout is deprecated, please use config.queue.max_coalescing_delay instead",
-                            { after = "4.0", })
-              end
-              return true
-            end
-          } },
         },
       },
     },

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -18,7 +18,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
     helpers.get_db_utils(nil, {}) -- runs migrations
     assert(helpers.start_kong {
       database = strategy,
-      plugins = "bundled,reports-api",
+      plugins = "bundled,reports-api,dummy",
       pg_password = "hide_me"
     })
     client = helpers.admin_client(10000)
@@ -517,6 +517,30 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local body = assert.res_status(404, res)
       local json = cjson.decode(body)
       assert.same({ message = "No plugin named 'not-present'" }, json)
+    end)
+    it("returns information about a deprecated field", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/schemas/plugins/dummy",
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.is_table(json.fields)
+
+      local found = false
+      for _, f in ipairs(json.fields) do
+        local config_fields = f.config and f.config.fields
+        for _, cf in ipairs(config_fields or {}) do
+          local deprecation = cf.old_field and cf.old_field.deprecation
+          if deprecation then
+            assert.is_string(deprecation.message)
+            assert.is_number(deprecation.old_default)
+            assert.is_string(deprecation.removal_in_version)
+            found = true
+          end
+        end
+      end
+      assert(found)
     end)
   end)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
@@ -18,7 +18,13 @@ return {
           }},
           { append_body = { type = "string" } },
           { resp_code = { type = "number" } },
-          { test_try = { type = "boolean", default = false}}
+          { test_try = { type = "boolean", default = false}},
+          { old_field = {
+              type = "number",
+              deprecation = {
+                message = "dummy: old_field is deprecated",
+                removal_in_version = "x.y.z",
+                old_default = 42 }, }, }
         },
       },
     },


### PR DESCRIPTION
### Summary

Add a deprecation record field attribute to identify fields that are deprecated. The attribute requires the `message` and `removal_in_version` fields to be configured, which are used to generate a warning when the deprecated field is configured (uses `kong.deprecation`). The optional `old_default` field can be used to determine whether the warning should be logged (in case the field was configured to a value other than the old default).

This PR adds the deprecation attribute to two kind of fields:
1. regular plugin fields that have been deprecated and that were not yet removed from the schema, i.e. the old queue parameters in datadog, opentelemetry, http-log, statsd
2. shorthand fields, for fields that have been removed from the plugin's schema and that only exist as shorthands, i.e.  acme, rate-limiting, response-ratelimiting

Example of a deprecated field (in schema/fields):
```
{ retry_count = {
    description = "Number of times to retry when sending data to the upstream server.",
    type = "integer",
    deprecation = {
      message = "http-log: config.retry_count no longer works, please use config.queue.max_retry_time instead",
      removal_in_version = "4.0",
      old_default = 10 }, }, },
```

Example of a deprecated field (in schema/shorthand_fields):
```
{ auth = {
  type = "string",
  len_min = 0,
  translate_backwards = {'password'},
  deprecation = {
    message = "acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
    removal_in_version = "4.0", },
  func = function(value)
    return { password = value }
  end
}},
```

### Checklist

- [x] The Pull Request has tests (individual plugins have tests to verify the deprecation warnings are logged correctly)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3915
