### PR TITLE
chore(cd): stop uploading to pulp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,10 +549,6 @@ jobs:
       env:
         ARCHITECTURE: ${{ steps.pkg-arch.outputs.arch }}
         OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
-        PULP_HOST: https://api.download.konghq.com
-        PULP_USERNAME: admin
-        # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}
-        PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
         ARTIFACT_VERSION: ${{ matrix.artifact-version }}
         ARTIFACT_TYPE: ${{ matrix.artifact-type }}
         ARTIFACT: ${{ matrix.artifact }}
@@ -564,7 +560,6 @@ jobs:
         CLOUDSMITH_DRY_RUN: ''
         IGNORE_CLOUDSMITH_FAILURES: ${{ vars.IGNORE_CLOUDSMITH_FAILURES }}
         USE_CLOUDSMITH: ${{ vars.USE_CLOUDSMITH }}
-        USE_PULP: ${{ vars.USE_PULP }}
       run: |
         sha256sum bazel-bin/pkg/*
 

--- a/scripts/release-kong.sh
+++ b/scripts/release-kong.sh
@@ -8,11 +8,10 @@ source .requirements
 KONG_VERSION=$(bash scripts/grep-kong-version.sh)
 KONG_RELEASE_LABEL=${KONG_RELEASE_LABEL:-$KONG_VERSION}
 
-PULP_HOST=${PULP_HOST:-"https://api.download-dev.konghq.com"}
-PULP_USERNAME=${PULP_USERNAME:-"admin"}
-PULP_PASSWORD=${PULP_PASSWORD:-}
+# allow package name (from .requirements) to be overridden by ENV
+KONG_PACKAGE_NAME="${KONG_PACKAGE_NAME_OVERRIDE:-${KONG_PACKAGE_NAME}}"
 
-PULP_DOCKER_IMAGE="kong/release-script"
+RELEASE_SCRIPT_DOCKER_IMAGE="kong/release-script"
 
 # Variables used by the release script
 ARCHITECTURE=${ARCHITECTURE:-amd64}
@@ -131,17 +130,13 @@ function push_package () {
   fi
 
   docker run \
-    -e PULP_HOST="$PULP_HOST" \
-    -e PULP_USERNAME="$PULP_USERNAME" \
-    -e PULP_PASSWORD="$PULP_PASSWORD" \
     -e VERBOSE \
     -e CLOUDSMITH_API_KEY \
     -e CLOUDSMITH_DRY_RUN \
     -e IGNORE_CLOUDSMITH_FAILURES \
     -e USE_CLOUDSMITH \
-    -e USE_PULP \
     -v "$(pwd)/$KONG_ARTIFACT:/files/$DIST_FILE" \
-    -i $PULP_DOCKER_IMAGE \
+    -i $RELEASE_SCRIPT_DOCKER_IMAGE \
           --file "/files/$DIST_FILE" \
           --dist-name "$ARTIFACT_TYPE" $dist_version \
           --major-version "${KONG_VERSION%%.*}.x" \


### PR DESCRIPTION
As we have passed the 6 months deprecation period (2023 Dec), artifact release to pulp should be stopped
to allow full removal of Pulp.

[KAG-4120](https://konghq.atlassian.net/browse/KAG-4120)

[KAG-4120]: https://konghq.atlassian.net/browse/KAG-4120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ