### PR TITLE
chore(ci): add permissions to cherry-pick job

### DIFF
--- a/.github/workflows/cherry-picks.yml
+++ b/.github/workflows/cherry-picks.yml
@@ -4,6 +4,9 @@ on:
     types: [closed, labeled]
   issue_comment:
     types: [created]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests and labels
 jobs:
   cross-repo-cherrypick:
     name: Cherry pick to remote repository


### PR DESCRIPTION
### Summary

The cherry-pick action failed to add a label when the action itself failed. [As seen for example here 
](https://github.com/Kong/kong/actions/runs/8700023067/job/23859557374)
<img width="657" alt="image" src="https://github.com/Kong/kong/assets/6840312/609a1acd-e270-4043-87bd-b8e437c72d19">

This can be resolved by adding [proper permissions ](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)to the job like we did in the backports job. Most notably the `pull-requests` permission which:

> Work with pull requests. For example, pull-requests: write permits an action to add a label to a pull request. For more information, see "[Permissions required for GitHub Apps](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests)."

Fix: https://konghq.atlassian.net/browse/KAG-4288
