### PR TITLE
refactor(template): eliminate manual indexing on certain Nginx variables due to inherent default indexing

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -64,9 +64,6 @@ log_format kong_log_format '$remote_addr - $remote_user [$time_local] '
 
 # Load variable indexes
 lua_kong_load_var_index default;
-lua_kong_load_var_index $http_x_kong_request_debug;
-lua_kong_load_var_index $http_x_kong_request_debug_token;
-lua_kong_load_var_index $http_x_kong_request_debug_log;
 
 upstream kong_upstream {
     server 0.0.0.1;


### PR DESCRIPTION
### Summary

The following ngx vars were added by https://github.com/Kong/kong/pull/11722 for performance:

``` plain
lua_kong_load_var_index $http_x_kong_request_debug;
lua_kong_load_var_index $http_x_kong_request_debug_token;
lua_kong_load_var_index $http_x_kong_request_debug_log;
```

And the lua-kong-nginx-module index these by default now: https://github.com/Kong/lua-kong-nginx-module/releases/tag/0.9.0, and we have already bumped it by https://github.com/Kong/kong/pull/12752, so we can remove these explicit indexing now.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

N/A