### PR TITLE
tests(dns): fix the flakiness of the individual_toip test case

### DIFF
--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -1500,10 +1500,11 @@ describe("[DNS client]", function()
       assert.are.equal("recursion detected", port)
     end)
 
-    it("individual_noip - force no sync", function()
+    it("individual_toip - force no sync", function()
       local resolve_count = 10
       assert(client.init({
         noSynchronisation = false,
+        order = { "A" },
       }))
 
       local callcount = 0
@@ -1521,14 +1522,14 @@ describe("[DNS client]", function()
         end)
       end
 
+      for i=1,#threads do
+        ngx.thread.wait(threads[i])
+      end
+
       -- only one thread must have called the query_func
       assert.are.equal(1, callcount,
         "synchronisation failed - out of " .. resolve_count .. " toip() calls " .. callcount ..
         " queries were made")
-
-      for i=1,#threads do
-        ngx.thread.wait(threads[i])
-      end
 
       callcount = 0
       threads = {}
@@ -1539,14 +1540,15 @@ describe("[DNS client]", function()
         end)
       end
 
+      for i=1,#threads do
+        ngx.thread.wait(threads[i])
+      end
+
       -- all threads must have called the query_func
       assert.are.equal(resolve_count, callcount,
         "force no sync failed - out of " .. resolve_count .. " toip() calls" ..
         callcount .. " queries were made")
 
-      for i=1,#threads do
-        ngx.thread.wait(threads[i])
-      end
     end)
 
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
The original test cases calls `toip` with the default option: `order=LAST,SRV,A,CNAME`,  resulting in 3 queries (SRV, SRV-dereference(CNAME), A) each time we call toip, but it actually expects single query each time.

### Checklist

- [x] The Pull Request has tests
- [x] N/A ~~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)~~
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-4520
