### PR TITLE
[backport -> release/3.4.x] fix(conf_loader): cluster_cert/cluster_ca_cert to support base64 encoded values (#11385)

### DIFF
--- a/changelog/unreleased/kong/fix-base64-cluster-cert.yml
+++ b/changelog/unreleased/kong/fix-base64-cluster-cert.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where cluster_cert or cluster_ca_cert is inserted into lua_ssl_trusted_certificate before being base64 decoded.
+type: bugfix
+scope: Core

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1214,6 +1214,45 @@ local function check_and_parse(conf, opts)
     end
   end
 
+  if conf.role == "control_plane" or conf.role == "data_plane" then
+    local cluster_cert = conf.cluster_cert
+    local cluster_cert_key = conf.cluster_cert_key
+    local cluster_ca_cert = conf.cluster_ca_cert
+
+    if not cluster_cert or not cluster_cert_key then
+      errors[#errors + 1] = "cluster certificate and key must be provided to use Hybrid mode"
+
+    else
+      if not exists(cluster_cert) then
+        cluster_cert = try_decode_base64(cluster_cert)
+        conf.cluster_cert = cluster_cert
+        local _, err = openssl_x509.new(cluster_cert)
+        if err then
+          errors[#errors + 1] = "cluster_cert: failed loading certificate from " .. cluster_cert
+        end
+      end
+
+      if not exists(cluster_cert_key) then
+        cluster_cert_key = try_decode_base64(cluster_cert_key)
+        conf.cluster_cert_key = cluster_cert_key
+        local _, err = openssl_pkey.new(cluster_cert_key)
+        if err then
+          errors[#errors + 1] = "cluster_cert_key: failed loading key from " .. cluster_cert_key
+        end
+      end
+    end
+
+    if cluster_ca_cert and not exists(cluster_ca_cert) then
+      cluster_ca_cert = try_decode_base64(cluster_ca_cert)
+      conf.cluster_ca_cert = cluster_ca_cert
+      local _, err = openssl_x509.new(cluster_ca_cert)
+      if err then
+        errors[#errors + 1] = "cluster_ca_cert: failed loading certificate from " ..
+                              cluster_ca_cert
+      end
+    end
+  end
+
   if conf.role == "control_plane" then
     if #conf.admin_listen < 1 or strip(conf.admin_listen[1]) == "off" then
       errors[#errors + 1] = "admin_listen must be specified when role = \"control_plane\""
@@ -1283,45 +1322,6 @@ local function check_and_parse(conf, opts)
 
   if conf.cluster_max_payload < 4194304 then
     errors[#errors + 1] = "cluster_max_payload must be 4194304 (4MB) or greater"
-  end
-
-  if conf.role == "control_plane" or conf.role == "data_plane" then
-    local cluster_cert = conf.cluster_cert
-    local cluster_cert_key = conf.cluster_cert_key
-    local cluster_ca_cert = conf.cluster_ca_cert
-
-    if not cluster_cert or not cluster_cert_key then
-      errors[#errors + 1] = "cluster certificate and key must be provided to use Hybrid mode"
-
-    else
-      if not exists(cluster_cert) then
-        cluster_cert = try_decode_base64(cluster_cert)
-        conf.cluster_cert = cluster_cert
-        local _, err = openssl_x509.new(cluster_cert)
-        if err then
-          errors[#errors + 1] = "cluster_cert: failed loading certificate from " .. cluster_cert
-        end
-      end
-
-      if not exists(cluster_cert_key) then
-        cluster_cert_key = try_decode_base64(cluster_cert_key)
-        conf.cluster_cert_key = cluster_cert_key
-        local _, err = openssl_pkey.new(cluster_cert_key)
-        if err then
-          errors[#errors + 1] = "cluster_cert_key: failed loading key from " .. cluster_cert_key
-        end
-      end
-    end
-
-    if cluster_ca_cert and not exists(cluster_ca_cert) then
-      cluster_ca_cert = try_decode_base64(cluster_ca_cert)
-      conf.cluster_ca_cert = cluster_ca_cert
-      local _, err = openssl_x509.new(cluster_ca_cert)
-      if err then
-        errors[#errors + 1] = "cluster_ca_cert: failed loading certificate from " ..
-                              cluster_ca_cert
-      end
-    end
   end
 
   if conf.upstream_keepalive_pool_size < 0 then

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1070,6 +1070,38 @@ describe("Configuration loader", function()
           assert.matches(".ca_combined", conf.lua_ssl_trusted_certificate_combined)
         end)
 
+        it("autoload base64 cluster_cert or cluster_ca_cert for data plane in lua_ssl_trusted_certificate", function()
+          local ssl_fixtures = require "spec.fixtures.ssl"
+          local cert = ssl_fixtures.cert
+          local cacert = ssl_fixtures.cert_ca
+          local key = ssl_fixtures.key
+          local conf, _, errors = conf_loader(nil, {
+            role = "data_plane",
+            database = "off",
+            cluster_cert = ngx.encode_base64(cert),
+            cluster_cert_key = ngx.encode_base64(key),
+          })
+          assert.is_nil(errors)
+          assert.contains(
+            cert,
+            conf.lua_ssl_trusted_certificate
+          )
+
+          local conf, _, errors = conf_loader(nil, {
+            role = "data_plane",
+            database = "off",
+            cluster_mtls = "pki",
+            cluster_cert = ngx.encode_base64(cert),
+            cluster_cert_key = ngx.encode_base64(key),
+            cluster_ca_cert = ngx.encode_base64(cacert),
+          })
+          assert.is_nil(errors)
+          assert.contains(
+            cacert,
+            conf.lua_ssl_trusted_certificate
+          )
+        end)
+
         it("validates proxy_server", function()
           local conf, _, errors = conf_loader(nil, {
             proxy_server = "http://cool:pwd@localhost:2333",


### PR DESCRIPTION
### Summary

Backporting https://github.com/Kong/kong/pull/11385

(cherry picked from commit 07475c431246bf9ec02181a3086b98e8c478e176)


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix https://konghq.atlassian.net/browse/FTI-5953
