### PR TITLE
fix(jwt-plugin): Add missing pkey sanity check for ES384 and ES512

### DIFF
--- a/changelog/unreleased/kong/fix-jwt-plugin-check.yml
+++ b/changelog/unreleased/kong/fix-jwt-plugin-check.yml
@@ -1,0 +1,3 @@
+message: "**Jwt**: fix an issue where the plugin would fail when using invalid public keys for ES384 and ES512 algorithms."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -111,23 +111,17 @@ local alg_verify = {
   RS256 = function(data, signature, key)
     local pkey, _ = openssl_pkey.new(key)
     assert(pkey, "Consumer Public Key is Invalid")
-    local digest = openssl_digest.new("sha256")
-    assert(digest:update(data))
-    return pkey:verify(signature, digest)
+    return pkey:verify(signature, data, "sha256")
   end,
   RS384 = function(data, signature, key)
     local pkey, _ = openssl_pkey.new(key)
     assert(pkey, "Consumer Public Key is Invalid")
-    local digest = openssl_digest.new("sha384")
-    assert(digest:update(data))
-    return pkey:verify(signature, digest)
+    return pkey:verify(signature, data, "sha384")
   end,
   RS512 = function(data, signature, key)
     local pkey, _ = openssl_pkey.new(key)
     assert(pkey, "Consumer Public Key is Invalid")
-    local digest = openssl_digest.new("sha512")
-    assert(digest:update(data))
-    return pkey:verify(signature, digest)
+    return pkey:verify(signature, data, "sha512")
   end,
   -- https://www.rfc-editor.org/rfc/rfc7518#section-3.4
   ES256 = function(data, signature, key)
@@ -150,6 +144,7 @@ local alg_verify = {
     --  ECDSA P-521 SHA-512, R and S will be 521 bits each, resulting in a
     --  132-octet sequence.
     local pkey, _ = openssl_pkey.new(key)
+    assert(pkey, "Consumer Public Key is Invalid")
     assert(#signature == 96, "Signature must be 96 bytes.")
     return pkey:verify(signature, data, "sha384", nil, { ecdsa_use_raw = true })
   end,
@@ -163,6 +158,7 @@ local alg_verify = {
     --  ECDSA P-521 SHA-512, R and S will be 521 bits each, resulting in a
     --  132-octet sequence.
     local pkey, _ = openssl_pkey.new(key)
+    assert(pkey, "Consumer Public Key is Invalid")
     assert(#signature == 132, "Signature must be 132 bytes.")
     return pkey:verify(signature, data, "sha512", nil, { ecdsa_use_raw = true })
   end,


### PR DESCRIPTION
### Summary

The plugin might fail due to invalid public keys. The sanity checks are in place for all algorithms except ES384 and ES512. In addition the usage of pkey:verify function has been harmonized across the different algorithms.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Martin Kölbel <martin.koelbel@mercedes-benz.com> on behalf of Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)

