### PR TITLE
fix(plugins/acme): fix certificate renew failure issue

### DIFF
--- a/changelog/unreleased/kong/fix-acme-renewal-bug.yml
+++ b/changelog/unreleased/kong/fix-acme-renewal-bug.yml
@@ -1,0 +1,3 @@
+message: "**ACME**: Fixed an issue where the certificate was not successfully renewed during ACME renewal."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/acme/api.lua
+++ b/kong/plugins/acme/api.lua
@@ -125,7 +125,7 @@ return {
     end,
 
     PATCH = function()
-      ngx_timer_at(0, client.renew_certificate)
+      ngx_timer_at(0, handler.renew)
       return kong.response.exit(202, { message = "Renewal process started successfully" })
     end,
   },

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -82,6 +82,9 @@ local function renew(premature)
 end
 
 
+ACMEHandler.renew = renew
+
+
 function ACMEHandler:init_worker()
   local worker_id = ngx.worker.id() or -1
   kong.log.info("acme renew timer started on worker ", worker_id)

--- a/spec/03-plugins/29-acme/01-client_spec.lua
+++ b/spec/03-plugins/29-acme/01-client_spec.lua
@@ -452,6 +452,18 @@ for _, strategy in ipairs({"off"}) do
         assert.is_nil(err)
         assert.is_falsy(renew)
       end)
+
+      it("calling handler.renew with a false argument should be successful", function()
+        local handler = require("kong.plugins.acme.handler")
+        handler:configure({{domains = {"example.com"}}})
+
+        local original = client.renew_certificate
+        client.renew_certificate = function (config)
+          print("mock renew_certificate")
+        end
+        handler.renew(false)
+        client.renew_certificate = original
+      end)
     end)
 
   end)


### PR DESCRIPTION
### Summary

Fix ACME renewal bug.

Using `client.renew_certificate` directly as the callback function in `ngx_timer_at` causes the parameter value to not be the plugin's config.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4008
Fix #12442
