### PR TITLE
chore(CI): fix the workflow that comments the docker image on the commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ env:
   # PRs opened from fork and from dependabot don't have access to repo secrets
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
+
 jobs:
   metadata:
     name: Metadata
@@ -313,6 +314,10 @@ jobs:
     needs: [metadata, build-packages]
     runs-on: ubuntu-22.04
 
+    permissions:
+      # create comments on commits for docker images needs the `write` permission
+      contents: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -402,7 +407,7 @@ jobs:
       if: github.event_name == 'push' && matrix.label == 'ubuntu'
       uses: peter-evans/commit-comment@5a6f8285b8f2e8376e41fe1b563db48e6cf78c09 # v3.0.0
       with:
-        token: ${{ secrets.GHA_COMMENT_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         body: |
           ### Bazel Build
           Docker image available `${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}`


### PR DESCRIPTION
### Summary

The `${{ secrets.GHA_COMMENT_TOKEN }}` needs to be manually rotated, replacing it by `${{ secrets.GITHUB_TOKEN }}`, which is generated by each run of the workflow, so we don't need to rotate tokens anymore.

* [Permissions required for creating a comment on a commit](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents)
* [How to set the permissions of the `${{ secrets.GITHUB_TOKEN }}`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
* [Github rest API to create a commit on a commit](https://docs.github.com/en/rest/commits/comments?apiVersion=2022-11-28#create-a-commit-comment
)


### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
