### PR TITLE
chore(release): simplify changelog automation

### DIFF
--- a/changelog/Makefile
+++ b/changelog/Makefile
@@ -40,7 +40,7 @@ check_version:
 	fi
 
 create_branch:
-	@git fetch
+	@git fetch --prune
 	@git submodule update --init --recursive
 	@git checkout -B $(BRANCH_NAME) $(ORIGIN_BRANCH)
 
@@ -48,47 +48,27 @@ generate:
 	@rm -f $(VERSION).md
 	@touch $(VERSION).md
 
-	@if [ -d "$(UNRELEASED_DIR)/kong" ] && [ -n "$$(shopt -s nullglob; echo $(UNRELEASED_DIR)/kong/*.yml)" ] ; then \
-		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(VERSION)/kong,$(UNRELEASED_DIR)/kong \
-				--title Kong \
-				--github-issue-repo $(OWNER_REPO) \
-				--github-api-repo $(OWNER_REPO) \
-				--with-jiras \
-				>> $(VERSION).md; \
-		else \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(UNRELEASED_DIR)/kong \
-				--title Kong \
-				--github-issue-repo $(OWNER_REPO) \
-				--github-api-repo $(OWNER_REPO) \
-				--with-jiras \
-				>> $(VERSION).md; \
-		fi \
+	@if [ -n "$$(shopt -s nullglob; echo $(UNRELEASED_DIR)/kong/*.yml)" ] || \
+		[ -n "$$(shopt -s nullglob; echo $(VERSION)/kong/*.yml)" ] ; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths $(VERSION)/kong,$(UNRELEASED_DIR)/kong \
+			--title Kong \
+			--github-issue-repo $(OWNER_REPO) \
+			--github-api-repo $(OWNER_REPO) \
+			--with-jiras \
+			>> $(VERSION).md; \
 	fi
-	@if [ -d "$(UNRELEASED_DIR)/kong-manager" ] && [ -n "$$(shopt -s nullglob; echo $(UNRELEASED_DIR)/kong-manager/*.yml)" ] ; then \
-		if [ -f "$(VERSION)/$(VERSION).md" ]; then \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(VERSION)/kong-manager,$(UNRELEASED_DIR)/kong-manager \
-				--title Kong-Manager \
-				--github-issue-repo Kong/kong-manager \
-				--github-api-repo $(OWNER_REPO) \
-				--with-jiras \
-				>> $(VERSION).md; \
-		else \
-			changelog --debug=$(DEBUG) generate \
-				--repo-path . \
-				--changelog-paths $(UNRELEASED_DIR)/kong-manager \
-				--title Kong-Manager \
-				--github-issue-repo Kong/kong-manager \
-				--github-api-repo $(OWNER_REPO) \
-				--with-jiras \
-				>> $(VERSION).md; \
-		fi \
+	@if [ -n "$$(shopt -s nullglob; echo $(UNRELEASED_DIR)/kong-manager/*.yml)" ] || \
+		[ -n "$$(shopt -s nullglob; echo $(VERSION)/kong-manager/*.yml)" ] ; then \
+		changelog --debug=$(DEBUG) generate \
+			--repo-path . \
+			--changelog-paths $(VERSION)/kong-manager,$(UNRELEASED_DIR)/kong-manager \
+			--title Kong-Manager \
+			--github-issue-repo Kong/kong-manager \
+			--github-api-repo $(OWNER_REPO) \
+			--with-jiras \
+			>> $(VERSION).md; \
     fi
 
 	@echo


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

docs(release): simplify changelog automation.

Cherry-pick https://github.com/Kong/kong-ee/pull/8586. Verified by https://github.com/Kong/kong/pull/12763.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5842]_


[FTI-5842]: https://konghq.atlassian.net/browse/FTI-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ