### PR TITLE
fix(dns): keep the force no sync option on recursive toip calls

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -1511,7 +1511,7 @@ local function execute_toip(qname, port, dnsCacheOnly, try_list, force_no_sync)
     -- our SRV entry might still contain a hostname, so recurse, with found port number
     local srvport = (entry.port ~= 0 and entry.port) or port -- discard port if it is 0
     add_status_to_try_list(try_list, "dereferencing SRV")
-    return execute_toip(entry.target, srvport, dnsCacheOnly, try_list)
+    return execute_toip(entry.target, srvport, dnsCacheOnly, try_list, force_no_sync)
   end
 
   -- must be A or AAAA


### PR DESCRIPTION
### Summary

The `force_no_sync` option was missing in the recursive calls to `execute_toip()`.

Skipping the changelog entry on this PR, as it is a fix for a feature not yet released.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-3795
