### PR TITLE
fix(build): remove the original websocket library from openresty

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -236,6 +236,9 @@ kong_genrule(
         mkdir -p ${BUILD_DESTDIR}/etc/kong/
         cp ${WORKSPACE_PATH}/kong.conf.default ${BUILD_DESTDIR}/etc/kong/kong.conf.default
 
+        # TODO: remove this after lua-resty-websocket becomes a patch or merged to upstream
+        rm -rf ${BUILD_DESTDIR}/openresty/lualib/resty/websocket
+
         # housecleaning
         if [[ -d ${BUILD_DESTDIR}/kong/lib64 ]]; then
             cp -r ${BUILD_DESTDIR}/kong/lib64/* ${BUILD_DESTDIR}/kong/lib/.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

ported from https://github.com/Kong/kong-ee/pull/8843
