### PR TITLE
perf(*): `ngx.re` uses are jitted and cached

### DIFF
--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -616,7 +616,7 @@ function _M:ai_introspect_body(request, system_prompt, http_opts, response_regex
   -- this is useful for AI models that pad with assistant text, even when
   -- we ask them NOT to.
   if response_regex_match then
-    local matches, err = re_match(new_request_body, response_regex_match, "ijm")
+    local matches, err = re_match(new_request_body, response_regex_match, "ijom")
     if err then
       return nil, "failed regex matching ai response: " .. err
     end

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -114,8 +114,8 @@ local function new(conf)
 
   -- backward compat
   local url = conf.api_uri
-  if not ngx_re_match(url, "/directory$") then
-    if not ngx_re_match(url, "/$") then
+  if not ngx_re_match(url, "/directory$", "jo") then
+    if not ngx_re_match(url, "/$", "jo") then
       url = url .. "/"
     end
     url = url .. "directory"

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -194,7 +194,7 @@ end
 local function add_to_table( t, path, v, typ )
   local tab = t -- set up pointer to table root
   local msg_typ = typ;
-  for m in re_gmatch( path , "([^.]+)(\\.)?") do
+  for m in re_gmatch( path , "([^.]+)(\\.)?", "jo" ) do
     local key, dot = m[1], m[2]
     msg_typ = get_field_type(msg_typ, key)
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -59,7 +59,7 @@ local function retrieve_tokens(conf)
       if type(token_header) == "table" then
         token_header = token_header[1]
       end
-      local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
+      local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)", "jo")
       if not iterator then
         kong.log.err(iter_err)
         break

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -438,7 +438,8 @@ local function retrieve_client_credentials(parameters, conf)
     from_authorization_header = true
 
     local iterator, iter_err = ngx_re_gmatch(authorization_header,
-                                             "\\s*[Bb]asic\\s*(.+)")
+                                             "\\s*[Bb]asic\\s*(.+)",
+                                             "jo")
     if not iterator then
       kong.log.err(iter_err)
       return

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -53,7 +53,7 @@ local function overwritable_header(header)
   local n_header = lower(header)
 
   return not hop_by_hop_headers[n_header]
-     and not ngx_re_match(n_header, "ratelimit-remaining")
+     and not ngx_re_match(n_header, "ratelimit-remaining", "jo")
 end
 
 local function set_header(conf, header, value)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -113,7 +113,7 @@ local function index_table(table, field)
   end
 
   local res = table
-  for segment, e in ngx.re.gmatch(field, "\\w+", "o") do
+  for segment, e in ngx.re.gmatch(field, "\\w+", "jo") do
     if res[segment[0]] then
       res = res[segment[0]]
     else

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -183,7 +183,7 @@ local function index_table(table, field)
   end
 
   local res = table
-  for segment, e in ngx.re.gmatch(field, "\\w+", "o") do
+  for segment, e in ngx.re.gmatch(field, "\\w+", "jo") do
     if res[segment[0]] then
       res = res[segment[0]]
     else


### PR DESCRIPTION
### Summary

This commit ensures that `ngx.re` uses (in critical (proxy path) code paths mostly) are both JITted and JIT-cached.

I have not had time to run some perf tests for this, so feel free to hold on merging until I have time to do so.
