### PR TITLE
refactor(router/atc): unify expression validation function in schema

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -50,12 +50,10 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
   local router = require("resty.router.router")
   local transform = require("kong.router.transform")
   local get_schema = require("kong.router.atc").schema
-  local get_expression = kong_router_flavor == "traditional_compatible" and
-                         require("kong.router.compat").get_expression or
-                         require("kong.router.expressions").transform_expression
 
   local is_null = transform.is_null
   local is_empty_field = transform.is_empty_field
+  local amending_expression = transform.amending_expression
 
   local HTTP_PATH_SEGMENTS_PREFIX = "http.path.segments."
   local HTTP_PATH_SEGMENTS_SUFFIX_REG = [[^(0|[1-9]\d*)(_([1-9]\d*))?$]]
@@ -102,7 +100,7 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
     end
 
     local schema = get_schema(entity.protocols)
-    local exp = get_expression(entity)
+    local exp = amending_expression(entity)
 
     local fields, err = router.validate(schema, exp)
     if not fields then

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -27,10 +27,6 @@ function _M.new(routes_and_services, cache, cache_neg, old_router)
 end
 
 
--- for schema validation and unit-testing
-_M.get_expression = get_expression
-
-
 -- for unit-testing purposes only
 _M._set_ngx = atc._set_ngx
 _M._get_priority = get_priority

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -29,7 +29,6 @@ end
 
 -- for unit-testing purposes only
 _M._set_ngx = atc._set_ngx
-_M._get_priority = get_priority
 
 
 return _M

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -1,24 +1,17 @@
 local _M = {}
 
 
-local re_gsub = ngx.re.gsub
-
-
 local atc = require("kong.router.atc")
 local transform = require("kong.router.transform")
 
 
-local get_expression = transform.get_expression
 local get_priority   = transform.get_priority
+local amending_expression = transform.amending_expression
 
 
 local gen_for_field = transform.gen_for_field
 local OP_EQUAL      = transform.OP_EQUAL
 local LOGICAL_AND   = transform.LOGICAL_AND
-
-
-local NET_PORT_REG = [[(net\.port)(\s*)([=><!])]]
-local NET_PORT_REPLACE = [[net.dst.port$2$3]]
 
 
 -- map to normal protocol
@@ -29,35 +22,8 @@ local PROTOCOLS_OVERRIDE = {
 }
 
 
--- net.port => net.dst.port
-local function transform_expression(route)
-  local exp = get_expression(route)
-
-  if not exp then
-    return nil
-  end
-
-  if not exp:find("net.port", 1, true) then
-    return exp
-  end
-
-  -- there is "net.port" in expression
-
-  local new_exp = re_gsub(exp, NET_PORT_REG, NET_PORT_REPLACE, "jo")
-
-  if exp ~= new_exp then
-    ngx.log(ngx.WARN, "The field 'net.port' of expression is deprecated " ..
-                      "and will be removed in the upcoming major release, " ..
-                      "please use 'net.dst.port' instead.")
-  end
-
-  return new_exp
-end
-_M.transform_expression = transform_expression
-
-
 local function get_exp_and_priority(route)
-  local exp = transform_expression(route)
+  local exp = amending_expression(route)
   if not exp then
     ngx.log(ngx.ERR, "expecting an expression route while it's not (probably a traditional route). ",
                      "Likely it's a misconfiguration. Please check the 'router_flavor' config in kong.conf")

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -790,6 +790,7 @@ do
   end
 end
 
+
 return {
   OP_EQUAL    = OP_EQUAL,
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Simplify the code, moving some logic into `transform.lua`.

KAG-4138

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
