### PR TITLE
feat: making status code available in the error template

### DIFF
--- a/changelog/unreleased/kong/feat-status-code-in-error-template.yml
+++ b/changelog/unreleased/kong/feat-status-code-in-error-template.yml
@@ -1,0 +1,3 @@
+message: |
+  Made the response HTTP code available in the error template.
+type: feature

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -247,11 +247,12 @@
                                  # override the default html kong error
                                  # template.
                                  #
-                                 # The template may contain up to two `%s`
+                                 # The template may contain up to three `%s`
                                  # placeholders. The first one will expand to
                                  # the error message. The second one will
-                                 # expand to the request ID. Both placeholders
-                                 # are optional, but recommended.
+                                 # expand to the request ID. The third one
+                                 # will expand to the HTTP status code.
+                                 # All placeholders are optional, but recommended.
                                  # Adding more than two placeholders will
                                  # result in a runtime error when trying to
                                  # render the template:
@@ -270,26 +271,26 @@
                                  # template.
                                  #
                                  # Similarly to `error_template_html`, the
-                                 # template may contain up to two `%s`
-                                 # placeholders for the error message and the
-                                 # request ID respectively.
+                                 # template may contain up to three `%s`
+                                 # placeholders for the error message, the
+                                 # request ID and the HTTP status code respectively.
 
 #error_template_xml =            # Path to the custom xml error template to
                                  # override the default xml kong error template
                                  #
                                  # Similarly to `error_template_html`, the
-                                 # template may contain up to two `%s`
-                                 # placeholders for the error message and the
-                                 # request ID respectively.
+                                 # template may contain up to three `%s`
+                                 # placeholders for the error message, the
+                                 # request ID and the HTTP status code respectively.
 
 #error_template_plain =          # Path to the custom plain error template to
                                  # override the default plain kong error
                                  # template
                                  #
                                  # Similarly to `error_template_html`, the
-                                 # template may contain up to two `%s`
-                                 # placeholders for the error message and the
-                                 # request ID respectively.
+                                 # template may contain up to three `%s`
+                                 # placeholders for the error message, the
+                                 # request ID and the HTTP status code respectively.
 
 #------------------------------------------------------------------------------
 # HYBRID MODE

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -73,7 +73,7 @@ return function(ctx)
   else
     local mime_type = utils.get_response_type(accept_header)
     local rid = request_id.get() or ""
-    message = fmt(utils.get_error_template(mime_type), message, rid)
+    message = fmt(utils.get_error_template(mime_type), message, rid, status)
     headers = { [CONTENT_TYPE] = mime_type }
 
   end

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -1156,7 +1156,7 @@ local function new(self, major_version)
     if content_type ~= CONTENT_TYPE_GRPC then
       local actual_message = message or get_http_error_message(status)
       local rid = request_id.get() or ""
-      body = fmt(utils.get_error_template(content_type), actual_message, rid)
+      body = fmt(utils.get_error_template(content_type), actual_message, rid, status)
     end
 
     local ctx = ngx.ctx


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In the https://datatracker.ietf.org/doc/html/rfc7807#section-3.1 `status` is listed as a field in the error responses, but sadly there is no way to get it currently, even when using a custom error template.

This PR fixes that without breaking current behaviour. 

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
