### PR TITLE
fix(aws-lambda): add missing version field into aws gateway compatible payload

### DIFF
--- a/changelog/unreleased/kong/fix-aws-lambda-gateway-compat-version-field.yml
+++ b/changelog/unreleased/kong/fix-aws-lambda-gateway-compat-version-field.yml
@@ -1,0 +1,3 @@
+message: "**AWS-Lambda**: fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled"
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-aws-lambda-gateway-compat-version-field.yml
+++ b/changelog/unreleased/kong/fix-aws-lambda-gateway-compat-version-field.yml
@@ -1,3 +1,3 @@
-message: "**AWS-Lambda**: fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled"
+message: "**AWS-Lambda**: Fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled."
 type: bugfix
 scope: Plugin

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -246,6 +246,7 @@ local function aws_serializer(ctx, config)
   end
 
   local request = {
+    version                         = "1.0",
     resource                        = ctx.router_matches.uri,
     path                            = path,
     httpMethod                      = var.request_method,

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -88,6 +88,7 @@ describe("[AWS Lambda] aws-gateway input", function()
     local out = aws_serialize()
 
     assert.same({
+        version = "1.0",
         httpMethod = "GET",
         path = "/123/strip/more",
         resource = "/(?<version>\\d+)/strip",
@@ -165,6 +166,7 @@ describe("[AWS Lambda] aws-gateway input", function()
     local out = aws_serialize()
 
     assert.same({
+        version = "1.0",
         httpMethod = "GET",
         path = "/plain/strip/more",
         resource = "/plain/strip",
@@ -262,6 +264,7 @@ describe("[AWS Lambda] aws-gateway input", function()
         local out = aws_serialize()
 
         assert.same({
+          version = "1.0",
           body = tdata.body_out,
           headers = {
             ["Content-Type"] = tdata.ct,


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds a missing `version` field into the `aws-lambda` plugin's `awsgateway_compatible` payload.
 
 The `awsgateway_compatible` field provides a way to send a wrapped request body which is compatible with the format of AWS API gateway's proxy integration. The format of the payload is described here: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
 
Some framework/projects that used to build Lambda function may check the `version` field sent by API gateway, so that they can apply different extracting logic according to different versions of payload. For example the logic in `mangum` looks like: https://github.com/jordaneremieff/mangum/blob/6086c268f32571c01f18e20875430db14a0570bc/mangum/handlers/api_gateway.py#L157-L176


The PR adds the missing `version` field for better compatibility.



<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5949
