### PR TITLE
fix(docs/pdk): Rename plain to plaintext for syntax highlighting

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -233,13 +233,13 @@ end
 -- Produced log lines have the following format when logging is invoked from
 -- within the core:
 --
--- ``` plain
+-- ``` plaintext
 -- [kong] %file_src:%line_src %message
 -- ```
 --
 -- In comparison, log lines produced by plugins have the following format:
 --
--- ``` plain
+-- ``` plaintext
 -- [kong] %file_src:%line_src [%namespace] %message
 -- ```
 --
@@ -258,14 +258,14 @@ end
 --
 -- would, within the core, produce a log line similar to:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
 -- If invoked from within a plugin (for example, `key-auth`) it would include the
 -- namespace prefix:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
@@ -298,14 +298,14 @@ end
 --
 -- would, within the core, produce a log line similar to:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
 -- If invoked from within a plugin (for example, `key-auth`) it would include the
 -- namespace prefix:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
@@ -447,14 +447,14 @@ end
 --
 -- would, within the core, produce a log line similar to:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
 -- If invoked from within a plugin (for example, `key-auth`) it would include the
 -- namespace prefix:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
@@ -466,7 +466,7 @@ end
 --
 -- would, within the core, produce a log line similar to:
 --
--- ``` plain
+-- ``` plaintext
 -- 2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world (deprecated after 2.5.0, scheduled for removal in 3.0.0), client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
 -- ```
 --
@@ -513,7 +513,7 @@ end
 -- When writing logs, `kong.log.inspect()` always uses its own format, defined
 -- as:
 --
--- ``` plain
+-- ``` plaintext
 -- %file_src:%func_name:%line_src %message
 -- ```
 --


### PR DESCRIPTION
### Summary

Replacing `plain` with `plaintext`, as the docs code syntax highlighter doesn't recognize `plain` and causes the generated codeblocks on the docs site to break on scroll.

![Screenshot 2024-04-09 at 8 55 54 AM](https://github.com/Kong/kong/assets/54370747/40bb92be-7095-49b2-a2cd-d085d0f708cc)
(source: https://docs.konghq.com/gateway/latest/plugin-development/pdk/kong.log/)

Issue reported in docs slack channel.

### Checklist

- [ N/A ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/7196

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
