### PR TITLE
chore(patches): fix pcre2 regex memory corruption issues

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.26_03-regex-memory-corruption.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_03-regex-memory-corruption.patch
@@ -1,0 +1,38 @@
+diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
+index 1b52fa2..30c1650 100644
+--- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
++++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
+@@ -688,11 +688,11 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+     ngx_pool_t  *old_pool;
+ 
+     if (flags & NGX_LUA_RE_MODE_DFA) {
+-        ovecsize = 2;
++        ovecsize = 1;
+         re->ncaptures = 0;
+ 
+     } else {
+-        ovecsize = (re->ncaptures + 1) * 3;
++        ovecsize = re->ncaptures + 1;
+     }
+ 
+     old_pool = ngx_http_lua_pcre_malloc_init(NULL);
+@@ -710,7 +710,7 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+         }
+ 
+         ngx_regex_match_data_size = ovecsize;
+-        ngx_regex_match_data = pcre2_match_data_create(ovecsize / 3, NULL);
++        ngx_regex_match_data = pcre2_match_data_create(ovecsize, NULL);
+ 
+         if (ngx_regex_match_data == NULL) {
+             rc = PCRE2_ERROR_NOMEMORY;
+@@ -756,8 +756,8 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+                    "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
+ #endif
+ 
+-    if (!(flags & NGX_LUA_RE_MODE_DFA) && n > ovecsize / 3) {
+-        n = ovecsize / 3;
++    if (n > ovecsize) {
++        n = ovecsize;
+     }
+ 
+     for (i = 0; i < n; i++) {

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_02-remove-useless-pcre-config.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_02-remove-useless-pcre-config.patch
@@ -1,0 +1,59 @@
+From f1499e3b06f698dc2813e0686aa0cc257299fcd7 Mon Sep 17 00:00:00 2001
+From: swananan <jt26wzz@gmail.com>
+Date: Thu, 11 Jan 2024 08:46:17 +0800
+Subject: [PATCH] changes: remove the useless pcre config.
+
+---
+ config | 39 ---------------------------------------
+ 1 file changed, 39 deletions(-)
+
+diff --git a/bundle/ngx_stream_lua-0.0.14/config b/bundle/ngx_stream_lua-0.0.14/config
+index 8db90628..e1470b7a 100644
+--- a/bundle/ngx_stream_lua-0.0.14/config
++++ b/bundle/ngx_stream_lua-0.0.14/config
+@@ -405,45 +405,6 @@ fi
+ 
+ # ----------------------------------------
+ 
+-if [ $USE_PCRE = YES -o $PCRE != NONE ] && [ $PCRE != NO -a $PCRE != YES ] && [ $PCRE2 != YES ]; then
+-    # force pcre_version symbol to be required when PCRE is statically linked
+-    case "$NGX_PLATFORM" in
+-        Darwin:*)
+-            ngx_feature="require defined symbols (-u)"
+-            ngx_feature_name=
+-            ngx_feature_path=
+-            ngx_feature_libs="-Wl,-u,_strerror"
+-            ngx_feature_run=no
+-            ngx_feature_incs="#include <stdio.h>"
+-            ngx_feature_test='printf("hello");'
+-
+-            . auto/feature
+-
+-            if [ $ngx_found = yes ]; then
+-                CORE_LIBS="-Wl,-u,_pcre_version $CORE_LIBS"
+-            fi
+-        ;;
+-
+-        *)
+-            ngx_feature="require defined symbols (--require-defined)"
+-            ngx_feature_name=
+-            ngx_feature_path=
+-            ngx_feature_libs="-Wl,--require-defined=strerror"
+-            ngx_feature_run=no
+-            ngx_feature_incs="#include <stdio.h>"
+-            ngx_feature_test='printf("hello");'
+-
+-            . auto/feature
+-
+-            if [ $ngx_found = yes ]; then
+-                CORE_LIBS="-Wl,--require-defined=pcre_version $CORE_LIBS"
+-            fi
+-        ;;
+-    esac
+-fi
+-
+-# ----------------------------------------
+-
+ USE_MD5=YES
+ USE_SHA1=YES
+ 

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_03-regex-memory-corruption.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_03-regex-memory-corruption.patch
@@ -1,0 +1,60 @@
+diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
+index e32744e..241ec00 100644
+--- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
++++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
+@@ -695,11 +695,11 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+     ngx_pool_t  *old_pool;
+ 
+     if (flags & NGX_LUA_RE_MODE_DFA) {
+-        ovecsize = 2;
++        ovecsize = 1;
+         re->ncaptures = 0;
+ 
+     } else {
+-        ovecsize = (re->ncaptures + 1) * 3;
++        ovecsize = re->ncaptures + 1;
+     }
+ 
+     old_pool = ngx_stream_lua_pcre_malloc_init(NULL);
+@@ -717,7 +717,7 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+         }
+ 
+         ngx_regex_match_data_size = ovecsize;
+-        ngx_regex_match_data = pcre2_match_data_create(ovecsize / 3, NULL);
++        ngx_regex_match_data = pcre2_match_data_create(ovecsize, NULL);
+ 
+         if (ngx_regex_match_data == NULL) {
+             rc = PCRE2_ERROR_NOMEMORY;
+@@ -762,8 +762,8 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+                    "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
+ #endif
+ 
+-    if (!(flags & NGX_LUA_RE_MODE_DFA) && n > ovecsize / 3) {
+-        n = ovecsize / 3;
++    if (n > ovecsize) {
++        n = ovecsize;
+     }
+ 
+     for (i = 0; i < n; i++) {
+@@ -796,6 +796,21 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+         re->ncaptures = 0;
+ 
+     } else {
++        /* How pcre_exec() returns captured substrings
++         * The first two-thirds of the vector is used to pass back captured
++         * substrings, each substring using a pair of integers. The remaining
++         * third of the vector is used as workspace by pcre_exec() while
++         * matching capturing subpatterns, and is not available for passing
++         * back information. The number passed in ovecsize should always be a
++         * multiple of three. If it is not, it is rounded down.
++         *
++         * When a match is successful, information about captured substrings is
++         * returned in pairs of integers, starting at the beginning of ovector,
++         * and continuing up to two-thirds of its length at the most. The first
++         * element of each pair is set to the byte offset of the first character
++         * in a substring, and the second is set to the byte offset of the first
++         * character after the end of a substring.
++         */
+         ovecsize = (re->ncaptures + 1) * 3;
+     }
+ 


### PR DESCRIPTION
### Summary

Adds couple of patches that were recently merged to upstream project.

This should finally fix test issues with PCRE2 on EE master.

The EE commit can be already found here:
https://github.com/Kong/kong-ee/pull/7961

[KAG-3614](https://konghq.atlassian.net/browse/KAG-3614)

[KAG-3614]: https://konghq.atlassian.net/browse/KAG-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ