### PR TITLE
chore(deps): bump lua-resty-http to 0.17.2

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-http-0.17.2.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-http-0.17.2.yml
@@ -1,0 +1,2 @@
+message: Bump lua-resty-http to 0.17.2.
+type: dependency

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "luasec == 1.3.2",
   "luasocket == 3.0-rc1",
   "penlight == 1.14.0",
-  "lua-resty-http == 0.17.1",
+  "lua-resty-http == 0.17.2",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.6",
   "multipart == 0.5.9",


### PR DESCRIPTION

### Summary

Backports the lua-resty-http bump from EE to CE:
https://github.com/Kong/kong-ee/pull/8424