### PR TITLE
refactor(concurrency): consistent node-level locks

### DIFF
--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -51,7 +51,8 @@ function concurrency.with_worker_mutex(opts, fn)
   local elapsed, err = rlock:lock(opts_name)
   if not elapsed then
     if err == "timeout" then
-      return nil, err
+      local ttl = rlock.dict and rlock.dict:ttl(opts_name)
+      return nil, err, ttl
     end
     return nil, "failed to acquire worker lock: " .. err
   end


### PR DESCRIPTION
### Summary

Several places in the gateway need a node-level lock, some of them used slightly different implementations. This refactor brings consistency in the ways we do node-level locking by using the same implementation (concurrency.with_worker_mutex) everywhere.

Note: in order to maintain the logic of `declarative.import` unaltered, the `concurrency.with_worker_mutex` function has been slightly modified to return an additional value `ttl` in case of timeout error, so that `retry_after` could be implemented as before.

### Checklist

- [x] (no/refactor) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (noo) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-2337
