### PR TITLE
fix(router/atc): uri replace didn't works well if contains the optional group

### DIFF
--- a/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
@@ -1,0 +1,4 @@
+message: |
+  **reqeust-transformer**: Fixed the uri replace didn't works well if contains the optional group.
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue where the URI captures are unavailable when an optional group is absent.
+  Fixed an issue where the URI captures are unavailable when the first capture group is absent.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
@@ -1,4 +1,4 @@
 message: |
-  **reqeust-transformer**: Fixed an issue where the URI captures are unavailable when an optional group is absent.
+  Fixed an issue where the URI captures are unavailable when an optional group is absent.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
@@ -1,4 +1,4 @@
 message: |
-  **reqeust-transformer**: Fixed the uri replace didn't works well if contains the optional group.
+  **reqeust-transformer**: Fixed an issue where the URI captures are unavailable when an optional group is absent.
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/unreleased/kong/fix-request-transformer-uri-replace.yml
@@ -1,4 +1,4 @@
 message: |
   **reqeust-transformer**: Fixed an issue where the URI captures are unavailable when an optional group is absent.
 type: bugfix
-scope: Plugin
+scope: Core

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -2,7 +2,7 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
-local isempty= require("table.isempty")
+local tb_nkeys = require("table.nkeys")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
 local utils = require("kong.router.utils")
@@ -384,7 +384,7 @@ function _M:matching(params)
   local request_prefix = matched_route.strip_path and matched_path or nil
 
   local uri_captures = nil
-  if matched_path and captures and not isempty(captures) then
+  if matched_path and captures and tb_nkeys(captures) > 1 then
     uri_captures = captures
   end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -349,6 +349,9 @@ end
 -- this function tests if there are captures other than the full path
 -- by checking if there are 2 or more than 2 keys
 local function has_capture(captures)
+  if not captures then
+    return nil
+  end
   local next_i = next(captures)
   return next_i and next(captures, next_i) ~= nil
 end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -2,9 +2,9 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
-local tb_nkeys = require("table.nkeys")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
+local tb_nkeys = require("table.nkeys")
 local utils = require("kong.router.utils")
 local transform = require("kong.router.transform")
 local rat = require("kong.tools.request_aware_table")
@@ -384,7 +384,9 @@ function _M:matching(params)
   local request_prefix = matched_route.strip_path and matched_path or nil
 
   local uri_captures = nil
-  if matched_path and captures and tb_nkeys(captures) > 1 then
+  -- The whole matched uri will be put in captures[0], so we need to check
+  -- the number of table keys >= 2 to determine if there has any uri captured.
+  if matched_path and captures and tb_nkeys(captures) >= 2 then
     uri_captures = captures
   end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -15,6 +15,7 @@ local assert = assert
 local setmetatable = setmetatable
 local pairs = pairs
 local ipairs = ipairs
+local next = next
 local max = math.max
 
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -2,7 +2,7 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
-local pl_tablex = require("pl.tablex")
+local isempty= require("table.isempty")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
 local utils = require("kong.router.utils")
@@ -384,7 +384,7 @@ function _M:matching(params)
   local request_prefix = matched_route.strip_path and matched_path or nil
 
   local uri_captures = nil
-  if matched_path and captures and pl_tablex.size(captures) > 1 then
+  if matched_path and captures and not isempty(captures) then
     uri_captures = captures
   end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -385,8 +385,8 @@ function _M:matching(params)
 
   local uri_captures = nil
   -- The whole matched uri will be put in captures[0], so we need to check
-  -- the number of table keys >= 2 to determine if there has any uri captured.
-  if matched_path and captures and tb_nkeys(captures) >= 2 then
+  -- the number of table keys >= 2 to determine if there is any uri captured.
+  if captures and tb_nkeys(captures) >= 2 then
     uri_captures = captures
   end
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -2,6 +2,7 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
+local pl_tablex = require("pl.tablex")
 local lrucache = require("resty.lrucache")
 local tb_new = require("table.new")
 local utils = require("kong.router.utils")
@@ -382,12 +383,16 @@ function _M:matching(params)
 
   local request_prefix = matched_route.strip_path and matched_path or nil
 
+    local uri_captures = nil
+    if matched_path and captures and pl_tablex.size(captures) > 1 then
+      uri_captures = captures
+    end
   return {
     route           = matched_route,
     service         = service,
     prefix          = request_prefix,
     matches = {
-      uri_captures = (captures and captures[1]) and captures or nil,
+      uri_captures = uri_captures
     },
     upstream_url_t = {
       type = service_hostname_type,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -344,7 +344,7 @@ local function set_upstream_uri(req_uri, match_t)
 end
 
 
--- captures has the form { [0] = full_path, [1] = capture1, [2] = capture2, ... }
+-- captures has the form { [0] = full_path, [1] = capture1, [2] = capture2, ..., ["named1"] = named1, ... }
 -- and captures[0] will be the full matched path
 -- this function tests if there are captures other than the full path
 -- by checking if there are 2 or more than 2 keys

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -350,7 +350,7 @@ end
 -- by checking if there are 2 or more than 2 keys
 local function has_capture(captures)
   if not captures then
-    return nil
+    return false
   end
   local next_i = next(captures)
   return next_i and next(captures, next_i) ~= nil

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -383,10 +383,11 @@ function _M:matching(params)
 
   local request_prefix = matched_route.strip_path and matched_path or nil
 
-    local uri_captures = nil
-    if matched_path and captures and pl_tablex.size(captures) > 1 then
-      uri_captures = captures
-    end
+  local uri_captures = nil
+  if matched_path and captures and pl_tablex.size(captures) > 1 then
+    uri_captures = captures
+  end
+
   return {
     route           = matched_route,
     service         = service,

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -393,7 +393,7 @@ function _M:matching(params)
     service         = service,
     prefix          = request_prefix,
     matches = {
-      uri_captures = uri_captures
+      uri_captures = uri_captures,
     },
     upstream_url_t = {
       type = service_hostname_type,

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3484,7 +3484,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         assert.is_nil(match_t.matches.headers)
       end)
 
-      it("uri_captreus works well with the optional capture group. Fix #13014", function()
+      it("uri_captures works well with the optional capture group. Fix #13014", function()
         local use_case = {
           {
             service = service,

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3502,7 +3502,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         local match_t = router:exec()
         assert.equal("users/", match_t.matches.uri_captures[1])
         assert.equal("profile", match_t.matches.uri_captures.subpath)
-        assert.same(nil, match_t.matches.uri_captures.scope)
+        assert.is_nil(match_t.matches.uri_captures.scope)
       end)
 
       it("returns uri_captures from a [uri regex]", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3484,6 +3484,26 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         assert.is_nil(match_t.matches.headers)
       end)
 
+      it("uri_captreus works well with the optional capture group. Fix #13014", function()
+        local use_case = {
+          {
+            service = service,
+            route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+              paths = { [[~/(users/)?1984/(?<subpath>profile)$]] },
+            },
+          },
+        }
+
+        local router = assert(new_router(use_case))
+        local _ngx = mock_ngx("GET", "/users/1984/profile",
+          { host = "domain.org" })
+        router._set_ngx(_ngx)
+        local match_t = router:exec()
+        assert.equal("users/", match_t.matches.uri_captures[1])
+        assert.equal("profile", match_t.matches.uri_captures.subpath)
+        assert.same(nil, match_t.matches.uri_captures.scope)
+      end)
       it("returns uri_captures from a [uri regex]", function()
         local use_case = {
           {

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3496,11 +3496,13 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         }
 
         local router = assert(new_router(use_case))
-        local _ngx = mock_ngx("GET", "/users/1984/profile",
+        local _ngx = mock_ngx("GET", "/1984/profile",
                                                  { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router:exec()
-        assert.equal("users/", match_t.matches.uri_captures[1])
+        if flavor ~= "traditional" then
+          assert.is_nil(match_t.matches.uri_captures[1])
+        end
         assert.equal("profile", match_t.matches.uri_captures.subpath)
         assert.is_nil(match_t.matches.uri_captures.scope)
       end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3497,7 +3497,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         local router = assert(new_router(use_case))
         local _ngx = mock_ngx("GET", "/users/1984/profile",
-          { host = "domain.org" })
+                                                 { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router:exec()
         assert.equal("users/", match_t.matches.uri_captures[1])

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3496,13 +3496,10 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         }
 
         local router = assert(new_router(use_case))
-        local _ngx = mock_ngx("GET", "/1984/profile",
-                                                 { host = "domain.org" })
+        local _ngx = mock_ngx("GET", "/1984/profile", { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router:exec()
-        if flavor ~= "traditional" then
-          assert.is_nil(match_t.matches.uri_captures[1])
-        end
+        assert.falsy(match_t.matches.uri_captures[1])
         assert.equal("profile", match_t.matches.uri_captures.subpath)
         assert.is_nil(match_t.matches.uri_captures.scope)
       end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3504,6 +3504,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         assert.equal("profile", match_t.matches.uri_captures.subpath)
         assert.same(nil, match_t.matches.uri_captures.scope)
       end)
+
       it("returns uri_captures from a [uri regex]", function()
         local use_case = {
           {

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -1142,7 +1142,8 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local body = assert(assert.response(r).has.jsonbody())
       assert.equals("/api/v2/htest", body.vars.request_uri)
     end)
-    it("replace reqest uri with the capature prefix", function()
+
+    it("replace request uri with the capature prefix", function()
       local r = assert(client:send {
         method = "GET",
         path = "/gw/api/htest",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -131,6 +131,12 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       hosts = { "test28.test" }
     })
 
+    local route29 = bp.routes:insert({
+      hosts = { "test29.test" },
+      paths = { "~/(gw/)?api/(?<subpath>htest)$" },
+      strip_path = false
+    })
+
     bp.plugins:insert {
       route = { id = route1.id },
       name = "request-transformer",
@@ -467,6 +473,16 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       config = {
         add = {
           headers = { "X-Write-Attempt:$(shared.written = true)" },
+        }
+      }
+    }
+
+    bp.plugins:insert {
+      route = { id = route29.id },
+      name = "request-transformer",
+      config = {
+        replace = {
+          uri = "/api/v2/$(uri_captures[\"subpath\"])",
         }
       }
     }
@@ -1112,6 +1128,30 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.response(r).has.jsonbody()
       local json = assert.request(r).has.jsonbody()
       assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
+    end)
+    it("replace request uri with optional capature prefix", function()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/api/htest",
+        headers = {
+          host = "test29.test"
+        }
+      })
+      assert.response(r).has.status(404)
+      local body = assert(assert.response(r).has.jsonbody())
+      assert.equals("/api/v2/htest", body.vars.request_uri)
+    end)
+    it("replace reqest uri with the capature prefix", function()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/gw/api/htest",
+        headers = {
+          host = "test29.test"
+        }
+      })
+      assert.response(r).has.status(404)
+      local body = assert(assert.response(r).has.jsonbody())
+      assert.equals("/api/v2/htest", body.vars.request_uri)
     end)
 
     pending("escape UTF-8 characters when replacing upstream path - enable after Kong 2.4", function()

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -1129,7 +1129,8 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local json = assert.request(r).has.jsonbody()
       assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
     end)
-    it("replace request uri with optional capature prefix", function()
+
+    it("replace request uri with optional capture prefix", function()
       local r = assert(client:send {
         method = "GET",
         path = "/api/htest",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -1130,7 +1130,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
     end)
 
-    it("replace request uri with optional capture prefix", function()
+    it("replaces request uri with optional capture prefix", function()
       local r = assert(client:send {
         method = "GET",
         path = "/api/htest",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -1143,7 +1143,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.equals("/api/v2/htest", body.vars.request_uri)
     end)
 
-    it("replace request uri with the capature prefix", function()
+    it("replaces request uri with the capature prefix", function()
       local r = assert(client:send {
         method = "GET",
         path = "/gw/api/htest",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -134,7 +134,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
     local route29 = bp.routes:insert({
       hosts = { "test29.test" },
       paths = { "~/(gw/)?api/(?<subpath>htest)$" },
-      strip_path = false
+      strip_path = false,
     })
 
     bp.plugins:insert {


### PR DESCRIPTION
### Summary

URI captures are not usable if the first capture is an empty string.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Ticket reference

Fix #13014, KAG-4474