### PR TITLE
fix(pluginsocket.proto): type for `set_upstream`

### DIFF
--- a/changelog/unreleased/kong/pluginsocket-proto-wrong-type.yml
+++ b/changelog/unreleased/kong/pluginsocket-proto-wrong-type.yml
@@ -1,0 +1,3 @@
+message: |
+  Fix an issue where external plugins using the protobuf-based protocol would fail to call the `kong.Service.SetUpstream` method with an error `bad argument #2 to 'encode' (table expected, got boolean)`.
+type: bugfix

--- a/kong/include/kong/pluginsocket.proto
+++ b/kong/include/kong/pluginsocket.proto
@@ -328,7 +328,7 @@ service Kong {
     rpc Router_GetRoute(google.protobuf.Empty) returns (Route);
     rpc Router_GetService(google.protobuf.Empty) returns (Service);
 
-    rpc Service_SetUpstream(String) returns (google.protobuf.Empty);
+    rpc Service_SetUpstream(String) returns (Bool);
     rpc Service_SetTarget(Target) returns (google.protobuf.Empty);
 
     rpc Service_Request_SetScheme(String) returns (google.protobuf.Empty);


### PR DESCRIPTION
### Summary

Fix the return type for the `.Service.SetUpstream` external plugin PDK method.

Fixes issue https://github.com/Kong/go-pdk/issues/114.

Sister PR: https://github.com/Kong/go-pdk/pull/191

### Issue reference

Fixes issue https://github.com/Kong/go-pdk/issues/114.