### PR TITLE
chore(makefile): add target 'test-logs' to show test logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ endif
 	@$(VENV) $(TEST_CMD) $(test_spec)
 
 test-logs:
-	mkdir -p servroot/logs && touch servroot/logs/error.log
 	tail -F servroot/logs/error.log
 
 pdk-phase-checks: dev

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 .PHONY: install dev \
 	lint test test-integration test-plugins test-all \
 	pdk-phase-check functional-tests \
-	fix-windows release wasm-test-filters
+	fix-windows release wasm-test-filters test-logs
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
@@ -159,6 +159,10 @@ ifndef test_spec
 endif
 	@$(VENV) $(TEST_CMD) $(test_spec)
 
+test-logs:
+	mkdir -p servroot/logs && touch servroot/logs/error.log
+	tail -F servroot/logs/error.log
+
 pdk-phase-checks: dev
 	rm -f t/phase_checks.stats
 	rm -f t/phase_checks.report
@@ -198,3 +202,4 @@ install-legacy:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) YAML_DIR=$(YAML_DIR)
 
 dev-legacy: remove install-legacy dependencies
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

When running tests, this target allows one to show the logs of the running tests. Simply by open another terminal and doing `make test-logs`.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
