### PR TITLE
chore(patches): add patches from upstream openresty

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.26_04-head-request-smuggling.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_04-head-request-smuggling.patch
@@ -1,0 +1,27 @@
+From e5248aa8203d3e0075822a577c1cdd19f5f1f831 Mon Sep 17 00:00:00 2001
+From: lijunlong <lijunlong@openresty.com>
+Date: Sat, 9 Mar 2024 12:30:14 +0800
+Subject: [PATCH] bugfix: fixed HTTP HEAD request smuggling issue.
+
+---
+ src/ngx_http_lua_util.c |  6 ++++
+ t/020-subrequest.t      | 80 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 86 insertions(+)
+
+diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_util.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_util.c
+index 8fd26561a7..727ca3da39 100644
+--- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_util.c
++++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_util.c
+@@ -599,6 +599,12 @@ ngx_http_lua_send_chain_link(ngx_http_request_t *r, ngx_http_lua_ctx_t *ctx,
+     if (r->header_only) {
+         ctx->eof = 1;
+ 
++        if (!r->request_body && r == r->main) {
++            if (ngx_http_discard_request_body(r) != NGX_OK) {
++                return NGX_ERROR;
++            }
++        }
++
+         if (ctx->buffering) {
+             return ngx_http_lua_send_http10_headers(r, ctx);
+         }

--- a/build/openresty/patches/ngx_lua-0.10.26_05-setkeepalive-data-integrity.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_05-setkeepalive-data-integrity.patch
@@ -1,0 +1,135 @@
+From e2067ddd2b2897d3c6fa6f91ce4e8169fe8c97c6 Mon Sep 17 00:00:00 2001
+From: lijunlong <lijunlong@openresty.com>
+Date: Wed, 20 Mar 2024 12:02:38 +0800
+Subject: [PATCH] bugfix: wrong arguments of setkeepalive() result in the
+ compromise of data integrity.
+
+==338736== Invalid read of size 8
+==338736==    at 0x209890: ngx_http_lua_socket_tcp_handler (ngx_http_lua_socket_tcp.c:3341)
+==338736==    by 0x16CB21: ngx_epoll_process_events (ngx_epoll_module.c:1001)
+==338736==    by 0x160213: ngx_process_events_and_timers (ngx_event.c:262)
+==338736==    by 0x16B772: ngx_single_process_cycle (ngx_process_cycle.c:338)
+==338736==    by 0x13E8B7: main (nginx.c:394)
+==338736==  Address 0x68c8678 is 8 bytes inside a block of size 1,488 free'd
+==338736==    at 0x48472AC: free (vg_replace_malloc.c:974)
+==338736==    by 0x14035D: ngx_destroy_pool (ngx_palloc.c:76)
+==338736==    by 0x18694E: ngx_http_free_request (ngx_http_request.c:3799)
+==338736==    by 0x186AE0: ngx_http_close_request (ngx_http_request.c:3708)
+==338736==    by 0x187A6A: ngx_http_finalize_connection (ngx_http_request.c:2812)
+==338736==    by 0x1887C7: ngx_http_finalize_request (ngx_http_request.c:2685)
+==338736==    by 0x1883CC: ngx_http_finalize_request (ngx_http_request.c:2571)
+==338736==    by 0x2010B2: ngx_http_lua_finalize_request (ngx_http_lua_util.c:3706)
+==338736==    by 0x20B6A1: ngx_http_lua_socket_tcp_resume_helper (ngx_http_lua_socket_tcp.c:6132)
+==338736==    by 0x20BA75: ngx_http_lua_socket_tcp_read_resume (ngx_http_lua_socket_tcp.c:6030)
+==338736==    by 0x20356B: ngx_http_lua_content_wev_handler (ngx_http_lua_contentby.c:152)
+==338736==    by 0x20CA9F: ngx_http_lua_socket_handle_read_success (ngx_http_lua_socket_tcp.c:3602)
+==338736==    by 0x20CA9F: ngx_http_lua_socket_tcp_read (ngx_http_lua_socket_tcp.c:2607)
+==338736==    by 0x20D289: ngx_http_lua_socket_read_handler (ngx_http_lua_socket_tcp.c:3405)
+==338736==    by 0x20991D: ngx_http_lua_socket_tcp_handler (ngx_http_lua_socket_tcp.c:3356)
+==338736==    by 0x16C970: ngx_epoll_process_events (ngx_epoll_module.c:968)
+==338736==    by 0x160213: ngx_process_events_and_timers (ngx_event.c:262)
+==338736==    by 0x16B772: ngx_single_process_cycle (ngx_process_cycle.c:338)
+==338736==    by 0x13E8B7: main (nginx.c:394)
+==338736==  Block was alloc'd at
+==338736==    at 0x484482F: malloc (vg_replace_malloc.c:431)
+==338736==    by 0x165448: ngx_alloc (ngx_alloc.c:22)
+==338736==    by 0x1401B2: ngx_malloc (ngx_palloc.c:137)
+==338736==    by 0x1403EC: ngx_palloc (ngx_palloc.c:120)
+==338736==    by 0x140503: ngx_pcalloc (ngx_palloc.c:215)
+==338736==    by 0x185BC9: ngx_http_alloc_request (ngx_http_request.c:580)
+==338736==    by 0x186356: ngx_http_create_request (ngx_http_request.c:536)
+==338736==    by 0x189F2A: ngx_http_wait_request_handler (ngx_http_request.c:518)
+==338736==    by 0x16C970: ngx_epoll_process_events (ngx_epoll_module.c:968)
+==338736==    by 0x160213: ngx_process_events_and_timers (ngx_event.c:262)
+==338736==    by 0x16B772: ngx_single_process_cycle (ngx_process_cycle.c:338)
+==338736==    by 0x13E8B7: main (nginx.c:394)
+==338736==
+---
+ src/ngx_http_lua_socket_tcp.c |  50 ++++++-----
+ t/068-socket-keepalive.t      | 160 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 188 insertions(+), 22 deletions(-)
+
+diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
+index 0aa7109758..214e78329e 100644
+--- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
++++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
+@@ -5385,6 +5385,34 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
+ 
+     luaL_checktype(L, 1, LUA_TTABLE);
+ 
++    r = ngx_http_lua_get_req(L);
++    if (r == NULL) {
++        return luaL_error(L, "no request found");
++    }
++
++    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
++
++    /* luaL_checkinteger will throw error if the argument is not a number.
++     * e.g.: bad argument \#2 to '?' (number expected, got string)
++     *
++     * We should check the argument in advance; otherwise,
++     * throwing an exception in the middle can compromise data integrity.
++     * e.g.: set pc->connection to NULL without following cleanup.
++     */
++    if (n >= 2 && !lua_isnil(L, 2)) {
++        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
++
++    } else {
++        timeout = llcf->keepalive_timeout;
++    }
++
++    if (n >= 3 && !lua_isnil(L, 3)) {
++        pool_size = luaL_checkinteger(L, 3);
++
++    } else {
++        pool_size = llcf->pool_size;
++    }
++
+     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
+     u = lua_touserdata(L, -1);
+     lua_pop(L, 1);
+@@ -5411,11 +5439,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
+         return 2;
+     }
+ 
+-    r = ngx_http_lua_get_req(L);
+-    if (r == NULL) {
+-        return luaL_error(L, "no request found");
+-    }
+-
+     if (u->request != r) {
+         return luaL_error(L, "bad request");
+     }
+@@ -5486,18 +5509,8 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
+ 
+     /* stack: obj timeout? size? pools cache_key */
+ 
+-    llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+-
+     if (spool == NULL) {
+         /* create a new socket pool for the current peer key */
+-
+-        if (n >= 3 && !lua_isnil(L, 3)) {
+-            pool_size = luaL_checkinteger(L, 3);
+-
+-        } else {
+-            pool_size = llcf->pool_size;
+-        }
+-
+         if (pool_size <= 0) {
+             msg = lua_pushfstring(L, "bad \"pool_size\" option value: %d",
+                                   pool_size);
+@@ -5561,13 +5574,6 @@ ngx_http_lua_socket_tcp_setkeepalive(lua_State *L)
+         ngx_del_timer(c->write);
+     }
+ 
+-    if (n >= 2 && !lua_isnil(L, 2)) {
+-        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
+-
+-    } else {
+-        timeout = llcf->keepalive_timeout;
+-    }
+-
+ #if (NGX_DEBUG)
+     if (timeout == 0) {
+         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/build/openresty/patches/ngx_lua-0.10.26_06-ngx-arg-connection-close.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_06-ngx-arg-connection-close.patch
@@ -1,0 +1,41 @@
+From 6c00bd4765ec5f7bf090a2c6424d11845fc4ab72 Mon Sep 17 00:00:00 2001
+From: Liu Wei <375636559@qq.com>
+Date: Thu, 11 Apr 2024 20:54:19 +0800
+Subject: [PATCH] bugfix: the connection won't be closed normally when set
+ arg[1] = "" before arg[2] = true.
+
+---
+ src/ngx_http_lua_bodyfilterby.c | 18 ++++++++++++--
+ t/082-body-filter-2.t           | 44 +++++++++++++++++++++++++++++++++
+ 2 files changed, 60 insertions(+), 2 deletions(-)
+
+diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_bodyfilterby.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_bodyfilterby.c
+index 78e3b5c2d6..c0484c8de0 100644
+--- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_bodyfilterby.c
++++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_bodyfilterby.c
+@@ -532,9 +532,23 @@ ngx_http_lua_body_filter_param_set(lua_State *L, ngx_http_request_t *r,
+         if (last) {
+             ctx->seen_last_in_filter = 1;
+ 
+-            /* the "in" chain cannot be NULL and we set the "last_buf" or
+-             * "last_in_chain" flag in the last buf of "in" */
++            /* the "in" chain cannot be NULL except that we set arg[1] = ""
++             * before arg[2] = true
++             */
++            if (in == NULL) {
++                in = ngx_http_lua_chain_get_free_buf(r->connection->log,
++                                                     r->pool,
++                                                     &ctx->free_bufs, 0);
++                if (in == NULL) {
++                    return luaL_error(L, "no memory");
++                }
++
++                in->buf->tag = (ngx_buf_tag_t) &ngx_http_lua_body_filter;
++                lmcf->body_filter_chain = in;
++            }
+ 
++            /* we set the "last_buf" or "last_in_chain" flag
++             * in the last buf of "in" */
+             for (cl = in; cl; cl = cl->next) {
+                 if (cl->next == NULL) {
+                     if (r == r->main) {

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_04-setkeepalive-data-integrity.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_04-setkeepalive-data-integrity.patch
@@ -1,0 +1,95 @@
+From cb82db3574f42fd3f22f98c51f5183e975eaa766 Mon Sep 17 00:00:00 2001
+From: lijunlong <lijunlong@openresty.com>
+Date: Wed, 20 Mar 2024 12:12:30 +0800
+Subject: [PATCH] bugfix: wrong arguments of setkeepalive() result in the
+ compromise of data integrity.
+
+---
+ src/ngx_stream_lua_socket_tcp.c |  49 +++++++-----
+ t/068-socket-keepalive.t        | 138 ++++++++++++++++++++++++++++++++
+ 2 files changed, 166 insertions(+), 21 deletions(-)
+
+diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
+index 57f389d0..9d5472a2 100644
+--- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
++++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
+@@ -5250,6 +5250,34 @@ ngx_stream_lua_socket_tcp_setkeepalive(lua_State *L)
+ 
+     luaL_checktype(L, 1, LUA_TTABLE);
+ 
++    r = ngx_stream_lua_get_req(L);
++    if (r == NULL) {
++        return luaL_error(L, "no request found");
++    }
++
++    llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
++
++    /* luaL_checkinteger will throw error if the argument is not a number.
++     * e.g.: bad argument \#2 to '?' (number expected, got string)
++     *
++     * We should check the argument in advance; otherwise,
++     * throwing an exception in the middle can compromise data integrity.
++     * e.g.: set pc->connection to NULL without following cleanup.
++     */
++    if (n >= 2 && !lua_isnil(L, 2)) {
++        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
++
++    } else {
++        timeout = llcf->keepalive_timeout;
++    }
++
++    if (n >= 3 && !lua_isnil(L, 3)) {
++        pool_size = luaL_checkinteger(L, 3);
++
++    } else {
++        pool_size = llcf->pool_size;
++    }
++
+     lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
+     u = lua_touserdata(L, -1);
+     lua_pop(L, 1);
+@@ -5271,11 +5299,6 @@ ngx_stream_lua_socket_tcp_setkeepalive(lua_State *L)
+         return 2;
+     }
+ 
+-    r = ngx_stream_lua_get_req(L);
+-    if (r == NULL) {
+-        return luaL_error(L, "no request found");
+-    }
+-
+     if (u->request != r) {
+         return luaL_error(L, "bad request");
+     }
+@@ -5349,18 +5372,9 @@ ngx_stream_lua_socket_tcp_setkeepalive(lua_State *L)
+ 
+     /* stack: obj timeout? size? pools cache_key */
+ 
+-    llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
+-
+     if (spool == NULL) {
+         /* create a new socket pool for the current peer key */
+ 
+-        if (n >= 3 && !lua_isnil(L, 3)) {
+-            pool_size = luaL_checkinteger(L, 3);
+-
+-        } else {
+-            pool_size = llcf->pool_size;
+-        }
+-
+         if (pool_size <= 0) {
+             msg = lua_pushfstring(L, "bad \"pool_size\" option value: %i",
+                                   pool_size);
+@@ -5425,13 +5439,6 @@ ngx_stream_lua_socket_tcp_setkeepalive(lua_State *L)
+         ngx_del_timer(c->write);
+     }
+ 
+-    if (n >= 2 && !lua_isnil(L, 2)) {
+-        timeout = (ngx_msec_t) luaL_checkinteger(L, 2);
+-
+-    } else {
+-        timeout = llcf->keepalive_timeout;
+-    }
+-
+ #if (NGX_DEBUG)
+     if (timeout == 0) {
+         ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_05-ssl-context.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_05-ssl-context.patch
@@ -1,0 +1,54 @@
+From bea8a0c0de94cede71554f53818ac0267d675d63 Mon Sep 17 00:00:00 2001
+From: Konstantin Pavlov <pavlov.konstantin@gmail.com>
+Date: Fri, 22 Mar 2024 16:41:46 -0700
+Subject: [PATCH] bugfix: Check for SSL context instead of listen.
+
+This fixes FTBFS with nginx 1.25.5 after changes in
+https://hg.nginx.org/nginx/rev/e28b044908cb and
+https://hg.nginx.org/nginx/rev/fa75fccf7fa0
+---
+ src/ngx_stream_lua_module.c     | 8 ++++++++
+ src/ngx_stream_lua_ssl_certby.c | 4 ++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_module.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_module.c
+index f7dca968..5c9024e7 100644
+--- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_module.c
++++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_module.c
+@@ -864,12 +864,20 @@ ngx_stream_lua_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+     ngx_stream_lua_srv_conf_t       *conf = child;
+ 
+ #if (NGX_STREAM_SSL)
++#if defined(nginx_version) && nginx_version >= 1025005
++    ngx_stream_ssl_srv_conf_t       *sscf;
++#else
+     ngx_stream_ssl_conf_t           *sscf;
++#endif
+ 
+     dd("merge srv conf");
+ 
+     sscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_ssl_module);
++#if defined(nginx_version) && nginx_version >= 1025005
++    if (sscf && sscf->ssl.ctx) {
++#else
+     if (sscf && sscf->listen) {
++#endif
+         if (conf->srv.ssl_client_hello_src.len == 0) {
+             conf->srv.ssl_client_hello_src = prev->srv.ssl_client_hello_src;
+             conf->srv.ssl_client_hello_src_key =
+diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_ssl_certby.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_ssl_certby.c
+index 7aae86a7..3ac8c7aa 100644
+--- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_ssl_certby.c
++++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_ssl_certby.c
+@@ -1385,7 +1385,11 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
+ 
+     ngx_stream_lua_ctx_t        *ctx;
+     ngx_ssl_conn_t              *ssl_conn;
++#if defined(nginx_version) && nginx_version >= 1025005
++    ngx_stream_ssl_srv_conf_t   *sscf;
++#else
+     ngx_stream_ssl_conf_t       *sscf;
++#endif
+     STACK_OF(X509)              *chain = ca_certs;
+     STACK_OF(X509_NAME)         *name_chain = NULL;
+     X509                        *x509 = NULL;


### PR DESCRIPTION
### Summary

#### ngx_lua patches

- https://github.com/openresty/lua-nginx-module/commit/e5248aa8203d3e0075822a577c1cdd19f5f1f831
- https://github.com/openresty/lua-nginx-module/commit/e2067ddd2b2897d3c6fa6f91ce4e8169fe8c97c6
- https://github.com/openresty/lua-nginx-module/commit/6c00bd4765ec5f7bf090a2c6424d11845fc4ab72

#### ngx_stream_lua patches

- https://github.com/openresty/stream-lua-nginx-module/commit/cb82db3574f42fd3f22f98c51f5183e975eaa766
- https://github.com/openresty/stream-lua-nginx-module/commit/bea8a0c0de94cede71554f53818ac0267d675d63 (this may not be necessary as we are not having the nginx 1.25.5 as of now, but doesn't hurt either)

KAG-4379