### PR TITLE
fix(rpc): disable cluster_rpc for 3.7

### DIFF
--- a/changelog/unreleased/kong/cp-dp-rpc.yml
+++ b/changelog/unreleased/kong/cp-dp-rpc.yml
@@ -1,3 +1,0 @@
-message: "Remote procedure call (RPC) framework for Hybrid mode deployments."
-type: feature
-scope: Clustering

--- a/changelog/unreleased/kong/dynamic-log-level-rpc.yml
+++ b/changelog/unreleased/kong/dynamic-log-level-rpc.yml
@@ -1,6 +1,0 @@
-message: |
-  Dynamic log level over Hybrid mode RPC which allows setting DP log level
-  to a different level for specified duration before reverting back
-  to the `kong.conf` configured value.
-type: feature
-scope: Clustering

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -934,6 +934,12 @@ local function load(path, custom_conf, opts)
     end
   end
 
+  -- TODO: remove this when cluster_rpc is ready for GA
+  if conf.cluster_rpc then
+    log.warn("Cluster RPC has been forcibly disabled")
+    conf.cluster_rpc = "off"
+  end
+
   -- initialize the dns client, so the globally patched tcp.connect method
   -- will work from here onwards.
   assert(require("kong.tools.dns")(conf))

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -41,7 +41,7 @@ cluster_ocsp = off
 cluster_max_payload = 16777216
 cluster_use_proxy = off
 cluster_dp_labels = NONE
-cluster_rpc = on
+cluster_rpc = off
 
 lmdb_environment_path = dbless.lmdb
 lmdb_map_size = 2048m

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -309,11 +309,26 @@ describe("NGINX conf compiler", function()
       assert.not_matches("ssl_dhparam", kong_nginx_conf)
     end)
 
-    it("renders RPC server", function()
+    -- TODO: enable when cluster RPC is GA
+    pending("renders RPC server", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         role = "control_plane",
         cluster_cert = "spec/fixtures/kong_clustering.crt",
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_listen = "127.0.0.1:9005",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("location = /v2/outlet {", kong_nginx_conf)
+    end)
+
+    -- TODO: remove when cluster RPC is GA
+    it("does not render RPC server, even when cluster_rpc enabled", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        role = "control_plane",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_rpc = "on",
         cluster_listen = "127.0.0.1:9005",
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))

--- a/spec/02-integration/18-hybrid_rpc/01-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/01-rpc_spec.lua
@@ -15,6 +15,7 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         database = strategy,
         cluster_listen = "127.0.0.1:9005",
+        cluster_rpc = "on",
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
 
@@ -25,6 +26,7 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert = "spec/fixtures/kong_clustering.crt",
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         cluster_control_plane = "127.0.0.1:9005",
+        cluster_rpc = "on",
         proxy_listen = "0.0.0.0:9002",
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
@@ -36,7 +38,32 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("status API", function()
-      it("shows DP RPC capability status", function()
+      -- TODO: remove this test once cluster RPC is GA
+      it("no DR RPC capabilities exist", function()
+        -- This should time out, we expect no RPC capabilities
+        local status = pcall(helpers.wait_until, function()
+          local admin_client = helpers.admin_client()
+          finally(function()
+            admin_client:close()
+          end)
+
+          local res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.ip == "127.0.0.1" and v.rpc_capabilities and #v.rpc_capabilities ~= 0 then
+              table.sort(v.rpc_capabilities)
+              assert.near(14 * 86400, v.ttl, 3)
+              assert.same({ "kong.debug.log_level.v1", }, v.rpc_capabilities)
+              return true
+            end
+          end
+        end, 10)
+        assert.is_false(status)
+      end)
+
+      pending("shows DP RPC capability status", function()
         helpers.wait_until(function()
           local admin_client = helpers.admin_client()
           finally(function()

--- a/spec/02-integration/18-hybrid_rpc/02-log-level_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/02-log-level_spec.lua
@@ -41,6 +41,7 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         database = strategy,
         cluster_listen = "127.0.0.1:9005",
+        cluster_rpc = "on",
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
 
@@ -51,6 +52,7 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert = "spec/fixtures/kong_clustering.crt",
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         cluster_control_plane = "127.0.0.1:9005",
+        cluster_rpc = "on",
         proxy_listen = "0.0.0.0:9002",
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
@@ -62,7 +64,22 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("Dynamic log level over RPC", function()
-      it("can get the current log level", function()
+
+      -- TODO: remove when cluster RPC is GA
+      it("log level API is unavailable", function()
+        local dp_node_id = obtain_dp_node_id()
+
+        local admin_client = helpers.admin_client()
+        finally(function()
+          admin_client:close()
+        end)
+
+        local res = assert(admin_client:get("/clustering/data-planes/" .. dp_node_id .. "/log-level"))
+        assert.res_status(404, res)
+      end)
+
+      -- TODO: enable when cluster RPC is GA
+      pending("can get the current log level", function()
         local dp_node_id = obtain_dp_node_id()
 
         local admin_client = helpers.admin_client()
@@ -78,7 +95,8 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("debug", json.original_level)
       end)
 
-      it("can set the current log level", function()
+    -- TODO: enable when cluster RPC is GA
+      pending("can set the current log level", function()
         local dp_node_id = obtain_dp_node_id()
 
         local admin_client = helpers.admin_client()
@@ -106,7 +124,8 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("debug", json.original_level)
       end)
 
-      it("set current log level to original_level turns off feature", function()
+      -- TODO: enable when cluster RPC is GA
+      pending("set current log level to original_level turns off feature", function()
         local dp_node_id = obtain_dp_node_id()
 
         local admin_client = helpers.admin_client()
@@ -146,7 +165,8 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("debug", json.original_level)
       end)
 
-      it("DELETE turns off feature", function()
+      -- TODO: enable when cluster RPC is GA
+      pending("DELETE turns off feature", function()
         local dp_node_id = obtain_dp_node_id()
 
         local admin_client = helpers.admin_client()

--- a/spec/02-integration/18-hybrid_rpc/04-concentrator_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/04-concentrator_spec.lua
@@ -74,7 +74,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("Dynamic log level over RPC", function()
-      it("can get the current log level", function()
+      pending("can get the current log level", function()
         local dp_node_id = obtain_dp_node_id()
 
         -- this sleep is *not* needed for the below wait_until to succeed,


### PR DESCRIPTION
### Summary

The new hybrid RPC still requires some additional changes before it is ready for GA. This disables cluster RPC and does not allow it to be re-enabled. This feature will be enabled in a future release.

### Checklist

- [x] The Pull Request has tests

### Issue reference

Fix: KAG-4407
