### PR TITLE
feat(log-serializer): add `latencies.receive` property to log-serializer

### DIFF
--- a/changelog/unreleased/kong/log-serializer-receive-latency.yml
+++ b/changelog/unreleased/kong/log-serializer-receive-latency.yml
@@ -1,0 +1,3 @@
+message: 'Add `latencies.receive` property to log serializer'
+type: feature
+scope: Core

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -845,6 +845,7 @@ do
                  (ctx.KONG_RECEIVE_TIME or 0),
           proxy = ctx.KONG_WAITING_TIME or -1,
           request = tonumber(var.request_time) * 1000,
+          receive = ctx.KONG_RECEIVE_TIME or 0,
         },
         tries = (ctx.balancer_data or {}).tries,
         authenticated_entity = build_authenticated_entity(ctx),

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -76,6 +76,7 @@ describe("kong.log.serialize", function()
         assert.equal(0, res.latencies.kong)
         assert.equal(-1, res.latencies.proxy)
         assert.equal(2000, res.latencies.request)
+        assert.equal(0, res.latencies.receive)
 
         -- Request
         assert.is_table(res.request)


### PR DESCRIPTION
### Summary

This adds receive time to the latencies object, as reported in `ctx.KONG_RECEIVE_TIME`:

https://github.com/Kong/kong/blob/15a3797ba0c6124cb73d20a9037fc7aee9e86bbe/kong/init.lua#L1685-L1692


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] There is a user-facing docs PR ([link](https://github.com/Kong/docs.konghq.com/pull/7077))

### Issue reference

KAG-3798