### PR TITLE
chore: bump cherry-pick action to v1.2.0

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
       - name: Create backport pull requests
-        uses: jschmid1/cross-repo-cherrypick-action@2d2a475d31b060ac21521b5eda0a78876bbae94e #v1.1.0
+        uses: jschmid1/cross-repo-cherrypick-action@9d2ead0043acba474373992c8175f2b8ffcdb31c #v1.2.0
         id: cherry_pick
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}


### PR DESCRIPTION
### Summary

Bump cherry pick bot to https://github.com/jschmid1/cross-repo-cherrypick-action/releases/tag/v1.2.0

Major additions are:

* The bot now correctly sets the output & failure when encountering issues.
* In addition to requesting a review from the individual who merged the original PR, but also copies over all reviewers that were assigned to it.


Fix: https://konghq.atlassian.net/browse/KAG-4016
