### PR TITLE
fix(cjson): port cjson fix that throws error when T_END found in the

### DIFF
--- a/build/openresty/patches/lua-cjson-2.1.0.13_01-error-on-t_end.patch
+++ b/build/openresty/patches/lua-cjson-2.1.0.13_01-error-on-t_end.patch
@@ -1,0 +1,26 @@
+From e1fca089680e76896744ec2f25219dd705fe21da Mon Sep 17 00:00:00 2001
+From: Wangchong Zhou <wangchong@konghq.com>
+Date: Wed, 17 Apr 2024 18:00:10 +0800
+Subject: [PATCH 1/4] bugfix: throw error if T_END found in the middle of input
+
+---
+ lua_cjson.c    | 4 ++++
+ tests/test.lua | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/bundle/lua-cjson-2.1.0.13/lua_cjson.c b/bundle/lua-cjson-2.1.0.13/lua_cjson.c
+index 363466c..7343f32 100644
+--- a/bundle/lua-cjson-2.1.0.13/lua_cjson.c
++++ b/bundle/lua-cjson-2.1.0.13/lua_cjson.c
+@@ -1437,6 +1437,10 @@ static int json_decode(lua_State *l)
+     if (token.type != T_END)
+         json_throw_parse_error(l, &json, "the end", &token);
+
++    /* Make sure T_END (\x00) doesn't occur at middle of input */
++    if (json.data + json_len > json.ptr)
++        json_throw_parse_error(l, &json, "EOF", &token);
++
+     strbuf_free(json.tmp);
+
+     return 1;
+

--- a/changelog/unreleased/kong/fix-cjson-t-end.yml
+++ b/changelog/unreleased/kong/fix-cjson-t-end.yml
@@ -1,0 +1,3 @@
+message: |
+  Improve the robustness of lua-cjson when handling unexpected input. 
+type: dependency


### PR DESCRIPTION
middle

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

https://github.com/Kong/lua-cjson/pull/1

KAG-4275
