### PR TITLE
[KAG-4004] feat(ci): always pull base images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,6 +392,7 @@ jobs:
       with:
         file: build/dockerfiles/${{ matrix.package }}.Dockerfile
         context: .
+        pull: true
         push: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We use [docker/build-push-action](https://github.com/docker/build-push-action) to build images. It has a parameter "pull" which defaults to `false`. Using the default value of `false`, in conjunction with using self-hosted runners, and in the case of Github-hosted runners having an older cached image (no idea if this happens or not), opens us up to possibly having an older, stale base image.

Setting this to `true` will cause the action to always pull so that we can be sure we are always using the latest base image.

### Checklist

- [na] The Pull Request has tests
- [na] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-4004]_


[KAG-4004]: https://konghq.atlassian.net/browse/KAG-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ