### PR TITLE
feat(conf): add concurrency_timeout option

### DIFF
--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -410,6 +410,8 @@ local CONF_PARSERS = {
   lua_max_uri_args = { typ = "number" },
   lua_max_post_args = { typ = "number" },
 
+  concurrency_timeout = { typ = "number" },
+
   ssl_protocols = {
     typ = "string",
     directives = {

--- a/kong/conf_loader/parse.lua
+++ b/kong/conf_loader/parse.lua
@@ -559,6 +559,14 @@ local function check_and_parse(conf, opts)
     errors[#errors + 1] = "pg_semaphore_timeout must be an integer greater than 0"
   end
 
+  if conf.concurrency_timeout < 0 then
+    errors[#errors + 1] = "concurrency_timeout must be greater than 0"
+  end
+
+  if conf.concurrency_timeout ~= floor(conf.concurrency_timeout) then
+    errors[#errors + 1] = "concurrency_timeout must be an integer greater than 0"
+  end
+
   if conf.pg_keepalive_timeout then
     if conf.pg_keepalive_timeout < 0 then
       errors[#errors + 1] = "pg_keepalive_timeout must be greater than 0"

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -1206,11 +1206,13 @@ local function new(self)
       return execute_callback(callback, options)
     end
 
+    local concurrency_timeout = self and self.configuration and self.configuration.concurrency_timeout / 1000
+                                or ROTATION_INTERVAL
     -- Is it worth to have node level mutex instead?
     -- If so, the RETRY_LRU also needs to be node level.
     concurrency.with_coroutine_mutex({
       name = name,
-      timeout = ROTATION_INTERVAL,
+      timeout = concurrency_timeout,
     }, function()
       -- Check if references were updated while waiting for a lock
       new_updated_at = RETRY_LRU:get(name) or 0

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -932,6 +932,10 @@ return {
           rebuild_timeout = kong.configuration.pg_timeout / 1000
         end
 
+        if strategy == "off" and kong.configuration.concurrency_timeout then
+          rebuild_timeout = kong.configuration.concurrency_timeout / 1000
+        end
+
         if strategy == "off" then
           RECONFIGURE_OPTS = {
             name = "reconfigure",

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -201,6 +201,8 @@ admin_gui_api_url = NONE
 
 openresty_path =
 
+concurrency_timeout = 60000
+
 opentelemetry_tracing = off
 opentelemetry_tracing_sampling_rate = 0.01
 tracing_instrumentations = off

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -75,6 +75,7 @@ describe("Configuration loader", function()
     assert.same(false, conf.allow_debug_header)
     assert.same(KONG_VERSION, conf.lmdb_validation_tag)
     assert.is_nil(getmetatable(conf))
+    assert.equal(60000, conf.concurrency_timeout)
   end)
   it("loads a given file, with higher precedence", function()
     local conf = assert(conf_loader(helpers.test_conf_path))
@@ -1723,6 +1724,32 @@ describe("Configuration loader", function()
       })
       assert.is_nil(conf)
       assert.equal("pg_semaphore_timeout must be an integer greater than 0", err)
+    end)
+  end)
+
+  describe("concurrency_timeout option", function()
+    it("rejects a concurrency_timeout with a negative number", function()
+      local conf, err = conf_loader(nil, {
+        concurrency_timeout = -1,
+      })
+      assert.is_nil(conf)
+      assert.equal("concurrency_timeout must be greater than 0", err)
+    end)
+
+    it("rejects a concurrency_timeout with a decimal", function()
+      local conf, err = conf_loader(nil, {
+        concurrency_timeout = 0.1,
+      })
+      assert.is_nil(conf)
+      assert.equal("concurrency_timeout must be an integer greater than 0", err)
+    end)
+
+    it("accept a concurrency_timeout with integer greater than 0", function()
+      local conf, err = conf_loader(nil, {
+        concurrency_timeout = 65432,
+      })
+      assert.is_nil(err)
+      assert.equal(65432, conf.concurrency_timeout)
     end)
   end)
 

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -50,3 +50,5 @@ vaults = bundled
 pg_password = foo\#bar# this is a comment that should be stripped
 
 wasm_filters_path = ./spec/fixtures/proxy_wasm_filters/build
+
+concurrency_timeout = 60000


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

feat(conf): add concurrency_timeout option

  Sets the timeout (in ms) for which a concurrency
  job (e.g. declaractive reconfigure) should wait
  for mutex before giving up. After the timeout,
  Kong gateway would skip the job, and log an error
  message.

  If you happen to see "timeout acquiring ... lock"
  log entries, try to adjust this value accordingly.
  Please be careful that setting a large value might
  result in a long list of concurreny jobs in queue,
  which could overflow the queue.

  It is fine to timeout if a job is safe to be
  overriden by subsequent jobs, like declaractive
  reconfigure. Do not touch this option unless you
  clear about it.

### Checklist

- [X] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-5930]_ #_[KAG-4480]_


[FTI-5930]: https://konghq.atlassian.net/browse/FTI-5930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ