### PR TITLE
chore(cache): increased the default lock timeout to 10s that mlcache

### DIFF
--- a/kong/global.lua
+++ b/kong/global.lua
@@ -20,8 +20,8 @@ local KONG_VERSION_NUM = tonumber(string.format("%d%.2d%.2d",
                                   meta._VERSION_TABLE.patch))
 
 local LOCK_OPTS = {
-  exptime = 10,
-  timeout = 5,
+  exptime = 20,
+  timeout = 10,
 }
 
 


### PR DESCRIPTION
### Summary

Currently, this lock timeout is hardcoded and does not provide an optional configuration parameter out of the box. We have received multiple complaints from users with the following error in their logs:

```
failed to get from node cache: could not acquire callback lock: timeout
```

So, here we double the default timeout time

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix FTI-4299
