### PR TITLE
chore(tracing): do not error on too short trace id + tests

### DIFF
--- a/changelog/unreleased/kong/tracing-pdk-short-trace-ids.yml
+++ b/changelog/unreleased/kong/tracing-pdk-short-trace-ids.yml
@@ -1,0 +1,3 @@
+message: "**Tracing**: enhanced robustness of trace ID parsing"
+type: bugfix
+scope: PDK

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -71,7 +71,7 @@ local function get_trace_id_based_sampler(options_sampling_rate)
     sampling_rate = sampling_rate or options_sampling_rate
 
     if type(sampling_rate) ~= "number" then
-      error("invalid fraction", 2)
+      return nil, "invalid fraction"
     end
 
     -- always on sampler
@@ -88,7 +88,7 @@ local function get_trace_id_based_sampler(options_sampling_rate)
     local bound = sampling_rate * BOUND_MAX
 
     if #trace_id < SAMPLING_BYTE then
-      error(TOO_SHORT_MESSAGE, 2)
+      return nil, TOO_SHORT_MESSAGE
     end
 
     local truncated = ffi_cast(SAMPLING_UINT_PTR_TYPE, ffi_str(trace_id, SAMPLING_BYTE))[0]
@@ -187,7 +187,18 @@ local function create_span(tracer, options)
     sampled = options.should_sample
 
   else
-    sampled = tracer and tracer.sampler(trace_id)
+    if not tracer then
+      sampled = false
+
+    else
+      local err
+      sampled, err = tracer.sampler(trace_id)
+
+      if err then
+        sampled = false
+        ngx_log(ngx_ERR, "sampler failure: ", err)
+      end
+    end
   end
 
   span.parent_id = span.parent and span.parent.span_id
@@ -589,7 +600,13 @@ local function new_tracer(name, options)
 
     else
       -- use probability-based sampler
-      sampled = self.sampler(trace_id, sampling_rate)
+      local err
+      sampled, err = self.sampler(trace_id, sampling_rate)
+
+      if err then
+        sampled = false
+        ngx_log(ngx_ERR, "sampler failure: ", err)
+      end
     end
 
     -- enforce boolean

--- a/spec/01-unit/26-tracing/01-tracer_pdk_spec.lua
+++ b/spec/01-unit/26-tracing/01-tracer_pdk_spec.lua
@@ -323,11 +323,10 @@ describe("Tracer PDK", function()
         end
 
         -- for cases where the traceID is too short
-        -- just throw an error
         if len < SAMPLING_BYTE then
-          assert.error(function()
-            tracer.sampler(gen_id())
-          end)
+          local sampled, err = tracer.sampler(gen_id())
+          assert.is_nil(sampled)
+          assert.matches("sampling needs trace ID to be longer than", err)
           return
         end
   

--- a/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
@@ -602,6 +602,158 @@ describe("propagation tests #"    .. strategy         ..
   end
 end)
 end
+
+for _, sampling_rate in ipairs({1, 0, 0.5}) do
+  describe("propagation tests #" .. strategy .. " instrumentations: " .. instrumentations .. " dynamic sampling_rate: " .. sampling_rate, function()
+    local service
+    local proxy_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
+
+      service = bp.services:insert()
+
+      bp.plugins:insert({
+        name = "opentelemetry",
+        route = {id = bp.routes:insert({
+          service = service,
+          hosts = { "http-route" },
+        }).id},
+        config = {
+          -- fake endpoint, request to backend will sliently fail
+          endpoint = "http://localhost:8080/v1/traces",
+          sampling_rate = sampling_rate,
+        }
+      })
+
+      helpers.start_kong({
+        database = strategy,
+        plugins = "bundled",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        tracing_instrumentations = instrumentations,
+      })
+
+      proxy_client = helpers.proxy_client()
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    it("propagates tracing headers (b3 request)", function()
+      local trace_id = gen_trace_id()
+      local r = proxy_client:get("/", {
+        headers = {
+          ["x-b3-sampled"] = "1",
+          ["x-b3-traceid"] = trace_id,
+          host  = "http-route",
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+      assert.equals(trace_id, json.headers["x-b3-traceid"])
+    end)
+
+    describe("propagates tracing headers (b3-single request)", function()
+      it("with parent_id", function()
+        local trace_id = gen_trace_id()
+        local span_id = gen_span_id()
+        local parent_id = gen_span_id()
+
+        local r = proxy_client:get("/", {
+          headers = {
+            b3 = fmt("%s-%s-%s-%s", trace_id, span_id, "1", parent_id),
+            host = "http-route",
+          },
+        })
+        local body = assert.response(r).has.status(200)
+        local json = cjson.decode(body)
+        assert.matches(trace_id .. "%-%x+%-%x+%-%x+", json.headers.b3)
+      end)
+    end)
+
+    it("propagates w3c tracing headers", function()
+      local trace_id = gen_trace_id() -- w3c only admits 16-byte trace_ids
+      local parent_id = gen_span_id()
+
+      local r = proxy_client:get("/", {
+        headers = {
+          traceparent = fmt("00-%s-%s-01", trace_id, parent_id),
+          host = "http-route"
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+      assert.matches("00%-" .. trace_id .. "%-%x+%-%x+", json.headers.traceparent)
+    end)
+
+    it("propagates jaeger tracing headers", function()
+      local trace_id = gen_trace_id()
+      local span_id = gen_span_id()
+      local parent_id = gen_span_id()
+
+      local r = proxy_client:get("/", {
+        headers = {
+          ["uber-trace-id"] = fmt("%s:%s:%s:%s", trace_id, span_id, parent_id, "1"),
+          host = "http-route"
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+      -- Trace ID is left padded with 0 for assert
+      assert.matches( ('0'):rep(32-#trace_id) .. trace_id .. ":%x+:%x+:%x+", json.headers["uber-trace-id"])
+    end)
+
+    it("propagates ot headers", function()
+      local trace_id = gen_trace_id()
+      local span_id = gen_span_id()
+      local r = proxy_client:get("/", {
+        headers = {
+          ["ot-tracer-traceid"] = trace_id,
+          ["ot-tracer-spanid"] = span_id,
+          ["ot-tracer-sampled"] = "1",
+          host = "http-route",
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+
+      assert.equals(trace_id, json.headers["ot-tracer-traceid"])
+    end)
+
+    describe("propagates datadog tracing headers", function()
+      it("with datadog headers in client request", function()
+        local trace_id  = "7532726115487256575"
+        local r = proxy_client:get("/", {
+          headers = {
+            ["x-datadog-trace-id"] = trace_id,
+            host = "http-route",
+          },
+        })
+        local body = assert.response(r).has.status(200)
+        local json = cjson.decode(body)
+
+        assert.equals(trace_id, json.headers["x-datadog-trace-id"])
+        assert.is_not_nil(tonumber(json.headers["x-datadog-parent-id"]))
+      end)
+
+      it("with a shorter-than-64b trace_id", function()
+        local trace_id  = "1234567890"
+        local r = proxy_client:get("/", {
+          headers = {
+            ["x-datadog-trace-id"] = trace_id,
+            host = "http-route",
+          },
+        })
+        local body = assert.response(r).has.status(200)
+        local json = cjson.decode(body)
+
+        assert.equals(trace_id, json.headers["x-datadog-trace-id"])
+        assert.is_not_nil(tonumber(json.headers["x-datadog-parent-id"]))
+      end)
+    end)
+  end)
+  end
 end
 end
 


### PR DESCRIPTION
### Summary

This is a forward port of `kong-ee/pull/8767` the actual fix is not needed because already covered by the new propagation module.

This commit ports the updates to the pdk (no longer throw error on too short id) and tests.

### Checklist

- [x] The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-4218](https://konghq.atlassian.net/browse/KAG-4218)


[KAG-4218]: https://konghq.atlassian.net/browse/KAG-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ