### PR TITLE
fix(migrations): split redis migrations into up and teardown

### DIFF
--- a/changelog/unreleased/kong/fix-migrations-for-redis-plugins-acme.yml
+++ b/changelog/unreleased/kong/fix-migrations-for-redis-plugins-acme.yml
@@ -1,0 +1,3 @@
+message: "**ACME**: Fixed migration of redis configuration."
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-migrations-for-redis-plugins-response-rl.yml
+++ b/changelog/unreleased/kong/fix-migrations-for-redis-plugins-response-rl.yml
@@ -1,0 +1,3 @@
+message: "**Response-RateLimiting**: Fixed migration of redis configuration."
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-migrations-for-redis-plugins-rl.yml
+++ b/changelog/unreleased/kong/fix-migrations-for-redis-plugins-rl.yml
@@ -1,0 +1,3 @@
+message: "**Rate-Limiting**: Fixed migration of redis configuration."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/acme/migrations/003_350_to_360.lua
+++ b/kong/plugins/acme/migrations/003_350_to_360.lua
@@ -5,30 +5,16 @@ return {
         BEGIN
           UPDATE plugins
           SET config =
-            config
-                #- '{storage_config,redis}'
-
-            || jsonb_build_object(
-                'storage_config',
-                (config -> 'storage_config') - 'redis'
+              jsonb_set(
+                config,
+                '{storage_config,redis}',
+                config #> '{storage_config, redis}'
                 || jsonb_build_object(
-                  'redis',
-                  jsonb_build_object(
-                      'host', config #> '{storage_config, redis, host}',
-                      'port', config #> '{storage_config, redis, port}',
-                      'password', config #> '{storage_config, redis, auth}',
-                      'username', config #> '{storage_config, redis, username}',
-                      'ssl', config #> '{storage_config, redis, ssl}',
-                      'ssl_verify', config #> '{storage_config, redis, ssl_verify}',
-                      'server_name', config #> '{storage_config, redis, ssl_server_name}',
-                      'timeout', config #> '{storage_config, redis, timeout}',
-                      'database', config #> '{storage_config, redis, database}'
-                  ) || jsonb_build_object(
-                      'extra_options',
-                      jsonb_build_object(
-                          'scan_count', config #> '{storage_config, redis, scan_count}',
-                          'namespace', config #> '{storage_config, redis, namespace}'
-                      )
+                  'password', config #> '{storage_config, redis, auth}',
+                  'server_name', config #> '{storage_config, redis, ssl_server_name}',
+                  'extra_options', jsonb_build_object(
+                    'scan_count', config #> '{storage_config, redis, scan_count}',
+                    'namespace', config #> '{storage_config, redis, namespace}'
                   )
                 )
               )
@@ -37,5 +23,24 @@ return {
           -- Do nothing, accept existing state
         END$$;
       ]],
+      teardown = function(connector, _)
+        local sql = [[
+          DO $$
+          BEGIN
+            UPDATE plugins
+            SET config =
+              config
+                #- '{storage_config,redis,auth}'
+                #- '{storage_config,redis,ssl_server_name}'
+                #- '{storage_config,redis,scan_count}'
+                #- '{storage_config,redis,namespace}'
+            WHERE name = 'acme';
+          EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+            -- Do nothing, accept existing state
+          END$$;
+        ]]
+        assert(connector:query(sql))
+        return true
+      end,
     },
 }

--- a/kong/plugins/rate-limiting/migrations/006_350_to_360.lua
+++ b/kong/plugins/rate-limiting/migrations/006_350_to_360.lua
@@ -6,15 +6,6 @@ return {
           UPDATE plugins
           SET config =
             config::jsonb
-                - 'redis_host'
-                - 'redis_port'
-                - 'redis_password'
-                - 'redis_username'
-                - 'redis_ssl'
-                - 'redis_ssl_verify'
-                - 'redis_server_name'
-                - 'redis_timeout'
-                - 'redis_database'
             || jsonb_build_object(
                 'redis',
                 jsonb_build_object(
@@ -34,5 +25,30 @@ return {
           -- Do nothing, accept existing state
         END$$;
       ]],
+      teardown = function(connector, _)
+        local sql = [[
+          DO $$
+          BEGIN
+            UPDATE plugins
+            SET config =
+              config::jsonb
+                - 'redis_host'
+                - 'redis_port'
+                - 'redis_password'
+                - 'redis_username'
+                - 'redis_ssl'
+                - 'redis_ssl_verify'
+                - 'redis_server_name'
+                - 'redis_timeout'
+                - 'redis_database'
+            WHERE name = 'rate-limiting';
+          EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+            -- Do nothing, accept existing state
+          END$$;
+        ]]
+        assert(connector:query(sql))
+
+        return true
+      end,
     },
 }

--- a/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
+++ b/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
@@ -6,15 +6,6 @@ return {
           UPDATE plugins
           SET config =
             config::jsonb
-              - 'redis_host'
-              - 'redis_port'
-              - 'redis_password'
-              - 'redis_username'
-              - 'redis_ssl'
-              - 'redis_ssl_verify'
-              - 'redis_server_name'
-              - 'redis_timeout'
-              - 'redis_database'
             || jsonb_build_object(
               'redis',
               jsonb_build_object(
@@ -34,5 +25,30 @@ return {
           -- Do nothing, accept existing state
         END$$;
       ]],
+      teardown = function(connector, _)
+        local sql = [[
+          DO $$
+          BEGIN
+            UPDATE plugins
+            SET config =
+              config::jsonb
+                - 'redis_host'
+                - 'redis_port'
+                - 'redis_password'
+                - 'redis_username'
+                - 'redis_ssl'
+                - 'redis_ssl_verify'
+                - 'redis_server_name'
+                - 'redis_timeout'
+                - 'redis_database'
+            WHERE name = 'response-ratelimiting';
+          EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+            -- Do nothing, accept existing state
+          END$$;
+        ]]
+        assert(connector:query(sql))
+
+        return true
+      end,
     },
 }

--- a/spec/05-migration/plugins/acme/migrations/003_350_to_360_spec.lua
+++ b/spec/05-migration/plugins/acme/migrations/003_350_to_360_spec.lua
@@ -41,7 +41,7 @@ if uh.database_type() == 'postgres' then
             admin_client:close()
         end)
 
-        uh.new_after_up("has updated acme redis configuration", function ()
+        uh.new_after_finish("has updated acme redis configuration", function ()
             local admin_client = assert(uh.admin_client())
             local res = assert(admin_client:send {
                 method = "GET",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

"UP" phase should only contain non-destructive operations. "TEARDOWN" (or "FINISH") phase should be used to change/delete data.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-4419
https://github.com/Kong/kong/issues/12978
