### PR TITLE
refactor(tools/system): move system module out of tools.utils

### DIFF
--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -1,5 +1,6 @@
 local cjson = require "cjson.safe"
-local utils = require "kong.tools.utils"
+local system = require "kong.tools.system"
+local rand = require "kong.tools.rand"
 local constants = require "kong.constants"
 local counter = require "resty.counter"
 local knode = (kong and kong.node) and kong.node or
@@ -62,7 +63,7 @@ local REQUEST_ROUTE_CACHE_HITS_KEY_NEG = REQUEST_COUNT_KEY .. ":" .. ROUTE_CACHE
 local _buffer = {}
 local _ping_infos = {}
 local _enabled = false
-local _unique_str = utils.random_string()
+local _unique_str = rand.random_string()
 local _buffer_immutable_idx
 local _ssl_session
 local _ssl_verify = false
@@ -75,7 +76,7 @@ do
 
   local meta = require "kong.meta"
 
-  local system_infos = utils.get_system_infos()
+  local system_infos = system.get_system_infos()
 
   system_infos.hostname = system_infos.hostname or knode.get_hostname()
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -22,7 +22,6 @@ do
     "kong.tools.string",
     "kong.tools.uuid",
     "kong.tools.rand",
-    "kong.tools.system",
     "kong.tools.time",
     "kong.tools.ip",
     "kong.tools.http",

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -4,6 +4,7 @@ local pl_path = require "pl.path"
 describe("Utils", function()
 
   describe("get_system_infos()", function()
+    local utils = require "kong.tools.system"
     it("retrieves various host infos", function()
       local infos = utils.get_system_infos()
       assert.is_number(infos.cores)
@@ -19,6 +20,7 @@ describe("Utils", function()
   end)
 
   describe("get_system_trusted_certs_filepath()", function()
+    local utils = require "kong.tools.system"
     local old_exists = pl_path.exists
     after_each(function()
       pl_path.exists = old_exists


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This is one of refactor `kong.tools` tasks.
KAG-3137

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
