### PR TITLE
chore(test): remove prefix directory when stop_kong called

### DIFF
--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -46,7 +46,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -24,7 +24,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()
@@ -1966,7 +1966,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -57,7 +57,7 @@ describe("Admin API #off", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -2741,7 +2741,7 @@ describe("Admin API (concurrency tests) #off", function()
   end)
 
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
 
     if client then
       client:close()
@@ -2862,7 +2862,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -3005,7 +3005,7 @@ describe("Admin API #off with cache key vs endpoint key #unique", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -3073,7 +3073,7 @@ describe("Admin API #off worker_consistency=eventual", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/19-vaults_spec.lua
+++ b/spec/02-integration/04-admin_api/19-vaults_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -27,7 +27,7 @@ for _, strategy in helpers.all_strategies() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/25-max_safe_integer_spec.lua
+++ b/spec/02-integration/04-admin_api/25-max_safe_integer_spec.lua
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()
@@ -63,7 +63,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -232,7 +232,7 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_teardown(function()
       if proxy_client then proxy_client:close() end
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("checks global configuration without credentials", function()
@@ -744,7 +744,7 @@ for _, strategy in helpers.each_strategy() do
 
       lazy_teardown(function()
         helpers.stop_kong("servroot2")
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
 
@@ -1277,7 +1277,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("certificate phase clears context, fix #7054", function()

--- a/spec/02-integration/05-proxy/09-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/09-websockets_spec.lua
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function open_socket(uri)

--- a/spec/02-integration/05-proxy/11-handler_spec.lua
+++ b/spec/02-integration/05-proxy/11-handler_spec.lua
@@ -43,7 +43,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("runs", function()
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()
@@ -175,7 +175,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -12,7 +12,7 @@ describe("Proxy error handlers", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
+++ b/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
@@ -125,7 +125,7 @@ describe("#postgres upstream keepalive", function()
       proxy_client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -82,8 +82,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1196,8 +1196,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1337,8 +1337,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()

--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -57,7 +57,7 @@ describe("worker respawn", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/11-dbless/02-workers_spec.lua
+++ b/spec/02-integration/11-dbless/02-workers_spec.lua
@@ -29,7 +29,7 @@ describe("Workers initialization #off", function()
   lazy_teardown(function()
     admin_client:close()
     proxy_client:close()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("restarts worker correctly without issues on the init_worker phase when config includes 1000+ plugins", function()

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -21,7 +21,7 @@ describe("dbless persistence #off", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("loads the lmdb config on restarts", function()
@@ -113,7 +113,7 @@ describe("dbless persistence with a declarative config #off", function()
   end)
 
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
   lazy_teardown(function()
     os.remove(yaml_file)

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -183,7 +183,7 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
       client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
     vault:teardown()
 
     helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")

--- a/spec/02-integration/13-vaults/07-resurrect_spec.lua
+++ b/spec/02-integration/13-vaults/07-resurrect_spec.lua
@@ -188,7 +188,7 @@ describe("vault resurrect_ttl and rotation (#" .. strategy .. ") #" .. vault.nam
       client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
     vault:teardown()
 
     helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")

--- a/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
+++ b/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
@@ -32,7 +32,7 @@ for _, strategy in helpers.each_strategy() do
       if admin_client then
         admin_client:close()
       end
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
@@ -58,7 +58,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function hmac_sha1_binary(secret, data)

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -63,7 +63,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         local function cache_key(conf, username, password)

--- a/spec/03-plugins/23-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/03-api_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     describe("POST", function()

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -375,7 +375,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         describe("Without authentication (IP address)", function()
@@ -619,7 +619,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("expires a counter", function()
@@ -696,7 +696,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
@@ -739,7 +739,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         before_each(function()
@@ -828,7 +828,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             after_each(function()
-              helpers.stop_kong(nil, true)
+              helpers.stop_kong()
             end)
 
             it("does not work if an error occurs", function()
@@ -930,7 +930,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           after_each(function()
-            helpers.stop_kong(nil, true)
+            helpers.stop_kong()
           end)
 
           it("does not work if an error occurs", function()

--- a/spec/03-plugins/29-acme/05-redis_storage_spec.lua
+++ b/spec/03-plugins/29-acme/05-redis_storage_spec.lua
@@ -252,7 +252,7 @@ describe("Plugin: acme (storage.redis)", function()
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -364,7 +364,7 @@ do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("caches a simple request", function()

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -64,7 +64,7 @@ describe("Plugin: proxy-cache", function()
   end)
 
   teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("(schema)", function()

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -98,8 +98,8 @@ describe("proxy-cache invalidations via: " .. strategy, function()
   end)
 
   teardown(function()
-    helpers.stop_kong("servroot1", true)
-    helpers.stop_kong("servroot2", true)
+    helpers.stop_kong("servroot1")
+    helpers.stop_kong("servroot2")
   end)
 
   before_each(function()

--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -512,7 +512,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
@@ -365,7 +365,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
@@ -358,7 +358,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
@@ -372,7 +372,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
@@ -309,7 +309,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
@@ -157,7 +157,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
@@ -237,7 +237,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
@@ -188,7 +188,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
@@ -304,7 +304,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
     
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/02-integration_spec.lua
@@ -54,7 +54,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/42-ai-prompt-guard/02-integration_spec.lua
+++ b/spec/03-plugins/42-ai-prompt-guard/02-integration_spec.lua
@@ -130,7 +130,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/43-ai-prompt-template/02-integration_spec.lua
+++ b/spec/03-plugins/43-ai-prompt-template/02-integration_spec.lua
@@ -125,7 +125,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/05-migration/plugins/acme/migrations/003_350_to_360_spec.lua
+++ b/spec/05-migration/plugins/acme/migrations/003_350_to_360_spec.lua
@@ -9,7 +9,7 @@ if uh.database_type() == 'postgres' then
         end)
 
         lazy_teardown(function ()
-            assert(uh.stop_kong(nil, true))
+            assert(uh.stop_kong())
         end)
 
         uh.setup(function ()

--- a/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
+++ b/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
@@ -18,7 +18,7 @@ handler("http-log plugin migration", function()
     end)
 
     lazy_teardown(function ()
-      assert(uh.stop_kong(nil, true))
+      assert(uh.stop_kong())
     end)
 
     local log_server_url = "http://localhost:" .. HTTP_PORT .. "/"

--- a/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
+++ b/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
@@ -11,7 +11,7 @@ if uh.database_type() == 'postgres' then
         end)
 
         lazy_teardown(function ()
-            assert(uh.stop_kong(nil, true))
+            assert(uh.stop_kong())
         end)
 
         uh.setup(function ()

--- a/spec/05-migration/plugins/rate-limiting/migrations/006_350_to_360_spec.lua
+++ b/spec/05-migration/plugins/rate-limiting/migrations/006_350_to_360_spec.lua
@@ -10,7 +10,7 @@ if uh.database_type() == 'postgres' then
         end)
 
         lazy_teardown(function ()
-            assert(uh.stop_kong(nil, true))
+            assert(uh.stop_kong())
         end)
 
         uh.setup(function ()

--- a/spec/05-migration/plugins/response-ratelimiting/migrations/001_350_to_360_spec.lua
+++ b/spec/05-migration/plugins/response-ratelimiting/migrations/001_350_to_360_spec.lua
@@ -10,7 +10,7 @@ if uh.database_type() == 'postgres' then
         end)
 
         lazy_teardown(function ()
-            assert(uh.stop_kong(nil, true))
+            assert(uh.stop_kong())
         end)
 
         uh.setup(function ()


### PR DESCRIPTION
### Summary

This PR cleans up the prefix in the tests.
If the prefix is not cleaned up when `stop_kong` is called, it could impact subsequent tests, especially when later tests start Kong by a shell command, the Kong instance might be started up with the default `servroot` prefix.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3808
