### PR TITLE
 fix(pdk): fix log serialize upstream_status entry nil bug in subrequest case

### DIFF
--- a/changelog/unreleased/kong/fix-log-upstream-status-nil-subrequest.yml
+++ b/changelog/unreleased/kong/fix-log-upstream-status-nil-subrequest.yml
@@ -1,0 +1,4 @@
+message: |
+  **PDK:** fix log serialize `upstream_status` entry nil bug in subrequest case
+type: bugfix
+scope: PDK

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -815,10 +815,7 @@ do
         end
       end
 
-      -- The value of upstream_status is a string, and status codes may be
-      -- seperated by comma or grouped by colon, according to
-      -- the nginx doc: http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream_status
-      local upstream_status = var.upstream_status or ""
+      local upstream_status = kong.service.response.get_status()
 
       local response_source = okong.response.get_source(ongx.ctx)
       local response_source_name = TYPE_NAMES[response_source]


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
