### PR TITLE
fix(prometheus): improve logging when having the inconsistent labels count

### DIFF
--- a/changelog/unreleased/kong/improve-prometheus-error-logging.yml
+++ b/changelog/unreleased/kong/improve-prometheus-error-logging.yml
@@ -1,4 +1,4 @@
 message: |
-  **prometheus**: Improve logging when having the inconsistent labels count.
+  **Prometheus**: Improved error logging when having inconsistent labels count.
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/improve-prometheus-error-logging.yml
+++ b/changelog/unreleased/kong/improve-prometheus-error-logging.yml
@@ -1,0 +1,4 @@
+message: |
+  **prometheus**: Improve logging when having the inconsistent labels count.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -377,8 +377,8 @@ local function lookup_or_create(self, label_values)
   local cnt = label_values and #label_values or 0
   -- specially, if first element is nil, # will treat it as "non-empty"
   if cnt ~= self.label_count or (self.label_count > 0 and label_values[1] == nil) then
-    return nil, string.format("inconsistent labels count, expected %d, got %d",
-                              self.label_count, cnt)
+    return nil, string.format("metric '%s' has inconsistent labels count, expected %d, got %d",
+      self.name, self.label_count, cnt)
   end
   local t = self.lookup
   if label_values then


### PR DESCRIPTION
### Summary

Currently, the Prometheus plugin will log the following error if we have encountered an inconsistent label count while debugging:

```
[error]... inconsistent labels count, expected 6, got 5
```

It's hard to identify which metric is going wrong, and it will be helpful if we can bring the metric name as well:

```
[error]... metric 'bandwidth_bytes' has the inconsistent labels count, expected 6, got 5

```
### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
