### PR TITLE
[KAG-4210] Incorporate wasm filters into bazel build

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//build:build_system.bzl", "kong_directory_genrule", "kong_rules_group", "kong_template_file")
+load("@kong//build/openresty/wasmx/filters:variables.bzl", "WASM_FILTERS_TARGETS")
 
 exports_files([
     "package/nfpm.yaml",
@@ -45,6 +46,18 @@ install_webui_cmd = select({
         cp -r $(location @kong_admin_gui//:dist_files) ${BUILD_DESTDIR}/kong/gui
     """,
     "@kong//:skip_webui_flags": "\n",
+})
+
+install_wasm_filters_cmd = select({
+    "@kong//:wasmx_flag": """
+            mkdir -pv ${BUILD_DESTDIR}/kong/include/filters
+        """ + " ".join(["""
+            tpath="$(locations %s)"
+            fname="$(echo "${tpath}" | cut -d'/' -f2)"
+
+            cp -v "$tpath" "${BUILD_DESTDIR}/kong/include/filters/${fname}"
+        """ % t for t in WASM_FILTERS_TARGETS]),
+    "//conditions:default": "\n",
 })
 
 install_wasm_deps_cmd = select({
@@ -99,7 +112,7 @@ kong_directory_genrule(
         "@kong//:wasmx_flag": [
             "@ngx_wasmx_module//:lua_libs",
             "@openresty//:wasm_runtime",
-        ],
+        ] + WASM_FILTERS_TARGETS,
         "//conditions:default": [],
     }) + lib_deps + lualib_deps,
     cmd =
@@ -147,7 +160,14 @@ kong_directory_genrule(
 
         cp -r $(locations @protoc//:all_srcs) ${BUILD_DESTDIR}/kong/.
 
-    """ + install_lib_deps_cmd + install_lualib_deps_cmd + install_webui_cmd + link_modules_dir + install_wasm_deps_cmd + """
+    """ +
+        install_lib_deps_cmd +
+        install_lualib_deps_cmd +
+        install_webui_cmd +
+        link_modules_dir +
+        install_wasm_filters_cmd +
+        install_wasm_deps_cmd +
+        """
         mkdir -p ${BUILD_DESTDIR}/etc/kong
         cp kong.conf.default ${BUILD_DESTDIR}/etc/kong/kong.conf.default
 

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -50,12 +50,12 @@ install_webui_cmd = select({
 
 install_wasm_filters_cmd = select({
     "@kong//:wasmx_flag": """
-            mkdir -pv ${BUILD_DESTDIR}/kong/include/filters
+            mkdir -pv ${BUILD_DESTDIR}/kong/filters
         """ + " ".join(["""
             tpath="$(locations %s)"
             fname="$(echo "${tpath}" | cut -d'/' -f2)"
 
-            cp -v "$tpath" "${BUILD_DESTDIR}/kong/include/filters/${fname}"
+            cp -v "$tpath" "${BUILD_DESTDIR}/kong/filters/${fname}"
         """ % t for t in WASM_FILTERS_TARGETS]),
     "//conditions:default": "\n",
 })

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -50,12 +50,12 @@ install_webui_cmd = select({
 
 install_wasm_filters_cmd = select({
     "@kong//:wasmx_flag": """
-            mkdir -pv ${BUILD_DESTDIR}/kong/filters
+            mkdir -pv ${BUILD_DESTDIR}/kong/wasm
         """ + " ".join(["""
             tpath="$(locations %s)"
             fname="$(echo "${tpath}" | cut -d'/' -f2)"
 
-            cp -v "$tpath" "${BUILD_DESTDIR}/kong/filters/${fname}"
+            cp -v "$tpath" "${BUILD_DESTDIR}/kong/wasm/${fname}"
         """ % t for t in WASM_FILTERS_TARGETS]),
     "//conditions:default": "\n",
 })

--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -3,6 +3,7 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@kong//build/openresty/wasmx:rules.bzl", "wasm_runtime", "wasmx_configure_options", "wasmx_env")
 load("@openresty_binding//:variables.bzl", "LUAJIT_VERSION")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
+load("@kong//build/openresty/wasmx/filters:variables.bzl", "WASM_FILTERS_TARGETS")
 
 filegroup(
     name = "luajit_srcs",
@@ -274,7 +275,7 @@ configure_make(
             # wasm_runtime has to be a "data" (target) instead of "build_data" (exec)
             # to be able to lookup by its path (relative to INSTALLDIR)
             ":wasm_runtime",
-        ],
+        ] + WASM_FILTERS_TARGETS,
         "//conditions:default": [],
     }),
     env = wasmx_env,

--- a/build/openresty/repositories.bzl
+++ b/build/openresty/repositories.bzl
@@ -8,7 +8,7 @@ load("//build/openresty/pcre:pcre_repositories.bzl", "pcre_repositories")
 load("//build/openresty/openssl:openssl_repositories.bzl", "openssl_repositories")
 load("//build/openresty/atc_router:atc_router_repositories.bzl", "atc_router_repositories")
 load("//build/openresty/wasmx:wasmx_repositories.bzl", "wasmx_repositories")
-load("//build/openresty/wasmx/filters:repositories.bzl", "filters_repositories")
+load("//build/openresty/wasmx/filters:repositories.bzl", "wasm_filters_repositories")
 load("//build/openresty/brotli:brotli_repositories.bzl", "brotli_repositories")
 
 # This is a dummy file to export the module's repository.
@@ -25,7 +25,7 @@ def openresty_repositories():
     openssl_repositories()
     atc_router_repositories()
     wasmx_repositories()
-    filters_repositories()
+    wasm_filters_repositories()
     brotli_repositories()
 
     openresty_version = KONG_VAR["OPENRESTY"]

--- a/build/openresty/repositories.bzl
+++ b/build/openresty/repositories.bzl
@@ -8,6 +8,7 @@ load("//build/openresty/pcre:pcre_repositories.bzl", "pcre_repositories")
 load("//build/openresty/openssl:openssl_repositories.bzl", "openssl_repositories")
 load("//build/openresty/atc_router:atc_router_repositories.bzl", "atc_router_repositories")
 load("//build/openresty/wasmx:wasmx_repositories.bzl", "wasmx_repositories")
+load("//build/openresty/wasmx/filters:repositories.bzl", "filters_repositories")
 load("//build/openresty/brotli:brotli_repositories.bzl", "brotli_repositories")
 
 # This is a dummy file to export the module's repository.
@@ -24,6 +25,7 @@ def openresty_repositories():
     openssl_repositories()
     atc_router_repositories()
     wasmx_repositories()
+    filters_repositories()
     brotli_repositories()
 
     openresty_version = KONG_VAR["OPENRESTY"]

--- a/build/openresty/wasmx/filters/BUILD.bazel
+++ b/build/openresty/wasmx/filters/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@kong//build/openresty/wasmx/filters:variables.bzl", "WASM_FILTERS_TARGETS")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(
+        include = ["**"],
+        exclude = ["*.bazel"],
+    ),
+)
+
+exports_files(
+    WASM_FILTERS_TARGETS,
+    visibility = ["//visibility:public"],
+)

--- a/build/openresty/wasmx/filters/repositories.bzl
+++ b/build/openresty/wasmx/filters/repositories.bzl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load(":variables.bzl", "WASM_FILTERS")
+
+def filters_repositories():
+    for filter in WASM_FILTERS:
+        for file in filter["files"].keys():
+            renamed_file = file.replace("filter", filter["name"])
+
+            maybe(
+                http_file,
+                name = renamed_file,
+                url = "https://github.com/%s/releases/download/%s/%s" % (
+                    filter["repo"],
+                    filter["tag"],
+                    file,
+                ),
+                sha256 = filter["files"][file],
+            )

--- a/build/openresty/wasmx/filters/repositories.bzl
+++ b/build/openresty/wasmx/filters/repositories.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(":variables.bzl", "WASM_FILTERS")
 
-def filters_repositories():
+def wasm_filters_repositories():
     for filter in WASM_FILTERS:
         for file in filter["files"].keys():
             renamed_file = file.replace("filter", filter["name"])

--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -4,23 +4,14 @@ A list of wasm filters.
 
 WASM_FILTERS = [
     {
-        "name": "proxy-wasm-rust-response-transformer",
-        "repo": "Kong/proxy-wasm-rust-response-transformer",
-        "tag": "0.1.2",
+        "name": "datakit-filter",
+        "repo": "Kong/datakit-filter",
+        "tag": "0.1.0",
         "files": {
-            "response_transformer.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
-            "response_transformer.wasm": "95429bf14878bc67b6f70a555f77e304b5f2b8f9ee77b49da99cbf4474c22046",
+            "datakit.meta.json": "b9f3b6d51d9566fae1a34c0e5c00f0d5ad5dc8f6ce7bf81931fd0be189de205d",
+            "datakit.wasm": "a494c254915e222c3bd2b36944156680b4534bdadf438fb2143df9e0a4ef60ad",
         },
     },
-    # {
-    #     "name": "datakit-filter",
-    #     "repo": "Kong/datakit-filter",
-    #     "tag": "0.1.0",
-    #     "files": {
-    #         "datakit_filter.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
-    #         "datakit_filter.wasm": "2d03b5e3fc076a6b1b786914107a9d38c6ece8fca886dcbb6b1dee82d18c0063",
-    #     },
-    # },
 ]
 
 WASM_FILTERS_TARGETS = [

--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -25,10 +25,7 @@ WASM_FILTERS = [
 
 WASM_FILTERS_TARGETS = [
     [
-        "@%s//file" % file.replace(
-            "filter",
-            filter["name"],
-        )
+        "@%s//file" % file,
         for file in filter["files"].keys()
     ]
     for filter in WASM_FILTERS

--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -6,10 +6,10 @@ WASM_FILTERS = [
     {
         "name": "proxy-wasm-rust-response-transformer",
         "repo": "Kong/proxy-wasm-rust-response-transformer",
-        "tag": "0.1.1",
+        "tag": "0.1.2",
         "files": {
-            "filter.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
-            "filter.wasm": "2d03b5e3fc076a6b1b786914107a9d38c6ece8fca886dcbb6b1dee82d18c0063",
+            "response_transformer.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
+            "response_transformer.wasm": "95429bf14878bc67b6f70a555f77e304b5f2b8f9ee77b49da99cbf4474c22046",
         },
     },
     # {

--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -1,0 +1,35 @@
+"""
+A list of wasm filters.
+"""
+
+WASM_FILTERS = [
+    {
+        "name": "proxy-wasm-rust-response-transformer",
+        "repo": "Kong/proxy-wasm-rust-response-transformer",
+        "tag": "0.1.1",
+        "files": {
+            "filter.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
+            "filter.wasm": "2d03b5e3fc076a6b1b786914107a9d38c6ece8fca886dcbb6b1dee82d18c0063",
+        },
+    },
+    # {
+    #     "name": "datakit-filter",
+    #     "repo": "Kong/datakit-filter",
+    #     "tag": "0.1.0",
+    #     "files": {
+    #         "datakit_filter.meta.json": "cf5e51e7118287000656def07ec42b2482d60e02966b72426beab3ea0c39302a",
+    #         "datakit_filter.wasm": "2d03b5e3fc076a6b1b786914107a9d38c6ece8fca886dcbb6b1dee82d18c0063",
+    #     },
+    # },
+]
+
+WASM_FILTERS_TARGETS = [
+    [
+        "@%s//file" % file.replace(
+            "filter",
+            filter["name"],
+        )
+        for file in filter["files"].keys()
+    ]
+    for filter in WASM_FILTERS
+][0]

--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -25,7 +25,7 @@ WASM_FILTERS = [
 
 WASM_FILTERS_TARGETS = [
     [
-        "@%s//file" % file,
+        "@%s//file" % file
         for file in filter["files"].keys()
     ]
     for filter in WASM_FILTERS


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The changes in this PR cause the defined wasm filters to be downloaded from github and packaged with Kong.

### Checklist

- [na] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-4210]_


[KAG-4210]: https://konghq.atlassian.net/browse/KAG-4210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ