### PR TITLE
feat(db/schema): do not allow setting priority with traditional route in mixed mode

### DIFF
--- a/changelog/unreleased/kong/feat-dont-allow-priority-with-others.yml
+++ b/changelog/unreleased/kong/feat-dont-allow-priority-with-others.yml
@@ -1,0 +1,5 @@
+message: |
+  Do not allow setting priority field in traditional mode route
+  When 'router_flavor' is configrued as 'expressions'.
+type: feature
+scope: Core

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -84,13 +84,15 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
                   "simultaneously"
     end
 
-    if not is_expression_empty and not is_null(entity.regex_priority) then
+    local is_regex_priority_exists = not is_null(entity.regex_priority) and entity.regex_priority ~= 0
+    if not is_expression_empty and is_regex_priority_exists then
       return nil, "Router Expression failed validation: " ..
                   "cannot set 'regex_priority' with 'expression' " ..
                   "simultaneously"
     end
 
-    if not is_others_empty and not is_null(entity.priority) then
+    local is_priority_exists = not is_null(entity.priority) and entity.priority ~= 0
+    if not is_others_empty and is_priority_exists then
       return nil, "Router Expression failed validation: " ..
                   "cannot set 'priority' with " ..
                   "'methods', 'hosts', 'paths', 'headers', 'snis', 'sources' or 'destinations' " ..
@@ -127,6 +129,7 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
                         "snis", "sources", "destinations",
                         "methods", "hosts", "paths", "headers",
                         "expression",
+                        "regex_priority", "priority",
                       },
       run_with_missing_fields = true,
       fn = validate_route,

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -84,15 +84,17 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
                   "simultaneously"
     end
 
-    local is_regex_priority_exists = not is_null(entity.regex_priority) and entity.regex_priority ~= 0
-    if not is_expression_empty and is_regex_priority_exists then
+    local is_regex_priority_empty = is_null(entity.regex_priority) or
+                                    entity.regex_priority == 0    -- default value 0 means 'no set'
+    if not is_expression_empty and not is_regex_priority_empty then
       return nil, "Router Expression failed validation: " ..
                   "cannot set 'regex_priority' with 'expression' " ..
                   "simultaneously"
     end
 
-    local is_priority_exists = not is_null(entity.priority) and entity.priority ~= 0
-    if not is_others_empty and is_priority_exists then
+    local is_priority_empty = is_null(entity.priority) or
+                              entity.priority == 0    -- default value 0 means 'no set'
+    if not is_others_empty and not is_priority_empty then
       return nil, "Router Expression failed validation: " ..
                   "cannot set 'priority' with " ..
                   "'methods', 'hosts', 'paths', 'headers', 'snis', 'sources' or 'destinations' " ..

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -84,6 +84,19 @@ if kong_router_flavor == "traditional_compatible" or kong_router_flavor == "expr
                   "simultaneously"
     end
 
+    if not is_expression_empty and not is_null(entity.regex_priority) then
+      return nil, "Router Expression failed validation: " ..
+                  "cannot set 'regex_priority' with 'expression' " ..
+                  "simultaneously"
+    end
+
+    if not is_others_empty and not is_null(entity.priority) then
+      return nil, "Router Expression failed validation: " ..
+                  "cannot set 'priority' with " ..
+                  "'methods', 'hosts', 'paths', 'headers', 'snis', 'sources' or 'destinations' " ..
+                  "simultaneously"
+    end
+
     local schema = get_schema(entity.protocols)
     local exp = get_expression(entity)
 

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1347,6 +1347,40 @@ describe("routes schema (flavor = expressions)", function()
       snis           = { "example.org" },
       sources        = {{ ip = "127.0.0.1" }},
       destinations   = {{ ip = "127.0.0.1" }},
+
+      regex_priority = 100,
+    }
+
+    for k, v in pairs(others) do
+      route[k] = v
+
+      local r = Routes:process_auto_fields(route, "insert")
+      local ok, errs = Routes:validate_insert(r)
+      assert.falsy(ok)
+      assert.truthy(errs["@entity"])
+
+      route[k] = nil
+    end
+  end)
+
+  it("fails when set 'priority' and others simultaneously", function()
+    local route = {
+      id             = a_valid_uuid,
+      name           = "my_route",
+      protocols      = { "http" },
+      priority       = 100,
+      service        = { id = another_uuid },
+    }
+
+    local others = {
+      methods        = { "GET", "POST" },
+      hosts          = { "example.com" },
+      headers        = { location = { "location-1" } },
+      paths          = { "/ovo" },
+
+      snis           = { "example.org" },
+      sources        = {{ ip = "127.0.0.1" }},
+      destinations   = {{ ip = "127.0.0.1" }},
     }
 
     for k, v in pairs(others) do


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Notice: `regex_priority` and `priority` have the default value `0`, so we think `0` is equivalent  to "not set".

KAG-4411

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
