### PR TITLE
tests(router): use router.transform.get_expression

### DIFF
--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1,7 +1,7 @@
 local Router
-local atc_compat = require "kong.router.compat"
 local path_handling_tests = require "spec.fixtures.router_path_handling_tests"
 local uuid = require("kong.tools.utils").uuid
+local get_expression = require("kong.router.transform").get_expression
 
 local function reload_router(flavor, subsystem)
   _G.kong = {
@@ -2165,7 +2165,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("check empty route fields", function()
           local use_case
-          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -2223,7 +2222,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("raw string", function()
           local use_case
-          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -2256,7 +2254,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("check regex with '\\'", function()
           local use_case
-          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -2289,7 +2286,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("generate http expression", function()
           local use_case
-          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -4732,8 +4728,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
       describe("#stream context", function()
         -- enable stream subsystem
         reload_router(flavor, "stream")
-
-        local get_expression = require("kong.router.compat").get_expression
 
         describe("check empty route fields", function()
           local use_case


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-4138

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
