### PR TITLE
chore(deps): bump penlight to 1.14.0

### DIFF
--- a/changelog/unreleased/kong/bump-penlight.yml
+++ b/changelog/unreleased/kong/bump-penlight.yml
@@ -1,0 +1,3 @@
+message: "Bumped penlight to 1.14.0"
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "inspect == 3.1.3",
   "luasec == 1.3.2",
   "luasocket == 3.0-rc1",
-  "penlight == 1.13.1",
+  "penlight == 1.14.0",
   "lua-resty-http == 0.17.1",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.6",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -2127,7 +2127,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.response(r).has.status(500)
     end)
     it("rendering error (header) is correctly propagated in error.log, issue #25", function()
-      local pattern = [[error:%[string "TMP"%]:4: attempt to call global 'foo' %(a nil value%)]]
+      local pattern = [[error:%[string "TMP"%]:1: attempt to call global 'foo' %(a nil value%)]]
       local start_count = count_log_lines(pattern)
 
       local r = assert(client:send {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Changelog:
> 1.14.0 (2024-Apr-15)
fix(path): make path.expanduser more sturdy https://github.com/lunarmodules/Penlight/pull/469
feat(func): extend compose to support N functions https://github.com/lunarmodules/Penlight/pull/448
fix(utils) nil values in utils.choose(cond, val1, val2) https://github.com/lunarmodules/Penlight/pull/447
fix(template) using % as an escape character caused the expression to not be recognized https://github.com/lunarmodules/Penlight/pull/452
enhance(template): Preserve line numbers https://github.com/lunarmodules/Penlight/pull/468
fix(pretty) integers for Lua 5.4 https://github.com/lunarmodules/Penlight/pull/456

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
