### PR TITLE
fix(clustering/rpc): more strict parameter checking when generating a RPC error

### DIFF
--- a/changelog/unreleased/kong/fix-rpc-err-msg-checking.yml
+++ b/changelog/unreleased/kong/fix-rpc-err-msg-checking.yml
@@ -1,4 +1,0 @@
-message: |
-  More strict parameter checking when generating a RPC error.
-type: bugfix
-scope: Core

--- a/changelog/unreleased/kong/fix-rpc-err-msg-checking.yml
+++ b/changelog/unreleased/kong/fix-rpc-err-msg-checking.yml
@@ -1,0 +1,4 @@
+message: |
+  More strict parameter checking when generating a RPC error.
+type: bugfix
+scope: Core

--- a/kong/clustering/rpc/json_rpc_v2.lua
+++ b/kong/clustering/rpc/json_rpc_v2.lua
@@ -32,7 +32,7 @@ function _M.new_error(id, code, msg)
     id = id,
     error = {
       code = code,
-      message = msg,
+      message = tostring(msg),
     }
   }
 end

--- a/kong/clustering/rpc/json_rpc_v2.lua
+++ b/kong/clustering/rpc/json_rpc_v2.lua
@@ -30,7 +30,7 @@ function _M.new_error(id, code, msg)
       -- generate a meaningful string, we should consider it as a
       -- bug since we should not expose something like
       -- `"table: 0x7fff0000"` to the RPC caller.
-      assert(mt.__tostring)
+      assert(type(mt.__tostring) == "function")
     end
 
     msg = tostring(msg)

--- a/kong/clustering/rpc/json_rpc_v2.lua
+++ b/kong/clustering/rpc/json_rpc_v2.lua
@@ -24,7 +24,16 @@ local ERROR_MSG = {
 
 function _M.new_error(id, code, msg)
   if msg then
-    msg = assert(tostring(msg))
+    if type(msg) ~= "string" then
+      local mt = getmetatable(msg)
+      -- other types without the metamethod `__tostring` don't
+      -- generate a meaningful string, we should consider it as a
+      -- bug since we should not expose something like
+      -- `"table: 0x7fff0000"` to the RPC caller.
+      assert(mt.__tostring)
+    end
+
+    msg = tostring(msg)
 
   else
     msg = assert(ERROR_MSG[code], "unknown code: " .. tostring(code))

--- a/kong/clustering/rpc/json_rpc_v2.lua
+++ b/kong/clustering/rpc/json_rpc_v2.lua
@@ -23,7 +23,10 @@ local ERROR_MSG = {
 
 
 function _M.new_error(id, code, msg)
-  if not msg then
+  if msg then
+    msg = assert(tostring(msg))
+
+  else
     msg = assert(ERROR_MSG[code], "unknown code: " .. tostring(code))
   end
 
@@ -32,7 +35,7 @@ function _M.new_error(id, code, msg)
     id = id,
     error = {
       code = code,
-      message = tostring(msg),
+      message = msg,
     }
   }
 end

--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -14,6 +14,7 @@ local constants = require("kong.constants")
 
 
 local assert = assert
+local unpack = unpack
 local string_format = string.format
 local kong = kong
 local is_timeout = utils.is_timeout
@@ -68,7 +69,7 @@ function _M._dispatch(premature, self, cb, payload)
     ngx_log(ngx_WARN, "[rpc] RPC callback failed: ", err)
 
     res, err = self.outgoing:push(new_error(payload.id, jsonrpc.SERVER_ERROR,
-                                            tostring(err)))
+                                            err))
     if not res then
       ngx_log(ngx_WARN, "[rpc] unable to push RPC call error: ", err)
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

minor code style improvement.

KAG-4441

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
