### PR TITLE
chore(deps): bump lua-resty-timer-ng from 0.2.6 to 0.2.7

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-timer-ng.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-timer-ng.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-timer-ng to 0.2.7"
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.12.0",
   "lua-resty-session == 4.0.5",
-  "lua-resty-timer-ng == 0.2.6",
+  "lua-resty-timer-ng == 0.2.7",
   "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
 }


### PR DESCRIPTION
### Summary

### What's Changed
* perf: remove NYIs to be more JIT-friendly by @ADD-SP in https://github.com/Kong/lua-resty-timer-ng/pull/25
* chore(rockspec): release 0.2.7-1 by @ADD-SP in https://github.com/Kong/lua-resty-timer-ng/pull/26


**Full Changelog**: https://github.com/Kong/lua-resty-timer-ng/compare/0.2.6...0.2.7

### Checklist

- [N/A] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3653]_


[KAG-3653]: https://konghq.atlassian.net/browse/KAG-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ