### PR TITLE
feat(jwt): add claims_to_reject list

### DIFF
--- a/changelog/unreleased/kong/feat_jwt_reject-claims.yml
+++ b/changelog/unreleased/kong/feat_jwt_reject-claims.yml
@@ -1,0 +1,3 @@
+message: |
+  Adds a `jwt_reject_claims` configuration option to the JWT plugin to allow for rejecting tokens that contain specific claims.
+type: feature

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -173,6 +173,14 @@ local function do_authentication(conf)
   local claims = jwt.claims
   local header = jwt.header
 
+  if conf.claims_to_reject then
+    for _, claim in ipairs(conf.claims_to_reject) do
+      if claims[claim] then
+        return false, { status = 401, message = "Token rejected due to claim " .. claim }
+      end
+    end
+  end
+
   local jwt_secret_key = claims[conf.key_claim_name] or header[conf.key_claim_name]
   if not jwt_secret_key then
     return false, { status = 401, message = "No mandatory '" .. conf.key_claim_name .. "' in claims" }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -30,6 +30,12 @@ return {
                 type = "string",
                 one_of = { "exp", "nbf" },
           }, }, },
+          { claims_to_reject = {
+            description = "A list of claims that if present will lead to an auth failure.",
+            type = "set",
+            elements = {
+              type = "string",
+          }, }, },
           { anonymous = { description = "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.", type = "string" }, },
           { run_on_preflight = { description = "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed.", type = "boolean", required = true, default = true }, },
           { maximum_expiration = {


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

If the JWT contains any of the listed claim names, the request is rejected with a 401.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


