### PR TITLE
perf(hook): remove NYIs to be more JIT-friendly

### DIFF
--- a/changelog/unreleased/kong/speed_up_internal_hooking_mechanism.yml
+++ b/changelog/unreleased/kong/speed_up_internal_hooking_mechanism.yml
@@ -1,0 +1,3 @@
+message: Speeded up internal hooking mechanism.
+type: performance
+scope: Performance

--- a/kong/hooks.lua
+++ b/kong/hooks.lua
@@ -84,7 +84,7 @@ function _M.run_hook(name, a0, a1, a2, a3, a4, a5, ...)
 
   local acc
 
-  -- `select` only JIT-table when first argument 
+  -- `select` only JIT-able when first argument 
   -- is a constant (Has to be positive if used with varg).
   local extra_argc = select("#", ...)
 

--- a/kong/hooks.lua
+++ b/kong/hooks.lua
@@ -8,7 +8,33 @@ local ipairs = ipairs
 local pack = table.pack
 local unpack = table.unpack
 local insert = table.insert
+local type = type
+local select = select
 local EMPTY = require("pl.tablex").readonly({})
+
+--[[
+  The preferred maximum number of return values from a hook,
+  which can avoid the performance issue of using `...` (varargs),
+  because calling a function with `...` is NYI in LuaJIT,
+  and NYI will abort the trace that impacts the performance.
+
+  This value should large enough to cover the majority of the cases,
+  and small enough to avoid the performance overhead to pass too many
+  arguments to the hook functions.
+
+  IF YOU CHANGE THIS VALUE, MAKE SURE YOU CHECK ALL THE PLACE
+  THAT USES THIS VALUE TO MAKE SURE IT'S SAFE TO CHANGE.
+  THE PLACE THAT USES THIS VALUE SHOULD LOOK LIKE THIS:
+
+  ```
+  -- let's assume PREFERED_MAX_HOOK_RETS is 4
+  if retc <= PREFERED_MAX_HOOK_RETS then
+    local r0, r1, r2, r3= unpack(retv, 1, retc)
+    return r0, r1, r2, r3
+  end
+  ```
+--]]
+local PREFERED_MAX_HOOK_RETS = 4
 
 
 local function wrap_hook(f)
@@ -51,15 +77,44 @@ function _M.register_hook(name, hook, opts)
 end
 
 
-function _M.run_hook(name, ...)
+function _M.run_hook(name, a0, a1, a2, a3, a4, a5, ...)
   if not hooks[name] then
-    return (...) -- return only the first value
+    return a0 -- return only the first value
   end
 
   local acc
 
+  -- `select` only JIT-table when first argument 
+  -- is a constant (Has to be positive if used with varg).
+  local extra_argc = select("#", ...)
+
   for _, f in ipairs(hooks[name] or EMPTY) do
-    acc = f(acc, ...)
+    if extra_argc == 0 then
+      --[[
+        This is the reason that we don't use the `...` (varargs) here,
+        because calling a function with `...` is NYI in LuaJIT,
+        and NYI will abort the trace that impacts the performance.
+      --]]
+      acc = f(acc, a0, a1, a2, a3, a4, a5)
+
+    else
+      acc = f(acc, a0, a1, a2, a3, a4, a5, ...)
+    end
+  end
+
+  if type(acc) == "table"          and
+     type(acc.n) == "number"       and
+     acc.n <= PREFERED_MAX_HOOK_RETS
+  then
+    --[[
+      try to avoid returning `unpack()` directly,
+      because it is a tail call
+      that is not fully supported by the JIT compiler.
+      So it is better to return the values directly to avoid
+      NYI.
+    --]]
+    local r0, r1, r2, r3 = unpack(acc, 1, acc.n)
+    return r0, r1, r2, r3
   end
 
   return unpack(acc, 1, acc.n)

--- a/kong/hooks.lua
+++ b/kong/hooks.lua
@@ -29,7 +29,7 @@ local EMPTY = require("pl.tablex").readonly({})
   ```
   -- let's assume PREFERED_MAX_HOOK_RETS is 4
   if retc <= PREFERED_MAX_HOOK_RETS then
-    local r0, r1, r2, r3= unpack(retv, 1, retc)
+    local r0, r1, r2, r3 = unpack(retv, 1, retc)
     return r0, r1, r2, r3
   end
   ```


### PR DESCRIPTION
### Summary

* Invoking a function using varargs (...) is NYI.

EE PR: kong/kong-ee#8046

### Checklist

- [N/A] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-3653]_


[KAG-3653]: https://konghq.atlassian.net/browse/KAG-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ