### PR TITLE
chore(deps): bump lua-resty-aws to 1.4.1

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-aws.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-aws.yml
@@ -1,3 +1,3 @@
-message: "Bumped lua-resty-aws from 1.3.6 to 1.4.0"
+message: "Bumped lua-resty-aws from 1.3.6 to 1.4.1"
 type: dependency
 scope: Core

--- a/changelog/unreleased/kong/bump-lua-resty-aws.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-aws.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-aws from 1.3.6 to 1.4.0"
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.0.1",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.4.0",
+  "lua-resty-aws == 1.4.1",
   "lua-resty-openssl == 1.2.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.0.1",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.3.6",
+  "lua-resty-aws == 1.4.0",
   "lua-resty-openssl == 1.2.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Changelog:
> fix: aws configuration cannot be loaded due to pl.path cannot resolve the path started with ~ https://github.com/Kong/lua-resty-aws/pull/94
fix: fix the bug of missing boolean type with a value of false in the generated request body https://github.com/Kong/lua-resty-aws/pull/100
security: remove the documentation entry that contains a sample access key from AWS SDK. This avoids false postive vulnerability report. https://github.com/Kong/lua-resty-aws/pull/102
feat: container credential provider now supports using auth token defined in AWS_CONTAINER_AUTHORIZATION_TOKEN and AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE. https://github.com/Kong/lua-resty-aws/pull/107
fix: operations without inputs (eg, some S3 ones) would cause errors to be thrown https://github.com/Kong/lua-resty-aws/pull/108

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Related FTIs:
KAG-3424
FTI-5732