### PR TITLE
refactor(router/atc): iterate and append items properly when splitting routes

### DIFF
--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -704,6 +704,8 @@ end
 -- one for each prefix length and one for all regular expressions
 local function split_routes_and_services_by_path(routes_and_services)
   local routes_and_services_count = #routes_and_services
+  local appending_index = routes_and_services_count
+
   for routes_and_services_index = 1, routes_and_services_count do
     local route_and_service = routes_and_services[routes_and_services_index]
     local original_route = route_and_service.route
@@ -741,8 +743,8 @@ local function split_routes_and_services_by_path(routes_and_services)
       -- at the end of the routes and services array.
       local index = routes_and_services_index
       if grouped_paths_index > 1 then
-        routes_and_services_count = routes_and_services_count + 1
-        index = routes_and_services_count
+        appending_index = appending_index + 1
+        index = appending_index
       end
 
       routes_and_services[index] = {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We iterate items from `1`  to `routes_and_services_count`, but in the loop
`routes_and_services_count` may be changed, it is not our expected.

The variable `routes_and_services_count` should not be changed,
so we could use another variable `appending_index`, which has the same effect.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
