### PR TITLE
fix(ci): require correct `socket` module

### DIFF
--- a/spec/busted-ci-helper.lua
+++ b/spec/busted-ci-helper.lua
@@ -1,5 +1,9 @@
 -- busted-ci-helper.lua
 
+
+-- needed before requiring 'socket.unix'
+require 'socket'
+
 local busted = require 'busted'
 local cjson = require 'cjson'
 local socket_unix = require 'socket.unix'


### PR DESCRIPTION
### Summary

require 'socket.unix' was causing a different socket module to be loaded

If 'socket.unix' was loaded before the `socket` module, it resulted in a different socket implementation to be used, which resulted in failures when trying to access nil fields of the socket object.


### Checklist

- [x] (no) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4472
