### PR TITLE
feat(ai-proxy): AWS Bedrock driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM kong:3.7.1
+FROM kong:3.6.1
 
 USER root
 
-RUN luarocks install lua-resty-gcp
 COPY kong/plugins/ai-proxy/ /usr/local/share/lua/5.1/kong/plugins/ai-proxy/
 COPY kong/llm/ /usr/local/share/lua/5.1/kong/llm/
-COPY kong/tools/aws_stream.lua /usr/local/share/lua/5.1/kong/tools/aws_stream.lua
 
 USER kong

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ USER root
 RUN luarocks install lua-resty-gcp
 COPY kong/plugins/ai-proxy/ /usr/local/share/lua/5.1/kong/plugins/ai-proxy/
 COPY kong/llm/ /usr/local/share/lua/5.1/kong/llm/
+COPY kong/tools/aws_stream.lua /usr/local/share/lua/5.1/kong/tools/aws_stream.lua
 
 USER kong

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM kong:3.6.1
+
+USER root
+
+COPY kong/plugins/ai-proxy/ /usr/local/share/lua/5.1/kong/plugins/ai-proxy/
+COPY kong/llm/ /usr/local/share/lua/5.1/kong/llm/
+
+USER kong

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM kong:3.6.1
 
 USER root
 
+RUN luarocks install lua-resty-gcp
 COPY kong/plugins/ai-proxy/ /usr/local/share/lua/5.1/kong/plugins/ai-proxy/
 COPY kong/llm/ /usr/local/share/lua/5.1/kong/llm/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:3.6.1
+FROM kong:3.7.1
 
 USER root
 

--- a/changelog/unreleased/kong/ai-proxy-fix-tuning-parameter-precedence
+++ b/changelog/unreleased/kong/ai-proxy-fix-tuning-parameter-precedence
@@ -1,0 +1,5 @@
+message: |
+  **AI-proxy-plugin**: Fix a bug where AI Proxy would not take precedence of  the plugin's
+  model tuning options, when configured, and instead would prefer the caller's JSON body parameters.
+scope: Plugin
+type: bugfix

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -44,6 +44,7 @@ dependencies = {
   "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
   "lua-resty-snappy == 1.0-1",
+  "lua-resty-gcp == 0.0.13-1",
 }
 build = {
   type = "builtin",
@@ -609,6 +610,7 @@ build = {
     ["kong.llm.drivers.anthropic"] = "kong/llm/drivers/anthropic.lua",
     ["kong.llm.drivers.mistral"] = "kong/llm/drivers/mistral.lua",
     ["kong.llm.drivers.llama2"] = "kong/llm/drivers/llama2.lua",
+    ["kong.llm.auth.gcp] = "kong/llm/auth/gcp.lua",
 
     ["kong.llm.drivers.gemini"] = "kong/llm/drivers/gemini.lua",
 

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -44,7 +44,6 @@ dependencies = {
   "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
   "lua-resty-snappy == 1.0-1",
-  "lua-resty-gcp == 0.0.13-1",
 }
 build = {
   type = "builtin",
@@ -610,7 +609,6 @@ build = {
     ["kong.llm.drivers.anthropic"] = "kong/llm/drivers/anthropic.lua",
     ["kong.llm.drivers.mistral"] = "kong/llm/drivers/mistral.lua",
     ["kong.llm.drivers.llama2"] = "kong/llm/drivers/llama2.lua",
-    ["kong.llm.auth.gcp] = "kong/llm/auth/gcp.lua",
 
     ["kong.llm.drivers.gemini"] = "kong/llm/drivers/gemini.lua",
 

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -44,6 +44,7 @@ dependencies = {
   "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
   "lua-resty-snappy == 1.0-1",
+  "lua-resty-gcp == 0.0.13-1",
 }
 build = {
   type = "builtin",
@@ -608,6 +609,7 @@ build = {
     ["kong.llm.drivers.anthropic"] = "kong/llm/drivers/anthropic.lua",
     ["kong.llm.drivers.mistral"] = "kong/llm/drivers/mistral.lua",
     ["kong.llm.drivers.llama2"] = "kong/llm/drivers/llama2.lua",
+    ["kong.llm.auth.gcp] = "kong/llm/auth/gcp.lua",
 
     ["kong.llm.drivers.gemini"] = "kong/llm/drivers/gemini.lua",
 

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -198,6 +198,7 @@ build = {
     ["kong.tools.cjson"] = "kong/tools/cjson.lua",
     ["kong.tools.emmy_debugger"] = "kong/tools/emmy_debugger.lua",
     ["kong.tools.redis.schema"] = "kong/tools/redis/schema.lua",
+    ["kong.tools.aws_stream"] = "kong/tools/aws_stream.lua",
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",
     ["kong.runloop.events"] = "kong/runloop/events.lua",

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -44,7 +44,6 @@ dependencies = {
   "lpeg == 1.1.0",
   "lua-resty-ljsonschema == 1.1.6-2",
   "lua-resty-snappy == 1.0-1",
-  "lua-resty-gcp == 0.0.13-1",
 }
 build = {
   type = "builtin",
@@ -609,7 +608,6 @@ build = {
     ["kong.llm.drivers.anthropic"] = "kong/llm/drivers/anthropic.lua",
     ["kong.llm.drivers.mistral"] = "kong/llm/drivers/mistral.lua",
     ["kong.llm.drivers.llama2"] = "kong/llm/drivers/llama2.lua",
-    ["kong.llm.auth.gcp] = "kong/llm/auth/gcp.lua",
 
     ["kong.llm.drivers.gemini"] = "kong/llm/drivers/gemini.lua",
 

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -321,8 +321,8 @@ end
 
 -- returns err or nil
 function _M.configure_request(conf, aws_sdk)
-  local operation = kong.ctx.shared.ai_proxy_streaming_mode and "messages-stream"
-                                                             or "messages"
+  local operation = kong.ctx.shared.ai_proxy_streaming_mode and "converse-stream"
+                                                             or "converse"
 
   local f_url = conf.model.options and conf.model.options.upstream_url
 

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -413,8 +413,12 @@ function _M.configure_request(conf, aws_sdk)
   local signature = signer(aws_sdk.config, r)
 
   kong.service.request.set_header("Authorization", signature.headers["Authorization"])
-  kong.service.request.set_header("X-Amz-Security-Token", signature.headers["X-Amz-Security-Token"] or "")
-  kong.service.request.set_header("X-Amz-Date", signature.headers["X-Amz-Date"] or "")
+  if signature.headers["X-Amz-Security-Token"] then 
+    kong.service.request.set_header("X-Amz-Security-Token", signature.headers["X-Amz-Security-Token"])
+  end
+  if signature.headers["X-Amz-Date"] then
+    kong.service.request.set_header("X-Amz-Date", signature.headers["X-Amz-Date"])
+  end
 
   return true
 end

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -103,25 +103,10 @@ local function handle_stream_event(event_t, model_info, route_type)
     }
 
   elseif event_type == "metadata" then
-    local function dump(o)
-      if type(o) == 'table' then
-         local s = '{ '
-         for k,v in pairs(o) do
-            if type(k) ~= 'number' then k = '"'..k..'"' end
-            s = s .. '['..k..'] = ' .. dump(v) .. ','
-         end
-         return s .. '} '
-      else
-         return tostring(o)
-      end
-    end
-    kong.log.warn(dump(body))
     metadata = {
       prompt_tokens = body.usage and body.usage.inputTokens or 0,
       completion_tokens = body.usage and body.usage.outputTokens or 0,
     }
-
-    kong.log.warn(dump(metadata))
 
     new_event = "[DONE]"
 
@@ -183,8 +168,6 @@ local function to_bedrock_chat_openai(request_table, model_info, route_type)
   end
 
   new_r.inferenceConfig = to_bedrock_generation_config(request_table)
-
-  kong.log.debug(new_r.inferenceConfig.maxTokens)
 
   return new_r, "application/json", nil
 end

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -412,6 +412,9 @@ function _M.configure_request(conf, aws_sdk)
 
   local signature = signer(aws_sdk.config, r)
 
+  if not signature then
+    return nil, "failed to sign AWS request"
+  end
   kong.service.request.set_header("Authorization", signature.headers["Authorization"])
   if signature.headers["X-Amz-Security-Token"] then 
     kong.service.request.set_header("X-Amz-Security-Token", signature.headers["X-Amz-Security-Token"])

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -1,0 +1,375 @@
+local _M = {}
+
+-- imports
+local cjson = require("cjson.safe")
+local fmt = string.format
+local ai_shared = require("kong.llm.drivers.shared")
+local socket_url = require("socket.url")
+local string_gsub = string.gsub
+local buffer = require("string.buffer")
+local table_insert = table.insert
+local string_lower = string.lower
+local string_sub = string.sub
+local signer = require("resty.aws.request.sign")
+--
+
+-- globals
+local DRIVER_NAME = "bedrock"
+--
+
+local _OPENAI_ROLE_MAPPING = {
+  ["system"] = "assistant",
+  ["user"] = "user",
+  ["assistant"] = "assistant",
+}
+
+local function to_bedrock_generation_config(request_table)
+  return {
+    ["maxTokenCount"] = request_table.max_tokens,
+    ["stopSequences"] = request_table.stop,
+    ["temperature"] = request_table.temperature,
+    ["topK"] = request_table.top_k,
+    ["topP"] = request_table.top_p,
+  }
+end
+
+local function handle_stream_event(event_t, model_info, route_type)
+  local metadata
+
+  -- discard empty frames, it should either be a random new line, or comment
+  if (not event_t.data) or (#event_t.data < 1) then
+    return
+  end
+  
+  local event, err = cjson.decode(event_t.data)
+  if err then
+    ngx.log(ngx.WARN, "failed to decode stream event frame from bedrock: " .. err)
+    return nil, "failed to decode stream event frame from bedrock", nil
+  end
+
+  local new_event
+  local metadata
+
+  if event.candidates and
+     #event.candidates > 0 then
+    
+    if event.candidates[1].content and
+        event.candidates[1].content.parts and
+        #event.candidates[1].content.parts > 0 and
+        event.candidates[1].content.parts[1].text then
+      
+      new_event = {
+        choices = {
+          [1] = {
+            delta = {
+              content = event.candidates[1].content.parts[1].text or "",
+              role = "assistant",
+            },
+            index = 0,
+          },
+        },
+      }
+    end
+
+    if event.candidates[1].finishReason then
+      metadata = metadata or {}
+      metadata.finished_reason = event.candidates[1].finishReason
+      new_event = "[DONE]"
+    end
+  end
+
+  if event.usageMetadata then
+    metadata = metadata or {}
+    metadata.completion_tokens = event.usageMetadata.candidatesTokenCount or 0
+    metadata.prompt_tokens     = event.usageMetadata.promptTokenCount or 0
+  end
+  
+  if new_event then
+    if new_event ~= "[DONE]" then
+      new_event = cjson.encode(new_event)
+    end
+
+    return new_event, nil, metadata
+  else
+    return nil, nil, metadata  -- caller code will handle "unrecognised" event types
+  end
+end
+
+local function to_bedrock_chat_openai(request_table, model_info, route_type)
+  if not request_table then  -- try-catch type mechanism
+    local err = "empty request table received for transformation"
+    ngx.log(ngx.ERR, err)
+    return nil, nil, err
+  end
+
+  local new_r = {}
+
+  -- anthropic models support variable versions, just like self-hosted
+  new_r.anthropic_version = model_info.options and model_info.options.anthropic_version
+                         or "bedrock-2023-05-31"
+
+  if request_table.messages and #request_table.messages > 0 then
+    local system_prompt
+
+    for i, v in ipairs(request_table.messages) do
+      -- for 'system', we just concat them all into one Gemini instruction
+      if v.role and v.role == "system" then
+        system_prompt = system_prompt or buffer.new()
+        system_prompt:put(v.content or "")
+
+      else
+        -- for any other role, just construct the chat history as 'parts.text' type
+        new_r.messages = new_r.messages or {}
+        table_insert(new_r.messages, {
+          role = _OPENAI_ROLE_MAPPING[v.role or "user"],  -- default to 'user'
+          content = {
+            {
+              text = v.content or ""
+            },
+          },
+        })
+      end
+    end
+
+    -- only works for 
+    if system_prompt then
+      new_r.system = system_prompt:get()
+    end
+  end
+
+  new_r.inferenceConfig = to_bedrock_generation_config(request_table)
+
+  return new_r, "application/json", nil
+end
+
+local function from_bedrock_chat_openai(response, model_info, route_type)
+  local response, err = cjson.decode(response)
+
+  if err then
+    local err_client = "failed to decode response from Bedrock"
+    ngx.log(ngx.ERR, fmt("%s: %s", err_client, err))
+    return nil, err_client
+  end
+
+  -- messages/choices table is only 1 size, so don't need to static allocate
+  local client_response = {}
+  client_response.choices = {}
+
+  if response.output
+        and response.output.message
+        and response.output.message.content
+        and #response.output.message.content > 0
+        and response.output.message.content[1].text then
+
+          client_response.choices[1] = {
+      index = 0,
+      message = {
+        role = "assistant",
+        content = response.output.message.content[1].text,
+      },
+      finish_reason = string_lower(response.stopReason),
+    }
+    client_response.object = "chat.completion"
+    client_response.model = model_info.name
+
+  else -- probably a server fault or other unexpected response
+    local err = "no generation candidates received from Bedrock, or max_tokens too short"
+    ngx.log(ngx.ERR, err)
+    return nil, err
+  end
+
+  -- process analytics
+  if response.usage then
+    client_response.usage = {
+      prompt_tokens = response.usage.inputTokens,
+      completion_tokens = response.usage.outputTokens,
+      total_tokens = response.usage.totalTokens,
+    }
+  end
+
+  return cjson.encode(client_response)
+end
+
+local transformers_to = {
+  ["llm/v1/chat"] = to_bedrock_chat_openai,
+}
+
+local transformers_from = {
+  ["llm/v1/chat"] = from_bedrock_chat_openai,
+  ["stream/llm/v1/chat"] = handle_stream_event,
+}
+
+function _M.from_format(response_string, model_info, route_type)
+  ngx.log(ngx.DEBUG, "converting from ", model_info.provider, "://", route_type, " type to kong")
+
+  -- MUST return a string, to set as the response body
+  if not transformers_from[route_type] then
+    return nil, fmt("no transformer available from format %s://%s", model_info.provider, route_type)
+  end
+  
+  local ok, response_string, err, metadata = pcall(transformers_from[route_type], response_string, model_info, route_type)
+  if not ok or err then
+    return nil, fmt("transformation failed from type %s://%s: %s",
+                    model_info.provider,
+                    route_type,
+                    err or "unexpected_error"
+                  )
+  end
+
+  return response_string, nil, metadata
+end
+
+function _M.to_format(request_table, model_info, route_type)
+  ngx.log(ngx.DEBUG, "converting from kong type to ", model_info.provider, "/", route_type)
+
+  if route_type == "preserve" then
+    -- do nothing
+    return request_table, nil, nil
+  end
+
+  if not transformers_to[route_type] then
+    return nil, nil, fmt("no transformer for %s://%s", model_info.provider, route_type)
+  end
+
+  request_table = ai_shared.merge_config_defaults(request_table, model_info.options, model_info.route_type)
+
+  local ok, response_object, content_type, err = pcall(
+    transformers_to[route_type],
+    request_table,
+    model_info
+  )
+  if err or (not ok) then
+    return nil, nil, fmt("error transforming to %s://%s: %s", model_info.provider, route_type, err)
+  end
+
+  return response_object, content_type, nil
+end
+
+function _M.subrequest(body, conf, http_opts, return_res_table)
+  -- use shared/standard subrequest routine
+  local body_string, err
+
+  if type(body) == "table" then
+    body_string, err = cjson.encode(body)
+    if err then
+      return nil, nil, "failed to parse body to json: " .. err
+    end
+  elseif type(body) == "string" then
+    body_string = body
+  else
+    return nil, nil, "body must be table or string"
+  end
+
+  -- may be overridden
+  local url = (conf.model.options and conf.model.options.upstream_url)
+    or fmt(
+    "%s%s",
+    ai_shared.upstream_url_format[DRIVER_NAME],
+    ai_shared.operation_map[DRIVER_NAME][conf.route_type].path
+  )
+
+  local method = ai_shared.operation_map[DRIVER_NAME][conf.route_type].method
+
+  local headers = {
+    ["Accept"] = "application/json",
+    ["Content-Type"] = "application/json",
+  }
+
+  if conf.auth and conf.auth.header_name then
+    headers[conf.auth.header_name] = conf.auth.header_value
+  end
+
+  local res, err, httpc = ai_shared.http_request(url, body_string, method, headers, http_opts, return_res_table)
+  if err then
+    return nil, nil, "request to ai service failed: " .. err
+  end
+
+  if return_res_table then
+    return res, res.status, nil, httpc
+  else
+    -- At this point, the entire request / response is complete and the connection
+    -- will be closed or back on the connection pool.
+    local status = res.status
+    local body   = res.body
+
+    if status > 299 then
+      return body, res.status, "status code " .. status
+    end
+
+    return body, res.status, nil
+  end
+end
+
+function _M.header_filter_hooks(body)
+  -- nothing to parse in header_filter phase
+end
+
+function _M.post_request(conf)
+  if ai_shared.clear_response_headers[DRIVER_NAME] then
+    for i, v in ipairs(ai_shared.clear_response_headers[DRIVER_NAME]) do
+      kong.response.clear_header(v)
+    end
+  end
+end
+
+function _M.pre_request(conf, body)
+  -- disable gzip for bedrock because it breaks streaming
+  kong.service.request.set_header("Accept-Encoding", "gzip, identity")
+
+  return true, nil
+end
+
+-- returns err or nil
+function _M.configure_request(conf, aws_sdk)
+  local operation = kong.ctx.shared.ai_proxy_streaming_mode and "messages-stream"
+                                                             or "messages"
+
+  local f_url = conf.model.options and conf.model.options.upstream_url
+
+  if not f_url then  -- upstream_url override is not set
+    local uri = fmt(ai_shared.upstream_url_format[DRIVER_NAME], aws_sdk.config.region)
+    local path = fmt(
+      ai_shared.operation_map[DRIVER_NAME][conf.route_type].path,
+      conf.model.name,
+      operation)
+
+    f_url = fmt("%s%s", uri, path)
+  end
+
+  local parsed_url = socket_url.parse(f_url)
+
+  if conf.model.options and conf.model.options.upstream_path then
+    -- upstream path override is set (or templated from request params)
+    parsed_url.path = conf.model.options.upstream_path
+  end
+
+  -- if the path is read from a URL capture, ensure that it is valid
+  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+
+  kong.service.request.set_path(parsed_url.path)
+  kong.service.request.set_scheme(parsed_url.scheme)
+  kong.service.set_target(parsed_url.host, (tonumber(parsed_url.port) or 443))
+
+  -- do the IAM auth and signature headers
+  aws_sdk.config.signatureVersion = "v4"
+  aws_sdk.config.endpointPrefix = "bedrock"
+
+  local r = {
+    headers = {},
+    method = ai_shared.operation_map[DRIVER_NAME][conf.route_type].method,
+    path = parsed_url.path,
+    host = parsed_url.host,
+    port = tonumber(parsed_url.port) or 443,
+    body = kong.request.get_raw_body()
+  }
+
+  local signature = signer(aws_sdk.config, r)
+
+  kong.service.request.set_header("Authorization", signature.headers["Authorization"])
+  kong.service.request.set_header("X-Amz-Security-Token", signature.headers["X-Amz-Security-Token"])
+  kong.service.request.set_header("X-Amz-Date", signature.headers["X-Amz-Date"])
+
+  return true
+end
+
+return _M

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -103,10 +103,25 @@ local function handle_stream_event(event_t, model_info, route_type)
     }
 
   elseif event_type == "metadata" then
+    local function dump(o)
+      if type(o) == 'table' then
+         local s = '{ '
+         for k,v in pairs(o) do
+            if type(k) ~= 'number' then k = '"'..k..'"' end
+            s = s .. '['..k..'] = ' .. dump(v) .. ','
+         end
+         return s .. '} '
+      else
+         return tostring(o)
+      end
+    end
+    kong.log.warn(dump(body))
     metadata = {
-      prompt_tokens = body.metrics and body.metrics.inputTokens or 0,
-      completion_tokens = body.metrics and body.metrics.outputTokens or 0,
+      prompt_tokens = body.usage and body.usage.inputTokens or 0,
+      completion_tokens = body.usage and body.usage.outputTokens or 0,
     }
+
+    kong.log.warn(dump(metadata))
 
     new_event = "[DONE]"
 

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -136,10 +136,8 @@ local function to_gemini_chat_openai(request_table, model_info, route_type)
         }
       end
     end
-
+    
     new_r.generationConfig = to_gemini_generation_config(request_table)
-
-    kong.log.debug(cjson.encode(new_r))
 
     return new_r, "application/json", nil
   end

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -21,7 +21,7 @@ local _OPENAI_ROLE_MAPPING = {
   ["assistant"] = "model",
 }
 
-local function to_gemini_generation_config(request_table)
+local function to_bard_generation_config(request_table)
   return {
     ["maxOutputTokens"] = request_table.max_tokens,
     ["stopSequences"] = request_table.stop,
@@ -31,76 +31,7 @@ local function to_gemini_generation_config(request_table)
   }
 end
 
-local function is_response_content(content)
-  return content
-        and content.candidates
-        and #content.candidates > 0
-        and content.candidates[1].content
-        and content.candidates[1].content.parts
-        and #content.candidates[1].content.parts > 0
-        and content.candidates[1].content.parts[1].text
-end
-
-local function is_response_finished(content)
-  return content
-     and content.candidates
-     and #content.candidates > 0
-     and content.candidates[1].finishReason
-end
-
-local function handle_stream_event(event_t, model_info, route_type)  
-  -- discard empty frames, it should either be a random new line, or comment
-  if (not event_t.data) or (#event_t.data < 1) then
-    return
-  end
-  
-  local event, err = cjson.decode(event_t.data)
-  if err then
-    ngx.log(ngx.WARN, "failed to decode stream event frame from gemini: " .. err)
-    return nil, "failed to decode stream event frame from gemini", nil
-  end
-
-  local new_event
-  local metadata = nil
-
-  if is_response_content(event) then
-    new_event = {
-      choices = {
-        [1] = {
-          delta = {
-            content = event.candidates[1].content.parts[1].text or "",
-            role = "assistant",
-          },
-          index = 0,
-        },
-      },
-    }
-  end
-
-  if is_response_finished(event) then
-    metadata = metadata or {}
-    metadata.finished_reason = event.candidates[1].finishReason
-    new_event = "[DONE]"
-  end
-
-  if event.usageMetadata then
-    metadata = metadata or {}
-    metadata.completion_tokens = event.usageMetadata.candidatesTokenCount or 0
-    metadata.prompt_tokens     = event.usageMetadata.promptTokenCount or 0
-  end
-  
-  if new_event then
-    if new_event ~= "[DONE]" then
-      new_event = cjson.encode(new_event)
-    end
-
-    return new_event, nil, metadata
-  else
-    return nil, nil, metadata  -- caller code will handle "unrecognised" event types
-  end
-end
-
-local function to_gemini_chat_openai(request_table, model_info, route_type)
+local function to_bard_chat_openai(request_table, model_info, route_type)
   if request_table then  -- try-catch type mechanism
     local new_r = {}
 
@@ -127,58 +58,34 @@ local function to_gemini_chat_openai(request_table, model_info, route_type)
         end
       end
 
-      -- This was only added in Gemini 1.5
-      if system_prompt and model_info.name:sub(1, 10) == "gemini-1.0" then
-        return nil, nil, "system prompts aren't supported on gemini-1.0 models"
+      ---- TODO for some reason this is broken?
+      ---- I think it's something to do with which "regional" endpoint of Gemini you hit...
+      -- if system_prompt then
+      --   new_r.systemInstruction = {
+      --     parts = {
+      --       {
+      --         text = system_prompt:get(),
+      --       },
+      --     },
+      --   }
+      -- end
+      ----
 
-      elseif system_prompt then
-        new_r.systemInstruction = {
-          parts = {
-            {
-              text = system_prompt:get(),
-            },
-          },
-        }
-      end
     end
-    
-    new_r.generationConfig = to_gemini_generation_config(request_table)
+
+    new_r.generationConfig = to_bard_generation_config(request_table)
+
+    kong.log.debug(cjson.encode(new_r))
 
     return new_r, "application/json", nil
   end
 
-  local new_r = {}
-
-  if request_table.messages and #request_table.messages > 0 then
-    local system_prompt
-
-    for i, v in ipairs(request_table.messages) do
-
-      -- for 'system', we just concat them all into one Gemini instruction
-      if v.role and v.role == "system" then
-        system_prompt = system_prompt or buffer.new()
-        system_prompt:put(v.content or "")
-      else
-        -- for any other role, just construct the chat history as 'parts.text' type
-        new_r.contents = new_r.contents or {}
-        table_insert(new_r.contents, {
-          role = _OPENAI_ROLE_MAPPING[v.role or "user"],  -- default to 'user'
-          parts = {
-            {
-              text = v.content or ""
-            },
-          },
-        })
-      end
-    end
-  end
-
-  new_r.generationConfig = to_gemini_generation_config(request_table)
-
-  return new_r, "application/json", nil
+  local err = "empty request table received for transformation"
+  ngx.log(ngx.ERR, err)
+  return nil, nil, err
 end
 
-local function from_gemini_chat_openai(response, model_info, route_type)
+local function from_bard_chat_openai(response, model_info, route_type)
   local response, err = cjson.decode(response)
 
   if err then
@@ -193,7 +100,10 @@ local function from_gemini_chat_openai(response, model_info, route_type)
 
   if response.candidates
         and #response.candidates > 0
-        and is_response_content(response) then
+        and response.candidates[1].content
+        and response.candidates[1].content.parts
+        and #response.candidates[1].content.parts > 0
+        and response.candidates[1].content.parts[1].text then
 
     messages.choices[1] = {
       index = 0,
@@ -215,13 +125,22 @@ local function from_gemini_chat_openai(response, model_info, route_type)
   return cjson.encode(messages)
 end
 
+local function to_bard_chat_bard(request_table, model_info, route_type)
+  return nil, nil, "bard to bard not yet implemented"
+end
+
+local function from_bard_chat_bard(request_table, model_info, route_type)
+  return nil, nil, "bard to bard not yet implemented"
+end
+
 local transformers_to = {
-  ["llm/v1/chat"] = to_gemini_chat_openai,
+  ["llm/v1/chat"] = to_bard_chat_openai,
+  ["gemini/v1/chat"] = to_gemini_chat_bard,
 }
 
 local transformers_from = {
-  ["llm/v1/chat"] = from_gemini_chat_openai,
-  ["stream/llm/v1/chat"] = handle_stream_event,
+  ["llm/v1/chat"] = from_bard_chat_openai,
+  ["gemini/v1/chat"] = from_gemini_chat_bard,
 }
 
 function _M.from_format(response_string, model_info, route_type)
@@ -232,7 +151,7 @@ function _M.from_format(response_string, model_info, route_type)
     return nil, fmt("no transformer available from format %s://%s", model_info.provider, route_type)
   end
   
-  local ok, response_string, err, metadata = pcall(transformers_from[route_type], response_string, model_info, route_type)
+  local ok, response_string, err = pcall(transformers_from[route_type], response_string, model_info, route_type)
   if not ok or err then
     return nil, fmt("transformation failed from type %s://%s: %s",
                     model_info.provider,
@@ -241,7 +160,7 @@ function _M.from_format(response_string, model_info, route_type)
                   )
   end
 
-  return response_string, nil, metadata
+  return response_string, nil
 end
 
 function _M.to_format(request_table, model_info, route_type)
@@ -264,7 +183,7 @@ function _M.to_format(request_table, model_info, route_type)
     model_info
   )
   if err or (not ok) then
-    return nil, nil, fmt("error transforming to %s://%s: %s", model_info.provider, route_type, err)
+    return nil, nil, fmt("error transforming to %s://%s", model_info.provider, route_type)
   end
 
   return response_object, content_type, nil
@@ -338,51 +257,31 @@ function _M.post_request(conf)
 end
 
 function _M.pre_request(conf, body)
-  -- disable gzip for gemini because it breaks streaming
-  kong.service.request.set_header("Accept-Encoding", "identity")
+  kong.service.request.set_header("Accept-Encoding", "gzip, identity") -- tell server not to send brotli
 
   return true, nil
 end
 
 -- returns err or nil
-function _M.configure_request(conf, identity_interface)
+function _M.configure_request(conf)
   local parsed_url
-  local operation = kong.ctx.shared.ai_proxy_streaming_mode and "streamGenerateContent"
-                                                             or "generateContent"
-  local f_url = conf.model.options and conf.model.options.upstream_url
 
-  if not f_url then  -- upstream_url override is not set
-    -- check if this is "public" or "vertex" gemini deployment
-    if conf.model.options
-        and conf.model.options.gemini
-        and conf.model.options.gemini.api_endpoint
-        and conf.model.options.gemini.project_id
-        and conf.model.options.gemini.location_id
-    then
-      -- vertex mode
-      f_url = fmt(ai_shared.upstream_url_format["gemini_vertex"],
-                  conf.model.options.gemini.api_endpoint) ..
-              fmt(ai_shared.operation_map["gemini_vertex"][conf.route_type].path,
-                  conf.model.options.gemini.project_id,
-                  conf.model.options.gemini.location_id,
-                  conf.model.name,
-                  operation)
-    else
-      -- public mode
-      f_url = ai_shared.upstream_url_format["gemini"] ..
-              fmt(ai_shared.operation_map["gemini"][conf.route_type].path,
-                  conf.model.name,
-                  operation)
+  if (conf.model.options and conf.model.options.upstream_url) then
+    parsed_url = socket_url.parse(conf.model.options.upstream_url)
+  else
+    local path = conf.model.options
+             and conf.model.options.upstream_path
+             or ai_shared.operation_map[DRIVER_NAME][conf.route_type]
+             and fmt(ai_shared.operation_map[DRIVER_NAME][conf.route_type].path, conf.model.name)
+             or "/"
+    if not path then
+      return nil, fmt("operation %s is not supported for openai provider", conf.route_type)
     end
+
+    parsed_url = socket_url.parse(ai_shared.upstream_url_format[DRIVER_NAME])
+    parsed_url.path = path
   end
-
-  parsed_url = socket_url.parse(f_url)
-
-  if conf.model.options and conf.model.options.upstream_path then
-    -- upstream path override is set (or templated from request params)
-    parsed_url.path = conf.model.options.upstream_path
-  end
-
+  
   -- if the path is read from a URL capture, ensure that it is valid
   parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
 
@@ -396,7 +295,6 @@ function _M.configure_request(conf, identity_interface)
   local auth_param_value = conf.auth and conf.auth.param_value
   local auth_param_location = conf.auth and conf.auth.param_location
 
-  -- DBO restrictions makes sure that only one of these auth blocks runs in one plugin config
   if auth_header_name and auth_header_value then
     kong.service.request.set_header(auth_header_name, auth_header_value)
   end
@@ -406,28 +304,9 @@ function _M.configure_request(conf, identity_interface)
     query_table[auth_param_name] = auth_param_value
     kong.service.request.set_query(query_table)
   end
+
   -- if auth_param_location is "form", it will have already been set in a global pre-request hook
-
-  -- if we're passed a GCP SDK, for cloud identity / SSO, use it appropriately
-  if identity_interface then
-    if identity_interface:needsRefresh() then
-      -- HACK: A bug in lua-resty-gcp tries to re-load the environment
-      --       variable every time, which fails in nginx
-      --       Create a whole new interface instead.
-      --       Memory leaks are mega unlikely because this should only
-      --       happen about once an hour, and the old one will be
-      --       cleaned up anyway.
-      local service_account_json = identity_interface.service_account_json
-      local identity_interface_new = identity_interface:new(service_account_json)
-      identity_interface.token = identity_interface_new.token
-
-      kong.log.notice("gcp identity token for ", kong.plugin.get_id(), " has been refreshed")
-    end
-
-    kong.service.request.set_header("Authorization", "Bearer " .. identity_interface.token)
-  end
-
-  return true
+  return true, nil
 end
 
 return _M

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -9,6 +9,7 @@ local string_gsub = string.gsub
 local buffer = require("string.buffer")
 local table_insert = table.insert
 local string_lower = string.lower
+local string_sub = string.sub
 --
 
 -- globals
@@ -21,7 +22,7 @@ local _OPENAI_ROLE_MAPPING = {
   ["assistant"] = "model",
 }
 
-local function to_bard_generation_config(request_table)
+local function to_gemini_generation_config(request_table)
   return {
     ["maxOutputTokens"] = request_table.max_tokens,
     ["stopSequences"] = request_table.stop,
@@ -31,7 +32,7 @@ local function to_bard_generation_config(request_table)
   }
 end
 
-local function to_bard_chat_openai(request_table, model_info, route_type)
+local function to_gemini_chat_openai(request_table, model_info, route_type)
   if request_table then  -- try-catch type mechanism
     local new_r = {}
 
@@ -58,22 +59,22 @@ local function to_bard_chat_openai(request_table, model_info, route_type)
         end
       end
 
-      ---- TODO for some reason this is broken?
-      ---- I think it's something to do with which "regional" endpoint of Gemini you hit...
-      -- if system_prompt then
-      --   new_r.systemInstruction = {
-      --     parts = {
-      --       {
-      --         text = system_prompt:get(),
-      --       },
-      --     },
-      --   }
-      -- end
-      ----
+      -- This was only added in Gemini 1.5
+      if system_prompt and model_info.name:sub(1, 10) == "gemini-1.0" then
+        return nil, nil, "system prompts aren't supported on gemini-1.0 models"
 
+      elseif system_prompt then
+        new_r.systemInstruction = {
+          parts = {
+            {
+              text = system_prompt:get(),
+            },
+          },
+        }
+      end
     end
 
-    new_r.generationConfig = to_bard_generation_config(request_table)
+    new_r.generationConfig = to_gemini_generation_config(request_table)
 
     kong.log.debug(cjson.encode(new_r))
 
@@ -85,7 +86,7 @@ local function to_bard_chat_openai(request_table, model_info, route_type)
   return nil, nil, err
 end
 
-local function from_bard_chat_openai(response, model_info, route_type)
+local function from_gemini_chat_openai(response, model_info, route_type)
   local response, err = cjson.decode(response)
 
   if err then
@@ -125,22 +126,22 @@ local function from_bard_chat_openai(response, model_info, route_type)
   return cjson.encode(messages)
 end
 
-local function to_bard_chat_bard(request_table, model_info, route_type)
-  return nil, nil, "bard to bard not yet implemented"
+local function to_gemini_chat_gemini(request_table, model_info, route_type)
+  return nil, nil, "gemini to gemini not yet implemented"
 end
 
-local function from_bard_chat_bard(request_table, model_info, route_type)
-  return nil, nil, "bard to bard not yet implemented"
+local function from_gemini_chat_gemini(request_table, model_info, route_type)
+  return nil, nil, "gemini to gemini not yet implemented"
 end
 
 local transformers_to = {
-  ["llm/v1/chat"] = to_bard_chat_openai,
-  ["gemini/v1/chat"] = to_gemini_chat_bard,
+  ["llm/v1/chat"] = to_gemini_chat_openai,
+  ["gemini/v1/chat"] = to_gemini_chat_gemini,
 }
 
 local transformers_from = {
-  ["llm/v1/chat"] = from_bard_chat_openai,
-  ["gemini/v1/chat"] = from_gemini_chat_bard,
+  ["llm/v1/chat"] = from_gemini_chat_openai,
+  ["gemini/v1/chat"] = from_gemini_chat_gemini,
 }
 
 function _M.from_format(response_string, model_info, route_type)

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -316,7 +316,8 @@ function _M.configure_request(conf)
 
   if not f_url then  -- upstream_url override is not set
     -- check if this is "public" or "vertex" gemini deployment
-    if conf.model.options.gemini
+    if conf.model.options
+        and conf.model.options.gemini
         and conf.model.options.gemini.api_endpoint
         and conf.model.options.gemini.project_id
         and conf.model.options.gemini.location_id
@@ -370,10 +371,10 @@ function _M.configure_request(conf)
     kong.service.request.set_query(query_table)
   end
 
-  ---- DEBUG REMOVE THIS
-  local auth = require("resty.gcp.request.credentials.accesstoken"):new(conf.auth.gcp_service_account_json)
-  kong.service.request.set_header("Authorization", "Bearer " .. auth.token)
-  ----
+  -- ---- DEBUG REMOVE THIS
+  -- local auth = require("resty.gcp.request.credentials.accesstoken"):new(conf.auth.gcp_service_account_json)
+  -- kong.service.request.set_header("Authorization", "Bearer " .. auth.token)
+  -- ----
 
   -- if auth_param_location is "form", it will have already been set in a global pre-request hook
   return true, nil

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -74,6 +74,7 @@ _M.upstream_url_format = {
   cohere = "https://api.cohere.com:443",
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
+  gemini_vertex = "https://%s",
 }
 
 _M.operation_map = {
@@ -119,7 +120,13 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1/models/%s:generateContent",
+      path = "/v1beta/models/%s:%s",
+      method = "POST",
+    },
+  },
+  gemini_vertex = {
+    ["llm/v1/chat"] = {
+      path = "/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
       method = "POST",
     },
   },

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -539,6 +539,10 @@ end
 function _M.post_request(conf, response_object)
   local body_string, err
 
+  if not response_object then
+    return
+  end
+
   if type(response_object) == "string" then
     -- set raw string body first, then decode
     body_string = response_object
@@ -691,6 +695,7 @@ function _M.http_request(url, body, method, headers, http_opts, buffered)
         method = method,
         body = body,
         headers = headers,
+        ssl_server_name = parsed.host,
         ssl_verify = http_opts.https_verify,
       })
     if not res then

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -248,7 +248,7 @@ function _M.frame_to_events(frame, provider)
 
   -- some new LLMs return the JSON object-by-object,
   -- because that totally makes sense to parse?!
-  if raw_json_mode then
+  if provider == "gemini" then
     -- if this is the first frame, it will begin with array opener '['
     frame = (string.sub(str_ltrim(frame), 1, 1) == "[" and string.sub(str_ltrim(frame), 2)) or frame
 
@@ -261,6 +261,18 @@ function _M.frame_to_events(frame, provider)
     -- for multiple events that arrive in the same frame, split by top-level comma
     for _, v in ipairs(split(frame, "\n,")) do
       events[#events+1] = { data = v }
+    end
+
+  elseif provider == "bedrock" then
+    local parser = aws_stream:new(frame)
+    while true do
+      local msg = parser:next_message()
+
+      if not msg then
+        break
+      end
+
+      events[#events+1] = "data: " .. cjson.encode(msg)
     end
 
   -- check if it's raw json and just return the split up data frame

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -119,7 +119,7 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1/models/%s:generateContent",  -- /v1/models/gemini-pro:generateContent,
+      path = "/v1/models/%s:generateContent",
       method = "POST",
     },
   },

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -222,7 +222,7 @@ end
 function _M.frame_to_events(frame, raw_json_mode)
   local events = {}
 
-  if (not frame) or #frame < 1 then
+  if (not frame) or (#frame < 1) or (type(frame)) ~= "string" then
     return
   end
 
@@ -236,39 +236,50 @@ function _M.frame_to_events(frame, raw_json_mode)
       }
     end
 
-  -- standard SSE parser
+  -- some new LLMs return the JSON object-by-object,
+  -- because that totally makes sense to parse?!
+  elseif raw_json_mode then
+    -- if this is the first frame, it will begin with array opener '['
+    frame = (string.sub(str_ltrim(frame), 1, 1) == "[" and string.sub(str_ltrim(frame), 2)) or frame
+
+    -- it may start with ',' which is the start of the new frame
+    frame = (string.sub(str_ltrim(frame), 1, 1) == "," and string.sub(str_ltrim(frame), 2)) or frame
+    
+    -- finally, it may end with the array terminator ']' indicating the finished stream
+    frame = (string.sub(str_ltrim(frame), -1) == "]" and string.sub(str_ltrim(frame), 1, -2)) or frame
+
+    -- for multiple events that arrive in the same frame, split by top-level comma
+    for _, v in ipairs(split(frame, "\n,")) do
+      events[#events+1] = { data = v }
+    end
+
   else
     local event_lines = split(frame, "\n")
     local struct = { event = nil, id = nil, data = nil }
 
-    for i, dat in ipairs(event_lines) do
-      if #dat < 1 then
-        events[#events + 1] = struct
-        struct = { event = nil, id = nil, data = nil }
-      end
+    -- test for truncated chunk on the last line (no trailing \r\n\r\n)
+    if #dat > 0 and #event_lines == i then
+      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
+      kong.ctx.plugin.truncated_frame = dat
+      break  -- stop parsing immediately, server has done something wrong
+    end
 
-      -- test for truncated chunk on the last line (no trailing \r\n\r\n)
-      if #dat > 0 and #event_lines == i then
-        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
-        if kong then
-          kong.ctx.plugin.truncated_frame = dat
-        end
+    -- test for abnormal start-of-frame (truncation tail)
+    if kong and kong.ctx.plugin.truncated_frame then
+      -- this is the tail of a previous incomplete chunk
+      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
+      dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
+      kong.ctx.plugin.truncated_frame = nil
+    end
 
-        break  -- stop parsing immediately, server has done something wrong
-      end
+    local s1, _ = str_find(dat, ":") -- find where the cut point is
 
-      -- test for abnormal start-of-frame (truncation tail)
-      if kong and kong.ctx.plugin.truncated_frame then
-        -- this is the tail of a previous incomplete chunk
-        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
-        dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
-        kong.ctx.plugin.truncated_frame = nil
-      end
-
-      local s1, _ = str_find(dat, ":") -- find where the cut point is
+    if s1 and s1 ~= 1 then
+      local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
+      local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
       if s1 and s1 ~= 1 then
-        local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
+        local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
         -- for now not checking if the value is already been set

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -60,14 +60,6 @@ _M.streaming_has_token_counts = {
   ["bedrock"] = true,
 }
 
-_M.bedrock_unsupported_system_role_patterns = {
-  "amazon.titan.-.*",
-  "cohere.command.-text.-.*",
-  "cohere.command.-light.-text.-.*",
-  "mistral.mistral.-7b.-instruct.-.*",
-  "mistral.mixtral.-8x7b.-instruct.-.*",
-}
-
 _M.upstream_url_format = {
   openai = fmt("%s://api.openai.com:%s", (openai_override and "http") or "https", (openai_override) or "443"),
   anthropic = "https://api.anthropic.com:443",

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -258,29 +258,31 @@ function _M.frame_to_events(frame, raw_json_mode)
     local event_lines = split(frame, "\n")
     local struct = { event = nil, id = nil, data = nil }
 
-    -- test for truncated chunk on the last line (no trailing \r\n\r\n)
-    if #dat > 0 and #event_lines == i then
-      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
-      kong.ctx.plugin.truncated_frame = dat
-      break  -- stop parsing immediately, server has done something wrong
-    end
+    for i, dat in ipairs(event_lines) do
+      if #dat < 1 then
+        events[#events + 1] = struct
+        struct = { event = nil, id = nil, data = nil }
+      end
 
-    -- test for abnormal start-of-frame (truncation tail)
-    if kong and kong.ctx.plugin.truncated_frame then
-      -- this is the tail of a previous incomplete chunk
-      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
-      dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
-      kong.ctx.plugin.truncated_frame = nil
-    end
+      -- test for truncated chunk on the last line (no trailing \r\n\r\n)
+      if #dat > 0 and #event_lines == i then
+        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
+        kong.ctx.plugin.truncated_frame = dat
+        break  -- stop parsing immediately, server has done something wrong
+      end
 
-    local s1, _ = str_find(dat, ":") -- find where the cut point is
+      -- test for abnormal start-of-frame (truncation tail)
+      if kong and kong.ctx.plugin.truncated_frame then
+        -- this is the tail of a previous incomplete chunk
+        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
+        dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
+        kong.ctx.plugin.truncated_frame = nil
+      end
 
-    if s1 and s1 ~= 1 then
-      local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
-      local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
+      local s1, _ = str_find(dat, ":") -- find where the cut point is
 
       if s1 and s1 ~= 1 then
-        local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
+        local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
         -- for now not checking if the value is already been set

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -277,7 +277,6 @@ function _M.frame_to_events(frame, provider)
       }
     end
 
-  -- standard SSE parser
   else
     -- standard SSE parser
     local event_lines = split(frame, "\n")
@@ -288,9 +287,6 @@ function _M.frame_to_events(frame, provider)
         events[#events + 1] = struct
         struct = { event = nil, id = nil, data = nil }
       end
-    else
-      local event_lines = split(frame, "\n")
-      local struct = { event = nil, id = nil, data = nil }
 
       -- test for truncated chunk on the last line (no trailing \r\n\r\n)
       if #dat > 0 and #event_lines == i then
@@ -313,17 +309,12 @@ function _M.frame_to_events(frame, provider)
         local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
-        if s1 and s1 ~= 1 then
-          local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
-          local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
-
-          -- for now not checking if the value is already been set
-          if     field == "event" then struct.event = value
-          elseif field == "id"    then struct.id = value
-          elseif field == "data"  then struct.data = value
-          end -- if
+        -- for now not checking if the value is already been set
+        if     field == "event" then struct.event = value
+        elseif field == "id"    then struct.id = value
+        elseif field == "data"  then struct.data = value
         end -- if
-      end
+      end -- if
     end
   end
   

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -278,29 +278,31 @@ function _M.frame_to_events(frame, provider)
     local event_lines = split(frame, "\n")
     local struct = { event = nil, id = nil, data = nil }
 
-    -- test for truncated chunk on the last line (no trailing \r\n\r\n)
-    if #dat > 0 and #event_lines == i then
-      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
-      kong.ctx.plugin.truncated_frame = dat
-      break  -- stop parsing immediately, server has done something wrong
-    end
+    for i, dat in ipairs(event_lines) do
+      if #dat < 1 then
+        events[#events + 1] = struct
+        struct = { event = nil, id = nil, data = nil }
+      end
 
-    -- test for abnormal start-of-frame (truncation tail)
-    if kong and kong.ctx.plugin.truncated_frame then
-      -- this is the tail of a previous incomplete chunk
-      ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
-      dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
-      kong.ctx.plugin.truncated_frame = nil
-    end
+      -- test for truncated chunk on the last line (no trailing \r\n\r\n)
+      if #dat > 0 and #event_lines == i then
+        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
+        kong.ctx.plugin.truncated_frame = dat
+        break  -- stop parsing immediately, server has done something wrong
+      end
 
-    local s1, _ = str_find(dat, ":") -- find where the cut point is
+      -- test for abnormal start-of-frame (truncation tail)
+      if kong and kong.ctx.plugin.truncated_frame then
+        -- this is the tail of a previous incomplete chunk
+        ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame tail")
+        dat = fmt("%s%s", kong.ctx.plugin.truncated_frame, dat)
+        kong.ctx.plugin.truncated_frame = nil
+      end
 
-    if s1 and s1 ~= 1 then
-      local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
-      local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
+      local s1, _ = str_find(dat, ":") -- find where the cut point is
 
       if s1 and s1 ~= 1 then
-        local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
+        local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
         -- for now not checking if the value is already been set

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -60,6 +60,14 @@ _M.streaming_has_token_counts = {
   ["bedrock"] = true,
 }
 
+_M.bedrock_unsupported_system_role_patterns = {
+  "amazon.titan.-.*",
+  "cohere.command.-text.-.*",
+  "cohere.command.-light.-text.-.*",
+  "mistral.mistral.-7b.-instruct.-.*",
+  "mistral.mixtral.-8x7b.-instruct.-.*",
+}
+
 _M.upstream_url_format = {
   openai = fmt("%s://api.openai.com:%s", (openai_override and "http") or "https", (openai_override) or "443"),
   anthropic = "https://api.anthropic.com:443",

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -64,7 +64,6 @@ _M.upstream_url_format = {
   cohere = "https://api.cohere.com:443",
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
-  gemini_vertex = "https://%s",
 }
 
 _M.operation_map = {
@@ -110,13 +109,7 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1beta/models/%s:%s",
-      method = "POST",
-    },
-  },
-  gemini_vertex = {
-    ["llm/v1/chat"] = {
-      path = "/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
+      path = "/v1/models/%s:generateContent",  -- /v1/models/gemini-pro:generateContent,
       method = "POST",
     },
   },

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -57,6 +57,7 @@ _M.streaming_has_token_counts = {
   ["llama2"] = true,
   ["anthropic"] = true,
   ["gemini"] = true,
+  ["bedrock"] = true,
 }
 
 _M.upstream_url_format = {

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -277,8 +277,8 @@ function _M.frame_to_events(frame, provider)
       }
     end
 
-  -- standard SSE parser
   else
+    -- standard SSE parser
     local event_lines = split(frame, "\n")
     local struct = { event = nil, id = nil, data = nil }
 
@@ -287,9 +287,6 @@ function _M.frame_to_events(frame, provider)
         events[#events + 1] = struct
         struct = { event = nil, id = nil, data = nil }
       end
-    else
-      local event_lines = split(frame, "\n")
-      local struct = { event = nil, id = nil, data = nil }
 
       -- test for truncated chunk on the last line (no trailing \r\n\r\n)
       if #dat > 0 and #event_lines == i then
@@ -312,17 +309,12 @@ function _M.frame_to_events(frame, provider)
         local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
-        if s1 and s1 ~= 1 then
-          local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
-          local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
-
-          -- for now not checking if the value is already been set
-          if     field == "event" then struct.event = value
-          elseif field == "id"    then struct.id = value
-          elseif field == "data"  then struct.data = value
-          end -- if
+        -- for now not checking if the value is already been set
+        if     field == "event" then struct.event = value
+        elseif field == "id"    then struct.id = value
+        elseif field == "data"  then struct.data = value
         end -- if
-      end
+      end -- if
     end
   end
   

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -245,19 +245,9 @@ function _M.frame_to_events(frame, provider)
     return
   end
 
-  -- check if it's raw json and just return the split up data frame
-  -- Cohere / Other flat-JSON format parser
-  -- just return the split up data frame
-  elseif (not kong or not kong.ctx.plugin.truncated_frame) and string.sub(str_ltrim(frame), 1, 1) == "{" then
-    for event in frame:gmatch("[^\r\n]+") do
-      events[#events + 1] = {
-        data = event,
-      }
-    end
-
   -- some new LLMs return the JSON object-by-object,
   -- because that totally makes sense to parse?!
-  elseif raw_json_mode then
+  if raw_json_mode then
     -- if this is the first frame, it will begin with array opener '['
     frame = (string.sub(str_ltrim(frame), 1, 1) == "[" and string.sub(str_ltrim(frame), 2)) or frame
 
@@ -272,6 +262,17 @@ function _M.frame_to_events(frame, provider)
       events[#events+1] = { data = v }
     end
 
+  -- check if it's raw json and just return the split up data frame
+  -- Cohere / Other flat-JSON format parser
+  -- just return the split up data frame
+  elseif (not kong or not kong.ctx.plugin.truncated_frame) and string.sub(str_ltrim(frame), 1, 1) == "{" then
+    for event in frame:gmatch("[^\r\n]+") do
+      events[#events + 1] = {
+        data = event,
+      }
+    end
+
+  -- standard SSE parser
   else
     -- standard SSE parser
     local event_lines = split(frame, "\n")

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -263,7 +263,7 @@ function _M.frame_to_events(frame, provider)
         break
       end
 
-      events[#events+1] = "data: " .. cjson.encode(msg)
+      events[#events+1] = { data = cjson.encode(msg) }
     end
 
   -- check if it's raw json and just return the split up data frame

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -75,6 +75,7 @@ _M.upstream_url_format = {
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
   gemini_vertex = "https://%s",
+  bedrock = "https://bedrock-runtime.%s.amazonaws.com",
 }
 
 _M.operation_map = {

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -299,7 +299,11 @@ function _M.frame_to_events(frame, provider)
       -- test for truncated chunk on the last line (no trailing \r\n\r\n)
       if #dat > 0 and #event_lines == i then
         ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
-        kong.ctx.plugin.truncated_frame = dat
+
+        if kong then
+          kong.ctx.plugin.truncated_frame = dat
+        end
+
         break  -- stop parsing immediately, server has done something wrong
       end
 

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -74,8 +74,6 @@ _M.upstream_url_format = {
   cohere = "https://api.cohere.com:443",
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
-  gemini_vertex = "https://%s",
-  bedrock = "https://bedrock-runtime.%s.amazonaws.com",
 }
 
 _M.operation_map = {
@@ -121,13 +119,7 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1beta/models/%s:%s",
-      method = "POST",
-    },
-  },
-  gemini_vertex = {
-    ["llm/v1/chat"] = {
-      path = "/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
+      path = "/v1/models/%s:generateContent",  -- /v1/models/gemini-pro:generateContent,
       method = "POST",
     },
   },

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -241,38 +241,9 @@ end
 function _M.frame_to_events(frame, provider)
   local events = {}
 
-  if (not frame) or (#frame < 1) or (type(frame)) ~= "string" then
+  if (not frame) or #frame < 1 then
     return
   end
-
-  -- some new LLMs return the JSON object-by-object,
-  -- because that totally makes sense to parse?!
-  if provider == "gemini" then
-    -- if this is the first frame, it will begin with array opener '['
-    frame = (string.sub(str_ltrim(frame), 1, 1) == "[" and string.sub(str_ltrim(frame), 2)) or frame
-
-    -- it may start with ',' which is the start of the new frame
-    frame = (string.sub(str_ltrim(frame), 1, 1) == "," and string.sub(str_ltrim(frame), 2)) or frame
-    
-    -- finally, it may end with the array terminator ']' indicating the finished stream
-    frame = (string.sub(str_ltrim(frame), -1) == "]" and string.sub(str_ltrim(frame), 1, -2)) or frame
-
-    -- for multiple events that arrive in the same frame, split by top-level comma
-    for _, v in ipairs(split(frame, "\n,")) do
-      events[#events+1] = { data = v }
-    end
-
-  elseif provider == "bedrock" then
-    local parser = aws_stream:new(frame)
-    while true do
-      local msg = parser:next_message()
-
-      if not msg then
-        break
-      end
-
-      events[#events+1] = { data = cjson.encode(msg) }
-    end
 
   -- check if it's raw json and just return the split up data frame
   -- Cohere / Other flat-JSON format parser

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -283,6 +283,9 @@ function _M.frame_to_events(frame, provider)
         events[#events + 1] = struct
         struct = { event = nil, id = nil, data = nil }
       end
+    else
+      local event_lines = split(frame, "\n")
+      local struct = { event = nil, id = nil, data = nil }
 
       -- test for truncated chunk on the last line (no trailing \r\n\r\n)
       if #dat > 0 and #event_lines == i then
@@ -305,12 +308,17 @@ function _M.frame_to_events(frame, provider)
         local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
-        -- for now not checking if the value is already been set
-        if     field == "event" then struct.event = value
-        elseif field == "id"    then struct.id = value
-        elseif field == "data"  then struct.data = value
+        if s1 and s1 ~= 1 then
+          local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
+          local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
+
+          -- for now not checking if the value is already been set
+          if     field == "event" then struct.event = value
+          elseif field == "id"    then struct.id = value
+          elseif field == "data"  then struct.data = value
+          end -- if
         end -- if
-      end -- if
+      end
     end
   end
   

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -222,26 +222,9 @@ end
 function _M.frame_to_events(frame, raw_json_mode)
   local events = {}
 
-  if (not frame) or (#frame < 1) or (type(frame)) ~= "string" then
+  if (not frame) or #frame < 1 then
     return
   end
-
-  -- some new LLMs return the JSON object-by-object,
-  -- because that totally makes sense to parse?!
-  if raw_json_mode then
-    -- if this is the first frame, it will begin with array opener '['
-    frame = (string.sub(str_ltrim(frame), 1, 1) == "[" and string.sub(str_ltrim(frame), 2)) or frame
-
-    -- it may start with ',' which is the start of the new frame
-    frame = (string.sub(str_ltrim(frame), 1, 1) == "," and string.sub(str_ltrim(frame), 2)) or frame
-    
-    -- finally, it may end with the array terminator ']' indicating the finished stream
-    frame = (string.sub(str_ltrim(frame), -1) == "]" and string.sub(str_ltrim(frame), 1, -2)) or frame
-
-    -- for multiple events that arrive in the same frame, split by top-level comma
-    for _, v in ipairs(split(frame, "\n,")) do
-      events[#events+1] = { data = v }
-    end
 
   -- check if it's raw json and just return the split up data frame
   -- Cohere / Other flat-JSON format parser

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -263,6 +263,9 @@ function _M.frame_to_events(frame, raw_json_mode)
         events[#events + 1] = struct
         struct = { event = nil, id = nil, data = nil }
       end
+    else
+      local event_lines = split(frame, "\n")
+      local struct = { event = nil, id = nil, data = nil }
 
       -- test for truncated chunk on the last line (no trailing \r\n\r\n)
       if #dat > 0 and #event_lines == i then
@@ -285,12 +288,17 @@ function _M.frame_to_events(frame, raw_json_mode)
         local field = str_sub(dat, 1, s1-1) -- returns "data" from data: hello world
         local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
 
-        -- for now not checking if the value is already been set
-        if     field == "event" then struct.event = value
-        elseif field == "id"    then struct.id = value
-        elseif field == "data"  then struct.data = value
+        if s1 and s1 ~= 1 then
+          local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
+          local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
+
+          -- for now not checking if the value is already been set
+          if     field == "event" then struct.event = value
+          elseif field == "id"    then struct.id = value
+          elseif field == "data"  then struct.data = value
+          end -- if
         end -- if
-      end -- if
+      end
     end
   end
   

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -64,6 +64,7 @@ _M.upstream_url_format = {
   cohere = "https://api.cohere.com:443",
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
+  gemini_vertex = "https://%s",
 }
 
 _M.operation_map = {
@@ -109,7 +110,13 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1/models/%s:generateContent",
+      path = "/v1beta/models/%s:%s",
+      method = "POST",
+    },
+  },
+  gemini_vertex = {
+    ["llm/v1/chat"] = {
+      path = "/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
       method = "POST",
     },
   },

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -272,7 +272,7 @@ function _M.frame_to_events(frame, provider)
         break
       end
 
-      events[#events+1] = "data: " .. cjson.encode(msg)
+      events[#events+1] = { data = cjson.encode(msg) }
     end
 
   -- check if it's raw json and just return the split up data frame

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -65,6 +65,7 @@ _M.upstream_url_format = {
   azure = "https://%s.openai.azure.com:443/openai/deployments/%s",
   gemini = "https://generativelanguage.googleapis.com",
   gemini_vertex = "https://%s",
+  bedrock = "https://bedrock-runtime.%s.amazonaws.com",
 }
 
 _M.operation_map = {
@@ -120,6 +121,12 @@ _M.operation_map = {
       method = "POST",
     },
   },
+  bedrock = {
+    ["llm/v1/chat"] = {
+      path = "/model/%s/%s",
+      method = "POST",
+    },
+  },
 }
 
 _M.clear_response_headers = {
@@ -136,6 +143,9 @@ _M.clear_response_headers = {
     "Set-Cookie",
   },
   gemini = {
+    "Set-Cookie",
+  },
+  bedrock = {
     "Set-Cookie",
   },
 }
@@ -679,6 +689,10 @@ end
 
 -- Function to count the number of words in a string
 local function count_words(str)
+  if type(str) ~= "string" then
+    return 0
+  end
+
   local count = 0
   if type(str) == "string" then
     for word in str:gmatch("%S+") do

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -109,7 +109,7 @@ _M.operation_map = {
   },
   gemini = {
     ["llm/v1/chat"] = {
-      path = "/v1/models/%s:generateContent",  -- /v1/models/gemini-pro:generateContent,
+      path = "/v1/models/%s:generateContent",
       method = "POST",
     },
   },

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -91,20 +91,51 @@ do
   function LLM:ai_introspect_body(request, system_prompt, http_opts, response_regex_match)
     local err, _
 
-    -- set up the request
-    local ai_request = {
-      messages = {
-        [1] = {
-          role = "system",
-          content = system_prompt,
+    -- set up the LLM request for transformation instructions
+    local ai_request
+
+    -- mistral, cohere, titan (with Bedrock) don't support system commands
+    if self.driver == "bedrock" then
+      for _, p in ipairs(ai_shared.bedrock_unsupported_system_role_patterns) do
+        if request.model:find(p) then
+          ai_request = {
+            messages = {
+              [1] = {
+                role = "user",
+                content = system_prompt,
+              },
+              [2] = {
+                role = "assistant",
+                content = "What is the message?",
+              },
+              [3] = {
+                role = "user",
+                content = request,
+              }
+            },
+            stream = false,
+          }
+          break
+        end
+      end
+    end
+
+    -- not Bedrock, or didn't match banned pattern - continue as normal
+    if not ai_request then
+      ai_request = {
+        messages = {
+          [1] = {
+            role = "system",
+            content = system_prompt,
+          },
+          [2] = {
+            role = "user",
+            content = request,
+          }
         },
-        [2] = {
-          role = "user",
-          content = request,
-        }
-      },
-      stream = false,
-    }
+        stream = false,
+      }
+    end
 
     -- convert it to the specified driver format
     ai_request, _, err = self.driver.to_format(ai_request, self.conf.model, "llm/v1/chat")
@@ -204,8 +235,8 @@ do
     }
     setmetatable(self, LLM)
 
-    local provider = (self.conf.model or {}).provider or "NONE_SET"
-    local driver_module = "kong.llm.drivers." .. provider
+    self.provider = (self.conf.model or {}).provider or "NONE_SET"
+    local driver_module = "kong.llm.drivers." .. self.provider
     local ok
     ok, self.driver = pcall(require, driver_module)
     if not ok then

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -92,50 +92,22 @@ do
     local err, _
 
     -- set up the LLM request for transformation instructions
-    local ai_request
-
-    -- mistral, cohere, titan (with Bedrock) don't support system commands
-    if self.driver == "bedrock" then
-      for _, p in ipairs(ai_shared.bedrock_unsupported_system_role_patterns) do
-        if request.model:find(p) then
-          ai_request = {
-            messages = {
-              [1] = {
-                role = "user",
-                content = system_prompt,
-              },
-              [2] = {
-                role = "assistant",
-                content = "What is the message?",
-              },
-              [3] = {
-                role = "user",
-                content = request,
-              }
-            },
-            stream = false,
-          }
-          break
-        end
-      end
-    end
-
-    -- not Bedrock, or didn't match banned pattern - continue as normal
-    if not ai_request then
-      ai_request = {
-        messages = {
-          [1] = {
-            role = "system",
-            content = system_prompt,
-          },
-          [2] = {
-            role = "user",
-            content = request,
-          }
+    local ai_request = {
+      messages = {
+        [1] = {
+          role = "system",
+          content = system_prompt,
         },
-        stream = false,
-      }
-    end
+        [2] = {
+          role = "user",
+          content = request,
+        }
+      },
+      stream = false,
+    }
+
+    -- needed for some drivers later
+    self.conf.model.source = "transformer-plugins"
 
     -- convert it to the specified driver format
     ai_request, _, err = self.driver.to_format(ai_request, self.conf.model, "llm/v1/chat")

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -10,7 +10,6 @@ local _M = {
   config_schema = require "kong.llm.schemas",
 }
 
-
 do
   -- formats_compatible is a map of formats that are compatible with each other.
   local formats_compatible = {

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -10,6 +10,7 @@ local _M = {
   config_schema = require "kong.llm.schemas",
 }
 
+
 do
   -- formats_compatible is a map of formats that are compatible with each other.
   local formats_compatible = {

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -32,6 +32,9 @@ local gemini_options_schema = {
         description = "If running Gemini on Vertex, specify the location ID.",
         required = false }},
   },
+  entity_checks = {
+    { mutually_required = { "api_endpoint", "project_id", "location_id" }, },
+  },
 }
 
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -68,6 +68,20 @@ local auth_schema = {
                       "environment variable `GCP_SERVICE_ACCOUNT`.",
         required = false,
         referenceable = true }},
+    { aws_access_key_id = {
+        type = "string",
+        description = "Set this if you are using an AWS provider (Bedrock, SageMaker) and you are authenticating " ..
+                      "using static IAM User credentials.",
+        required = false,
+        encrypted = true,
+        referenceable = true }},
+    { aws_secret_access_key = {
+        type = "string",
+        description = "Set this if you are using an AWS provider (Bedrock, SageMaker) and you are authenticating " ..
+                      "using static IAM User credentials.",
+        required = false,
+        encrypted = true,
+        referenceable = true }},
   }
 }
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -19,9 +19,6 @@ local gemini_options_schema = {
         description = "If running Gemini on Vertex, specify the location ID.",
         required = false }},
   },
-  entity_checks = {
-    { mutually_required = { "api_endpoint", "project_id", "location_id" }, },
-  },
 }
 
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -32,9 +32,6 @@ local gemini_options_schema = {
         description = "If running Gemini on Vertex, specify the location ID.",
         required = false }},
   },
-  entity_checks = {
-    { mutually_required = { "api_endpoint", "project_id", "location_id" }, },
-  },
 }
 
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -2,6 +2,19 @@ local typedefs = require("kong.db.schema.typedefs")
 local fmt = string.format
 
 
+local bedrock_options_schema = {
+  type = "record",
+  required = false,
+  fields = {
+    { aws_region = {
+      description = "If using AWS providers (Bedrock) you can override the `AWS_REGION` " ..
+                    "environment variable by setting this option.",
+      type = "string",
+      required = false }},
+  },
+}
+
+
 local gemini_options_schema = {
   type = "record",
   required = false,
@@ -158,6 +171,7 @@ local model_options_schema = {
         type = "string",
         required = false }},
     { gemini = gemini_options_schema },
+    { bedrock = bedrock_options_schema },
   }
 }
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -185,7 +185,7 @@ local model_schema = {
         type = "string", description = "AI provider request format - Kong translates "
                                     .. "requests to and from the specified backend compatible formats.",
         required = true,
-        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini" }}},
+        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini", "bedrock" }}},
     { name = {
         type = "string",
         description = "Model name to execute.",

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -19,6 +19,9 @@ local gemini_options_schema = {
         description = "If running Gemini on Vertex, specify the location ID.",
         required = false }},
   },
+  entity_checks = {
+    { mutually_required = { "api_endpoint", "project_id", "location_id" }, },
+  },
 }
 
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -62,6 +62,11 @@ local _KEYBASTION = setmetatable({}, {
 })
 
 
+-- static messages
+local ERROR_MSG = { error = { message = "" } }
+local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported transformer response"}'
+
+
 local _KEYBASTION = setmetatable({}, {
   __mode = "k",
   __index = function(this_cache, plugin_config)
@@ -151,8 +156,11 @@ local function handle_streaming_frame(conf)
     end
 
     if not events then
-      local response = 'data: {"error": true, "message": "empty transformer response"}'
-      
+      -- usually a not-supported-transformer or empty frames.
+      -- header_filter has already run, so all we can do is log it,
+      -- and then send the client a readable error in a single chunk
+      local response = ERROR__NOT_SET
+
       if is_gzip then
         response = kong_utils.deflate_gzip(response)
       end

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -104,7 +104,7 @@ local _KEYBASTION = setmetatable({}, {
           aws_secret_access_key = plugin_config.auth.aws_secret_access_key,
         })
       else
-        aws = AWS({ region = plugin_config.model.options.aws_region or AWS_REGION })
+        aws = AWS({ region = (plugin_config.model.options and plugin_config.model.options.aws_region) or AWS_REGION })
       end
 
       this_cache[plugin_config] = { interface = aws, error = nil }
@@ -160,11 +160,17 @@ local function handle_streaming_frame(conf)
       chunk = kong_utils.inflate_gzip(ngx.arg[1])
     end
 
-    local to_hex        = require("resty.string").to_hex
+    local to_hex = require("resty.string").to_hex
 
     kong.log.warn("")
     kong.log.warn(to_hex(chunk))
     kong.log.warn("")
+
+    
+    -- for i = 1, #chunk do
+    --   local c = chunk:sub(i,i)
+    --   kong.log.debug(to_hex(c))
+    -- end
 
     local events = ai_shared.frame_to_events(chunk, conf.model.provider == "gemini")
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -18,8 +18,12 @@ local GCP = require("resty.gcp.request.credentials.accesstoken")
 local GCP_SERVICE_ACCOUNT do
   GCP_SERVICE_ACCOUNT = os.getenv("GCP_SERVICE_ACCOUNT")
 end
+local AWS_REGION do
+  AWS_REGION = os.getenv("AWS_REGION")
+end
 
 local GCP = require("resty.gcp.request.credentials.accesstoken")
+local AWS = require("resty.aws")
 --
 
 
@@ -88,6 +92,25 @@ local _KEYBASTION = setmetatable({}, {
 
       return { interface = nil, error = "cloud-authentication with GCP failed" }
     end
+
+    if plugin_config.model.provider == "bedrock" then
+      ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
+
+      local aws
+      if plugin_config.model.options and plugin_config.model.options.aws then
+        aws = AWS({
+          region = plugin_config.model.options.aws_region or AWS_REGION,
+          aws_access_key_id = plugin_config.auth.aws_access_key_id,
+          aws_secret_access_key = plugin_config.auth.aws_secret_access_key,
+        })
+      else
+        aws = AWS({ region = plugin_config.model.options.aws_region or AWS_REGION })
+      end
+
+      this_cache[plugin_config] = { interface = aws, error = nil }
+
+      return this_cache[plugin_config]
+    end
   end,
 })
 
@@ -136,6 +159,12 @@ local function handle_streaming_frame(conf)
     if (not finished) and (is_gzip) then
       chunk = kong_utils.inflate_gzip(ngx.arg[1])
     end
+
+    local to_hex        = require("resty.string").to_hex
+
+    kong.log.warn("")
+    kong.log.warn(to_hex(chunk))
+    kong.log.warn("")
 
     local events = ai_shared.frame_to_events(chunk, conf.model.provider == "gemini")
 
@@ -547,7 +576,6 @@ function _M:access(conf)
   end
 
   -- lights out, and away we go
-
 end
 
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -109,6 +109,11 @@ local _KEYBASTION = setmetatable({}, {
 })
 
 
+-- static messages
+local ERROR_MSG = { error = { message = "" } }
+local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported transformer response"}'
+
+
 local _KEYBASTION = setmetatable({}, {
   __mode = "k",
   __index = function(this_cache, plugin_config)
@@ -198,8 +203,11 @@ local function handle_streaming_frame(conf)
     end
 
     if not events then
-      local response = 'data: {"error": true, "message": "empty transformer response"}'
-      
+      -- usually a not-supported-transformer or empty frames.
+      -- header_filter has already run, so all we can do is log it,
+      -- and then send the client a readable error in a single chunk
+      local response = ERROR__NOT_SET
+
       if is_gzip then
         response = kong_utils.deflate_gzip(response)
       end

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -151,7 +151,7 @@ local _KEYBASTION = setmetatable({}, {
           aws_secret_access_key = plugin_config.auth.aws_secret_access_key,
         })
       else
-        aws = AWS({ region = plugin_config.model.options.aws_region or AWS_REGION })
+        aws = AWS({ region = (plugin_config.model.options and plugin_config.model.options.aws_region) or AWS_REGION })
       end
 
       this_cache[plugin_config] = { interface = aws, error = nil }
@@ -207,11 +207,17 @@ local function handle_streaming_frame(conf)
       chunk = kong_utils.inflate_gzip(ngx.arg[1])
     end
 
-    local to_hex        = require("resty.string").to_hex
+    local to_hex = require("resty.string").to_hex
 
     kong.log.warn("")
     kong.log.warn(to_hex(chunk))
     kong.log.warn("")
+
+    
+    -- for i = 1, #chunk do
+    --   local c = chunk:sub(i,i)
+    --   kong.log.debug(to_hex(c))
+    -- end
 
     local events = ai_shared.frame_to_events(chunk, conf.model.provider == "gemini")
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -169,22 +169,6 @@ local function handle_streaming_frame(conf)
 
     local events = ai_shared.frame_to_events(chunk, conf.model.provider)
 
-    -- TODO: DELETE THIS
-    local function dump(o)
-      if type(o) == 'table' then
-        local s = '{ '
-        for k,v in pairs(o) do
-            if type(k) ~= 'number' then k = '"'..k..'"' end
-            s = s .. '['..k..'] = ' .. dump(v) .. ','
-        end
-        return s .. '} '
-      else
-        return tostring(o)
-      end
-    end
-
-    kong.log.warn(dump(events))
-
     if not events then
       -- usually a not-supported-transformer or empty frames.
       -- header_filter has already run, so all we can do is log it,

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -131,22 +131,24 @@ local _KEYBASTION = setmetatable({}, {
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
 
-      local aws
-      if plugin_config.model.options 
-         and plugin_config.model.options.bedrock
-         and plugin_config.model.auth then
-        aws = AWS({
-          -- if any of these are nil, they either use the SDK default or
-          -- are deliberately null so that a different auth chain is used
-          region = plugin_config.model.options.bedrock.aws_region or AWS_REGION,
-          aws_access_key_id = plugin_config.auth.aws_access_key_id or AWS_ACCESS_KEY_ID,
-          aws_secret_access_key = plugin_config.auth.aws_secret_access_key or AWS_SECRET_ACCESS_KEY,
-        })
-      else
-        aws = AWS({ region = (plugin_config.model.options 
-                              and plugin_config.model.options.bedrock
-                              and plugin_config.model.options.bedrock.aws_region) or AWS_REGION })
-      end
+      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
+                      or AWS_ACCESS_KEY_ID
+      
+      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
+                      or AWS_ACCESS_KEY_ID
+
+      local region = plugin_config.model.options
+                 and plugin_config.model.options.bedrock
+                 and plugin_config.model.options.bedrock.aws_region
+                  or AWS_REGION
+
+      local aws = AWS({
+        -- if any of these are nil, they either use the SDK default or
+        -- are deliberately null so that a different auth chain is used
+        region = region,
+        aws_access_key_id = access_key,
+        aws_secret_access_key = secret_key,
+      })
 
       this_cache[plugin_config] = { interface = aws, error = nil }
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -27,18 +27,6 @@ local GCP = require("resty.gcp.request.credentials.accesstoken")
 local AWS = require("resty.aws")
 --
 
--- cloud auth/sdk providers
-local GCP_SERVICE_ACCOUNT do
-  GCP_SERVICE_ACCOUNT = os.getenv("GCP_SERVICE_ACCOUNT")
-end
-local AWS_REGION do
-  AWS_REGION = os.getenv("AWS_REGION")
-end
-
-local GCP = require("resty.gcp.request.credentials.accesstoken")
-local AWS = require("resty.aws")
---
-
 
 local EMPTY = {}
 
@@ -144,14 +132,20 @@ local _KEYBASTION = setmetatable({}, {
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
 
       local aws
-      if plugin_config.model.options and plugin_config.model.options.aws then
+      if plugin_config.model.options 
+         and plugin_config.model.options.bedrock
+         and plugin_config.model.auth then
         aws = AWS({
-          region = plugin_config.model.options.aws_region or AWS_REGION,
-          aws_access_key_id = plugin_config.auth.aws_access_key_id,
-          aws_secret_access_key = plugin_config.auth.aws_secret_access_key,
+          -- if any of these are nil, they either use the SDK default or
+          -- are deliberately null so that a different auth chain is used
+          region = plugin_config.model.options.bedrock.aws_region or AWS_REGION,
+          aws_access_key_id = plugin_config.auth.aws_access_key_id or AWS_ACCESS_KEY_ID,
+          aws_secret_access_key = plugin_config.auth.aws_secret_access_key or AWS_SECRET_ACCESS_KEY,
         })
       else
-        aws = AWS({ region = (plugin_config.model.options and plugin_config.model.options.aws_region) or AWS_REGION })
+        aws = AWS({ region = (plugin_config.model.options 
+                              and plugin_config.model.options.bedrock
+                              and plugin_config.model.options.bedrock.aws_region) or AWS_REGION })
       end
 
       this_cache[plugin_config] = { interface = aws, error = nil }
@@ -207,19 +201,23 @@ local function handle_streaming_frame(conf)
       chunk = kong_utils.inflate_gzip(ngx.arg[1])
     end
 
-    local to_hex = require("resty.string").to_hex
+    local events = ai_shared.frame_to_events(chunk, conf.model.provider)
 
-    kong.log.warn("")
-    kong.log.warn(to_hex(chunk))
-    kong.log.warn("")
+    -- TODO: DELETE THIS
+    local function dump(o)
+      if type(o) == 'table' then
+        local s = '{ '
+        for k,v in pairs(o) do
+            if type(k) ~= 'number' then k = '"'..k..'"' end
+            s = s .. '['..k..'] = ' .. dump(v) .. ','
+        end
+        return s .. '} '
+      else
+        return tostring(o)
+      end
+    end
 
-    
-    -- for i = 1, #chunk do
-    --   local c = chunk:sub(i,i)
-    --   kong.log.debug(to_hex(c))
-    -- end
-
-    local events = ai_shared.frame_to_events(chunk, conf.model.provider == "gemini")
+    kong.log.warn(dump(events))
 
     if not events then
       -- usually a not-supported-transformer or empty frames.

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -97,22 +97,24 @@ local _KEYBASTION = setmetatable({}, {
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
 
-      local aws
-      if plugin_config.model.options 
-         and plugin_config.model.options.bedrock
-         and plugin_config.model.auth then
-        aws = AWS({
-          -- if any of these are nil, they either use the SDK default or
-          -- are deliberately null so that a different auth chain is used
-          region = plugin_config.model.options.bedrock.aws_region or AWS_REGION,
-          aws_access_key_id = plugin_config.auth.aws_access_key_id or AWS_ACCESS_KEY_ID,
-          aws_secret_access_key = plugin_config.auth.aws_secret_access_key or AWS_SECRET_ACCESS_KEY,
-        })
-      else
-        aws = AWS({ region = (plugin_config.model.options 
-                              and plugin_config.model.options.bedrock
-                              and plugin_config.model.options.bedrock.aws_region) or AWS_REGION })
-      end
+      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
+                      or AWS_ACCESS_KEY_ID
+      
+      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
+                      or AWS_ACCESS_KEY_ID
+
+      local region = plugin_config.model.options
+                 and plugin_config.model.options.bedrock
+                 and plugin_config.model.options.bedrock.aws_region
+                  or AWS_REGION
+
+      local aws = AWS({
+        -- if any of these are nil, they either use the SDK default or
+        -- are deliberately null so that a different auth chain is used
+        region = region,
+        aws_access_key_id = access_key,
+        aws_secret_access_key = secret_key,
+      })
 
       this_cache[plugin_config] = { interface = aws, error = nil }
 

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -37,11 +37,6 @@ local _M = {
 }
 
 
--- static messages
-local ERROR_MSG = { error = { message = "" } }
-local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported transformer response"}'
-
-
 local _KEYBASTION = setmetatable({}, {
   __mode = "k",
   __index = function(this_cache, plugin_config)
@@ -170,6 +165,19 @@ local function handle_streaming_frame(conf)
       -- and then send the client a readable error in a single chunk
       local response = ERROR__NOT_SET
 
+      if is_gzip then
+        response = kong_utils.deflate_gzip(response)
+      end
+
+      ngx.arg[1] = response
+      ngx.arg[2] = true
+
+      return
+    end
+
+    if not events then
+      local response = 'data: {"error": true, "message": "empty transformer response"}'
+      
       if is_gzip then
         response = kong_utils.deflate_gzip(response)
       end
@@ -539,7 +547,7 @@ function _M:access(conf)
 
   -- get the provider's cached identity interface - nil may come back, which is fine
   local identity_interface = _KEYBASTION[conf]
-  if identity_interface and identity_interface.error then
+  if identity_interface.error then
     kong.ctx.shared.skip_response_transformer = true
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)
 
@@ -547,8 +555,7 @@ function _M:access(conf)
   end
 
   -- now re-configure the request for this operation type
-  local ok, err = ai_driver.configure_request(conf_m,
-               identity_interface and identity_interface.interface)
+  local ok, err = ai_driver.configure_request(conf_m, identity_interface.interface)
   if not ok then
     kong_ctx_shared.skip_response_transformer = true
     kong.log.err("failed to configure request for AI service: ", err)

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -63,36 +63,6 @@ local _KEYBASTION = setmetatable({}, {
 
       return { interface = nil, error = "cloud-authentication with GCP failed" }
     end
-  end,
-})
-
-
--- static messages
-local ERROR_MSG = { error = { message = "" } }
-local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported transformer response"}'
-
-
-local _KEYBASTION = setmetatable({}, {
-  __mode = "k",
-  __index = function(this_cache, plugin_config)
-    if plugin_config.model.provider == "gemini" and
-       plugin_config.auth and
-       plugin_config.auth.gcp_use_service_account then
-
-      ngx.log(ngx.NOTICE, "loading gcp sdk for plugin ", kong.plugin.get_id())
-
-      local service_account_json = (plugin_config.auth and plugin_config.auth.gcp_service_account_json) or GCP_SERVICE_ACCOUNT
-
-      local ok, gcp_auth = pcall(GCP.new, nil, service_account_json)
-      if ok and gcp_auth then
-        -- store our item for the next time we need it
-        gcp_auth.service_account_json = service_account_json
-        this_cache[plugin_config] = { interface = gcp_auth, error = nil }
-        return this_cache[plugin_config]
-      end
-
-      return { interface = nil, error = "cloud-authentication with GCP failed" }
-    end
 
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -24,6 +24,11 @@ local _M = {
 }
 
 
+-- static messages
+local ERROR_MSG = { error = { message = "" } }
+local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported transformer response"}'
+
+
 local _KEYBASTION = setmetatable({}, {
   __mode = "k",
   __index = function(this_cache, plugin_config)
@@ -95,8 +100,7 @@ local function handle_streaming_frame(conf)
       chunk = kong_utils.inflate_gzip(ngx.arg[1])
     end
 
-    local is_raw_json = conf.model.provider == "gemini"
-    local events = ai_shared.frame_to_events(chunk, is_raw_json )
+    local events = ai_shared.frame_to_events(chunk, conf.model.provider == "gemini")
 
     if not events then
       -- usually a not-supported-transformer or empty frames.
@@ -104,35 +108,6 @@ local function handle_streaming_frame(conf)
       -- and then send the client a readable error in a single chunk
       local response = ERROR__NOT_SET
 
-      if is_gzip then
-        response = kong_utils.deflate_gzip(response)
-      end
-
-      ngx.arg[1] = response
-      ngx.arg[2] = true
-
-      return
-    end
-
-    if not events then
-      -- usually a not-supported-transformer or empty frames.
-      -- header_filter has already run, so all we can do is log it,
-      -- and then send the client a readable error in a single chunk
-      local response = ERROR__NOT_SET
-
-      if is_gzip then
-        response = kong_utils.deflate_gzip(response)
-      end
-
-      ngx.arg[1] = response
-      ngx.arg[2] = true
-
-      return
-    end
-
-    if not events then
-      local response = 'data: {"error": true, "message": "empty transformer response"}'
-      
       if is_gzip then
         response = kong_utils.deflate_gzip(response)
       end
@@ -502,7 +477,7 @@ function _M:access(conf)
 
   -- get the provider's cached identity interface - nil may come back, which is fine
   local identity_interface = _KEYBASTION[conf]
-  if identity_interface.error then
+  if identity_interface and identity_interface.error then
     kong.ctx.shared.skip_response_transformer = true
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)
 
@@ -510,7 +485,8 @@ function _M:access(conf)
   end
 
   -- now re-configure the request for this operation type
-  local ok, err = ai_driver.configure_request(conf_m, identity_interface.interface)
+  local ok, err = ai_driver.configure_request(conf_m,
+               identity_interface and identity_interface.interface)
   if not ok then
     kong_ctx_shared.skip_response_transformer = true
     kong.log.err("failed to configure request for AI service: ", err)

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -27,6 +27,14 @@ local GCP = require("resty.gcp.request.credentials.accesstoken")
 local AWS = require("resty.aws")
 --
 
+-- cloud auth/sdk providers
+local GCP_SERVICE_ACCOUNT do
+  GCP_SERVICE_ACCOUNT = os.getenv("GCP_SERVICE_ACCOUNT")
+end
+
+local GCP = require("resty.gcp.request.credentials.accesstoken")
+--
+
 
 local EMPTY = {}
 
@@ -100,6 +108,31 @@ local _KEYBASTION = setmetatable({}, {
   end,
 })
 
+
+local _KEYBASTION = setmetatable({}, {
+  __mode = "k",
+  __index = function(this_cache, plugin_config)
+    if plugin_config.model.provider == "gemini" and
+       plugin_config.auth and
+       plugin_config.auth.gcp_use_service_account then
+
+      ngx.log(ngx.NOTICE, "loading gcp sdk for plugin ", kong.plugin.get_id())
+
+      local service_account_json = (plugin_config.auth and plugin_config.auth.gcp_service_account_json) or GCP_SERVICE_ACCOUNT
+
+      local ok, gcp_auth = pcall(GCP.new, nil, service_account_json)
+      if ok and gcp_auth then
+        -- store our item for the next time we need it
+        gcp_auth.service_account_json = service_account_json
+        this_cache[plugin_config] = { interface = gcp_auth, error = nil }
+        return this_cache[plugin_config]
+      end
+
+      return { interface = nil, error = "cloud-authentication with GCP failed" }
+    end
+  end,
+})
+
 local function bad_request(msg)
   kong.log.info(msg)
   return kong.response.exit(400, { error = { message = msg } })
@@ -154,6 +187,19 @@ local function handle_streaming_frame(conf)
       -- and then send the client a readable error in a single chunk
       local response = ERROR__NOT_SET
 
+      if is_gzip then
+        response = kong_utils.deflate_gzip(response)
+      end
+
+      ngx.arg[1] = response
+      ngx.arg[2] = true
+
+      return
+    end
+
+    if not events then
+      local response = 'data: {"error": true, "message": "empty transformer response"}'
+      
       if is_gzip then
         response = kong_utils.deflate_gzip(response)
       end

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -203,22 +203,6 @@ local function handle_streaming_frame(conf)
 
     local events = ai_shared.frame_to_events(chunk, conf.model.provider)
 
-    -- TODO: DELETE THIS
-    local function dump(o)
-      if type(o) == 'table' then
-        local s = '{ '
-        for k,v in pairs(o) do
-            if type(k) ~= 'number' then k = '"'..k..'"' end
-            s = s .. '['..k..'] = ' .. dump(v) .. ','
-        end
-        return s .. '} '
-      else
-        return tostring(o)
-      end
-    end
-
-    kong.log.warn(dump(events))
-
     if not events then
       -- usually a not-supported-transformer or empty frames.
       -- header_filter has already run, so all we can do is log it,

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -130,6 +130,7 @@ local _KEYBASTION = setmetatable({}, {
 
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
+      local aws
 
       local region = plugin_config.model.options
                  and plugin_config.model.options.bedrock
@@ -142,13 +143,19 @@ local _KEYBASTION = setmetatable({}, {
       local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
                       or AWS_SECRET_ACCESS_KEY
 
-      local aws = AWS({
-        -- if any of these are nil, they either use the SDK default or
-        -- are deliberately null so that a different auth chain is used
-        region = region,
-        aws_access_key_id = access_key,
-        aws_secret_access_key = secret_key,
-      })
+      if access_key and secret_key then
+        aws = AWS({
+          -- if any of these are nil, they either use the SDK default or
+          -- are deliberately null so that a different auth chain is used
+          region = region,
+          aws_access_key_id = access_key,
+          aws_secret_access_key = secret_key,
+        })
+      else
+        aws = AWS({
+          region = region,
+        })
+      end
 
       this_cache[plugin_config] = { interface = aws, error = nil }
 
@@ -595,9 +602,7 @@ function _M:access(conf)
   end
 
   -- get the provider's cached identity interface - nil may come back, which is fine
-  ngx.log(ngx.WARN, "----> IN")
   local identity_interface = _KEYBASTION[conf]
-  ngx.log(ngx.WARN, "----> OUT")
   if identity_interface and identity_interface.error then
     kong.ctx.shared.skip_response_transformer = true
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -131,16 +131,16 @@ local _KEYBASTION = setmetatable({}, {
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
 
-      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
-                      or AWS_ACCESS_KEY_ID
-      
-      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
-                      or AWS_ACCESS_KEY_ID
-
       local region = plugin_config.model.options
                  and plugin_config.model.options.bedrock
                  and plugin_config.model.options.bedrock.aws_region
                   or AWS_REGION
+
+      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
+                      or AWS_ACCESS_KEY_ID
+      
+      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
+                      or AWS_SECRET_ACCESS_KEY
 
       local aws = AWS({
         -- if any of these are nil, they either use the SDK default or
@@ -595,7 +595,9 @@ function _M:access(conf)
   end
 
   -- get the provider's cached identity interface - nil may come back, which is fine
+  ngx.log(ngx.WARN, "----> IN")
   local identity_interface = _KEYBASTION[conf]
+  ngx.log(ngx.WARN, "----> OUT")
   if identity_interface and identity_interface.error then
     kong.ctx.shared.skip_response_transformer = true
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)

--- a/kong/plugins/ai-proxy/handler.lua
+++ b/kong/plugins/ai-proxy/handler.lua
@@ -97,16 +97,16 @@ local _KEYBASTION = setmetatable({}, {
     if plugin_config.model.provider == "bedrock" then
       ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
 
-      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
-                      or AWS_ACCESS_KEY_ID
-      
-      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
-                      or AWS_ACCESS_KEY_ID
-
       local region = plugin_config.model.options
                  and plugin_config.model.options.bedrock
                  and plugin_config.model.options.bedrock.aws_region
                   or AWS_REGION
+
+      local access_key = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
+                      or AWS_ACCESS_KEY_ID
+      
+      local secret_key = (plugin_config.auth and plugin_config.auth.aws_secret_access_key)
+                      or AWS_SECRET_ACCESS_KEY
 
       local aws = AWS({
         -- if any of these are nil, they either use the SDK default or
@@ -561,7 +561,9 @@ function _M:access(conf)
   end
 
   -- get the provider's cached identity interface - nil may come back, which is fine
+  ngx.log(ngx.WARN, "----> IN")
   local identity_interface = _KEYBASTION[conf]
+  ngx.log(ngx.WARN, "----> OUT")
   if identity_interface and identity_interface.error then
     kong.ctx.shared.skip_response_transformer = true
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)

--- a/kong/tools/aws_stream.lua
+++ b/kong/tools/aws_stream.lua
@@ -1,0 +1,189 @@
+--- Stream class.
+-- Decodes AWS response-stream types, currently application/vnd.amazon.eventstream
+-- @classmod Stream
+
+local buf = require("string.buffer")
+local to_hex = require("resty.string").to_hex
+
+local Stream = {}
+Stream.__index = Stream
+
+
+local _HEADER_EXTRACTORS = {
+  -- bool true
+  [0] = function(stream)
+    return true, 0
+  end,
+  
+  -- bool false
+  [1] = function(stream)
+    return false, 0
+  end,
+
+  -- string type
+  [7] = function(stream)
+    local header_value_len = stream:next_int(16)
+    return stream:next_utf_8(header_value_len), header_value_len + 2  -- add the 2 bits read for the length
+  end,
+
+  -- TODO ADD THE REST OF THE DATA TYPES
+  -- EVEN THOUGH THEY'RE NOT REALLY USED
+}
+
+--- Constructor.
+-- @function aws:Stream
+-- @param chunk string complete AWS response stream chunk for decoding
+-- @param is_hex boolean specify if the chunk bytes are already decoded to hex
+-- @usage
+-- local stream_parser = stream:new("00000120af0310f.......", true)
+-- local next, err = stream_parser:next_message()
+function Stream:new(chunk, is_hex)
+  local self = {}  -- override 'self' to be the new object/class
+  setmetatable(self, Stream)
+  
+  if #chunk < ((is_hex and 32) or 16) then
+    return nil, "cannot parse a chunk less than 16 bytes long"
+  end
+  
+  self.read_count = 0  
+  self.chunk = buf.new()
+  self.chunk:put((is_hex and chunk) or to_hex(chunk))
+  
+  return self
+end
+
+
+--- return the next `count` ascii bytes from the front of the chunk
+--- and then trims the chunk of those bytes
+-- @param count number whole utf-8 bytes to return
+-- @return string resulting utf-8 string
+function Stream:next_utf_8(count)
+  local utf_bytes = self:next_bytes(count)
+  
+  local ascii_string = ""
+  for i = 1, #utf_bytes, 2 do
+      local hex_byte = utf_bytes:sub(i, i + 1)
+      local ascii_byte = string.char(tonumber(hex_byte, 16))
+      ascii_string = ascii_string .. ascii_byte
+  end
+  return ascii_string
+end
+
+--- returns the next `count` bytes from the front of the chunk
+--- and then trims the chunk of those bytes
+-- @param count number whole integer of bytes to return
+-- @return string hex-encoded next `count` bytes
+function Stream:next_bytes(count)
+  if not self.chunk then
+    return nil, "function cannot be called on its own - initialise a chunk reader with :new(chunk)"
+  end
+
+  local bytes = self.chunk:get(count * 2)
+  self.read_count = (count) + self.read_count
+
+  return bytes
+end
+
+--- returns the next unsigned int from the front of the chunk
+--- and then trims the chunk of those bytes
+-- @param size integer bit length (8, 16, 32, etc)
+-- @return number whole integer of size specified
+-- @return string the original bytes, for reference/checksums
+function Stream:next_int(size)
+  if not self.chunk then
+    return nil, nil, "function cannot be called on its own - initialise a chunk reader with :new(chunk)"
+  end
+
+  if size < 8 then
+    return nil, nil, "cannot work on integers smaller than 8 bits long"
+  end
+
+  local int, err = self:next_bytes(size / 8, trim)
+  if err then
+    return nil, nil, err
+  end
+
+  return tonumber(int, 16), int
+end
+
+--- returns the next message in the chunk, as a table.
+--- can be used as an iterator.
+-- @return table formatted next message from the given constructor chunk 
+function Stream:next_message()
+  if not self.chunk then
+    return nil, "function cannot be called on its own - initialise a chunk reader with :new(chunk)"
+  end
+
+  if #self.chunk < 1 then
+    return false
+  end
+
+  -- get the message length and pull that many bytes
+  --
+  -- this is a chicken and egg problem, because we need to
+  -- read the message to get the length, to then re-read the
+  -- whole message at correct offset
+  local msg_len, orig_len, err = self:next_int(32)
+  if err then
+    return err
+  end
+  
+  -- get the headers length
+  local headers_len, orig_headers_len, err = self:next_int(32)
+
+  -- get the preamble checksum
+  local preamble_checksum, orig_preamble_checksum, err = self:next_int(32)
+
+  -- TODO: calculate checksum
+  -- local result = crc32(orig_len .. origin_headers_len, preamble_checksum)
+  -- if not result then
+  --   return nil, "preamble checksum failed - message is corrupted"
+  -- end
+
+  -- pull the headers from the buf
+  local headers = {}
+  local headers_bytes_read = 0
+
+  while headers_bytes_read < headers_len do
+    -- the next 8-bit int is the "header key length"
+    local header_key_len = self:next_int(8)
+    local header_key = self:next_utf_8(header_key_len)
+    headers_bytes_read = 1 + header_key_len + headers_bytes_read
+
+    -- next 8-bits is the header type, which is an enum
+    local header_type = self:next_int(8)
+    headers_bytes_read = 1 + headers_bytes_read
+
+    -- depending on the header type, depends on how long the header should max out at
+    local header_value, header_value_len = _HEADER_EXTRACTORS[header_type](self)
+    headers_bytes_read = header_value_len + headers_bytes_read
+
+    headers[#headers+1] = {
+      key = header_key,
+      value = header_value,
+    }
+  end
+
+  -- finally, extract the body as a string by
+  -- subtracting what's read so far from the
+  -- total length obtained right at the start
+  local body = self:next_utf_8(msg_len - self.read_count - 4)
+
+  -- last 4 bytes is a body checksum
+  local msg_checksum = self:next_int(32)
+  -- TODO CHECK FULL MESSAGE CHECKSUM
+  -- local result = crc32(original_full_msg, msg_checksum)
+  -- if not result then
+  --   return nil, "preamble checksum failed - message is corrupted"
+  -- end
+
+  -- rewind the tape
+  self.read_count = 0
+
+  return {
+    headers = headers,
+    body = body,
+  }
+end
+
+return Stream

--- a/kong/tools/aws_stream.lua
+++ b/kong/tools/aws_stream.lua
@@ -158,10 +158,7 @@ function Stream:next_message()
     local header_value, header_value_len = _HEADER_EXTRACTORS[header_type](self)
     headers_bytes_read = header_value_len + headers_bytes_read
 
-    headers[#headers+1] = {
-      key = header_key,
-      value = header_value,
-    }
+    headers[header_key] = header_value
   end
 
   -- finally, extract the body as a string by

--- a/kong/tools/aws_stream.lua
+++ b/kong/tools/aws_stream.lua
@@ -158,7 +158,10 @@ function Stream:next_message()
     local header_value, header_value_len = _HEADER_EXTRACTORS[header_type](self)
     headers_bytes_read = header_value_len + headers_bytes_read
 
-    headers[header_key] = header_value
+    headers[#headers+1] = {
+      key = header_key,
+      value = header_value,
+    }
   end
 
   -- finally, extract the body as a string by

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -237,6 +237,20 @@ local FORMATS = {
       },
     },
   },
+  bedrock = {
+    ["llm/v1/chat"] = {
+      config = {
+        name = "bedrock",
+        provider = "bedrock",
+        options = {
+          max_tokens = 8192,
+          temperature = 0.8,
+          top_k = 1,
+          top_p = 0.6,
+        },
+      },
+    },
+  },
 }
 
 local STREAMS = {

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -678,7 +678,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
     
     it("transforms truncated-json type (beginning of stream)", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/partial-json-beginning/input.bin"))
-      local events = ai_shared.frame_to_events(input, true)
+      local events = ai_shared.frame_to_events(input, "gemini")
 
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/partial-json-beginning/expected-output.json"))
       local expected_events = cjson.decode(expected)
@@ -688,7 +688,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
     it("transforms truncated-json type (end of stream)", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/partial-json-end/input.bin"))
-      local events = ai_shared.frame_to_events(input, true)
+      local events = ai_shared.frame_to_events(input, "gemini")
 
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/partial-json-end/expected-output.json"))
       local expected_events = cjson.decode(expected)
@@ -698,7 +698,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
     
     it("transforms complete-json type", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/complete-json/input.bin"))
-      local events = ai_shared.frame_to_events(input, false)  -- not "truncated json mode" like Gemini
+      local events = ai_shared.frame_to_events(input, "cohere")  -- not "truncated json mode" like Gemini
 
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/complete-json/expected-output.json"))
       local expected_events = cjson.decode(expected)
@@ -708,7 +708,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
     it("transforms text/event-stream type", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/input.bin"))
-      local events = ai_shared.frame_to_events(input, false)  -- not "truncated json mode" like Gemini
+      local events = ai_shared.frame_to_events(input, "openai")  -- not "truncated json mode" like Gemini
 
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/expected-output.json"))
       local expected_events = cjson.decode(expected)


### PR DESCRIPTION
### Summary

This is a draft PR that adds AWS Bedrock "chat inference" driver support.

Now Kong users can call a massive array of Anthropic, Cohere, Mistral, Amazon, Meta, AI21, and loads more models; all using the same flat format.

**This is missing streaming support - I need to write a C/Lua decoder for the AWS application/vnd.amazon.eventstream format, and need e.g. Thijs help.**

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Internal (KAI-38).
