### PR TITLE
tests(plugin): a more reliable way to wait for config update

### DIFF
--- a/spec/03-plugins/17-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/02-access_spec.lua
@@ -905,16 +905,7 @@ for _, strategy in helpers.each_strategy() do
       })
       assert.res_status(200, res)
 
-      local cache_key = db.plugins:cache_key(plugin)
-
-      helpers.wait_until(function()
-        res = assert(admin_client:send {
-          method = "GET",
-          path   = "/cache/" .. cache_key
-        })
-        res:read_body()
-        return res.status ~= 200
-      end)
+      helpers.wait_for_all_config_update()
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -939,16 +930,7 @@ for _, strategy in helpers.each_strategy() do
       })
       assert.res_status(200, res)
 
-      local cache_key = db.plugins:cache_key(plugin)
-
-      helpers.wait_until(function()
-        res = assert(admin_client:send {
-          method = "GET",
-          path   = "/cache/" .. cache_key
-        })
-        res:read_body()
-        return res.status ~= 200
-      end)
+      helpers.wait_for_all_config_update()
 
       local res = assert(proxy_client:send {
         method  = "GET",


### PR DESCRIPTION
### Summary

DO NOT CHERRY-PICK THIS PR TO EE! A corresponding PR is intentionally manually created: https://github.com/Kong/kong-ee/pull/9162

### Checklist

- [N/A] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-4523
