### PR TITLE
fix(migration): make redis schema migrations reentrant

### DIFF
--- a/kong/plugins/acme/migrations/003_350_to_360.lua
+++ b/kong/plugins/acme/migrations/003_350_to_360.lua
@@ -10,11 +10,11 @@ return {
                 '{storage_config,redis}',
                 config #> '{storage_config, redis}'
                 || jsonb_build_object(
-                  'password', config #> '{storage_config, redis, auth}',
-                  'server_name', config #> '{storage_config, redis, ssl_server_name}',
+                  'password', COALESCE(config #> '{storage_config, redis, auth}', config #> '{storage_config, redis, password}'),
+                  'server_name', COALESCE(config #> '{storage_config, redis, ssl_server_name}', config #> '{storage_config, redis, server_name}'),
                   'extra_options', jsonb_build_object(
-                    'scan_count', config #> '{storage_config, redis, scan_count}',
-                    'namespace', config #> '{storage_config, redis, namespace}'
+                    'scan_count', COALESCE(config #> '{storage_config, redis, scan_count}', config #> '{storage_config, redis, extra_options, scan_count}'),
+                    'namespace', COALESCE(config #> '{storage_config, redis, namespace}', config #> '{storage_config, redis, extra_options, namespace}')
                   )
                 )
               )

--- a/kong/plugins/rate-limiting/migrations/006_350_to_360.lua
+++ b/kong/plugins/rate-limiting/migrations/006_350_to_360.lua
@@ -9,15 +9,15 @@ return {
             || jsonb_build_object(
                 'redis',
                 jsonb_build_object(
-                    'host', config->'redis_host',
-                    'port', config->'redis_port',
-                    'password', config->'redis_password',
-                    'username', config->'redis_username',
-                    'ssl', config->'redis_ssl',
-                    'ssl_verify', config->'redis_ssl_verify',
-                    'server_name', config->'redis_server_name',
-                    'timeout', config->'redis_timeout',
-                    'database', config->'redis_database'
+                    'host', COALESCE(config->'redis_host', config #> '{redis, host}'),
+                    'port', COALESCE(config->'redis_port', config #> '{redis, port}'),
+                    'password', COALESCE(config->'redis_password', config #> '{redis, password}'),
+                    'username', COALESCE(config->'redis_username', config #> '{redis, username}'),
+                    'ssl', COALESCE(config->'redis_ssl', config #> '{redis, ssl}'),
+                    'ssl_verify', COALESCE(config->'redis_ssl_verify', config #> '{redis, ssl_verify}'),
+                    'server_name', COALESCE(config->'redis_server_name', config #> '{redis, server_name}'),
+                    'timeout', COALESCE(config->'redis_timeout', config #> '{redis, timeout}'),
+                    'database', COALESCE(config->'redis_database', config #> '{redis, database}')
                 )
             )
             WHERE name = 'rate-limiting';

--- a/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
+++ b/kong/plugins/response-ratelimiting/migrations/001_350_to_360.lua
@@ -9,15 +9,15 @@ return {
             || jsonb_build_object(
               'redis',
               jsonb_build_object(
-                'host', config->'redis_host',
-                'port', config->'redis_port',
-                'password', config->'redis_password',
-                'username', config->'redis_username',
-                'ssl', config->'redis_ssl',
-                'ssl_verify', config->'redis_ssl_verify',
-                'server_name', config->'redis_server_name',
-                'timeout', config->'redis_timeout',
-                'database', config->'redis_database'
+                'host', COALESCE(config->'redis_host', config #> '{redis, host}'),
+                'port', COALESCE(config->'redis_port', config #> '{redis, port}'),
+                'password', COALESCE(config->'redis_password', config #> '{redis, password}'),
+                'username', COALESCE(config->'redis_username', config #> '{redis, username}'),
+                'ssl', COALESCE(config->'redis_ssl', config #> '{redis, ssl}'),
+                'ssl_verify', COALESCE(config->'redis_ssl_verify', config #> '{redis, ssl_verify}'),
+                'server_name', COALESCE(config->'redis_server_name', config #> '{redis, server_name}'),
+                'timeout', COALESCE(config->'redis_timeout', config #> '{redis, timeout}'),
+                'database', COALESCE(config->'redis_database', config #> '{redis, database}')
               )
             )
             WHERE name = 'response-ratelimiting';


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The migrations should be reentrant. This migration was working well on it's own but it tried to pull data from "old" columns. However if a user runs `kong migrations finish` and then `kong migrations up -f` it would have tried to pull data from nonexisting columns overwriting it's current data. Therefore we need those COALESCE statements so that if the "old" data is not there then it tries to read it from the "new" columns.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] N/A ~~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
[KAG-4419](https://konghq.atlassian.net/browse/KAG-4419)


[KAG-4419]: https://konghq.atlassian.net/browse/KAG-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ