### PR TITLE
chore(deps): bump lua-resty-healthcheck to 3.0.2

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-healthcheck.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-healthcheck.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-healthcheck from 3.0.1 to 3.0.2, to reduce active healthcheck timer usage."
+type: dependency
+scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.5.1",
-  "lua-resty-healthcheck == 3.0.1",
+  "lua-resty-healthcheck == 3.0.2",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.4.1",
   "lua-resty-openssl == 1.3.1",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Bumps `lua-resty-healthcheck` to 3.0.2.

Changelogs:
> What's Changed
fix(*): avoid creating multiple timers to run the same active check
https://github.com/Kong/lua-resty-healthcheck/pull/157

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5847