### PR TITLE
feat(clustering): add compatible checkers for mixed mode routes

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,6 +23,49 @@ end
 
 
 local compatible_checkers = {
+  { 3007000000, --[[ 3.7.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local flavor = kong and
+                     kong.configuration and
+                     kong.configuration.router_flavor
+
+      if flavor ~= "expressions" then
+        return false
+      end
+
+      local cur_routes = config_table.routes
+      local count = #cur_routes
+
+      local idx = 0
+      local routes = {}
+
+      for i = 1, count do
+        local r = cur_routes[i]
+
+        -- expression should be a string
+        if r.expression and r.expression ~= ngx.null then
+          idx = idx + 1
+          routes[idx] = r
+        end
+      end -- for
+
+      -- all routes are expression route
+      if idx == count then
+        return false
+      end
+
+      -- only pass expression routes to DP
+      for i = 1, count do
+        cur_routes[i] = routes[i]
+      end
+
+      log_warn_message("contains incompatible routes", 'remove them',
+                       dp_version, log_suffix)
+
+      return true
+    end,
+  },
+
   { 3006000000, --[[ 3.6.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update
@@ -47,6 +90,7 @@ local compatible_checkers = {
       return has_update
     end,
   },
+
   { 3005000000, --[[ 3.5.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -23,51 +23,6 @@ end
 
 
 local compatible_checkers = {
-  { 3007000000, --[[ 3.7.0.0 ]]
-    function(config_table, dp_version, log_suffix)
-      local flavor = kong and
-                     kong.configuration and
-                     kong.configuration.router_flavor
-
-      if flavor ~= "expressions" then
-        return false
-      end
-
-      local cur_routes = config_table.routes or {}
-      local count = #cur_routes
-
-      local idx = 0
-      local routes = {}
-
-      -- get all expression only routes
-      for i = 1, count do
-        local r = cur_routes[i]
-
-        -- expression should be a string
-        if r.expression and r.expression ~= ngx.null then
-          idx = idx + 1
-          routes[idx] = r
-        end
-      end -- for
-
-      -- all routes are expression route
-      if idx == count then
-        return false
-      end
-
-      -- only pass expression routes to DP
-      -- mixed mode routes will be set to nil
-      for i = 1, count do
-        cur_routes[i] = routes[i] -- or nil
-      end
-
-      log_warn_message("contains mixed mode route", "be removed",
-                       dp_version, log_suffix)
-
-      return true
-    end,
-  },
-
   { 3006000000, --[[ 3.6.0.0 ]]
     function(config_table, dp_version, log_suffix)
       local has_update

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -33,12 +33,13 @@ local compatible_checkers = {
         return false
       end
 
-      local cur_routes = config_table.routes
+      local cur_routes = config_table.routes or {}
       local count = #cur_routes
 
       local idx = 0
       local routes = {}
 
+      -- get all expression only routes
       for i = 1, count do
         local r = cur_routes[i]
 
@@ -55,11 +56,12 @@ local compatible_checkers = {
       end
 
       -- only pass expression routes to DP
+      -- mixed mode routes will be set to nil
       for i = 1, count do
-        cur_routes[i] = routes[i]
+        cur_routes[i] = routes[i] -- or nil
       end
 
-      log_warn_message("contains incompatible routes", 'remove them',
+      log_warn_message("contains mixed mode route", "be removed",
                        dp_version, log_suffix)
 
       return true

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -404,8 +404,8 @@ end
 
 -- If mixed config is detected and a 3.6 or lower DP is attached to the CP,
 -- no config will be sent at all
-function _M.check_mixed_route_entities(payload, dp_version)
-  local flavor = kong and
+function _M.check_mixed_route_entities(payload, dp_version, flavor)
+  local flavor = flavor or kong and
                  kong.configuration and
                  kong.configuration.router_flavor
 

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -402,4 +402,46 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
 end
 
 
+-- If mixed config is detected and a 3.6 or lower DP is attached to the CP,
+-- no config will be sent at all
+function _M.check_mixed_route_entities(payload, dp_version)
+  local flavor = kong and
+                 kong.configuration and
+                 kong.configuration.router_flavor
+
+  if flavor ~= "expressions" then
+    return true
+  end
+
+  -- cp run with 'expressions' flavor
+
+  local dp_version_num = version_num(dp_version)
+
+  if dp_version_num >= 3007000000 then --[[ 3.7.0.0 ]]
+    return true
+  end
+
+  local routes = payload["config_table"].routes or {}
+  local routes_n = #routes
+  local count = 0   -- expression route count
+
+  for i = 1, routes_n do
+    local r = routes[i]
+
+    -- expression should be a string
+    if r.expression and r.expression ~= ngx.null then
+      count = count + 1
+    end
+  end
+
+  if count == routes_n or   -- all are expression only routes
+     count == 0             -- all are traditional routes
+  then
+    return true
+  end
+
+  return false, dp_version .. " do not support mixed mode route"
+end
+
+
 return _M

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -413,11 +413,11 @@ function _M.check_mixed_route_entities(payload, dp_version)
     return true
   end
 
-  -- cp run with 'expressions' flavor
+  -- CP runs with 'expressions' flavor
 
   local dp_version_num = version_num(dp_version)
 
-  if dp_version_num >= 3007000000 then --[[ 3.7.0.0 ]]
+  if dp_version_num >= 3007000000 then -- [[ 3.7.0.0 ]]
     return true
   end
 
@@ -440,7 +440,7 @@ function _M.check_mixed_route_entities(payload, dp_version)
     return true
   end
 
-  return false, dp_version .. " do not support mixed mode route"
+  return false, dp_version .. " does not support mixed mode route"
 end
 
 

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -405,10 +405,6 @@ end
 -- If mixed config is detected and a 3.6 or lower DP is attached to the CP,
 -- no config will be sent at all
 function _M.check_mixed_route_entities(payload, dp_version, flavor)
-  local flavor = flavor or kong and
-                 kong.configuration and
-                 kong.configuration.router_flavor
-
   if flavor ~= "expressions" then
     return true
   end

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -433,7 +433,9 @@ function _M:handle_cp_websocket(cert)
         goto continue
       end
 
-      ok, err = check_mixed_route_entities(self.reconfigure_payload, dp_version)
+      ok, err = check_mixed_route_entities(self.reconfigure_payload, dp_version,
+                                           kong and kong.configuration and
+                                           kong.configuration.router_flavor)
       if not ok then
         ngx_log(ngx_WARN, _log_prefix, "unable to send updated configuration to data plane: ", err, log_suffix)
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -39,6 +39,7 @@ local sleep = ngx.sleep
 
 local plugins_list_to_map = compat.plugins_list_to_map
 local update_compatible_payload = compat.update_compatible_payload
+local check_mixed_route_entities = compat.check_mixed_route_entities
 local deflate_gzip = require("kong.tools.gzip").deflate_gzip
 local yield = require("kong.tools.yield").yield
 local connect_dp = clustering_utils.connect_dp
@@ -428,6 +429,13 @@ function _M:handle_cp_websocket(cert)
         if sync_status ~= previous_sync_status then
           update_sync_status()
         end
+
+        goto continue
+      end
+
+      ok, err = check_mixed_route_entities(self.reconfigure_payload, dp_version)
+      if not ok then
+        ngx_log(ngx_WARN, _log_prefix, "unable to send updated configuration to data plane: ", err, log_suffix)
 
         goto continue
       end

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -634,34 +634,47 @@ describe("kong.clustering.compat", function()
 
   describe("route entities compatible changes", function()
     it("mixed mode routes in expressions flavor", function()
+      _G.kong = { configuration = { router_flavor = "expressions" } }
+
+
+      package.loaded["kong.db.schema.entities.routes"] = nil
+      package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
+      package.loaded["spec.helpers"] = nil
+      package.loaded["kong.db.declarative"] = nil
+
+      local helpers = require ("spec.helpers")
+      local declarative = require("kong.db.declarative")
+
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })
       _G.kong.db = db
-      _G.kong.configuration = { router_flavor = "expressions" }
+
 
       -- mixed mode routes
       assert(declarative.load_into_db({
         routes = {
           route1 = {
+            protocols = { "http" },
             id = "00000000-0000-0000-0000-000000000001",
             hosts = { "example.com" },
-            --expression == ngx.null,
+            expression == ngx.null,
           },
-          --[[
+          --[==[
           route2 = {
+            protocols = { "http" },
             id = "00000000-0000-0000-0000-000000000002",
-            expression = "http.path == /foo"
+            expression = [[http.path == "/foo"]]
           },
-          --]]
+          --]==]
         },
       }, { _transform = true }))
 
       local config = { config_table = declarative.export_config() }
 
       local ok, err = compat.check_mixed_route_entities(config, "3.6.0")
-      assert.is_true(ok)
-      assert.is_nil(err)
+      assert.is_false(ok)
+      assert(string.find(err, "does not support mixed mode route"))
     end)
 
   end)  -- describe

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -659,12 +659,9 @@ describe("kong.clustering.compat", function()
 
       local config = { config_table = declarative.export_config() }
 
-      local has_update, result = compat.update_compatible_payload(config, "3.6.0", "test_")
-      assert.truthy(has_update)
-
-      result = cjson_decode(inflate_gzip(result)).config_table
-      local routes = assert(assert(assert(result).routes))
-      assert(#routes == 0)
+      local ok, err = compat.check_mixed_route_entities(config, "3.6.0")
+      assert.is_true(ok)
+      assert.is_nil(err)
     end)
 
   end)  -- describe

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -632,17 +632,20 @@ describe("kong.clustering.compat", function()
 
   end)  -- describe
 
-  describe("#only route entities compatible changes", function()
+  describe("route entities compatible changes", function()
     it("mixed mode routes in expressions flavor", function()
       _G.kong = { configuration = { router_flavor = "expressions" } }
-
 
       package.loaded["kong.db.schema.entities.routes"] = nil
       package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
       package.loaded["spec.helpers"] = nil
+      package.loaded["kong.clustering.compat"] = nil
       package.loaded["kong.db.declarative"] = nil
 
+      require("kong.db.schema.entities.routes")
       require("kong.db.schema.entities.routes_subschemas")
+
+      local compat = require("kong.clustering.compat")
       local helpers = require ("spec.helpers")
       local declarative = require("kong.db.declarative")
 
@@ -650,7 +653,6 @@ describe("kong.clustering.compat", function()
         "routes",
       })
       _G.kong.db = db
-
 
       -- mixed mode routes
       assert(declarative.load_into_db({
@@ -671,7 +673,7 @@ describe("kong.clustering.compat", function()
 
       local config = { config_table = declarative.export_config() }
 
-      local ok, err = compat.check_mixed_route_entities(config, "3.6.0")
+      local ok, err = compat.check_mixed_route_entities(config, "3.6.0", "expressions")
       assert.is_false(ok)
       assert(string.find(err, "does not support mixed mode route"))
     end)

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -648,7 +648,7 @@ describe("kong.clustering.compat", function()
     local helpers = require ("spec.helpers")
     local declarative = require("kong.db.declarative")
 
-    it("won't updated with mixed mode routes in expressions flavor", function()
+    it("won't updated with mixed mode routes in expressions flavor lower than 3.7", function()
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })
@@ -676,6 +676,10 @@ describe("kong.clustering.compat", function()
       local ok, err = compat.check_mixed_route_entities(config, "3.6.0", "expressions")
       assert.is_false(ok)
       assert(string.find(err, "does not support mixed mode route"))
+
+      local ok, err = compat.check_mixed_route_entities(config, "3.7.0", "expressions")
+      assert.is_true(ok)
+      assert.is_nil(err)
     end)
 
     it("update with traditional routes in expressions flavor", function()
@@ -702,7 +706,7 @@ describe("kong.clustering.compat", function()
       assert.is_nil(err)
     end)
 
-    it("update with mixed routes in expressions flavor", function()
+    it("update with expression routes in expressions flavor", function()
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -632,7 +632,7 @@ describe("kong.clustering.compat", function()
 
   end)  -- describe
 
-  describe("route entities compatible changes", function()
+  describe("#only route entities compatible changes", function()
     it("mixed mode routes in expressions flavor", function()
       _G.kong = { configuration = { router_flavor = "expressions" } }
 
@@ -642,6 +642,7 @@ describe("kong.clustering.compat", function()
       package.loaded["spec.helpers"] = nil
       package.loaded["kong.db.declarative"] = nil
 
+      require("kong.db.schema.entities.routes_subschemas")
       local helpers = require ("spec.helpers")
       local declarative = require("kong.db.declarative")
 
@@ -658,15 +659,13 @@ describe("kong.clustering.compat", function()
             protocols = { "http" },
             id = "00000000-0000-0000-0000-000000000001",
             hosts = { "example.com" },
-            expression == ngx.null,
+            expression = ngx.null,
           },
-          --[==[
           route2 = {
             protocols = { "http" },
             id = "00000000-0000-0000-0000-000000000002",
-            expression = [[http.path == "/foo"]]
+            expression = [[http.path == "/foo"]],
           },
-          --]==]
         },
       }, { _transform = true }))
 

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -648,7 +648,7 @@ describe("kong.clustering.compat", function()
     local helpers = require ("spec.helpers")
     local declarative = require("kong.db.declarative")
 
-    it("won't updated with mixed mode routes in expressions flavor lower than 3.7", function()
+    it("won't update with mixed mode routes in expressions flavor lower than 3.7", function()
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })
@@ -682,7 +682,7 @@ describe("kong.clustering.compat", function()
       assert.is_nil(err)
     end)
 
-    it("update with traditional routes in expressions flavor", function()
+    it("updates with all traditional routes in expressions flavor", function()
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })
@@ -706,7 +706,7 @@ describe("kong.clustering.compat", function()
       assert.is_nil(err)
     end)
 
-    it("update with expression routes in expressions flavor", function()
+    it("updates with all expression routes in expressions flavor", function()
       local _, db = helpers.get_db_utils(nil, {
         "routes",
       })

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -633,20 +633,31 @@ describe("kong.clustering.compat", function()
   end)  -- describe
 
   describe("route entities compatible changes", function()
-    _G.kong = { configuration = { router_flavor = "expressions" } }
+    local function reload_modules(flavor)
+      _G.kong = { configuration = { router_flavor = flavor } }
+      _G.kong.db = nil
 
-    package.loaded["kong.db.schema.entities.routes"] = nil
-    package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-    package.loaded["spec.helpers"] = nil
-    package.loaded["kong.clustering.compat"] = nil
-    package.loaded["kong.db.declarative"] = nil
+      package.loaded["kong.db.schema.entities.routes"] = nil
+      package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
+      package.loaded["spec.helpers"] = nil
+      package.loaded["kong.clustering.compat"] = nil
+      package.loaded["kong.db.declarative"] = nil
 
-    require("kong.db.schema.entities.routes")
-    require("kong.db.schema.entities.routes_subschemas")
+      require("kong.db.schema.entities.routes")
+      require("kong.db.schema.entities.routes_subschemas")
 
-    local compat = require("kong.clustering.compat")
-    local helpers = require ("spec.helpers")
-    local declarative = require("kong.db.declarative")
+      compat = require("kong.clustering.compat")
+      helpers = require ("spec.helpers")
+      declarative = require("kong.db.declarative")
+    end
+
+    lazy_setup(function()
+      reload_modules("expressions")
+    end)
+
+    lazy_teardown(function()
+      reload_modules()
+    end)
 
     it("won't update with mixed mode routes in expressions flavor lower than 3.7", function()
       local _, db = helpers.get_db_utils(nil, {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

~~Blocked by #12667.~~
KAG-3806

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
