### PR TITLE
chore(tests): fix flaky due to too close time for a timer

### DIFF
--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -348,10 +348,12 @@ for _, strategy in helpers.each_strategy() do
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_not_called() -- still not called
 
-        ngx.sleep(delay + 0.1) -- go past our desired `nbf` delay
+        ngx.sleep(delay) -- go past our desired `nbf` delay
 
-        assert(cluster_events_1:poll())
-        assert.spy(spy_func).was_called(1) -- called
+        helpers.wait_until(function()
+          assert(cluster_events_1:poll())
+          return pcall(assert.spy(spy_func).was_called, 1) -- called
+        end, 1) -- note that we have already waited for `delay` seconds
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

Timers do not always trigger precisely on time. Apply wait_until to stabilize the test.

### Issue reference

Fix KAG-3224

Reworking #12318
