### PR TITLE
fix(tests): fix the flakiness caused by incomplete migration in the Vault tests

### DIFF
--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -129,10 +129,6 @@ describe("vault ttl and rotation (#" .. strategy .. ") #" .. vault.name, functio
     helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
     helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
 
-    helpers.test_conf.loaded_plugins = {
-      dummy = true,
-    }
-
     vault:setup()
     vault:create_secret(secret, "init")
 

--- a/spec/02-integration/13-vaults/07-resurrect_spec.lua
+++ b/spec/02-integration/13-vaults/07-resurrect_spec.lua
@@ -134,10 +134,6 @@ describe("vault resurrect_ttl and rotation (#" .. strategy .. ") #" .. vault.nam
     helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
     helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
 
-    helpers.test_conf.loaded_plugins = {
-      dummy = true,
-    }
-
     vault:setup()
     vault:create_secret(secret, "init")
 


### PR DESCRIPTION
### Summary

Due to the inclusion of the following statement in the test code:
```lua
helpers.test_conf.loaded_plugins = {
  dummy = true,
}
```
This statement directly causes the `load_subsystems` function in `kong/db/migrations/state.lua` to only obtain the subsystems `core` and `enterprise`, which in turn causes most plugins to not undergo migration in `helpers.get_db_utils`. This ultimately leads to the issue when checking the migration of each plugin during `start_kong`.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4240
