### PR TITLE
chore(workflows): label-schema to overwrite slack message with pr title and footer as pr link

### DIFF
--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -13,4 +13,4 @@ jobs:
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}
         SLACK_MESSAGE: ${{ github.event.pull_request.title }}
-        SLACK_FOOTER: "${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+        SLACK_FOOTER: "<${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}>"

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -12,4 +12,5 @@ jobs:
       continue-on-error: true
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}
-        SLACK_FOOTER: ${{ github.event.pull_request.title }}
+        SLACK_MESSAGE: ${{ github.event.pull_request.title }}
+        SLACK_FOOTER: "${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Update rtBot to overwrite its message with the PR title, which is currently in the footer, and update the footer with the PR link. The existing message does not provide a clear understanding of the schema-related changes. This change will allow us to open the schema files directly from the message footer.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
