### PR TITLE
feat(wasm): support bundled filters

### DIFF
--- a/changelog/unreleased/kong/wasm-bundled-filters.yml
+++ b/changelog/unreleased/kong/wasm-bundled-filters.yml
@@ -1,0 +1,3 @@
+message: Add `wasm_filters` configuration value for enabling individual filters
+type: feature
+scope: Configuration

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2053,6 +2053,33 @@
                         #   top level are registered
                         # * This path _may_ be a symlink to a directory.
 
+#wasm_filters = bundled,user        # Comma-separated list of Wasm filters to be made
+                                    # available for use in filter chains.
+                                    #
+                                    # When the `off` keyword is specified as the
+                                    # only value, no filters will be available for use.
+                                    #
+                                    # When the `bundled` keyword is specified, all filters
+                                    # bundled with Kong will be available.
+                                    #
+                                    # When the `user` keyword is specified, all filters
+                                    # within the `wasm_filters_path` will be available.
+                                    #
+                                    # **Examples:**
+                                    #
+                                    # - `wasm_filters = bundled,user` enables _all_ bundled
+                                    #   and user-supplied filters
+                                    # - `wasm_filters = user` enables _only_ user-supplied
+                                    #   filters
+                                    # - `wasm_filters = filter-a,filter-b` enables _only_
+                                    #   filters named `filter-a` or `filter-b` (whether
+                                    #   bundled _or_ user-suppplied)
+                                    #
+                                    # If a conflict occurs where a bundled filter and a
+                                    # user-supplied filter share the same name, a warning
+                                    # will be logged, and the user-supplied filter will
+                                    # be used instead.
+
 #------------------------------------------------------------------------------
 # WASM injected directives
 #------------------------------------------------------------------------------

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -541,6 +541,7 @@ local CONF_PARSERS = {
 
   wasm = { typ = "boolean" },
   wasm_filters_path = { typ = "string" },
+  wasm_filters = { typ = "array" },
 
   error_template_html = { typ = "string" },
   error_template_json = { typ = "string" },
@@ -640,4 +641,6 @@ return {
   _NOP_TOSTRING_MT = _NOP_TOSTRING_MT,
 
   LMDB_VALIDATION_TAG = LMDB_VALIDATION_TAG,
+
+  WASM_BUNDLED_FILTERS_PATH = "/usr/local/kong/wasm",
 }

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -9,6 +9,7 @@ local socket_url = require "socket.url"
 local conf_constants = require "kong.conf_loader.constants"
 local listeners = require "kong.conf_loader.listeners"
 local conf_parse = require "kong.conf_loader.parse"
+local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local pl_pretty = require "pl.pretty"
 local pl_config = require "pl.config"
 local pl_file = require "pl.file"
@@ -171,11 +172,12 @@ local function load_config_file(path)
 end
 
 --- Get available Wasm filters list
--- @param[type=string] Path where Wasm filters are stored.
+---@param filters_path string # Path where Wasm filters are stored.
+---@return kong.configuration.wasm_filter[]
 local function get_wasm_filters(filters_path)
   local wasm_filters = {}
 
-  if filters_path then
+  if filters_path and pl_path.isdir(filters_path) then
     local filter_files = {}
     for entry in pl_path.dir(filters_path) do
       local pathname = pl_path.join(filters_path, entry)
@@ -547,8 +549,86 @@ local function load(path, custom_conf, opts)
 
   -- Wasm module support
   if conf.wasm then
-    local wasm_filters = get_wasm_filters(conf.wasm_filters_path)
-    conf.wasm_modules_parsed = setmetatable(wasm_filters, conf_constants._NOP_TOSTRING_MT)
+    ---@type table<string, boolean>
+    local allowed_filter_names = {}
+    local all_bundled_filters_enabled = false
+    local all_user_filters_enabled = false
+    local all_filters_disabled = false
+    for _, filter in ipairs(conf.wasm_filters) do
+      if filter == "bundled" then
+        all_bundled_filters_enabled = true
+
+      elseif filter == "user" then
+        all_user_filters_enabled = true
+
+      elseif filter == "off" then
+        all_filters_disabled = true
+
+      else
+        allowed_filter_names[filter] = true
+      end
+    end
+
+    if all_filters_disabled then
+      allowed_filter_names = {}
+      all_bundled_filters_enabled = false
+      all_user_filters_enabled = false
+    end
+
+    ---@type table<string, kong.configuration.wasm_filter>
+    local active_filters_by_name = {}
+
+    local bundled_filter_path = conf_constants.WASM_BUNDLED_FILTERS_PATH
+    if not pl_path.isdir(bundled_filter_path) then
+      local alt_path
+
+      local nginx_bin = nginx_signals.find_nginx_bin(conf)
+      if nginx_bin then
+        alt_path = pl_path.dirname(nginx_bin) .. "/../../../kong/wasm"
+        alt_path = pl_path.normpath(alt_path) or alt_path
+      end
+
+      if alt_path and pl_path.isdir(alt_path) then
+        log.debug("loading bundled proxy-wasm filters from alt path: %s",
+                  alt_path)
+        bundled_filter_path = alt_path
+
+      else
+        log.warn("Bundled proxy-wasm filters path (%s) does not exist " ..
+                 "or is not a directory. Bundled filters may not be " ..
+                 "available", bundled_filter_path)
+      end
+    end
+
+    conf.wasm_bundled_filters_path = bundled_filter_path
+    local bundled_filters = get_wasm_filters(bundled_filter_path)
+    for _, filter in ipairs(bundled_filters) do
+      if all_bundled_filters_enabled or allowed_filter_names[filter.name] then
+        active_filters_by_name[filter.name] = filter
+      end
+    end
+
+    local user_filters = get_wasm_filters(conf.wasm_filters_path)
+    for _, filter in ipairs(user_filters) do
+      if all_user_filters_enabled or allowed_filter_names[filter.name] then
+        if active_filters_by_name[filter.name] then
+          log.warn("Replacing bundled filter %s with a user-supplied " ..
+                   "filter at %s", filter.name, filter.path)
+        end
+        active_filters_by_name[filter.name] = filter
+      end
+    end
+
+    ---@type kong.configuration.wasm_filter[]
+    local active_filters = {}
+    for _, filter in pairs(active_filters_by_name) do
+      insert(active_filters, filter)
+    end
+    sort(active_filters, function(lhs, rhs)
+      return lhs.name < rhs.name
+    end)
+
+    conf.wasm_modules_parsed = setmetatable(active_filters, conf_constants._NOP_TOSTRING_MT)
 
     local function add_wasm_directive(directive, value, prefix)
       local directive_name = (prefix or "") .. directive

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -277,7 +277,7 @@ local constants = {
       exit = "kong",
       service = "upstream",
     }
-  }
+  },
 }
 
 for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -208,6 +208,7 @@ tracing_sampling_rate = 0.01
 wasm = off
 wasm_filters_path = NONE
 wasm_dynamic_module = NONE
+wasm_filters = bundled,user
 
 request_debug = on
 request_debug_token =

--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -77,6 +77,7 @@ describe("#wasm - hybrid mode #postgres", function()
   local cp_filter_path
 
   local dp_prefix = "dp"
+  local dp_errlog = dp_prefix .. "/logs/error.log"
 
   lazy_setup(function()
     helpers.clean_prefix(cp_prefix)
@@ -108,8 +109,16 @@ describe("#wasm - hybrid mode #postgres", function()
       cluster_listen      = "127.0.0.1:9005",
       nginx_conf          = "spec/fixtures/custom_nginx.template",
       wasm                = true,
+      wasm_filters        = "user", -- don't enable bundled filters for this test
       wasm_filters_path   = cp_filter_path,
+      nginx_main_worker_processes = 2,
     }))
+
+    assert.logfile(cp_errlog).has.line([[successfully loaded "response_transformer" module]], true, 10)
+    assert.logfile(cp_errlog).has.no.line("[error]", true, 0)
+    assert.logfile(cp_errlog).has.no.line("[alert]", true, 0)
+    assert.logfile(cp_errlog).has.no.line("[crit]",  true, 0)
+    assert.logfile(cp_errlog).has.no.line("[emerg]", true, 0)
   end)
 
   lazy_teardown(function()
@@ -138,9 +147,17 @@ describe("#wasm - hybrid mode #postgres", function()
         admin_listen          = "off",
         nginx_conf            = "spec/fixtures/custom_nginx.template",
         wasm                  = true,
+        wasm_filters          = "user", -- don't enable bundled filters for this test
         wasm_filters_path     = dp_filter_path,
         node_id               = node_id,
+        nginx_main_worker_processes = 2,
       }))
+
+      assert.logfile(dp_errlog).has.line([[successfully loaded "response_transformer" module]], true, 10)
+      assert.logfile(dp_errlog).has.no.line("[error]", true, 0)
+      assert.logfile(dp_errlog).has.no.line("[alert]", true, 0)
+      assert.logfile(dp_errlog).has.no.line("[crit]",  true, 0)
+      assert.logfile(dp_errlog).has.no.line("[emerg]", true, 0)
 
       client = helpers.proxy_client()
     end)
@@ -325,6 +342,7 @@ describe("#wasm - hybrid mode #postgres", function()
         admin_listen          = "off",
         nginx_conf            = "spec/fixtures/custom_nginx.template",
         wasm                  = true,
+        wasm_filters          = "user", -- don't enable bundled filters for this test
         wasm_filters_path     = tmp_dir,
         node_id               = node_id,
       }))

--- a/spec/02-integration/20-wasm/07-reports_spec.lua
+++ b/spec/02-integration/20-wasm/07-reports_spec.lua
@@ -81,7 +81,7 @@ for _, strategy in helpers.each_strategy() do
       local _, reports_data = assert(reports_server:join())
       reports_data = cjson.encode(reports_data)
 
-      assert.match("wasm_cnt=2", reports_data)
+      assert.match("wasm_cnt=3", reports_data)
     end)
 
     it("logs number of requests triggering a Wasm filter", function()

--- a/spec/02-integration/20-wasm/08-declarative_spec.lua
+++ b/spec/02-integration/20-wasm/08-declarative_spec.lua
@@ -192,6 +192,7 @@ describe("#wasm declarative config (no installed filters)", function()
         nginx_conf = "spec/fixtures/custom_nginx.template",
         wasm = true,
         wasm_filters_path = tmp_dir,
+        wasm_filters = "user",
       }))
 
       client = helpers.admin_client()
@@ -252,6 +253,7 @@ describe("#wasm declarative config (no installed filters)", function()
         nginx_conf = "spec/fixtures/custom_nginx.template",
         wasm = true,
         wasm_filters_path = tmp_dir,
+        wasm_filters = "user",
         declarative_config = kong_yaml,
       })
 


### PR DESCRIPTION
### Summary

An upcoming Kong release will ship with at least one bundled Wasm filter.

Previously there was no concept of "bundled" filters: all filters must be provided by the user in the `wasm_filters_path` directory.

This introduces a new `wasm_filters` kong.conf property. It is a comma-delimited array that functions quite similarly to the `plugins` property with the addition of a special `user` value:

```
# all filters disabled
wasm_filters = off

# all bundled filters enabled
wasm_filters = bundled

# all user filters (in `wasm_filters_path`) enabled
wasm_filters = user

# all available filters enabled
wasm_filters = bundled, user

# specific filters enabled
wasm_filters = some_bundled_filter, some_user_supplied_filter
```

In the case of a collision between bundled and user filters, the conf loader will prefer the user filter and log a warning.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4211