### PR TITLE
fix(admin_api): allow retrieval via uuid names

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-uuid-entity-names.yml
+++ b/changelog/unreleased/kong/fix-admin-api-uuid-entity-names.yml
@@ -1,0 +1,5 @@
+message: |
+  **Admin API**: Fixed an issue where an entity (like route) wouldn't be
+  retrievable through admin via it's name if it was set as uuid.
+type: bugfix
+scope: Admin API

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -256,6 +256,15 @@ for _, strategy in helpers.each_strategy() do
             assert.same(service, json)
           end)
 
+          it("retrieves by name - even when name is uuid", function()
+            local service = bp.named_services:insert({name = utils.uuid()}, { nulls = true })
+            local res  = client:get("/services/" .. service.name)
+            local body = assert.res_status(200, res)
+
+            local json = cjson.decode(body)
+            assert.same(service, json)
+          end)
+
           it("retrieves by utf-8 name and percent-escaped utf-8 name", function()
             local service = bp.services:insert({ name = "円" }, { nulls = true })
             local res  = client:get("/services/" .. service.name)


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Previously you could name an entity using a uuid however it wouldn't be retrievable from the API by it's name.

Example: 
`GET /routes/<uuid>` - where uuid was set as this route's name. 

This PR fixes that.

This PR changes behaviour of PUT operation as upsert with uuid-name as described in the docs PR: https://github.com/Kong/docs.konghq.com/pull/7107

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - [docs-PR](https://github.com/Kong/docs.konghq.com/pull/7107)

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-2581
