### PR TITLE
fix(proxy-cache): set Header `Accept-Encoding` as default values of vary_headers

### DIFF
--- a/changelog/unreleased/kong/fix-proxy-cache-encoding.yml
+++ b/changelog/unreleased/kong/fix-proxy-cache-encoding.yml
@@ -1,0 +1,4 @@
+message: |
+  **proxy-cache:** now `vary_headers` defaults to `"Accept-Encoding"`, so that responses won't be sent with the encoding-mismatched cache.
+type: bugfix
+scope: plugin

--- a/changelog/unreleased/kong/fix-proxy-cache-encoding.yml
+++ b/changelog/unreleased/kong/fix-proxy-cache-encoding.yml
@@ -1,4 +1,4 @@
 message: |
   **proxy-cache:** now `vary_headers` defaults to `"Accept-Encoding"`, so that responses won't be sent with the encoding-mismatched cache.
 type: bugfix
-scope: plugin
+scope: Plugin

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -72,6 +72,7 @@ return {
             elements = { type = "string" },
           }},
           { vary_headers = { description = "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.", type = "array",
+            default = { "Accept-Encoding" },
             elements = { type = "string" },
           }},
           { response_headers = {

--- a/spec/03-plugins/31-proxy-cache/01-schema_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/01-schema_spec.lua
@@ -112,6 +112,13 @@ describe("proxy-cache schema", function()
     assert.is_truthy(entity)
   end)
 
+  it("defines default vary_headers values", function()
+    local config = { strategy = "memory" }
+    local entity, err = v(config, proxy_cache_schema)
+    assert.is_nil(err)
+    assert.is_truthy(entity)
+    assert.same(entity.config.vary_headers, { "Accept-Encoding" })
+  end)
   it("supports vary_headers values", function()
     local entity, err = v({
       strategy = "memory",

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -259,6 +259,17 @@ describe("Plugin: proxy-cache", function()
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
       end)
+      it("miss if pass the Accept-Encoding", function()
+        local res = assert(proxy_client:get("/get", {
+          headers = {
+            host = "route-1.test",
+            ["kong-debug"] = 1,
+            ["Accept-Encoding"] = "gzip",
+          }
+        }))
+        assert.res_status(200, res)
+        assert.same("Miss", res.headers["X-Cache-Status"])
+      end)
       it("purge all the cache entries", function()
         -- make a `Hit` request to `route-1`
         local res = assert(proxy_client:get("/get", {

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -269,6 +269,16 @@ describe("Plugin: proxy-cache", function()
         }))
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
+        -- gzip request should be cached
+        res = assert(proxy_client:get("/get", {
+          headers = {
+            host = "route-1.test",
+            ["kong-debug"] = 1,
+            ["Accept-Encoding"] = "gzip",
+          }
+        }))
+        assert.res_status(200, res)
+        assert.same("Hit", res.headers["X-Cache-Status"])
       end)
       it("purge all the cache entries", function()
         -- make a `Hit` request to `route-1`


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Currently, proxy-cache might mix the compression and uncompression values while caching, and return unexpected compression response to the request if users didn't specify the vary_headers.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #12796
