### PR TITLE
[backport -> release/3.4.x] Backport 12691 to release/3.4.x

### DIFF
--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -15,7 +15,7 @@ describe("kong reload #" .. strategy, function()
     helpers.clean_prefix()
   end)
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("send a 'reload' signal to a running Nginx master process", function()
@@ -586,7 +586,7 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
 
     finally(function()
       os.remove(yaml_file)
-      helpers.stop_kong(helpers.test_conf.prefix, true)
+      helpers.stop_kong(helpers.test_conf.prefix)
       if admin_client then
         admin_client:close()
       end

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -46,7 +46,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -24,7 +24,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()
@@ -1966,7 +1966,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -57,7 +57,7 @@ describe("Admin API #off", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -2751,7 +2751,7 @@ describe("Admin API (concurrency tests) #off", function()
   end)
 
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
 
     if client then
       client:close()
@@ -2872,7 +2872,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -3015,7 +3015,7 @@ describe("Admin API #off with cache key vs endpoint key #unique", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()
@@ -3083,7 +3083,7 @@ describe("Admin API #off worker_consistency=eventual", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/04-admin_api/19-vaults_spec.lua
+++ b/spec/02-integration/04-admin_api/19-vaults_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -34,7 +34,7 @@ for _, strategy in helpers.all_strategies() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -231,7 +231,7 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_teardown(function()
       if proxy_client then proxy_client:close() end
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("checks global configuration without credentials", function()
@@ -743,7 +743,7 @@ for _, strategy in helpers.each_strategy() do
 
       lazy_teardown(function()
         helpers.stop_kong("servroot2")
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
 
@@ -1276,7 +1276,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("certificate phase clears context, fix #7054", function()

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -312,7 +312,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
         db:truncate("routes")
         db:truncate("services")
         db:truncate("consumers")
@@ -405,7 +405,7 @@ for _, strategy in helpers.each_strategy() do
 
         os.remove(FILE_LOG_PATH)
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()
@@ -516,7 +516,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
 
         db:truncate("routes")
         db:truncate("services")
@@ -563,7 +563,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end
 
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       it("runs without causing an internal error", function()
@@ -1117,7 +1117,7 @@ for _, strategy in helpers.each_strategy() do
             proxy_client:close()
           end
 
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("is executed", function()
@@ -1191,7 +1191,7 @@ for _, strategy in helpers.each_strategy() do
               admin_client:close()
             end
 
-            helpers.stop_kong(nil, true)
+            helpers.stop_kong()
           end)
 
           it("is executed", function()

--- a/spec/02-integration/05-proxy/09-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/09-websockets_spec.lua
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function open_socket(uri)

--- a/spec/02-integration/05-proxy/11-handler_spec.lua
+++ b/spec/02-integration/05-proxy/11-handler_spec.lua
@@ -43,7 +43,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("runs", function()
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()
@@ -175,7 +175,7 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_teardown(function()
           if admin_client then admin_client:close() end
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("doesn't run", function()

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -12,7 +12,7 @@ describe("Proxy error handlers", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
+++ b/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
@@ -125,7 +125,7 @@ describe("#postgres upstream keepalive", function()
       proxy_client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -82,8 +82,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1196,8 +1196,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()
@@ -1337,8 +1337,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()

--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -57,7 +57,7 @@ describe("worker respawn", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   before_each(function()

--- a/spec/02-integration/11-dbless/02-workers_spec.lua
+++ b/spec/02-integration/11-dbless/02-workers_spec.lua
@@ -29,7 +29,7 @@ describe("Workers initialization #off", function()
   lazy_teardown(function()
     admin_client:close()
     proxy_client:close()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("restarts worker correctly without issues on the init_worker phase when config includes 1000+ plugins", function()

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -21,7 +21,7 @@ describe("dbless persistence #off", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   it("loads the lmdb config on restarts", function()
@@ -113,7 +113,7 @@ describe("dbless persistence with a declarative config #off", function()
   end)
 
   after_each(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
   lazy_teardown(function()
     os.remove(yaml_file)

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -183,7 +183,7 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
       client:close()
     end
 
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
     vault:teardown()
 
     helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")

--- a/spec/02-integration/20-wasm/01-admin-api_spec.lua
+++ b/spec/02-integration/20-wasm/01-admin-api_spec.lua
@@ -56,7 +56,7 @@ describe("wasm admin API [#" .. strategy .. "]", function()
 
   lazy_teardown(function()
     if admin then admin:close() end
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 
@@ -563,7 +563,7 @@ describe("wasm admin API - wasm = off [#" .. strategy .. "]", function()
 
   lazy_teardown(function()
     if admin then admin:close() end
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("/filter-chains", function()

--- a/spec/02-integration/20-wasm/03-runtime_spec.lua
+++ b/spec/02-integration/20-wasm/03-runtime_spec.lua
@@ -365,7 +365,7 @@ describe("#wasm filter execution (#" .. strategy .. ")", function()
 
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
+++ b/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
@@ -75,7 +75,7 @@ describe("proxy-wasm filters (#wasm)", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
     os.remove(hosts_file)
   end)
 

--- a/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
+++ b/spec/02-integration/20-wasm/05-cache-invalidation_spec.lua
@@ -270,7 +270,7 @@ describe("#wasm filter chain cache " .. mode_suffix, function()
 
 
   lazy_teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
 

--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -100,7 +100,7 @@ describe("#wasm - hybrid mode", function()
   end)
 
   lazy_teardown(function()
-    helpers.stop_kong(cp_prefix, true)
+    helpers.stop_kong(cp_prefix)
   end)
 
   describe("[happy path]", function()
@@ -248,7 +248,7 @@ describe("#wasm - hybrid mode", function()
 
 
     lazy_teardown(function()
-      helpers.stop_kong(dp_prefix, true)
+      helpers.stop_kong(dp_prefix)
     end)
 
     it("does not sync configuration", function()

--- a/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
+++ b/spec/03-plugins/01-legacy_queue_parameter_warning_spec.lua
@@ -32,7 +32,7 @@ for _, strategy in helpers.each_strategy() do
       if admin_client then
         admin_client:close()
       end
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     before_each(function()

--- a/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
@@ -58,7 +58,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     local function hmac_sha1_binary(secret, data)

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -63,7 +63,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         local function cache_key(conf, username, password)

--- a/spec/03-plugins/23-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/03-api_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     describe("POST", function()

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -382,7 +382,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         describe("Without authentication (IP address)", function()
@@ -624,7 +624,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("expires a counter", function()
@@ -699,7 +699,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
@@ -740,7 +740,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         lazy_teardown(function()
-          helpers.stop_kong(nil, true)
+          helpers.stop_kong()
         end)
 
         before_each(function()
@@ -825,7 +825,7 @@ for _, strategy in helpers.each_strategy() do
             end)
 
             after_each(function()
-              helpers.stop_kong(nil, true)
+              helpers.stop_kong()
             end)
 
             it("does not work if an error occurs", function()
@@ -921,7 +921,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           after_each(function()
-            helpers.stop_kong(nil, true)
+            helpers.stop_kong()
           end)
 
           it("does not work if an error occurs", function()

--- a/spec/03-plugins/29-acme/05-redis_storage_spec.lua
+++ b/spec/03-plugins/29-acme/05-redis_storage_spec.lua
@@ -188,7 +188,7 @@ describe("Plugin: acme (storage.redis)", function()
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong(nil, true)
+        helpers.stop_kong()
       end)
 
       before_each(function()

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -340,7 +340,7 @@ do
         admin_client:close()
       end
 
-      helpers.stop_kong(nil, true)
+      helpers.stop_kong()
     end)
 
     it("caches a simple request", function()

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -64,7 +64,7 @@ describe("Plugin: proxy-cache", function()
   end)
 
   teardown(function()
-    helpers.stop_kong(nil, true)
+    helpers.stop_kong()
   end)
 
   describe("(schema)", function()

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -89,8 +89,8 @@ describe("proxy-cache invalidations via: " .. strategy, function()
   end)
 
   teardown(function()
-    helpers.stop_kong("servroot1", true)
-    helpers.stop_kong("servroot2", true)
+    helpers.stop_kong("servroot1")
+    helpers.stop_kong("servroot2")
   end)
 
   before_each(function()

--- a/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
+++ b/spec/05-migration/plugins/http-log/migrations/001_280_to_300_spec.lua
@@ -18,7 +18,7 @@ handler("http-log plugin migration", function()
     end)
 
     lazy_teardown(function ()
-      assert(uh.stop_kong(nil, true))
+      assert(uh.stop_kong())
     end)
 
     local log_server_url = "http://localhost:" .. HTTP_PORT .. "/"

--- a/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
+++ b/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
@@ -11,7 +11,7 @@ if uh.database_type() == 'postgres' then
         end)
 
         lazy_teardown(function ()
-            assert(uh.stop_kong(nil, true))
+            assert(uh.stop_kong())
         end)
 
         uh.setup(function ()


### PR DESCRIPTION
chore(test): remove prefix directory when stop_kong called (#12691)
    
If the prefix is not cleaned up when stop_kong is called, it could impact subsequent tests, especially when later tests start Kong by a shell command, the Kong instance might be started up with the default `servroot` prefix.
    
KAG-3808
    
(cherry picked from commit 3dd5bdb78ee9aa4b4f602ec241a4b52b1b0ae353)