### PR TITLE
fix(ai-proxy): removed compat fields pre-3.7

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -125,5 +125,15 @@ return {
     zipkin = {
       "propagation",
     },
+    ai_proxy = {
+      "response_streaming",
+      "model.options.upstream_path",
+    },
+    ai_request_transformer = {
+      "llm.model.options.upstream_path",
+    },
+    ai_response_transformer = {
+      "llm.model.options.upstream_path",
+    },
   },
 }


### PR DESCRIPTION
Add azure fields to removed_fields.lua to address CP/DP version compatibility issue reported at https://konghq.atlassian.net/browse/KAG-4356

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [x] The Pull Request has backports to all the versions it needs to cover
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-4356
