### PR TITLE
docs(pdk): fix a typo in kong.client.tls comment

### DIFF
--- a/kong/pdk/client/tls.lua
+++ b/kong/pdk/client/tls.lua
@@ -116,7 +116,7 @@ local function new()
   -- @treturn nil|err Returns `nil` if successful, or an error message if it fails.
   --
   -- @usage
-  -- local cert, err = kong.client.get_full_client_certificate_chain()
+  -- local cert, err = kong.client.tls.get_full_client_certificate_chain()
   -- if err then
   --   -- do something with err
   -- end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Access to `tls  table was missing

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
