### PR TITLE
fix(plugins): compatibility with older data planes

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -116,4 +116,14 @@ return {
       "sampling_rate",
     },
   },
+
+  -- Any dataplane older than 3.7.0
+  [3007000000] = {
+    opentelemetry = {
+      "propagation",
+    },
+    zipkin = {
+      "propagation",
+    },
+  },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -251,6 +251,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         local expected_otel_prior_35 = utils.cycle_aware_deep_copy(opentelemetry)
         expected_otel_prior_35.config.header_type = "preserve"
         expected_otel_prior_35.config.sampling_rate = nil
+        expected_otel_prior_35.config.propagation = nil
         do_assert(utils.uuid(), "3.4.0", expected_otel_prior_35)
 
         -- cleanup
@@ -271,6 +272,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         local expected_otel_prior_34 = utils.cycle_aware_deep_copy(opentelemetry)
         expected_otel_prior_34.config.header_type = "preserve"
         expected_otel_prior_34.config.sampling_rate = nil
+        expected_otel_prior_34.config.propagation = nil
         do_assert(utils.uuid(), "3.3.0", expected_otel_prior_34)
 
         -- cleanup
@@ -296,6 +298,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         local expected_zipkin_prior_35 = utils.cycle_aware_deep_copy(zipkin)
         expected_zipkin_prior_35.config.header_type = "preserve"
         expected_zipkin_prior_35.config.default_header_type = "b3"
+        expected_zipkin_prior_35.config.propagation = nil
         do_assert(utils.uuid(), "3.4.0", expected_zipkin_prior_35)
 
         -- cleanup
@@ -316,6 +319,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         local expected_zipkin_prior_34 = utils.cycle_aware_deep_copy(zipkin)
         expected_zipkin_prior_34.config.header_type = "preserve"
         expected_zipkin_prior_34.config.default_header_type = "b3"
+        expected_zipkin_prior_34.config.propagation = nil
         do_assert(utils.uuid(), "3.3.0", expected_zipkin_prior_34)
 
         -- cleanup


### PR DESCRIPTION
### Summary

added compatibility with older data planes for the new tracing headers propagation configuration options

### Checklist

- [x] The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-4139