### PR TITLE
chore(clustering): cleanup redundant checkers

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -30,46 +30,12 @@ local compatible_checkers = {
       for _, plugin in ipairs(config_table.plugins or {}) do
         if plugin.name == 'ai-proxy' then
           local config = plugin.config
-          if config.model and config.model.options then
-            if config.response_streaming then
-              config.response_streaming = nil
-              log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
-                              ' response_streaming == nil, because it is not supported' ..
-                              ' in this release',
-                              dp_version, log_suffix)
-              has_update = true
-            end
-
-            if config.model.options.upstream_path then
-              config.model.options.upstream_path = nil
-              log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
-                              ' upstream_path == nil, because it is not supported' ..
-                              ' in this release',
-                              dp_version, log_suffix)
-              has_update = true
-            end
-          end
-
           if config.route_type == "preserve" then
             config.route_type = "llm/v1/chat"
             log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
                               ' route_type == "llm/v1/chat", because preserve' ..
                               ' mode is not supported in this release',
                               dp_version, log_suffix)
-            has_update = true
-          end
-        end
-
-        if plugin.name == 'ai-request-transformer' or plugin.name == 'ai-response-transformer' then
-          local config = plugin.config
-          if config.llm.model
-              and config.llm.model.options
-              and config.llm.model.options.upstream_path then
-            config.llm.model.options.upstream_path = nil
-            log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
-                            ' upstream_path == nil, because it is not supported' ..
-                            ' in this release',
-                            dp_version, log_suffix)
             has_update = true
           end
         end


### PR DESCRIPTION
### Summary

some logic in checkers is made redundant by the fact [the same fields exist in removed_fields](https://github.com/Kong/kong/blob/d112f3c09bf049fe4614dc5f38e45cba5adce0f7/kong/clustering/compat/removed_fields.lua#L128-L137). This commit removes the redundant logic

### Checklist

- [x] The Pull Request has tests (removed_fields already covered by tests)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4457
