### PR TITLE
chore(cd): degrade actions/cache from v4 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Cache Git
       id: cache-git
       if: (matrix.package == 'rpm' || matrix.image == 'debian:10') && matrix.image != ''
-      uses: actions/cache@v4
+      uses: actions/cache@v3 # DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
       with:
         path: /usr/local/git
         key: ${{ matrix.label }}-git-2.41.0
@@ -194,7 +194,7 @@ jobs:
     - name: Cache Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v3 # DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
       with:
         path: bazel-bin/pkg
         key: ${{ steps.cache-key.outputs.cache-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Cache Git
       id: cache-git
       if: (matrix.package == 'rpm' || matrix.image == 'debian:10') && matrix.image != ''
-      uses: actions/cache@v3 # DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
+      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3, DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
       with:
         path: /usr/local/git
         key: ${{ matrix.label }}-git-2.41.0
@@ -194,7 +194,7 @@ jobs:
     - name: Cache Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@v3 # DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
+      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3, DO NOT BUMP, v4 BREAKS ON CENTOS7 OR AMAZONLINUX2
       with:
         path: bazel-bin/pkg
         key: ${{ steps.cache-key.outputs.cache-key }}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-4155

actions/cache@v4 breaks on old distros like centos7 and amazonlinux2
