### PR TITLE
tests(vaults): fix log file assertion

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -798,9 +798,9 @@ describe("kong start/stop #" .. strategy, function()
 
         assert.truthy(ok)
         assert.not_matches("error", err)
+        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true)
         assert.logfile().has.no.line("[error]", true, 0)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         assert(helpers.restart_kong({
@@ -810,9 +810,9 @@ describe("kong start/stop #" .. strategy, function()
           declarative_config = "",
         }))
 
+        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true)
         assert.logfile().has.no.line("[error]", true, 0)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         proxy_client = helpers.proxy_client()
@@ -829,8 +829,8 @@ describe("kong start/stop #" .. strategy, function()
           declarative_config = "",
         }))
 
+        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mocksocket/session-secret-unknown}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         proxy_client = helpers.proxy_client()
@@ -971,9 +971,9 @@ describe("kong start/stop #" .. strategy, function()
 
         assert.truthy(ok)
         assert.not_matches("error", err)
+        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true)
         assert.logfile().has.no.line("[error]", true, 0)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         proxy_client = helpers.proxy_client()
@@ -990,9 +990,9 @@ describe("kong start/stop #" .. strategy, function()
           declarative_config = "",
         }))
 
+        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true)
         assert.logfile().has.no.line("[error]", true, 0)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         proxy_client = helpers.proxy_client()
@@ -1009,8 +1009,8 @@ describe("kong start/stop #" .. strategy, function()
           declarative_config = "",
         }))
 
+        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true)
         assert.logfile().has.no.line("traceback", true, 0)
-        assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true, 0)
         assert.logfile().has.no.line("could not find vault", true, 0)
 
         proxy_client = helpers.proxy_client()


### PR DESCRIPTION
I've been seeing intermittent failures of these tests such as this one:

https://github.com/Kong/kong/actions/runs/8561323431/job/23462317673?pr=12829

```
FAIL spec/02-integration/02-cmd/02-start_stop_spec.lua:935: kong start/stop #off errors dbless does not fail fatally when referencing secrets doesn't work in declarative configuration using vault entities
spec/02-integration/02-cmd/02-start_stop_spec.lua:976: Expected file at:
(string) '/home/runner/work/kong/kong/servroot/logs/error.log'
To match:
(string) ' {vault://mock/session-secret-unknown-again}'
```

The log file assertion in question did not account for eventual consistency (zero timeout):

```lua
assert.logfile().has.line(" {vault://mock/session-secret-unknown-again}", true, 0)
```

I removed the 0 so that the assertion uses the default timeout. I also re-ordered the logfile assertions to be a bit more defensive, following this pattern:

1. assert an _eventual_ positive condition (log file matches a string)
2. assert negative condition(s) (log file does not match string)

This way the test is more safe from false negatives because we waited long enough for some expected event _before_ asserting that an undesired event did not happen (rather than asserting that the undesired event did not happen _yet_).

KAG-4190