### PR TITLE
fix(certificate): hybrid dp cannot refresh certificate entity with vault reference

### DIFF
--- a/changelog/unreleased/kong/fix-hybrid-dp-certificate-with-vault-not-refresh.yml
+++ b/changelog/unreleased/kong/fix-hybrid-dp-certificate-with-vault-not-refresh.yml
@@ -1,0 +1,3 @@
+message: Fixed a problem that in hybrid DP mode a certificate entity configured with vault reference may not get refreshed on time
+type: bugfix
+scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -900,32 +900,6 @@ local function new(self)
 
 
   ---
-  -- Return the theoretically remaining TTL value of
-  -- a reference before it gets refreshed. A remaining
-  -- time of 0 means the reference may be refreshed at any
-  -- second.
-  -- @local
-  -- @function ttl
-  -- @tparam string reference reference to look from the caches
-  -- @treturn number|nil the TTL value of the reference
-  -- @treturn nil|string a string describing an error if there was one
-  local function ttl(reference)
-    local strategy, err, config, cache_key = get_strategy(reference)
-    if not strategy then
-      return nil, fmt("could not fetch ttl (%s)", err)
-    end
-
-    local ttl = SECRETS_CACHE:ttl(cache_key)
-    if ttl and SECRETS_CACHE:get(cache_key) ~= NEGATIVELY_CACHED_VALUE then
-      local resurrect_ttl = max(config.resurrect_ttl or DAO_MAX_TTL, SECRETS_CACHE_MIN_TTL)
-      return max(ttl - resurrect_ttl, 0)
-    else
-      return ttl or 0
-    end
-  end
-
-
-  ---
   -- In place updates record's field from a cached reference.
   --
   -- @local
@@ -1512,9 +1486,7 @@ local function new(self)
   end
 
 
-  local _VAULT = {
-    SECRETS_CACHE_MIN_TTL = SECRETS_CACHE_MIN_TTL,
-  } -- the public PDK interfaces
+  local _VAULT = {} -- the public PDK interfaces
 
 
   ---
@@ -1602,21 +1574,6 @@ local function new(self)
   -- local value, err = kong.vault.get("{vault://env/cert/key}")
   function _VAULT.get(reference)
     return get(reference)
-  end
-
-
-  ---
-  -- Resolves the passed in reference and returns the TTL in the secret cache
-  --
-  -- @function kong.vault.get
-  -- @tparam string reference  reference to resolve
-  -- @treturn string|nil resolved value of the reference
-  -- @treturn string|nil error message on failure, otherwise `nil`
-  --
-  -- @usage
-  -- local value, err = kong.vault.get("{vault://env/cert/key}")
-  function _VAULT.ttl(reference)
-    return ttl(reference)
   end
 
 

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -46,6 +46,44 @@ local function log(lvl, ...)
   ngx_log(lvl, "[ssl] ", ...)
 end
 
+
+local function parse_cert(cert, parsed)
+  if cert == nil then
+    return nil, nil, parsed
+  end
+
+  if type(cert) == "cdata" then
+    return cert, nil, parsed
+  end
+
+  local err
+  cert, err = parse_pem_cert(cert)
+  if not cert then
+    return nil, "could not parse PEM certificate: " .. err
+  end
+  return cert, nil, true
+end
+
+
+
+local function parse_key(key, parsed)
+  if key == nil then
+    return nil, nil, parsed
+  end
+
+  if type(key) == "cdata" then
+    return key, nil, parsed
+  end
+
+  local err
+  key, err = parse_pem_priv_key(key)
+  if not key then
+    return nil, "could not parse PEM private key: " .. err
+  end
+  return key, nil, true
+end
+
+
 local function parse_key_and_cert(row)
   if row == false then
     return default_cert_and_key
@@ -53,36 +91,43 @@ local function parse_key_and_cert(row)
 
   -- parse cert and priv key for later usage by ngx.ssl
 
-  local cert, err = parse_pem_cert(row.cert)
-  if not cert then
-    return nil, "could not parse PEM certificate: " .. err
+  local err, parsed
+  local key, key_alt
+  local cert, cert_alt
+
+  cert, err, parsed = parse_cert(row.cert)
+  if err then
+    return nil, err
   end
 
-  local key, err = parse_pem_priv_key(row.key)
-  if not key then
-    return nil, "could not parse PEM private key: " .. err
+  key, err, parsed = parse_key(row.key, parsed)
+  if err then
+    return nil, err
   end
 
-  local cert_alt
-  local key_alt
-  if row.cert_alt and row.key_alt then
-    cert_alt, err = parse_pem_cert(row.cert_alt)
-    if not cert_alt then
-      return nil, "could not parse alternate PEM certificate: " .. err
+  cert_alt, err, parsed = parse_cert(row.cert_alt, parsed)
+  if err then
+    return nil, err
+  end
+
+  if cert_alt then
+    key_alt, err, parsed = parse_key(row.key_alt, parsed)
+    if err then
+      return nil, err
     end
-
-    key_alt, err = parse_pem_priv_key(row.key_alt)
-    if not key_alt then
-      return nil, "could not parse alternate PEM private key: " .. err
-    end
   end
 
-  return {
-    cert = cert,
-    key = key,
-    cert_alt = cert_alt,
-    key_alt = key_alt,
-  }
+  if parsed then
+    return {
+      cert = cert,
+      key = key,
+      cert_alt = cert_alt,
+      key_alt = key_alt,
+      ["$refs"] = row["$refs"],
+    }
+  end
+
+  return row
 end
 
 
@@ -162,25 +207,7 @@ local function fetch_certificate(pk, sni_name)
     return nil, "certificate " .. pk.id .. " not found"
   end
 
-  -- The default TTL of certificate entity should be nil
-  -- to follow the default TTL settings
-  local certificate_ttl
-  -- Calculate the TTL of the certificate based on
-  -- vault reference
-  if certificate["$refs"] then
-    -- When vault reference presents, default interval
-    -- is set to SECRETS_CACHE_MIN_TTL
-    certificate_ttl = kong.vault.SECRETS_CACHE_MIN_TTL
-    kong.vault.update(certificate)
-    for _, value in pairs(certificate["$refs"]) do
-      local ttl = kong.vault.ttl(value)
-      if ttl > 0 and ttl < certificate_ttl then
-        certificate_ttl = ttl
-      end
-    end
-  end
-
-  return certificate, nil, certificate_ttl
+  return certificate
 end
 
 
@@ -226,10 +253,14 @@ end
 
 local function get_certificate(pk, sni_name)
   local cache_key = kong.db.certificates:cache_key(pk)
-  local certificate, err, _ = kong.core_cache:get(cache_key,
-                                                  get_certificate_opts,
-                                                  fetch_certificate,
-                                                  pk, sni_name)
+  local certificate, err, hit_level = kong.core_cache:get(cache_key,
+                                                          get_certificate_opts,
+                                                          fetch_certificate,
+                                                          pk, sni_name)
+
+  if certificate and hit_level ~= 3 and certificate["$refs"] then
+    certificate = parse_key_and_cert(kong.vault.update(certificate))
+  end
 
   return certificate, err
 end

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -322,13 +322,13 @@ for _, strategy in helpers.each_strategy() do
     lazy_teardown(function()
       helpers.stop_kong()
     end)
-  
+
     local function get_tls_service_id(subsystems)
       if subsystems == "http" then
         return service_mtls.id
       else
         return tls_service_mtls.id
-      end      
+      end
     end
 
     local function get_proxy_client(subsystems, stream_port)
@@ -339,7 +339,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end
 
-    local function wait_for_all_config_update(subsystems) 
+    local function wait_for_all_config_update(subsystems)
       local opt = {}
       if subsystems == "stream" then
         opt.stream_enabled = true
@@ -894,7 +894,7 @@ for _, strategy in helpers.each_strategy() do
               end)
             end
           end, 10)
-          
+
           if subsystems == "http" then
             assert.matches("An invalid response was received from the upstream server", body)
           end

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -377,7 +377,7 @@ describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vau
     -- Switch to vault referenced key field
     local res = assert(admin_client:patch("/certificates/"..certificate.id, {
       body = {
-        key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 5),
+        key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 2),
         cert = ssl_fixtures.cert_client,
       },
       headers = {
@@ -402,7 +402,7 @@ describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vau
     assert.matches("No required SSL certificate was sent", body)
 
     -- Update secret value and let cert be correct
-    vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 5 })
+    vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 2 })
     assert.with_timeout(7)
           .with_step(0.5)
           .ignore_exceptions(true)

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -360,6 +360,10 @@ describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vau
 
 
   it("updates plugin config references (backend: #" .. vault.name .. ")", function()
+    helpers.wait_for_all_config_update({
+      forced_admin_port = 9001,
+      forced_proxy_port = 9002,
+    })
     -- Wrong cert-key pair is being used in the pre-configured cert object
     local res = client:get("/tls", {
       headers = {

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local ssl_fixtures = require "spec.fixtures.ssl"
 
 -- using the full path so that we don't have to modify package.path in
 -- this context
@@ -218,6 +219,201 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
 
     vault:update_secret(secret, "new", { ttl = 5 })
     check_plugin_secret("new", 5)
+  end)
+end)
+
+
+describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, function()
+  local client
+  local admin_client
+  local secret = "my-secret"
+  local certificate
+
+  local tls_fixtures = {
+    http_mock = {
+      upstream_tls = [[
+        server {
+            server_name example.com;
+            listen 16799 ssl;
+
+            ssl_certificate         ../spec/fixtures/mtls_certs/example.com.crt;
+            ssl_certificate_key     ../spec/fixtures/mtls_certs/example.com.key;
+            ssl_client_certificate  ../spec/fixtures/mtls_certs/ca.crt;
+            ssl_verify_client      on;
+            ssl_verify_depth       3;
+            ssl_session_tickets    off;
+            ssl_session_cache      off;
+            keepalive_requests     0;
+
+            location = / {
+                echo 'it works';
+            }
+        }
+      ]]
+    },
+  }
+
+  tls_fixtures.dns_mock = helpers.dns_mock.new({mocks_only = true})
+  tls_fixtures.dns_mock:A {
+    name = "example.com",
+    address = "127.0.0.1",
+  }
+
+  local vault_fixtures = vault:fixtures()
+  vault_fixtures.dns_mock = tls_fixtures.dns_mock
+
+  lazy_setup(function()
+    helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
+    helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
+
+    helpers.test_conf.loaded_plugins = {
+      dummy = true,
+    }
+
+    vault:setup()
+    vault:create_secret(secret, ssl_fixtures.key_alt)
+
+    local bp = helpers.get_db_utils(strategy,
+                                    { "vaults", "routes", "services", "certificates", "ca_certificates" },
+                                    {},
+                                    { vault.name })
+
+
+    assert(bp.vaults:insert({
+      name     = vault.name,
+      prefix   = vault.prefix,
+      config   = vault.config,
+    }))
+
+    -- Prepare TLS upstream service
+    -- cert_alt & key_alt pair is not a correct client certificate
+    -- and it will fail the client TLS verification on server side
+    --
+    -- On the other hand, cert_client & key_client pair is a correct
+    -- client certificate
+    certificate = assert(bp.certificates:insert({
+      key = ssl_fixtures.key_alt,
+      cert = ssl_fixtures.cert_alt,
+    }))
+
+    local service_tls = assert(bp.services:insert({
+      name = "tls-service",
+      url = "https://example.com:16799",
+      client_certificate = certificate,
+    }))
+
+    assert(bp.routes:insert({
+      name      = "tls-route",
+      hosts     = { "example.com" },
+      paths = { "/tls", },
+      service   = { id = service_tls.id },
+    }))
+
+    assert(helpers.start_kong({
+      role = "control_plane",
+      cluster_cert = "spec/fixtures/kong_clustering.crt",
+      cluster_cert_key = "spec/fixtures/kong_clustering.key",
+      database = strategy,
+      prefix = "vault_ttl_test_cp",
+      cluster_listen = "127.0.0.1:9005",
+      admin_listen = "127.0.0.1:9001",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      vaults         = vault.name,
+      plugins        = "dummy",
+      log_level      = "debug",
+    }, nil, nil, tls_fixtures ))
+
+    assert(helpers.start_kong({
+      role = "data_plane",
+      database = "off",
+      prefix = "vault_ttl_test_dp",
+      vaults         = vault.name,
+      plugins        = "dummy",
+      log_level      = "debug",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      cluster_cert = "spec/fixtures/kong_clustering.crt",
+      cluster_cert_key = "spec/fixtures/kong_clustering.key",
+      cluster_control_plane = "127.0.0.1:9005",
+      proxy_listen = "127.0.0.1:9002",
+      nginx_worker_processes = 1,
+    }, nil, nil, vault_fixtures ))
+
+    admin_client = helpers.admin_client(nil, 9001)
+    client = helpers.proxy_client(nil, 9002)
+  end)
+
+
+  lazy_teardown(function()
+    if client then
+      client:close()
+    end
+    if admin_client then
+      admin_client:close()
+    end
+
+    helpers.stop_kong("vault_ttl_test_cp")
+    helpers.stop_kong("vault_ttl_test_dp")
+    vault:teardown()
+
+    helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")
+  end)
+
+
+  it("updates plugin config references (backend: #" .. vault.name .. ")", function()
+    -- Wrong cert-key pair is being used in the pre-configured cert object
+    local res = client:get("/tls", {
+      headers = {
+        host = "example.com",
+      },
+      timeout = 2,
+    })
+    local body = assert.res_status(400, res)
+    assert.matches("The SSL certificate error", body)
+
+    -- Switch to vault referenced key field
+    local res = assert(admin_client:patch("/certificates/"..certificate.id, {
+      body = {
+        key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 5),
+        cert = ssl_fixtures.cert_client,
+      },
+      headers = {
+        ["Content-Type"] = "application/json",
+      },
+    }))
+    assert.res_status(200, res)
+    helpers.wait_for_all_config_update({
+      forced_admin_port = 9001,
+      forced_proxy_port = 9002,
+    })
+
+    -- Assume wrong cert-key pair still being used
+    local res = client:get("/tls", {
+      headers = {
+        host = "example.com",
+      },
+      timeout = 2,
+    })
+
+    local body = assert.res_status(400, res)
+    assert.matches("No required SSL certificate was sent", body)
+
+    -- Update secret value and let cert be correct
+    vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 5 })
+    assert.with_timeout(7)
+          .with_step(0.5)
+          .ignore_exceptions(true)
+          .eventually(function()
+            local res = client:get("/tls", {
+              headers = {
+                host = "example.com",
+              },
+              timeout = 2,
+            })
+
+            local body = assert.res_status(200, res)
+            assert.matches("it works", body)
+            return true
+          end).is_truthy("Expected certificate being refreshed")
   end)
 end)
 

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -266,10 +266,6 @@ describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vau
     helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
     helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
 
-    helpers.test_conf.loaded_plugins = {
-      dummy = true,
-    }
-
     vault:setup()
     vault:create_secret(secret, ssl_fixtures.key_alt)
 


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR fixes a problem that a certificate entity with cert/keys stored in a vault-referenced type cannot be refreshed even if the vault reference secret value has been updated both in L1/L2 vault PDK.

The root cause of this problem is that in a dp node running hybrid mode, kong cache interfaces force the cache TTL to be infinite(and it also does not respect cache TTL configured in `kong.conf`), thus the certificate object cannot be updated unless a new configuration is received and cache `purge` being called.

 The PR fixes the problem by caching the vault reference fields `$ref` and call `kong.vault.update` every time in `get_certificate`, and l1 serializer will keep the value serialized inside the certificate object.
 
This PR contains a test case that tests a certificate entity with a vault-referenced key that can be refreshed promptly, according to the TTL configured on the vault reference. The test case will fail consistently without the fix.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5881
