### PR TITLE
refactor(router/atc): remove unnecessary tb_nkeys()

### DIFF
--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -720,10 +720,8 @@ local function split_routes_and_services_by_path(routes_and_services)
       goto continue -- in case we only got one group, we can accept the original route
     end
 
-    -- make sure that route_and_service contains only
+    -- route_and_service should contain only
     -- the two expected entries, route and service
-    local nkeys = tb_nkeys(route_and_service)
-    assert(nkeys == 1 or nkeys == 2)
 
     local original_route_id = original_route.id
     local original_service = route_and_service.service


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-4138

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
