### PR TITLE
fix(pdk) - respect the trace flags from the parent span (if present)

### DIFF
--- a/changelog/unreleased/kong/respect-parent-span-sampledflags.yml
+++ b/changelog/unreleased/kong/respect-parent-span-sampledflags.yml
@@ -1,0 +1,3 @@
+message: "**Opentelemetry**: respect the trace flags from the parent span (if present) before applying sampling"
+type: bugfix
+scope: PDK

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -563,9 +563,9 @@ local function new_tracer(name, options)
 
   --- Get the sampling decision result
   --
-  -- Uses a parent-based sampler when the parent has sampled flag == false
-  -- to inherit the non-recording decision from the parent span, or when 
-  -- trace_id is not available.
+  -- Uses a parent-based sampler when the parent has sampled flag set
+  -- to inherit the decision from the parent span, or when trace_id is
+  -- not available.
   --
   -- Else, apply the probability-based should_sample decision.
   --
@@ -587,7 +587,7 @@ local function new_tracer(name, options)
       -- a dummy created only to propagate headers
       sampled = false
 
-    elseif parent_should_sample == false or not trace_id then
+    elseif parent_should_sample ~= nil or not trace_id then
       -- trace_id can be nil when tracing instrumentations are disabled
       -- and Kong is configured to only do headers propagation
       sampled = parent_should_sample


### PR DESCRIPTION
### Summary
Kong respects the `should_sample` decision from a parent span if one was provided. Previously it was not doing this resulting in incomplete traces.

When using kong as an internal api gateway we are seeing incomplete traces. The logs show that the following appears to be happening:

(this is based on a sampling rate of 0.01)

- Service A makes a request to Service B with no traceparent header specified
- Kong generates a traceparent header and specifies trace flags of `"01"` (i.e. the trace should be sampled)
- Service B handles the request from Service A and ingests the traceparent header
- Service B then makes a request to Service C, setting the traceparent header appropriately (i.e. using flags `"01"`)
- Kong then resets the trace flags to `"00"` (i.e. the trace should *not* be sampled)
- Service C handles the request from Service B and, respecting the flags from the traceparent header, does not sample the trace

This results in Kong and Services A and B sampling the trace, but Service C does not, and so we get an incomplete trace.

I identified the `get_sampling_decision` method as the most likely place where the issue occurs, and since `parent_should_sample` is a tri-state boolean (i.e. it can be `true`, `false`, or `nil`) it makes most sense (to me) to respect the value of `parent_should_sample` if it exists.

I tested this locally and it behaves as I would expect; when a traceparent header is included in the request, then the flags are respected, however if not, probabilistic sampling is applied.

However rereading the code, I can't work out *why* that should be the case, since the probablistic sampler is deterministic based on trace id (i.e. the same trace-id will always return the same outcome). Even stepping through the code, I couldn't work out exactly what was going on. It seems likely to me that it's something to do with how the root span is constructed, but I couldn't tell for sure.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
