### PR TITLE
fix(core): X-Kong-Upstream-Status header is not set

### DIFF
--- a/changelog/unreleased/kong/fix-upstream-status-unset.yml
+++ b/changelog/unreleased/kong/fix-upstream-status-unset.yml
@@ -1,0 +1,3 @@
+message: fix a bug that `X-Kong-Upstream-Status` will not appear in the response headers even if it is set in the `headers` parameter in the kong.conf when the response is hit and returned by proxy cache plugin.
+scope: Core
+type: bugfix

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1438,7 +1438,7 @@ return {
 
       local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
       if kong.configuration.enabled_headers[upstream_status_header] then
-        local upstream_status = ctx.buffered_status or tonumber(sub(var.upstream_status or "", -3))
+        local upstream_status = ctx.buffered_status or tonumber(sub(var.upstream_status or "", -3)) or ngx.status
         header[upstream_status_header] = upstream_status
         if not header[upstream_status_header] then
           log(ERR, "failed to set ", upstream_status_header, " header")


### PR DESCRIPTION
### Summary

Fix a bug that `X-Kong-Upstream-Status` header is not set when the response is provided by the `proxy-cache` plugin.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5827
