### PR TITLE
[backport -> release/2.8.x] Backport 12691 to release/2.8.x

### DIFF
--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -24,7 +24,7 @@ describe("kong reload #" .. strategy, function()
     helpers.clean_prefix()
   end)
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("send a 'reload' signal to a running Nginx master process", function()
@@ -580,7 +580,7 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
 
     finally(function()
       os.remove(yaml_file)
-      helpers.stop_kong(helpers.test_conf.prefix, true)
+      helpers.stop_kong(helpers.test_conf.prefix)
       if admin_client then
         admin_client:close()
       end

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -46,7 +46,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -24,7 +24,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()
@@ -1909,7 +1909,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -34,7 +34,7 @@ describe("Admin API #off", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -870,7 +870,7 @@ describe("Admin API (concurrency tests) #off", function()
   end)
 
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
 
     if client then
       client:close()
@@ -991,7 +991,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -1123,7 +1123,7 @@ describe("Admin API #off worker_consistency=eventual", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
+++ b/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
@@ -51,7 +51,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/18-worker-events.lua
+++ b/spec/02-integration/04-admin_api/18-worker-events.lua
@@ -55,7 +55,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/19-vaults_spec.lua
+++ b/spec/02-integration/04-admin_api/19-vaults_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -312,7 +312,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
         db:truncate("routes")
         db:truncate("services")
         db:truncate("consumers")
@@ -405,7 +405,7 @@ for _, strategy in helpers.each_strategy() do
 
         os.remove(FILE_LOG_PATH)
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()
@@ -516,7 +516,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
 
         db:truncate("routes")
         db:truncate("services")
@@ -563,7 +563,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       it("runs without causing an internal error", function()
@@ -1073,7 +1073,7 @@ for _, strategy in helpers.each_strategy() do
             proxy_client:close()
           end
 
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("is executed", function()
@@ -1147,7 +1147,7 @@ for _, strategy in helpers.each_strategy() do
               admin_client:close()
             end
 
-            helpers.stop_kong(nil, true)
+            helpers.stop_kong()
           end)
 
           it("is executed", function()

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -231,7 +231,7 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_teardown(function()
       if proxy_client then proxy_client:close() end
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("checks global configuration without credentials", function()
@@ -712,7 +712,7 @@ for _, strategy in helpers.each_strategy() do
 
       lazy_teardown(function()
         helpers.stop_kong("servroot2")
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
 
@@ -1227,7 +1227,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("certificate phase clears context, fix #7054", function()

--- a/spec/02-integration/05-proxy/09-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/09-websockets_spec.lua
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function open_socket(uri)

--- a/spec/02-integration/05-proxy/11-handler_spec.lua
+++ b/spec/02-integration/05-proxy/11-handler_spec.lua
@@ -43,7 +43,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("runs", function()
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()
@@ -175,7 +175,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -11,7 +11,7 @@ describe("Proxy error handlers", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
+++ b/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
@@ -104,7 +104,7 @@ describe("#postgres upstream keepalive", function()
       proxy_client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -88,8 +88,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1110,8 +1110,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1256,8 +1256,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()

--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -13,7 +13,7 @@ describe("worker respawn", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/11-dbless/02-workers_spec.lua
+++ b/spec/02-integration/11-dbless/02-workers_spec.lua
@@ -29,7 +29,7 @@ describe("Workers initialization #off", function()
   lazy_teardown(function()
     admin_client:close()
     proxy_client:close()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("restarts worker correctly without issues on the init_worker phase when config includes 1000+ plugins", function()

--- a/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
@@ -58,7 +58,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function hmac_sha1_binary(secret, data)

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -64,7 +64,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         local function cache_key(conf, username, password)

--- a/spec/03-plugins/23-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/03-api_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     describe("POST", function()

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -329,7 +329,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: #%s [#%
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("Without authentication (IP address)", function()
@@ -567,7 +567,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (expirations) with policy: #%
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("expires a counter", function()
@@ -638,7 +638,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access - global for single c
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
@@ -675,7 +675,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access - global) with policy
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -753,7 +753,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (fault tolerance) with policy
       end)
 
       after_each(function()
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       it("does not work if an error occurs", function()
@@ -848,7 +848,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (fault tolerance) with policy
     end)
 
     after_each(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("does not work if an error occurs", function()

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -270,7 +270,7 @@ do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("caches a simple request", function()

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -64,7 +64,7 @@ describe("Plugin: proxy-cache", function()
   end)
 
   teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("(schema)", function()

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -92,8 +92,8 @@ describe("proxy-cache invalidations via: " .. strategy, function()
   end)
 
   teardown(function()
-    helpers.stop_kong("servroot1", true)
-    helpers.stop_kong("servroot2", true)
+    helpers.stop_kong("servroot1")
+    helpers.stop_kong("servroot2")
   end)
 
   before_each(function()


### PR DESCRIPTION
chore(test): remove prefix directory when stop_kong called (#12691)
    
If the prefix is not cleaned up when stop_kong is called, it could impact subsequent tests, especially when later tests start Kong by a shell command, the Kong instance might be started up with the default `servroot` prefix.
    
KAG-3808
    
(cherry picked from commit 3dd5bdb78ee9aa4b4f602ec241a4b52b1b0ae353)