### PR TITLE
chore(build): use wasmx_dynamic_mod to mark dynamic module as created

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -293,7 +293,7 @@ configure_make(
     ],
     out_lib_dir = "",
     out_shared_libs = select({
-        "@kong//:wasmx_flag": [
+        "@kong//:wasmx_dynamic_mod": [
             "nginx/modules/ngx_wasmx_module.so",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
