### PR TITLE
chore(test): busted script support system trusted certificate store

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -4,7 +4,22 @@ setmetatable(_G, nil)
 
 local pl_path = require("pl.path")
 
-local cert_path = pl_path.abspath("spec/fixtures/kong_spec.crt")
+local pl_file = require("pl.file")
+
+local tools_system = require("kong.tools.system")
+
+local cert_path do
+  local busted_cert_file = pl_path.tmpname()
+  local busted_cert_content = pl_file.read("spec/fixtures/kong_spec.crt")
+
+  local system_cert_path, err = tools_system.get_system_trusted_certs_filepath()
+  if system_cert_path then
+    busted_cert_content = busted_cert_content .. pl_file.read(system_cert_path)
+  end
+
+  pl_file.write(busted_cert_file, busted_cert_content)
+  cert_path = busted_cert_file
+end
 
 local DEFAULT_RESTY_FLAGS=string.format(" -c 4096 --http-conf 'lua_ssl_trusted_certificate %s;' ", cert_path)
 

--- a/bin/busted
+++ b/bin/busted
@@ -14,7 +14,7 @@ local cert_path do
 
   local system_cert_path, err = tools_system.get_system_trusted_certs_filepath()
   if system_cert_path then
-    busted_cert_content = busted_cert_content .. pl_file.read(system_cert_path)
+    busted_cert_content = busted_cert_content .. "\n" .. pl_file.read(system_cert_path)
   end
 
   pl_file.write(busted_cert_file, busted_cert_content)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR makes bin/busted able to trust system certificate store for the convenience of some unit testing.

This is a partial cherry-picking from EE PR, although currently we don't have any OSS test that relies on this change, I created this cherry-picking PR just for keeping consistency between the two repos.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
