### PR TITLE
 fix(core): fix a deadlock issue on coroutine mutex

### DIFF
--- a/changelog/unreleased/kong/fix-coroutine-deadlock.yml
+++ b/changelog/unreleased/kong/fix-coroutine-deadlock.yml
@@ -1,0 +1,5 @@
+message: >-
+  Fixed an issue where deadlock happens when the light thread associated with coroutine mutex job
+  was killed.
+type: bugfix
+scope: Core

--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -135,9 +135,9 @@ function concurrency.with_coroutine_mutex(opts, fn)
     end
   end
 
+  running_jobs[opts_name] = true
   local pok, ok, err = pcall(fn)
 
-  running_jobs[opts_name] = true
   if lok then
     -- release lock
     semaphore:post(1)

--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -109,6 +109,15 @@ function concurrency.with_coroutine_mutex(opts, fn)
     semaphore:post(1)
   end
 
+  -- to resolve deadlock issue in case the worker event thread
+  -- associated with `pcall(fn)` below got killed
+  -- and the `:post(1)` followed is skipped.
+  if semaphore:count() <= 0 then
+    -- the `:post(1)` operation is guaranteed to run immediately
+    -- as the `:count()` does not yeild
+    semaphore:post(1)
+  end
+
   -- acquire lock
   local lok, err = semaphore:wait(timeout)
   if not lok then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

fix(core): fix a deadlock issue on coroutine mutex

Coroutine mutex uses semaphore to ensure only one job
is running for a specific event (e.g. `reconfigure_handler`).

However, if the coroutine job is wrapped within a light thread
(e.g. worker event's `event_thread`) and the associated thread
was killed in the middle of the job, semaphore post followed would
be skipped.

Light threads would be killed when it cannot connect to the worker
`0` which is common if the worker `0` is OOM Killed by OS.

All subsequent jobs of the same event would wait and timeout, as
there is not any semaphore resource available.

Please refer to the analysis here https://konghq.atlassian.net/browse/FTI-5930?focusedCommentId=131903.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5930]_


[FTI-5930]: https://konghq.atlassian.net/browse/FTI-5930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ