### PR TITLE
feat(build): allow use local path to replace git repositories

### DIFF
--- a/.requirements
+++ b/.requirements
@@ -6,6 +6,8 @@ OPENSSL=3.2.1
 PCRE=10.43
 LIBEXPAT=2.5.0
 
+# Note: git repositories can be loaded from local path if path is set as value
+
 LUA_KONG_NGINX_MODULE=691ba795ced07364d491e8abbdf0c8c8d3778c14 # 0.10.0
 LUA_RESTY_LMDB=7d2581cbe30cde18a8482d820c227ca0845c0ded # 1.4.2
 LUA_RESTY_EVENTS=8448a92cec36ac04ea522e78f6496ba03c9b1fd8 # 0.2.0

--- a/build/openresty/atc_router/atc_router_repositories.bzl
+++ b/build/openresty/atc_router/atc_router_repositories.bzl
@@ -1,12 +1,10 @@
 """A module defining the dependency atc-router"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//build:build_system.bzl", "git_or_local_repository")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
 def atc_router_repositories():
-    maybe(
-        git_repository,
+    git_or_local_repository(
         name = "atc_router",
         branch = KONG_VAR["ATC_ROUTER"],
         remote = "https://github.com/Kong/atc-router",

--- a/build/openresty/brotli/brotli_repositories.bzl
+++ b/build/openresty/brotli/brotli_repositories.bzl
@@ -1,12 +1,12 @@
 """A module defining the dependency """
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("//build:build_system.bzl", "git_or_local_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
 def brotli_repositories():
     maybe(
-        git_repository,
+        git_or_local_repository,
         name = "brotli",
         branch = KONG_VAR["BROTLI"],
         remote = "https://github.com/google/brotli",

--- a/build/openresty/repositories.bzl
+++ b/build/openresty/repositories.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("//build:build_system.bzl", "git_or_local_repository")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 load("//build/openresty/pcre:pcre_repositories.bzl", "pcre_repositories")
 load("//build/openresty/openssl:openssl_repositories.bzl", "openssl_repositories")
@@ -43,7 +43,7 @@ def openresty_repositories():
     )
 
     maybe(
-        new_git_repository,
+        git_or_local_repository,
         name = "lua-kong-nginx-module",
         branch = KONG_VAR["LUA_KONG_NGINX_MODULE"],
         remote = "https://github.com/Kong/lua-kong-nginx-module",
@@ -52,7 +52,7 @@ def openresty_repositories():
     )
 
     maybe(
-        new_git_repository,
+        git_or_local_repository,
         name = "lua-resty-lmdb",
         branch = KONG_VAR["LUA_RESTY_LMDB"],
         remote = "https://github.com/Kong/lua-resty-lmdb",
@@ -63,7 +63,7 @@ def openresty_repositories():
     )
 
     maybe(
-        new_git_repository,
+        git_or_local_repository,
         name = "lua-resty-events",
         branch = KONG_VAR["LUA_RESTY_EVENTS"],
         remote = "https://github.com/Kong/lua-resty-events",
@@ -72,7 +72,7 @@ def openresty_repositories():
     )
 
     maybe(
-        new_git_repository,
+        git_or_local_repository,
         name = "ngx_brotli",
         branch = KONG_VAR["NGX_BROTLI"],
         remote = "https://github.com/google/ngx_brotli",

--- a/build/openresty/wasmx/wasmx_repositories.bzl
+++ b/build/openresty/wasmx/wasmx_repositories.bzl
@@ -1,6 +1,6 @@
 """A module defining the third party dependency WasmX"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("//build:build_system.bzl", "git_or_local_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
@@ -57,7 +57,7 @@ def wasmx_repositories():
     if wasm_module_branch == "":
         wasm_module_branch = KONG_VAR["NGX_WASM_MODULE"]
 
-    new_git_repository(
+    git_or_local_repository(
         name = "ngx_wasmx_module",
         branch = wasm_module_branch,
         remote = KONG_VAR["NGX_WASM_MODULE_REMOTE"],

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("//build:build_system.bzl", "git_or_local_repository")
 load("//build/luarocks:luarocks_repositories.bzl", "luarocks_repositories")
 load("//build/cross_deps:repositories.bzl", "cross_deps_repositories")
 load("//build/libexpat:repositories.bzl", "libexpat_repositories")
@@ -67,7 +67,7 @@ filegroup(
     )
 
 def kong_resty_websocket_repositories():
-    new_git_repository(
+    git_or_local_repository(
         name = "lua-resty-websocket",
         branch = KONG_VAR["LUA_RESTY_WEBSOCKET"],
         remote = "https://github.com/Kong/lua-resty-websocket",


### PR DESCRIPTION
Now we are able to use like 
```
LUA_KONG_NGINX_MODULE=../lua-kong-nginx-module
```
to support local development

KAG-4280