### PR TITLE
fix(proxy-cache): changes age param

### DIFF
--- a/changelog/unreleased/kong/fix-age-header.yml
+++ b/changelog/unreleased/kong/fix-age-header.yml
@@ -1,0 +1,3 @@
+message: "proxy-cache response_headers age schema parameter changed from age to Age."
+type: bugfix
+scope: "Plugin"

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -538,6 +538,7 @@ build = {
     ["kong.plugins.proxy-cache.api"]                  = "kong/plugins/proxy-cache/api.lua",
     ["kong.plugins.proxy-cache.strategies"]           = "kong/plugins/proxy-cache/strategies/init.lua",
     ["kong.plugins.proxy-cache.strategies.memory"]    = "kong/plugins/proxy-cache/strategies/memory.lua",
+    ["kong.plugins.proxy-cache.clustering.compat.response_headers_translation"] = "kong/plugins/proxy-cache/clustering/compat/response_headers_translation.lua",
 
     ["kong.plugins.grpc-web.deco"] = "kong/plugins/grpc-web/deco.lua",
     ["kong.plugins.grpc-web.handler"] = "kong/plugins/grpc-web/handler.lua",

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,6 +23,24 @@ end
 
 
 local compatible_checkers = {
+  { 3008000000, --[[ 3.8.0.0 ]]
+    function (config_table, dp_version, log_suffix)
+      local has_update
+      local adapter = require("kong.plugins.proxy-cache.clustering.compat.response_headers_translation").adapter
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'proxy-cache' then
+          has_update = adapter(plugin.config)
+          if has_update then
+            log_warn_message('adapts ' .. plugin.name .. ' plugin response_headers configuration to older version',
+                             'revert to older schema',
+                             dp_version, log_suffix)
+          end
+        end
+      end
+
+      return has_update
+    end
+  },
   { 3007000000, --[[ 3.7.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update

--- a/kong/plugins/proxy-cache/clustering/compat/response_headers_translation.lua
+++ b/kong/plugins/proxy-cache/clustering/compat/response_headers_translation.lua
@@ -1,0 +1,13 @@
+local function adapter(config_to_update)
+    if config_to_update.response_headers["Age"] ~= nil then
+        config_to_update.response_headers.age = config_to_update.response_headers["Age"]
+        config_to_update.response_headers["Age"] = nil
+        return true
+    end
+
+    return false
+end
+
+return {
+    adapter = adapter
+}

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -78,7 +78,7 @@ return {
             description = "Caching related diagnostic headers that should be included in cached responses",
             type = "record",
             fields = {
-              { age  = {type = "boolean",  default = true} },
+              { ["Age"]  = {type = "boolean",  default = true} },
               { ["X-Cache-Status"]  = {type = "boolean",  default = true} },
               { ["X-Cache-Key"]  = {type = "boolean",  default = true} },
             },

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -329,7 +329,7 @@ do
           content_type = { "text/plain", "application/json" },
           [policy] = policy_config,
           response_headers = {
-            age = false,
+            ["Age"] = false,
             ["X-Cache-Status"] = false,
             ["X-Cache-Key"]  = false
           },


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The age parameter on the schema was in lower case which caused the header Age to appear only when the kong debug option was enabled. This commit changes the schema parameter from age to Age.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #12787
