### PR TITLE
chore(patches): cleanup the pcre2 regex patch

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.26_03-regex-memory-corruption.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_03-regex-memory-corruption.patch
@@ -1,38 +1,77 @@
 diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
-index 1b52fa2..30c1650 100644
+index 1b52fa2..646b483 100644
 --- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
 +++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_regex.c
-@@ -688,11 +688,11 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+@@ -591,7 +591,11 @@ ngx_http_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
+         re_comp.captures = 0;
+ 
+     } else {
++#if (NGX_PCRE2)
++        ovecsize = (re_comp.captures + 1) * 2;
++#else
+         ovecsize = (re_comp.captures + 1) * 3;
++#endif
+     }
+ 
+     dd("allocating cap with size: %d", (int) ovecsize);
+@@ -684,21 +688,21 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+ {
+     int          rc, exec_opts = 0;
+     size_t      *ov;
+-    ngx_uint_t   ovecsize, n, i;
++    ngx_uint_t   ovecpair, n, i;
      ngx_pool_t  *old_pool;
  
      if (flags & NGX_LUA_RE_MODE_DFA) {
 -        ovecsize = 2;
-+        ovecsize = 1;
++        ovecpair = 1;
          re->ncaptures = 0;
  
      } else {
 -        ovecsize = (re->ncaptures + 1) * 3;
-+        ovecsize = re->ncaptures + 1;
++        ovecpair = re->ncaptures + 1;
      }
  
      old_pool = ngx_http_lua_pcre_malloc_init(NULL);
-@@ -710,7 +710,7 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+ 
+     if (ngx_regex_match_data == NULL
+-        || ovecsize > ngx_regex_match_data_size)
++        || ovecpair > ngx_regex_match_data_size)
+     {
+         /*
+          * Allocate a match data if not yet allocated or smaller than
+@@ -709,8 +713,8 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+             pcre2_match_data_free(ngx_regex_match_data);
          }
  
-         ngx_regex_match_data_size = ovecsize;
+-        ngx_regex_match_data_size = ovecsize;
 -        ngx_regex_match_data = pcre2_match_data_create(ovecsize / 3, NULL);
-+        ngx_regex_match_data = pcre2_match_data_create(ovecsize, NULL);
++        ngx_regex_match_data_size = ovecpair;
++        ngx_regex_match_data = pcre2_match_data_create(ovecpair, NULL);
  
          if (ngx_regex_match_data == NULL) {
              rc = PCRE2_ERROR_NOMEMORY;
-@@ -756,8 +756,8 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
-                    "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
+@@ -741,7 +745,7 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+ #if (NGX_DEBUG)
+         ngx_log_debug4(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                        "pcre2_match failed: flags 0x%05Xd, options 0x%08Xd, "
+-                       "rc %d, ovecsize %ui", flags, exec_opts, rc, ovecsize);
++                       "rc %d, ovecpair %ui", flags, exec_opts, rc, ovecpair);
+ #endif
+ 
+         goto failed;
+@@ -753,11 +757,11 @@ ngx_http_lua_ffi_exec_regex(ngx_http_lua_regex_t *re, int flags,
+ #if (NGX_DEBUG)
+     ngx_log_debug5(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                    "pcre2_match: flags 0x%05Xd, options 0x%08Xd, rc %d, "
+-                   "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
++                   "n %ui, ovecpair %ui", flags, exec_opts, rc, n, ovecpair);
  #endif
  
 -    if (!(flags & NGX_LUA_RE_MODE_DFA) && n > ovecsize / 3) {
 -        n = ovecsize / 3;
-+    if (n > ovecsize) {
-+        n = ovecsize;
++    if (n > ovecpair) {
++        n = ovecpair;
      }
  
      for (i = 0; i < n; i++) {

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_03-regex-memory-corruption.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_03-regex-memory-corruption.patch
@@ -1,42 +1,81 @@
 diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
-index e32744e..241ec00 100644
+index e32744e..080e5dd 100644
 --- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
 +++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_regex.c
-@@ -695,11 +695,11 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+@@ -598,7 +598,11 @@ ngx_stream_lua_ffi_compile_regex(const unsigned char *pat, size_t pat_len,
+         re_comp.captures = 0;
+ 
+     } else {
++#if (NGX_PCRE2)
++        ovecsize = (re_comp.captures + 1) * 2;
++#else
+         ovecsize = (re_comp.captures + 1) * 3;
++#endif
+     }
+ 
+     dd("allocating cap with size: %d", (int) ovecsize);
+@@ -691,21 +695,21 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+ {
+     int          rc, exec_opts = 0;
+     size_t      *ov;
+-    ngx_uint_t   ovecsize, n, i;
++    ngx_uint_t   ovecpair, n, i;
      ngx_pool_t  *old_pool;
  
      if (flags & NGX_LUA_RE_MODE_DFA) {
 -        ovecsize = 2;
-+        ovecsize = 1;
++        ovecpair = 1;
          re->ncaptures = 0;
  
      } else {
 -        ovecsize = (re->ncaptures + 1) * 3;
-+        ovecsize = re->ncaptures + 1;
++        ovecpair = re->ncaptures + 1;
      }
  
      old_pool = ngx_stream_lua_pcre_malloc_init(NULL);
-@@ -717,7 +717,7 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+ 
+     if (ngx_regex_match_data == NULL
+-        || ovecsize > ngx_regex_match_data_size)
++        || ovecpair > ngx_regex_match_data_size)
+     {
+         /*
+          * Allocate a match data if not yet allocated or smaller than
+@@ -716,8 +720,8 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+             pcre2_match_data_free(ngx_regex_match_data);
          }
  
-         ngx_regex_match_data_size = ovecsize;
+-        ngx_regex_match_data_size = ovecsize;
 -        ngx_regex_match_data = pcre2_match_data_create(ovecsize / 3, NULL);
-+        ngx_regex_match_data = pcre2_match_data_create(ovecsize, NULL);
++        ngx_regex_match_data_size = ovecpair;
++        ngx_regex_match_data = pcre2_match_data_create(ovecpair, NULL);
  
          if (ngx_regex_match_data == NULL) {
              rc = PCRE2_ERROR_NOMEMORY;
-@@ -762,8 +762,8 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
-                    "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
+@@ -747,7 +751,7 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+ #if (NGX_DEBUG)
+     ngx_log_debug4(NGX_LOG_DEBUG_STREAM, ngx_cycle->log, 0,
+                    "pcre2_match failed: flags 0x%05Xd, options 0x%08Xd, rc %d, "
+-                   "ovecsize %ui", flags, exec_opts, rc, ovecsize);
++                   "ovecpair %ui", flags, exec_opts, rc, ovecpair);
+ #endif
+ 
+         goto failed;
+@@ -759,11 +763,11 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+ #if (NGX_DEBUG)
+     ngx_log_debug5(NGX_LOG_DEBUG_STREAM, ngx_cycle->log, 0,
+                    "pcre2_match: flags 0x%05Xd, options 0x%08Xd, rc %d, "
+-                   "n %ui, ovecsize %ui", flags, exec_opts, rc, n, ovecsize);
++                   "n %ui, ovecpair %ui", flags, exec_opts, rc, n, ovecpair);
  #endif
  
 -    if (!(flags & NGX_LUA_RE_MODE_DFA) && n > ovecsize / 3) {
 -        n = ovecsize / 3;
-+    if (n > ovecsize) {
-+        n = ovecsize;
++    if (n > ovecpair) {
++        n = ovecpair;
      }
  
      for (i = 0; i < n; i++) {
-@@ -796,6 +796,21 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
+@@ -796,6 +800,21 @@ ngx_stream_lua_ffi_exec_regex(ngx_stream_lua_regex_t *re, int flags,
          re->ncaptures = 0;
  
      } else {


### PR DESCRIPTION
### Summary

This adds two commits from @zhongweiy as found here: https://github.com/openresty/lua-nginx-module/pull/2291 https://github.com/openresty/stream-lua-nginx-module/pull/341

They are cleanups to original patch.

KAG-3614