### PR TITLE
fix(plugins/grpc-gateway):handle json decode error safely(#10028)

### DIFF
--- a/changelog/unreleased/kong/fix-grpc-gateway-json-decode-bug.yml
+++ b/changelog/unreleased/kong/fix-grpc-gateway-json-decode-bug.yml
@@ -1,0 +1,3 @@
+message: "**grpc-gateway**:Fixed an json decode issue so that kong will response 400 with error info in it's body instead of 500."
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-grpc-gateway-json-decode-bug.yml
+++ b/changelog/unreleased/kong/fix-grpc-gateway-json-decode-bug.yml
@@ -1,3 +1,3 @@
-message: "**grpc-gateway**:Fixed an json decode issue so that kong will response 400 with error info in it's body instead of 500."
+message: "**grpc-gateway**: When there is a JSON decoding error, respond with status 400 and error information in the body instead of status 500."
 type: bugfix
 scope: Plugin

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -1,6 +1,6 @@
 -- Copyright (c) Kong Inc. 2020
 
-local cjson = require "cjson"
+local cjson = require "cjson.safe".new()
 local buffer = require "string.buffer"
 local pb = require "pb"
 local grpc_tools = require "kong.tools.grpc"
@@ -227,7 +227,10 @@ function deco:upstream(body)
   local body_variable = self.endpoint.body_variable
   if body_variable then
     if body and #body > 0 then
-      local body_decoded = decode_json(body)
+      local body_decoded, err = decode_json(body)
+      if err then
+        return nil, err
+      end
       if body_variable ~= "*" then
         --[[
           // For HTTP methods that allow a request body, the `body` field

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -229,7 +229,7 @@ function deco:upstream(body)
     if body and #body > 0 then
       local body_decoded, err = decode_json(body)
       if err then
-        return nil, err
+        return nil, "decode json err: " .. err
       end
       if body_variable ~= "*" then
         --[[

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -120,7 +120,7 @@ function grpc_gateway:body_filter(conf)
   if not ret or #ret == 0 then
     if ngx_arg[2] then
       -- it's eof and we still cannot decode, fall through
-      ret = deco:get_raw_downstream_body()
+      ret = dec:get_raw_downstream_body()
     else
       -- clear output if we cannot decode, it could be body is not complete yet
       ret = nil

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -208,6 +208,24 @@ for _, strategy in helpers.each_strategy() do
       assert.equal(400, res.status)
     end)
 
+    test("invalid json", function()
+      local res, _ = proxy_client:post("/bounce", {
+        headers = { ["Content-Type"] = "application/json" },
+        body = [[{"message":"invalid}]]
+      })
+      assert.equal(400, res.status)
+      assert.same(res:read_body(),"Expected value but found unexpected end of string at character 21")
+    end)
+
+    test("field type mismatch", function()
+      local res, _ = proxy_client:post("/bounce", {
+        headers = { ["Content-Type"] = "application/json" },
+        body = [[{"message":1}]]
+      })
+      assert.equal(400, res.status)
+      assert.same(res:read_body(),"failed to encode payload")
+    end)
+
     describe("regression", function()
       test("empty array in json #10801", function()
         local req_body = { array = {}, nullable = "ahaha" }

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -214,7 +214,7 @@ for _, strategy in helpers.each_strategy() do
         body = [[{"message":"invalid}]]
       })
       assert.equal(400, res.status)
-      assert.same(res:read_body(),"Expected value but found unexpected end of string at character 21")
+      assert.same(res:read_body(),"decode json err: Expected value but found unexpected end of string at character 21")
     end)
 
     test("field type mismatch", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #10028
