### PR TITLE
refactor(clustering): an optimization for the compatibility of CP and DP

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -1,4 +1,107 @@
-return {
+-- An iterator that returns key and value pairs of removed fields from the removed_fields_mapping table.
+-- The key and the corresponding value pairs returned by the iterator should increase in version number.
+-- The value is a table of fields to be removed in that version.
+local function iterator(t)
+  local keys = {}
+  for k in pairs(t) do
+    keys[#keys+1] = k
+  end
+  table.sort(keys)
+  local len = #keys
+  local i = 0
+  return function()
+    if i > len then
+      i = 0
+    end
+    i = i + 1
+    return keys[i], t[keys[i]]
+  end
+end
+
+local removed_fields_mapping = {
+  -- Any dataplane older than 3.6.0
+  [3006000000] = {
+    opentelemetry = {
+      "sampling_rate",
+    },
+  },
+
+  -- Any dataplane older than 3.5.0
+  [3005000000] = {
+    acme = {
+      "storage_config.redis.scan_count",
+    },
+    cors = {
+      "private_network",
+    },
+    session = {
+      "read_body_for_logout",
+    },
+  },
+
+  -- Any dataplane older than 3.4.0
+  [3004000000] = {
+    rate_limiting = {
+      "sync_rate",
+    },
+    proxy_cache = {
+      "response_headers",
+    },
+  },
+
+  -- Any dataplane older than 3.3.0
+  [3003000000] = {
+    acme = {
+      "account_key",
+      "storage_config.redis.namespace",
+    },
+    aws_lambda = {
+      "disable_https",
+    },
+    proxy_cache = {
+      "ignore_uri_case",
+    },
+    opentelemetry = {
+      "http_response_header_for_traceid",
+      "queue",
+      "header_type",
+    },
+    http_log = {
+      "queue",
+    },
+    statsd = {
+      "queue",
+    },
+    datadog = {
+      "queue",
+    },
+    zipkin = {
+      "queue",
+    },
+  },
+
+  -- Any dataplane older than 3.2.0
+  [3002000000] = {
+    statsd = {
+      "tag_style",
+    },
+    session = {
+      "audience",
+      "absolute_timeout",
+      "remember_cookie_name",
+      "remember_rolling_timeout",
+      "remember_absolute_timeout",
+      "response_headers",
+      "request_headers",
+    },
+    aws_lambda = {
+      "aws_imds_protocol_version",
+    },
+    zipkin = {
+      "phase_duration_flavor",
+    }
+  },
+
   -- Any dataplane older than 3.1.0
   [3001000000] = {
     -- OSS
@@ -34,86 +137,8 @@ return {
       "http_response_header_for_traceid",
     },
   },
-  -- Any dataplane older than 3.2.0
-  [3002000000] = {
-    statsd = {
-      "tag_style",
-    },
-    session = {
-      "audience",
-      "absolute_timeout",
-      "remember_cookie_name",
-      "remember_rolling_timeout",
-      "remember_absolute_timeout",
-      "response_headers",
-      "request_headers",
-    },
-    aws_lambda = {
-      "aws_imds_protocol_version",
-    },
-    zipkin = {
-      "phase_duration_flavor",
-    }
-  },
-
-  -- Any dataplane older than 3.3.0
-  [3003000000] = {
-    acme = {
-      "account_key",
-      "storage_config.redis.namespace",
-    },
-    aws_lambda = {
-      "disable_https",
-    },
-    proxy_cache = {
-      "ignore_uri_case",
-    },
-    opentelemetry = {
-      "http_response_header_for_traceid",
-      "queue",
-      "header_type",
-    },
-    http_log = {
-      "queue",
-    },
-    statsd = {
-      "queue",
-    },
-    datadog = {
-      "queue",
-    },
-    zipkin = {
-      "queue",
-    },
-  },
-
-  -- Any dataplane older than 3.4.0
-  [3004000000] = {
-    rate_limiting = {
-      "sync_rate",
-    },
-    proxy_cache = {
-      "response_headers",
-    },
-  },
-
-  -- Any dataplane older than 3.5.0
-  [3005000000] = {
-    acme = {
-      "storage_config.redis.scan_count",
-    },
-    cors = {
-      "private_network",
-    },
-    session = {
-      "read_body_for_logout",
-    },
-  },
-
-  -- Any dataplane older than 3.6.0
-  [3006000000] = {
-    opentelemetry = {
-      "sampling_rate",
-    },
-  },
 }
+
+return function(fields)
+  return iterator(fields or removed_fields_mapping)
+end

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -6,7 +6,7 @@ local cjson_decode = require("cjson.safe").decode
 local ssl_fixtures = require ("spec.fixtures.ssl")
 
 local function reset_fields()
-  compat._set_removed_fields(require("kong.clustering.compat.removed_fields"))
+  compat._set_removed_fields()
 end
 
 describe("kong.clustering.compat", function()


### PR DESCRIPTION
### Summary

**Background:**

Kong ensures the backward compatibility through the logic of `remove_fields` that CP with higher verion can removes fields which are not supported by DPs in lower version before sending the configuration to DPs.

In detail, CP checks the version reporting by DP. If the version from DP is less than the version defined in `remove_fields`, the fields will be removed. So the logic is just a simple comparison.

**Issue:**

This logic works well for most of the cases. However, after serval backports to various version series, the comparsion should become more complex as there would be several incontinous ranges where the fields should be removed due to multiple backports.

**Solution:**

In this PR, a lower bound is added to the comparison when necessary rather than only a upper bound previously.

The new logic is that the comparison should punch through the range of the minor version for the earliest version since the field is supported, otherwise, the comparsion should be limited with the range of minor version.

**Example**

Let say a new field is initially introduced since 3.7.7. At this monent, an entry defined in `removed_fields.lua` should be:

```

-- Any dataplane older than 3.7.7
[3007007000] = {
    some_plugin = {
      "new_field",
    },
  },

```

And then it is backported into 3.5.5, 3.6.6. After that, the ranges where it's going to be removed or not turns into the followings:

- (-infinite,  3.5.5 ), remove
- [  3.5.5,    3.6.0 ), don't remove
- [  3.6.0,    3.6.6 ), remove
- [  3.6.6,    3.7.0 ), don't remove
- [  3.7.0,    3.7.7 ), remove
- [  3.7.7, +infinite), don't remove

At this monent, in terms of the new logic, the `removed_fields.lua` should be:

```

-- Any dataplane older than 3.5.5
[3005005000] = {
  some_plugin = {
    "new_field",
  },
},

-- Any dataplane older than 3.6.6
[3006006000] = {
  some_plugin = {
    "new_field",
  },
},

-- Any dataplane older than 3.7.7
[3007007000] = {
  some_plugin = {
    "new_field",
  },
},

```

The comparsion should be `dp_version < 3005005000` for the first entry as it is the earliest version it is supported and it should punch through the minor version.

The other two comparsions should be:
`dp_version < 3006006000 and dp_version >= 3006000000` and `dp_version < 3007007000 and dp_version >= 3007000000` respectively as it is not the earliest version it is supported and the comparison should be limited within the minor version.

With the help of this change, the `removed_fields.lua` can be consistent across version series, and we can easily append a new entry correspondingly when there is a backport.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
