### PR TITLE
chore(ci): cherry-pick only PRs targetting master

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -12,6 +12,7 @@ jobs:
     # or when a comment containing `/cherry-pick` is created
     # and the author is a member, collaborator or owner
     if: >
+      github.ref == 'refs/heads/master' &&
       (
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.merged


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Kong-ee uses different names for long-lived branches (they are not prefixed by `release` like in Kong CE).

This means that any pr targetting any branch other than master will get "confused" (since it will not find the branch it expects in EE) and throw an error.

Since our CE backport action copies the labels from the original PR, this means that all the backports are also labeled for cherrypicking. Which is not
our desired workflow: in general we want a change to be cherry-picked from kong-CE/master to kong-EE/master, and then backported to any kong-EE long-lived
branches if necessary.

This change makes the cherry-pick action ignore any PRs not targetting master to avoid these issues.


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
