### PR TITLE
[backport -> release/3.6.x] fix(core): ensure ngx.ctx.host_port is a number (and not a string)

### DIFF
--- a/changelog/unreleased/kong/fix-ctx-host-port.yml
+++ b/changelog/unreleased/kong/fix-ctx-host-port.yml
@@ -1,0 +1,5 @@
+message: |
+  **PDK:** fix kong.request.get_forwarded_port to always return a number which was caused by an incorrectly
+  stored string value in ngx.ctx.host_port.
+type: bugfix
+scope: PDK

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -803,7 +803,7 @@ do
 
       local request_uri = var.request_uri or ""
 
-      local host_port = ctx.host_port or var.server_port
+      local host_port = ctx.host_port or tonumber(var.server_port, 10)
 
       local upstream_uri = var.upstream_uri or ""
       if upstream_uri ~= "" and not find(upstream_uri, "?", nil, true) then
@@ -822,11 +822,18 @@ do
       local response_source = okong.response.get_source(ongx.ctx)
       local response_source_name = TYPE_NAMES[response_source]
 
+      local url
+      if host_port then
+        url = var.scheme .. "://" .. var.host .. ":" .. host_port .. request_uri
+      else
+        url = var.scheme .. "://" .. var.host .. request_uri
+      end
+
       local root = {
         request = {
           id = request_id_get() or "",
           uri = request_uri,
-          url = var.scheme .. "://" .. var.host .. ":" .. host_port .. request_uri,
+          url = url,
           querystring = okong.request.get_query(), -- parameters, as a table
           method = okong.request.get_method(), -- http method
           headers = okong.request.get_headers(),
@@ -870,7 +877,7 @@ do
       local ctx = ongx.ctx
       local var = ongx.var
 
-      local host_port = ctx.host_port or var.server_port
+      local host_port = ctx.host_port or tonumber(var.server_port, 10)
 
       local root = {
         session = {
@@ -878,7 +885,7 @@ do
           received = to_decimal(var.bytes_received),
           sent = to_decimal(var.bytes_sent),
           status = ongx.status,
-          server_port = to_decimal(host_port),
+          server_port = host_port,
         },
         upstream = {
           received = to_decimal(var.upstream_bytes_received),

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -139,8 +139,7 @@ if is_http then
       end
 
       if not params.dst_port then
-        params.dst_port = tonumber((ctx or ngx.ctx).host_port, 10) or
-                          tonumber(var.server_port, 10)
+        params.dst_port = (ctx or ngx.ctx).host_port or tonumber(var.server_port, 10)
       end
 
       return params.dst_port
@@ -183,11 +182,10 @@ else  -- stream
     function(params, ctx)
       if not params.dst_port then
         if var.kong_tls_passthrough_block == "1" or var.ssl_protocol then
-          params.dst_port = tonumber(var.proxy_protocol_server_port)
+          params.dst_port = tonumber(var.proxy_protocol_server_port, 10)
 
         else
-          params.dst_port = tonumber((ctx or ngx.ctx).host_port, 10) or
-                            tonumber(var.server_port, 10)
+          params.dst_port = (ctx or ngx.ctx).host_port or tonumber(var.server_port, 10)
         end
       end
 

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1781,8 +1781,7 @@ function _M.new(routes, cache, cache_neg)
       local src_ip = var.remote_addr
       local dst_ip = var.server_addr
       local src_port = tonumber(var.remote_port, 10)
-      local dst_port = tonumber((ctx or ngx.ctx).host_port, 10)
-                    or tonumber(var.server_port, 10)
+      local dst_port = (ctx or ngx.ctx).host_port or tonumber(var.server_port, 10)
       -- error value for non-TLS connections ignored intentionally
       local sni = server_name()
       -- fallback to preread SNI if current connection doesn't terminate TLS
@@ -1801,7 +1800,7 @@ function _M.new(routes, cache, cache_neg)
       -- rewrite the dst_ip, port back to what specified in proxy_protocol
       if var.kong_tls_passthrough_block == "1" or var.ssl_protocol then
         dst_ip = var.proxy_protocol_server_addr
-        dst_port = tonumber(var.proxy_protocol_server_port)
+        dst_port = tonumber(var.proxy_protocol_server_port, 10)
       end
 
       return find_route(nil, nil, nil, scheme,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1009,7 +1009,7 @@ return {
   preread = {
     before = function(ctx)
       local server_port = var.server_port
-      ctx.host_port = HOST_PORTS[server_port] or server_port
+      ctx.host_port = HOST_PORTS[server_port] or tonumber(server_port, 10)
 
       local router = get_updated_router()
 
@@ -1086,7 +1086,7 @@ return {
   rewrite = {
     before = function(ctx)
       local server_port = var.server_port
-      ctx.host_port = HOST_PORTS[server_port] or server_port
+      ctx.host_port = HOST_PORTS[server_port] or tonumber(server_port, 10)
       instrumentation.request(ctx)
     end,
   },
@@ -1145,8 +1145,7 @@ return {
       end
 
       local host           = var.host
-      local port           = tonumber(ctx.host_port, 10)
-                          or tonumber(var.server_port, 10)
+      local port           = ctx.host_port or tonumber(var.server_port, 10)
 
       local route          = match_t.route
       local service        = match_t.service

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-tests-response/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-tests-response/handler.lua
@@ -251,6 +251,7 @@ function CtxTests:preread()
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -290,6 +291,7 @@ function CtxTests:rewrite()
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -333,12 +335,12 @@ function CtxTests:access(config)
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
 function CtxTests:response(config)
---   assert(config.buffered == true, "response should only be executed when buffering the response was requested")
-
+  -- assert(config.buffered == true, "response should only be executed when buffering the response was requested")
   local ctx = ngx.ctx
   assert(is_equal_to_start_time(ctx, "KONG_PROCESSING_START"))
   assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_PROCESSING_START", "KONG_REWRITE_START"))
@@ -373,6 +375,7 @@ function CtxTests:response(config)
   assert(is_nil(ctx, "KONG_LOG_TIME"))
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -391,7 +394,7 @@ function CtxTests:log(config)
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_START", "KONG_UPSTREAM_DNS_END_AT"))
       assert(is_non_negative_integer(ctx, "KONG_UPSTREAM_DNS_TIME"))
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_END_AT", "KONG_LOG_START"))
-      assert(has_correct_upstream_dns_time(ctx)) 
+      assert(has_correct_upstream_dns_time(ctx))
     end
     assert(is_true(ctx, "KONG_PROXIED"))
     assert(has_correct_proxy_latency(ctx))
@@ -462,6 +465,8 @@ function CtxTests:log(config)
     assert(is_nil(ctx, "KONG_LOG_ENDED_AT"))
     assert(is_nil(ctx, "KONG_LOG_TIME"))
   end
+
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
@@ -260,6 +260,7 @@ function CtxTests:preread()
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -299,6 +300,7 @@ function CtxTests:rewrite()
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -342,6 +344,7 @@ function CtxTests:access(config)
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_WAITING_TIME"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -385,6 +388,7 @@ function CtxTests:header_filter(config)
   assert(is_nil(ctx, "KONG_LOG_TIME"))
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -433,6 +437,7 @@ function CtxTests:body_filter(config)
   assert(is_nil(ctx, "KONG_LOG_TIME"))
   assert(is_nil(ctx, "KONG_RESPONSE_LATENCY"))
   assert(is_nil(ctx, "KONG_RECEIVE_TIME"))
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 
@@ -451,7 +456,7 @@ function CtxTests:log(config)
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_START", "KONG_UPSTREAM_DNS_END_AT"))
       assert(is_non_negative_integer(ctx, "KONG_UPSTREAM_DNS_TIME"))
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_END_AT", "KONG_LOG_START"))
-      assert(has_correct_upstream_dns_time(ctx)) 
+      assert(has_correct_upstream_dns_time(ctx))
     end
     assert(is_true(ctx, "KONG_PROXIED"))
     assert(has_correct_proxy_latency(ctx))
@@ -515,7 +520,7 @@ function CtxTests:log(config)
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_START", "KONG_UPSTREAM_DNS_END_AT"))
       assert(is_non_negative_integer(ctx, "KONG_UPSTREAM_DNS_TIME"))
       assert(is_greater_or_equal_to_ctx_value(ctx, "KONG_UPSTREAM_DNS_END_AT", "KONG_LOG_START"))
-      assert(has_correct_upstream_dns_time(ctx)) 
+      assert(has_correct_upstream_dns_time(ctx))
     end
     assert(is_true(ctx, "KONG_PROXIED"))
     assert(has_correct_proxy_latency(ctx))
@@ -527,6 +532,8 @@ function CtxTests:log(config)
     assert(is_nil(ctx, "KONG_LOG_ENDED_AT"))
     assert(is_nil(ctx, "KONG_LOG_TIME"))
   end
+
+  assert(is_positive_integer(ctx, "host_port"))
 end
 
 


### PR DESCRIPTION
### Summary

Manual fix backport of https://github.com/Kong/kong/pull/12806

https://konghq.atlassian.net/browse/KAG-4158