### PR TITLE
fix(wasm): disable Lua DNS resolver for proxy-wasm

### DIFF
--- a/changelog/unreleased/kong/fix-wasm-disable-pwm-lua-resolver.yml
+++ b/changelog/unreleased/kong/fix-wasm-disable-pwm-lua-resolver.yml
@@ -1,0 +1,4 @@
+message: |
+   Disable usage of the Lua DNS resolver from proxy-wasm by default.
+type: bugfix
+scope: Configuration

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -563,7 +563,8 @@ local function load(path, custom_conf, opts)
     -- set it as such in kong_defaults, because it can only be used if wasm is
     -- _also_ enabled. We inject it here if the user has not opted to set it
     -- themselves.
-    add_wasm_directive("nginx_http_proxy_wasm_lua_resolver", "on")
+    -- TODO: as a temporary compatibility fix, we are forcing it to 'off'.
+    add_wasm_directive("nginx_http_proxy_wasm_lua_resolver", "off")
 
     -- wasm vm properties are inherited from previously set directives
     if conf.lua_ssl_trusted_certificate and #conf.lua_ssl_trusted_certificate >= 1 then

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -927,22 +927,29 @@ describe("NGINX conf compiler", function()
       end)
       it("injects default configurations if wasm=on", function()
         assert.matches(
-          ".+proxy_wasm_lua_resolver on;.+",
+          ".+proxy_wasm_lua_resolver off;.+",
           kong_ngx_cfg({ wasm = true, }, debug)
         )
       end)
       it("does not inject default configurations if wasm=off", function()
         assert.not_matches(
-          ".+proxy_wasm_lua_resolver on;.+",
+          ".+proxy_wasm_lua_resolver.+",
           kong_ngx_cfg({ wasm = false, }, debug)
         )
       end)
-      it("permits overriding proxy_wasm_lua_resolver", function()
+      it("permits overriding proxy_wasm_lua_resolver to off", function()
         assert.matches(
           ".+proxy_wasm_lua_resolver off;.+",
           kong_ngx_cfg({ wasm = true,
-                         -- or should this be `false`? IDK
                          nginx_http_proxy_wasm_lua_resolver = "off",
+                       }, debug)
+        )
+      end)
+      it("permits overriding proxy_wasm_lua_resolver to on", function()
+        assert.matches(
+          ".+proxy_wasm_lua_resolver on;.+",
+          kong_ngx_cfg({ wasm = true,
+                         nginx_http_proxy_wasm_lua_resolver = "on",
                        }, debug)
         )
       end)

--- a/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
+++ b/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
@@ -786,7 +786,7 @@ describe("proxy-wasm filters (#wasm) (#" .. strategy .. ")", function()
       assert.logfile().has.no.line("[crit]",  true, 0)
     end)
 
-    it("resolves DNS hostnames to send an http dispatch, return its response body", function()
+    pending("resolves DNS hostnames to send an http dispatch, return its response body", function()
       local client = helpers.proxy_client()
       finally(function() client:close() end)
 


### PR DESCRIPTION
### Summary

We need to disable this for the time being, as coroutine scheduling issues in the Wasm/Lua bridge are addressed in ngx_wasmx_module.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~

### Issue reference

* https://github.com/Kong/ngx_wasm_module/issues/524
