### PR TITLE
chore(conf): remove cluster RPC has been forcibly disabled warning

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -936,7 +936,6 @@ local function load(path, custom_conf, opts)
 
   -- TODO: remove this when cluster_rpc is ready for GA
   if conf.cluster_rpc then
-    log.warn("Cluster RPC has been forcibly disabled")
     conf.cluster_rpc = "off"
   end
 


### PR DESCRIPTION
### Summary

These warnings are not needed and make our users to unnecessarily think that is there something wrong with their installation.

Example:

```zsh
❯ ./bin/kong prepare
2024/05/10 11:54:18 [warn] Cluster RPC has been forcibly disabled
```

No value with that.


KAG-4407