### PR TITLE
chore(deps): bump lua-resty-openssl to 1.3.1

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-openssl-1-3-1.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-openssl-1-3-1.yml
@@ -1,0 +1,3 @@
+message: Bumped lua-resty-openssl to 1.3.1
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.0.1",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.4.1",
-  "lua-resty-openssl == 1.2.1",
+  "lua-resty-openssl == 1.3.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.12.0",


### PR DESCRIPTION
### Summary

**Please merge #12905 first.**

- Use the C functions provided by lua-kong-nginx-module as an alternative to the auxiliary C functions in lua-resty-openssl.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3791
