### PR TITLE
refactor(router/atc): remove closure to avoid NYIs

### DIFF
--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -277,6 +277,33 @@ do
 end
 
 
+local function sni_val_transform(_, p)
+  if #p > 1 and byte(p, -1) == DOT then
+    -- last dot in FQDNs must not be used for routing
+    return p:sub(1, -2)
+  end
+
+  return p
+end
+
+
+local function path_op_transform(path)
+  return is_regex_magic(path) and OP_REGEX or OP_PREFIX
+end
+
+
+local function path_val_transform(op, p)
+  if op == OP_REGEX then
+    -- 1. strip leading `~`
+    -- 2. prefix with `^` to match the anchored behavior of the traditional router
+    -- 3. update named capture opening tag for rust regex::Regex compatibility
+    return "^" .. p:sub(2):gsub("?<", "?P<")
+  end
+
+  return p
+end
+
+
 local function get_expression(route)
   local methods = route.methods
   local hosts   = route.hosts
@@ -289,6 +316,8 @@ local function get_expression(route)
 
   expr_buf:reset()
 
+  local gen = gen_for_field("tls.sni", OP_EQUAL, snis, sni_val_transform)
+  --[[
   local gen = gen_for_field("tls.sni", OP_EQUAL, snis, function(_, p)
     if #p > 1 and byte(p, -1) == DOT then
       -- last dot in FQDNs must not be used for routing
@@ -297,6 +326,7 @@ local function get_expression(route)
 
     return p
   end)
+  --]]
   if gen then
     -- See #6425, if `net.protocol` is not `https`
     -- then SNI matching should simply not be considered
@@ -368,6 +398,8 @@ local function get_expression(route)
                       hosts_buf:put(")"):get())
   end
 
+  gen = gen_for_field("http.path", path_op_transform, paths, path_val_transform)
+  --[[
   gen = gen_for_field("http.path", function(path)
     return is_regex_magic(path) and OP_REGEX or OP_PREFIX
   end, paths, function(op, p)
@@ -380,6 +412,7 @@ local function get_expression(route)
 
     return p
   end)
+  --]]
   if gen then
     expression_append(expr_buf, LOGICAL_AND, gen)
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Closure may cause unnecessary NYIs, removing them will improve performance.

KAG-4138

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
