### PR TITLE
chore(deps): bump resty.acme from 0.12.0 to 0.13.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-acme.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-acme.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-acme to 0.13.0"
+type: dependency
+scope: Core

--- a/kong-3.7.0-0.rockspec
+++ b/kong-3.7.0-0.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   "lua-resty-openssl == 1.2.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.12.0",
+  "lua-resty-acme == 0.13.0",
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.7",
   "lpeg == 1.1.0",


### PR DESCRIPTION
### Summary

#### [0.13.0] - 2024-03-28
##### bug fixes
- **autossl:** log the errors on the list certificates request ([#110](https://github.com/fffonion/lua-resty-acme/issues/110)) [6c9760f](https://github.com/fffonion/lua-resty-acme/commit/6c9760f21d38fccd7971a70019afc5fe1fc6f1be)

#### features
- **autossl:** add option to delete none whitelisted domains in certificate renewal ([#112](https://github.com/fffonion/lua-resty-acme/issues/112)) [1bbf39c](https://github.com/fffonion/lua-resty-acme/commit/1bbf39c84de90a54a3f61b3ee2e331e613eb5e7a)

KAG-4330