### PR TITLE
chore(CI): replace `bazelbuild/setup-bazelisk` with `bazel-contrib/setup-bazel`

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -1,24 +1,209 @@
-# please see matrix-full.yml for meaning of each field
 build-packages:
+# label: used to distinguish artifacts for later use
+# image: docker image name if the build is running in side a container
+# package: package type
+# package-type: the nfpm packaging target, //:kong_{package} target; only used when package is rpm
+# bazel-args: additional bazel build flags
+# check-manifest-suite: the check manifest suite as defined in scripts/explain_manifest/config.py
+
+# Ubuntu
+- label: ubuntu-20.04
+  image: ubuntu:20.04
+  package: deb
+  check-manifest-suite: ubuntu-20.04-amd64
 - label: ubuntu-22.04
-  os: ubuntu-22.04
   package: deb
   check-manifest-suite: ubuntu-22.04-amd64
+- label: ubuntu-22.04-arm64
+  package: deb
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
+  check-manifest-suite: ubuntu-22.04-arm64
+
+# Debian
+- label: debian-10
+  image: debian:10
+  package: deb
+  check-manifest-suite: debian-10-amd64
+- label: debian-11
+  image: debian:11
+  package: deb
+  check-manifest-suite: debian-11-amd64
+- label: debian-12
+  image: debian:12
+  package: deb
+  check-manifest-suite: debian-12-amd64
+
+# RHEL
+- label: rhel-7
+  image: centos:7
+  package: rpm
+  package-type: el7
+  bazel-args: --//:wasmx_el7_workaround=true --//:brotli=False
+  check-manifest-suite: el7-amd64
+- label: rhel-8
+  image: rockylinux:8
+  package: rpm
+  package-type: el8
+  check-manifest-suite: el8-amd64
+- label: rhel-9
+  image: rockylinux:9
+  package: rpm
+  package-type: el9
+  check-manifest-suite: el9-amd64
+- label: rhel-9-arm64
+  package: rpm
+  package-type: el9
+  bazel-args: --platforms=//:rhel9-crossbuild-aarch64 --//:brotli=False
+  check-manifest-suite: el9-arm64
+
+  # Amazon Linux
+- label: amazonlinux-2
+  image: amazonlinux:2
+  package: rpm
+  package-type: aws2
+  check-manifest-suite: amazonlinux-2-amd64
+- label: amazonlinux-2023
+  image: amazonlinux:2023
+  package: rpm
+  package-type: aws2023
+  check-manifest-suite: amazonlinux-2023-amd64
+- label: amazonlinux-2023-arm64
+  package: rpm
+  package-type: aws2023
+  bazel-args: --platforms=//:aws2023-crossbuild-aarch64 --//:brotli=False
+  check-manifest-suite: amazonlinux-2023-arm64
 
 build-images:
+# Only build images for the latest version of each major release.
+
+# label: used as compose docker image label ${github.sha}-${label}
+# base-image: docker image to use as base
+# package: package type
+# artifact-from: label of build-packages to use
+# artifact-from-alt: another label of build-packages to use for downloading package (to build multi-arch image)
+# docker-platforms: comma separated list of docker buildx platforms to build for
+
+# Ubuntu
 - label: ubuntu
   base-image: ubuntu:22.04
   package: deb
   artifact-from: ubuntu-22.04
+  artifact-from-alt: ubuntu-22.04-arm64
+  docker-platforms: linux/amd64, linux/arm64
+
+# Debian
+- label: debian
+  base-image: debian:12-slim
+  package: deb
+  artifact-from: debian-12
+
+# RHEL
+- label: rhel
+  base-image: registry.access.redhat.com/ubi9
+  package: rpm
+  rpm_platform: el9
+  artifact-from: rhel-9
+  artifact-from-alt: rhel-9-arm64
+  docker-platforms: linux/amd64, linux/arm64
 
 smoke-tests:
 - label: ubuntu
+- label: debian
+- label: rhel
 
 scan-vulnerabilities:
 - label: ubuntu
+- label: debian
+- label: rhel
 
 release-packages:
+# Ubuntu
+- label: ubuntu-20.04
+  package: deb
+  artifact-from: ubuntu-20.04
+  artifact-version: 20.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-22.04
+  package: deb
+  artifact-from: ubuntu-22.04
+  artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-22.04-arm64
+  package: deb
+  artifact-from: ubuntu-22.04-arm64
+  artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.arm64.deb
+
+# Debian
+- label: debian-10
+  package: deb
+  artifact-from: debian-10
+  artifact-version: 10
+  artifact-type: debian
+  artifact: kong.amd64.deb
+- label: debian-11
+  package: deb
+  artifact-from: debian-11
+  artifact-version: 11
+  artifact-type: debian
+  artifact: kong.amd64.deb
+- label: debian-12
+  package: deb
+  artifact-from: debian-12
+  artifact-version: 12
+  artifact-type: debian
+  artifact: kong.amd64.deb
+
+# RHEL
+- label: rhel-7
+  package: rpm
+  artifact-from: rhel-7
+  artifact-version: 7
+  artifact-type: rhel
+  artifact: kong.el7.amd64.rpm
+- label: rhel-8
+  package: rpm
+  artifact-from: rhel-8
+  artifact-version: 8
+  artifact-type: rhel
+  artifact: kong.el8.amd64.rpm
+- label: rhel-9
+  package: rpm
+  artifact-from: rhel-9
+  artifact-version: 9
+  artifact-type: rhel
+  artifact: kong.el9.amd64.rpm
+- label: rhel-9-arm64
+  package: rpm
+  artifact-from: rhel-9-arm64
+  artifact-version: 9
+  artifact-type: rhel
+  artifact: kong.el9.arm64.rpm
+
+# Amazon Linux
+- label: amazonlinux-2
+  package: rpm
+  artifact-from: amazonlinux-2
+  artifact-version: 2
+  artifact-type: amazonlinux
+  artifact: kong.aws2.amd64.rpm
+- label: amazonlinux-2023
+  package: rpm
+  artifact-from: amazonlinux-2023
+  artifact-version: 2023
+  artifact-type: amazonlinux
+  artifact: kong.aws2023.amd64.rpm
+- label: amazonlinux-2023-arm64
+  package: rpm
+  artifact-from: amazonlinux-2023-arm64
+  artifact-version: 2023
+  artifact-type: amazonlinux
+  artifact: kong.aws2023.arm64.rpm
 
 release-images:
 - label: ubuntu
-  package: deb
+- label: debian
+- label: rhel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,12 @@ jobs:
         grep -v '^#' .requirements >> $GITHUB_ENV
 
     - name: Setup Bazel
-      uses: bazelbuild/setup-bazelisk@95c9bf48d0c570bb3e28e57108f3450cd67c1a44 # v2.0.0
+      uses: bazel-contrib/setup-bazel@7d9487bea505c4779367dc5b21dfc4dc6a02d21d # v0.8.3
+      with:
+        bazelisk-cache: true
+        disk-cache: false
+        external-cache: false
+        repository-cache: false
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,9 @@ jobs:
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-        sudo find / -name 'bazel'
+        # find bazel executable
+        find / -name bazel -type f
+        exit 1
         sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 automake \
                 build-essential \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,10 +209,11 @@ jobs:
 
     - name: Setup Bazel
       run: |
-        wget -O /bin/bazelisk "${BAZELISK_DOWNLOAD_URL}"
+        wget -O /usr/bin/bazelisk "${BAZELISK_DOWNLOAD_URL}"
         # integrety check
         echo "${BAZELISK_SHA256}  /bin/bazelisk" | sha256sum -c -
-        ln -s /bin/bazelisk /bin/bazel
+        ln -s /usr/bin/bazelisk /usr/bin/bazel
+        which bazel
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,7 @@ jobs:
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
+        sudo find / -name 'bazel'
         sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 automake \
                 build-essential \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,9 +217,6 @@ jobs:
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'
       run: |
-        # find bazel executable
-        find / -name bazel -type f
-        exit 1
         sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 automake \
                 build-essential \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,11 +209,11 @@ jobs:
 
     - name: Setup Bazel
       run: |
-        wget -O /usr/bin/bazelisk "${BAZELISK_DOWNLOAD_URL}"
+        sudo wget -O /usr/bin/bazelisk "${BAZELISK_DOWNLOAD_URL}"
         # integrety check
         echo "${BAZELISK_SHA256}  /bin/bazelisk" | sha256sum -c -
-        ln -s /usr/bin/bazelisk /usr/bin/bazel
-        chmod +x /usr/bin/bazelisk
+        sudo ln -s /usr/bin/bazelisk /usr/bin/bazel
+        sudo chmod +x /usr/bin/bazelisk
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,8 +213,7 @@ jobs:
         # integrety check
         echo "${BAZELISK_SHA256}  /bin/bazelisk" | sha256sum -c -
         ln -s /usr/bin/bazelisk /usr/bin/bazel
-        echo $PATH
-        which bazel
+        chmod +x /usr/bin/bazelisk
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,14 +125,14 @@ jobs:
       if: matrix.package == 'rpm' && matrix.image != ''
       run: |
         # tar/gzip is needed to restore git cache (if available)
-        yum install -y tar gzip which file zlib-devel
+        yum install -y tar gzip which file zlib-devel wget
 
     - name: Early Deb in Container Setup
       if: matrix.package == 'deb' && matrix.image != ''
       run: |
         # tar/gzip is needed to restore git cache (if available)
         apt-get update
-        apt-get install -y git tar gzip file sudo
+        apt-get install -y git tar gzip file sudo wget
 
     - name: Cache Git
       id: cache-git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,7 @@ jobs:
         # integrety check
         echo "${BAZELISK_SHA256}  /bin/bazelisk" | sha256sum -c -
         ln -s /usr/bin/bazelisk /usr/bin/bazel
+        echo $PATH
         which bazel
 
     - name: Install Deb Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@7d9487bea505c4779367dc5b21dfc4dc6a02d21d # v0.8.3
       with:
-        bazelisk-cache: true
+        bazelisk-cache: false
         disk-cache: false
         external-cache: false
         repository-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,10 @@ jobs:
     name: Build & Package - ${{ matrix.label }}
     environment: ${{ needs.metadata.outputs.deploy-environment }}
 
+    env:
+      BAZELISK_DOWNLOAD_URL: https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-${{ endsWith(matrix.label, 'arm64') && 'arm64' || 'amd64' }}
+      BAZELISK_SHA256: ${{ endsWith(matrix.label, 'arm64') && '861a16ba9979613e70bd3d2f9d9ab5e3b59fe79471c5753acdc9c431ab6c9d94' || 'd28b588ac0916abd6bf02defb5433f6eddf7cba35ffa808eabb65a44aab226f7' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -204,12 +208,11 @@ jobs:
         grep -v '^#' .requirements >> $GITHUB_ENV
 
     - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@7d9487bea505c4779367dc5b21dfc4dc6a02d21d # v0.8.3
-      with:
-        bazelisk-cache: false
-        disk-cache: false
-        external-cache: false
-        repository-cache: false
+      run: |
+        wget -O /bin/bazelisk "${BAZELISK_DOWNLOAD_URL}"
+        # integrety check
+        echo "${BAZELISK_SHA256}  /bin/bazelisk" | sha256sum -c -
+        ln -s /bin/bazelisk /bin/bazel
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Summary

We should consider migrating to [bazel-contrib/setup-bazel](https://github.com/bazel-contrib/setup-bazel) since [bazelbuild/setup-bazelisk](https://github.com/bazelbuild/setup-bazelisk) has been archived.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-4450]_


[KAG-4450]: https://konghq.atlassian.net/browse/KAG-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ