### PR TITLE
fix(emmy-lua-debugger): add support status warning for feature

### DIFF
--- a/changelog/unreleased/kong/feat-emmy-debugger.yml
+++ b/changelog/unreleased/kong/feat-emmy-debugger.yml
@@ -1,3 +1,4 @@
 message: |
-  Added support for debugging with EmmyLuaDebugger
+  Added support for debugging with EmmyLuaDebugger.  This feature is a
+  tech preview and not officially supported by Kong Inc. for now.
 type: feature

--- a/kong/tools/emmy_debugger.lua
+++ b/kong/tools/emmy_debugger.lua
@@ -53,6 +53,7 @@ local function init()
   end
 
   ngx.log(ngx.NOTICE, "loading EmmyLua debugger " .. debugger)
+  ngx.log(ngx.WARN, "The EmmyLua integration for Kong is a feature solely for your convenience during development. Kong assumes no liability as a result of using the integration and does not endorse it’s usage. Issues related to usage of EmmyLua integration should be directed to the respective project instead.")
 
   _G.emmy = {
     fixPath = find_source


### PR DESCRIPTION
### Summary

Add a warning to point out that the EmmyLua debugger integration is not supported at this point.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4404