### PR TITLE
feat(ai-prompt-guard): increase the maximum length of regex expression

### DIFF
--- a/changelog/unreleased/kong/feat-increase-ai-anthropic-regex-expression-length.yml
+++ b/changelog/unreleased/kong/feat-increase-ai-anthropic-regex-expression-length.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI-Prompt-Guard**: increase the maximum length of regex expression for both allow and deny parameter
+  **AI-Prompt-Guard**: increase the maximum length of regex expression to 500 for both allow and deny parameter
 scope: Plugin
 type: feature

--- a/changelog/unreleased/kong/feat-increase-ai-anthropic-regex-expression-length.yml
+++ b/changelog/unreleased/kong/feat-increase-ai-anthropic-regex-expression-length.yml
@@ -1,0 +1,4 @@
+message: |
+  **AI-Prompt-Guard**: increase the maximum length of regex expression for both allow and deny parameter
+scope: Plugin
+type: feature

--- a/kong/plugins/ai-prompt-guard/schema.lua
+++ b/kong/plugins/ai-prompt-guard/schema.lua
@@ -15,7 +15,7 @@ return {
               elements = {
                 type = "string",
                 len_min = 1,
-                len_max = 50,
+                len_max = 500,
               }}},
           { deny_patterns = {
               description = "Array of invalid patterns, or invalid questions from the 'user' role in chat.",
@@ -25,7 +25,7 @@ return {
               elements = {
                 type = "string",
                 len_min = 1,
-                len_max = 50,
+                len_max = 500,
               }}},
           { allow_all_conversation_history = {
               description = "If true, will ignore all previous chat prompts from the conversation history.",

--- a/spec/03-plugins/42-ai-prompt-guard/00_config_spec.lua
+++ b/spec/03-plugins/42-ai-prompt-guard/00_config_spec.lua
@@ -42,7 +42,7 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     local config = {
       allow_all_conversation_history = true,
       allow_patterns = {
-        [1] = "123456789012345678901234567890123456789012345678901" -- 51
+        [1] = string.rep('x', 501)
       },
     }
 
@@ -50,7 +50,7 @@ describe(PLUGIN_NAME .. ": (schema)", function()
 
     assert.is_falsy(ok)
     assert.not_nil(err)
-    assert.same({ config = {allow_patterns = { [1] = "length must be at most 50" }}}, err)
+    assert.same({ config = {allow_patterns = { [1] = "length must be at most 500" }}}, err)
   end)
 
   it("won't allow too many array items", function()


### PR DESCRIPTION
### Summary

increase the maximum length of regex expression to 500 for both allow and deny parameter

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5767
