### PR TITLE
refactor(router/atc): do not create new table in `split_routes_and_services_by_path()`

### DIFF
--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -714,16 +714,17 @@ local function split_routes_and_services_by_path(routes_and_services)
     local original_route_id = original_route.id
     local original_service = route_and_service.service
 
-    -- `grouped_paths` is a hash table, like {true='regex', 2='/a', 3='/aa'}
+    -- `grouped_paths` is a hash table, like {true={'regex'}, 2={'/a'}, 3={'/aa'},}
     local grouped_paths = group_by(original_paths, sort_by_regex_or_length)
 
     local is_first = true
-    for idx, paths in pairs(grouped_paths) do
+    for key, paths in pairs(grouped_paths) do
       local route = shallow_copy(original_route)
 
+      -- create a new route from the original route
       route.original_route = original_route
       route.paths = paths
-      route.id = uuid_generator(original_route_id .. "#" .. tostring(idx))
+      route.id = uuid_generator(original_route_id .. "#" .. tostring(key))
 
       local cloned_route_and_service = {
         route = route,

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -706,11 +706,15 @@ local function split_routes_and_services_by_path(routes_and_services)
       goto continue
     end
 
-    -- make sure that route_and_service contains only the two expected entries, route and service
-    assert(tb_nkeys(route_and_service) == 1 or tb_nkeys(route_and_service) == 2)
+    -- make sure that route_and_service contains
+    -- only the two expected entries, route and service
+    local nkeys = tb_nkeys(route_and_service)
+    assert(nkeys == 1 or nkeys == 2)
 
     local original_route_id = original_route.id
     local original_service = route_and_service.service
+
+    -- `grouped_paths` is a hash table, like {true='regex', 2='/a', 3='/aa'}
     local grouped_paths = group_by(original_paths, sort_by_regex_or_length)
 
     local is_first = true

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -710,27 +710,30 @@ local function split_routes_and_services_by_path(routes_and_services)
     assert(tb_nkeys(route_and_service) == 1 or tb_nkeys(route_and_service) == 2)
 
     local original_route_id = original_route.id
+    local original_service = route_and_service.service
     local grouped_paths = group_by(original_paths, sort_by_regex_or_length)
 
     local is_first = true
     for idx, paths in pairs(grouped_paths) do
-      local cloned_route = {
-        route = shallow_copy(original_route),
-        service = route_and_service.service,
-      }
+      local route = shallow_copy(original_route)
 
-      cloned_route.route.original_route = original_route
-      cloned_route.route.paths = paths
-      cloned_route.route.id = uuid_generator(original_route_id .. "#" .. tostring(idx))
+      route.original_route = original_route
+      route.paths = paths
+      route.id = uuid_generator(original_route_id .. "#" .. tostring(idx))
+
+      local cloned_route_and_service = {
+        route = route,
+        service = original_service,
+      }
 
       if is_first then
         -- the first one will replace the original route
-        routes_and_services[i] = cloned_route
+        routes_and_services[i] = cloned_route_and_service
         is_first = false
 
       else
         -- the others will append to the original routes array
-        routes_and_services[count + append_count] = cloned_route
+        routes_and_services[count + append_count] = cloned_route_and_service
         append_count = append_count + 1
       end
     end -- for pairs(grouped_paths)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2,6 +2,7 @@ local Router
 local path_handling_tests = require "spec.fixtures.router_path_handling_tests"
 local uuid = require("kong.tools.utils").uuid
 local get_expression = require("kong.router.transform").get_expression
+local deep_copy = require("kong.tools.table").deep_copy
 
 local function reload_router(flavor, subsystem)
   _G.kong = {
@@ -3663,7 +3664,8 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         }
 
         lazy_setup(function()
-          router = assert(new_router(use_case_routes))
+          -- deep copy use_case_routes in case it changes
+          router = assert(new_router(deep_copy(use_case_routes)))
         end)
 
         it("strips the specified paths from the given uri if matching", function()
@@ -3717,7 +3719,8 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             },
           }
 
-          local router = assert(new_router(use_case_routes))
+          -- deep copy use_case_routes in case it changes
+          local router = assert(new_router(deep_copy(use_case_routes)))
 
           local _ngx = mock_ngx("POST", "/my-route/hello/world",
                                 { host = "domain.org" })
@@ -4900,7 +4903,8 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           },
         }
 
-        router = assert(new_router(use_case))
+          -- deep copy use_case in case it changes
+        router = assert(new_router(deep_copy(use_case)))
       end)
 
       it("[assigns different priorities to regex and non-regex path]", function()
@@ -4948,7 +4952,8 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           },
         }
 
-        router = assert(new_router(use_case))
+        -- deep copy use_case in case it changes
+        router = assert(new_router(deep_copy(use_case)))
       end)
 
       it("[assigns different priorities to each path]", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The original `split_routes_and_services_by_path()` will create a new table to contains all routes even if no splitting.
To erase this overhead, now `split_routes_and_services_by_path()` will insert the cloned routes directly into the passed in table.

KAG-4138

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
