### PR TITLE
chore(deps): bump libexpat from 2.5.0 to 2.6.2

### DIFF
--- a/.requirements
+++ b/.requirements
@@ -4,7 +4,7 @@ OPENRESTY=1.25.3.1
 LUAROCKS=3.11.0
 OPENSSL=3.2.1
 PCRE=10.43
-LIBEXPAT=2.5.0
+LIBEXPAT=2.6.2
 
 # Note: git repositories can be loaded from local path if path is set as value
 

--- a/build/libexpat/repositories.bzl
+++ b/build/libexpat/repositories.bzl
@@ -14,7 +14,7 @@ def libexpat_repositories():
         http_archive,
         name = "libexpat",
         url = "https://github.com/libexpat/libexpat/releases/download/" + tag + "/expat-" + version + ".tar.gz",
-        sha256 = "6b902ab103843592be5e99504f846ec109c1abb692e85347587f237a4ffa1033",
+        sha256 = "d4cf38d26e21a56654ffe4acd9cd5481164619626802328506a2869afab29ab3",
         strip_prefix = "expat-" + version,
         build_file = "//build/libexpat:BUILD.libexpat.bazel",
     )

--- a/changelog/unreleased/kong/bump-libexpat.yml
+++ b/changelog/unreleased/kong/bump-libexpat.yml
@@ -1,0 +1,3 @@
+message: "Bumped libexpat to 2.6.2"
+type: dependency
+scope: Core

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -206,4 +206,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
@@ -50,7 +50,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -192,4 +192,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-arm64.txt
@@ -40,7 +40,7 @@
   - libc.so.6
   Rpath     : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libm.so.6
   - libc.so.6
@@ -173,4 +173,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/debian-10-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-10-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -206,4 +206,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/debian-11-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-11-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libc.so.6
 
@@ -195,4 +195,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/debian-12-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-12-amd64.txt
@@ -50,7 +50,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libc.so.6
 
@@ -182,4 +182,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/el7-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el7-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -205,4 +205,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -205,4 +205,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/el9-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el9-amd64.txt
@@ -50,7 +50,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libstdc++.so.6
   - libm.so.6
@@ -192,4 +192,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/el9-arm64.txt
+++ b/scripts/explain_manifest/fixtures/el9-arm64.txt
@@ -40,7 +40,7 @@
   - libc.so.6
   Rpath     : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libm.so.6
   - libc.so.6
@@ -173,4 +173,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -55,7 +55,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libc.so.6
 

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -50,7 +50,7 @@
   - libc.so.6
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libc.so.6
 
@@ -186,4 +186,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-arm64.txt
@@ -37,7 +37,7 @@
   - ld-linux-aarch64.so.1
   Runpath   : /usr/local/kong/lib
 
-- Path      : /usr/local/kong/lib/libexpat.so.1.8.10
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
   Needed    :
   - libc.so.6
   - ld-linux-aarch64.so.1
@@ -184,4 +184,3 @@
   OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
-


### PR DESCRIPTION
### Summary

#### 2.6.0
```
Release 2.6.0 Tue February 6 2024
        Security fixes:
      #789 #814  CVE-2023-52425 -- Fix quadratic runtime issues with big tokens
                   that can cause denial of service, in partial where
                   dealing with compressed XML input.  Applications
                   that parsed a document in one go -- a single call to
                   functions XML_Parse or XML_ParseBuffer -- were not affected.
                   The smaller the chunks/buffers you use for parsing
                   previously, the bigger the problem prior to the fix.
                   Backporters should be careful to no omit parts of
                   pull request #789 and to include earlier pull request #771,
                   in order to not break the fix.
           #777  CVE-2023-52426 -- Fix billion laughs attacks for users
                   compiling *without* XML_DTD defined (which is not common).
                   Users with XML_DTD defined have been protected since
                   Expat >=2.4.0 (and that was CVE-2013-0340 back then).

        Bug fixes:
            #753  Fix parse-size-dependent "invalid token" error for
                    external entities that start with a byte order mark
            #780  Fix NULL pointer dereference in setContext via
                    XML_ExternalEntityParserCreate for compilation with
                    XML_DTD undefined
       #812 #813  Protect against closing entities out of order

        Other changes:
            #723  Improve support for arc4random/arc4random_buf
       #771 #788  Improve buffer growth in XML_GetBuffer and XML_Parse
       #761 #770  xmlwf: Support --help and --version
       #759 #770  xmlwf: Support custom buffer size for XML_GetBuffer and read
            #744  xmlwf: Improve language and URL clickability in help output
            #673  examples: Add new example "element_declarations.c"
            #764  Be stricter about macro XML_CONTEXT_BYTES at build time
            #765  Make inclusion to expat_config.h consistent
       #726 #727  Autotools: configure.ac: Support --disable-maintainer-mode
    #678 #705 ..
  #706 #733 #792  Autotools: Sync CMake templates with CMake 3.26
            #795  Autotools: Make installation of shipped man page doc/xmlwf.1
                    independent of docbook2man availability
            #815  Autotools|CMake: Add missing -DXML_STATIC to pkg-config file
                    section "Cflags.private" in order to fix compilation
                    against static libexpat using pkg-config on Windows
       #724 #751  Autotools|CMake: Require a C99 compiler
                    (a de-facto requirement already since Expat 2.2.2 of 2017)
            #793  Autotools|CMake: Fix PACKAGE_BUGREPORT variable
       #750 #786  Autotools|CMake: Make test suite require a C++11 compiler
            #749  CMake: Require CMake >=3.5.0
            #672  CMake: Lowercase off_t and size_t to help a bug in Meson
            #746  CMake: Sort xmlwf sources alphabetically
            #785  CMake|Windows: Fix generation of DLL file version info
            #790  CMake: Build tests/benchmark/benchmark.c as well for
                    a build with -DEXPAT_BUILD_TESTS=ON
       #745 #757  docs: Document the importance of isFinal + adjust tests
                    accordingly
            #736  docs: Improve use of "NULL" and "null"
            #713  docs: Be specific about version of XML (XML 1.0r4)
                    and version of C (C99); (XML 1.0r5 will need a sponsor.)
            #762  docs: reference.html: Promote function XML_ParseBuffer more
            #779  docs: reference.html: Add HTML anchors to XML_* macros
            #760  docs: reference.html: Upgrade to OK.css 1.2.0
       #763 #739  docs: Fix typos
            #696  docs|CI: Use HTTPS URLs instead of HTTP at various places
    #669 #670 ..
    #692 #703 ..
       #733 #772  Address compiler warnings
       #798 #800  Address clang-tidy warnings
       #775 #776  Version info bumped from 9:10:8 (libexpat*.so.1.8.10)
                    to 10:0:9 (libexpat*.so.1.9.0); see https://verbump.de/
                    for what these numbers do

        Infrastructure:
       #700 #701  docs: Document security policy in file SECURITY.md
            #766  docs: Improve parse buffer variables in-code documentation
    #674 #738 ..
    #740 #747 ..
  #748 #781 #782  Refactor coverage and conformance tests
       #714 #716  Refactor debug level variables to unsigned long
            #671  Improve handling of empty environment variable value
                    in function getDebugLevel (without visible user effect)
    #755 #774 ..
    #758 #783 ..
       #784 #787  tests: Improve test coverage with regard to parse chunk size
  #660 #797 #801  Fuzzing: Improve fuzzing coverage
       #367 #799  Fuzzing|CI: Start running OSS-Fuzz fuzzing regression tests
       #698 #721  CI: Resolve some Travis CI leftovers
            #669  CI: Be robust towards absence of Git tags
       #693 #694  CI: Set permissions to "contents: read" for security
            #709  CI: Pin all GitHub Actions to specific commits for security
            #739  CI: Reject spelling errors using codespell
            #798  CI: Enforce clang-tidy clean code
    #773 #808 ..
       #809 #810  CI: Upgrade Clang from 15 to 18
            #796  CI: Start using Clang's Control Flow Integrity sanitizer
  #675 #720 #722  CI: Adapt to breaking changes in GitHub Actions Ubuntu images
            #689  CI: Adapt to breaking changes in Clang/LLVM Debian packaging
            #763  CI: Adapt to breaking changes in codespell
            #803  CI: Adapt to breaking changes in Cppcheck

        Special thanks to:
            Ivan Galkin
            Joyce Brum
            Philippe Antoine
            Rhodri James
            Snild Dolkow
            spookyahell
            Steven Garske
                 and
            Clang AddressSanitizer
            Clang UndefinedBehaviorSanitizer
            codespell
            GCC Farm Project
            OSS-Fuzz
            Sony Mobile
```
#### 2.6.1
```
Release 2.6.1 Thu February 29 2024
        Bug fixes:
            #817  Make tests independent of CPU speed, and thus more robust
       #828 #836  Expose billion laughs API with XML_DTD defined and
                    XML_GE undefined, regression from 2.6.0

        Other changes:
            #829  Hide test-only code behind new internal macro
            #833  Autotools: Reject expat_config.h.in defining SIZEOF_VOID_P
            #819  Address compiler warnings
       #832 #834  Version info bumped from 10:0:9 (libexpat*.so.1.9.0)
                    to 10:1:9 (libexpat*.so.1.9.1); see https://verbump.de/
                    for what these numbers do

        Infrastructure:
            #818  CI: Adapt to breaking changes in clang-format

        Special thanks to:
            David Hall
            Snild Dolkow
```
#### 2.6.2
```
Release 2.6.2 Wed March 13 2024
        Security fixes:
       #839 #842  CVE-2024-28757 -- Prevent billion laughs attacks with
                    isolated use of external parsers.  Please see the commit
                    message of commit 1d50b80cf31de87750103656f6eb693746854aa8
                    for details.

        Bug fixes:
       #839 #841  Reject direct parameter entity recursion
                    and avoid the related undefined behavior

        Other changes:
            #847  Autotools: Fix build for DOCBOOK_TO_MAN containing spaces
            #837  Add missing #821 and #824 to 2.6.1 change log
       #838 #843  Version info bumped from 10:1:9 (libexpat*.so.1.9.1)
                    to 10:2:9 (libexpat*.so.1.9.2); see https://verbump.de/
                    for what these numbers do

        Special thanks to:
            Philippe Antoine
            Tomas Korbar
                 and
            Clang UndefinedBehaviorSanitizer
            OSS-Fuzz / ClusterFuzz
```

KAG-4331