### PR TITLE
chore(deps): bump lua-protobuf to v0.5.1

### DIFF
--- a/changelog/unreleased/kong/bump-lua-protobuf.yml
+++ b/changelog/unreleased/kong/bump-lua-protobuf.yml
@@ -1,0 +1,3 @@
+message: "Bump lua-protobuf to 0.5.1"
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.5.0",
+  "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.0.1",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.3.6",


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

v0.5.1 includes a fix for a segfault we have faced recently - as described in detail here: https://github.com/starwing/lua-protobuf/issues/261.

