### PR TITLE
[backport release/3.4.x] chore(CI): fix the workflow that comments the docker image on the commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ env:
 
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
+
 jobs:
   metadata:
     name: Metadata
@@ -311,6 +312,10 @@ jobs:
     needs: [metadata, build-packages]
     runs-on: ubuntu-22.04
 
+    permissions:
+      # create comments on commits for docker images needs the `write` permission
+      contents: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -397,7 +402,7 @@ jobs:
       if: github.event_name == 'push' && matrix.label == 'ubuntu'
       uses: peter-evans/commit-comment@76d2ae14b83cd171cd38507097b9616bb9ca7cb6 # v2.0.1
       with:
-        token: ${{ secrets.GHA_COMMENT_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         body: |
           ### Bazel Build
           Docker image available `${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ github.sha }}`


### PR DESCRIPTION
Backport https://github.com/Kong/kong/pull/12693

_[KAG-4021]_

[KAG-4021]: https://konghq.atlassian.net/browse/KAG-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ