### PR TITLE
docs(changelog): apply changelog suggestions

### DIFF
--- a/changelog/3.7.0/kong/add-ai-data-report.yml
+++ b/changelog/3.7.0/kong/add-ai-data-report.yml
@@ -1,3 +1,3 @@
-"message": Add `events:ai:response_tokens`, `events:ai:prompt_tokens` and `events:ai:requests` to the anonymous report to start counting AI usage
+"message": Added `events:ai:response_tokens`, `events:ai:prompt_tokens` and `events:ai:requests` to the anonymous report to start counting AI usage
 "type": feature
 "scope": Core

--- a/changelog/3.7.0/kong/add-messages-api-to-anthropic.yml
+++ b/changelog/3.7.0/kong/add-messages-api-to-anthropic.yml
@@ -1,5 +1,5 @@
 "message": |
-  **AI-Proxy**: To support the new messages API of `Anthropic`, the upstream path of the `Anthropic` for `llm/v1/chat` route type is changed from `/v1/complete` to `/v1/messages`
+  **AI Proxy**: To support the new messages API of `Anthropic`, the upstream path of the `Anthropic` for `llm/v1/chat` route type has changed from `/v1/complete` to `/v1/messages`.
 "type": breaking_change
 "scope": Plugin
 "jiras":

--- a/changelog/3.7.0/kong/add_tzdata.yml
+++ b/changelog/3.7.0/kong/add_tzdata.yml
@@ -1,3 +1,3 @@
 message: |
-  Add package `tzdata` to DEB Docker image for convenient timezone setting.
+  Added package `tzdata` to DEB Docker image for convenient timezone setting.
 type: dependency

--- a/changelog/3.7.0/kong/ai-proxy-client-params.yml
+++ b/changelog/3.7.0/kong/ai-proxy-client-params.yml
@@ -1,6 +1,6 @@
 message: |
-  AI Proxy now reads most prompt tuning parameters from the client, whilst the
-  plugin config 'model options' are now just defaults. This fixes support for 
-  using the respective provider's native SDK.
+  AI Proxy now reads most prompt tuning parameters from the client,
+  while the plugin config parameters under `model_options` are now just defaults.
+  This fixes support for using the respective provider's native SDK.
 type: feature
 scope: Plugin

--- a/changelog/3.7.0/kong/ai-proxy-preserve-mode.yml
+++ b/changelog/3.7.0/kong/ai-proxy-preserve-mode.yml
@@ -1,6 +1,6 @@
 message: |
-  AI Proxy now has a 'preserve' route_type option, where the requests and responses 
-  are passed directly to the upstream LLM. This is to enable compatilibity with any  
-  and all models and SDKs, that may be used when calling the AI services.
+  AI Proxy now has a `preserve` option for `route_type`, where the requests and responses
+  are passed directly to the upstream LLM. This is to enable compatibility with any
+  and all models and SDKs that may be used when calling the AI services.
 type: feature
 scope: Plugin

--- a/changelog/3.7.0/kong/analytics-for-anthropic.yml
+++ b/changelog/3.7.0/kong/analytics-for-anthropic.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI-proxy-plugin**: Fix the bug that the route_type `/llm/v1/chat` does not include the analytics in the responses.
+  **AI-proxy-plugin**: Fixed the bug that the `route_type` `/llm/v1/chat` didn't include the analytics in the responses.
 scope: Plugin
 type: bugfix

--- a/changelog/3.7.0/kong/bump-lua-protobuf.yml
+++ b/changelog/3.7.0/kong/bump-lua-protobuf.yml
@@ -1,3 +1,3 @@
-message: "Bump lua-protobuf to 0.5.1"
+message: "Bumped lua-protobuf to 0.5.1"
 type: dependency
 scope: Core

--- a/changelog/3.7.0/kong/bump-lua-resty-http-0.17.2.yml
+++ b/changelog/3.7.0/kong/bump-lua-resty-http-0.17.2.yml
@@ -1,2 +1,2 @@
-message: Bump lua-resty-http to 0.17.2.
+message: Bumped lua-resty-http to 0.17.2.
 type: dependency

--- a/changelog/3.7.0/kong/bump-ngx-wasm-module.yml
+++ b/changelog/3.7.0/kong/bump-ngx-wasm-module.yml
@@ -1,2 +1,2 @@
-message: "Bump `ngx_wasm_module` to `91d447ffd0e9bb08f11cc69d1aa9128ec36b4526`"
+message: "Bumped `ngx_wasm_module` to `91d447ffd0e9bb08f11cc69d1aa9128ec36b4526`"
 type: dependency

--- a/changelog/3.7.0/kong/bump-v8.yml
+++ b/changelog/3.7.0/kong/bump-v8.yml
@@ -1,2 +1,2 @@
-message: "Bump `V8` version to `12.0.267.17`"
+message: "Bumped `V8` version to `12.0.267.17`"
 type: dependency

--- a/changelog/3.7.0/kong/bump-wasmtime.yml
+++ b/changelog/3.7.0/kong/bump-wasmtime.yml
@@ -1,2 +1,2 @@
-message: "Bump `Wasmtime` version to `19.0.0`"
+message: "Bumped `Wasmtime` version to `19.0.0`"
 type: dependency

--- a/changelog/3.7.0/kong/decrease-cocurrency-limit-of-timer-ng.yml
+++ b/changelog/3.7.0/kong/decrease-cocurrency-limit-of-timer-ng.yml
@@ -1,3 +1,3 @@
 message: |
-    Fix a bug where the ulimit setting (open files) is low Kong will fail to start as the lua-resty-timer-ng exhausts the available worker_connections. Decrease the concurrency range of the lua-resty-timer-ng library from [512, 2048] to [256, 1024] to fix this bug.
+    Fixed a bug where, if the the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
 type: bugfix

--- a/changelog/3.7.0/kong/disable-TLSv1_1-in-openssl3.yml
+++ b/changelog/3.7.0/kong/disable-TLSv1_1-in-openssl3.yml
@@ -1,3 +1,3 @@
-message: now TLSv1.1 and lower is by default disabled in OpenSSL 3.x
+message: TLSv1.1 and lower versions are disabled by default in OpenSSL 3.x.
 type: feature
 scope: Configuration

--- a/changelog/3.7.0/kong/feat-ai-proxy-add-streaming.yml
+++ b/changelog/3.7.0/kong/feat-ai-proxy-add-streaming.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI-Proxy**: add support for streaming event-by-event responses back to client on supported providers
+  **AI Proxy**: Added support for streaming event-by-event responses back to the client on supported providers.
 scope: Plugin
 type: feature

--- a/changelog/3.7.0/kong/feat-hybrid-sync-mixed-route-policy.yml
+++ b/changelog/3.7.0/kong/feat-hybrid-sync-mixed-route-policy.yml
@@ -1,7 +1,7 @@
 message: |
-  When CP runs with `expressions` flavor:
-  - if mixed config is detected and a lower DP is attached to the CP, no config will be sent at all
-  - if the expression is invalid on CP, no config will be sent at all
-  - if the expression is invalid on lower DP, it will be sent to the DP and DP validation will catch this and communicate back to the CP (this could result in partial config application)
+  Improved config handling when the CP runs with the router set to the `expressions` flavor:
+    - If mixed config is detected and a lower DP is attached to the CP, no config will be sent at all
+    - If the expression is invalid on the CP, no config will be sent at all
+    - If the expression is invalid on a lower DP, it will be sent to the DP and DP validation will catch this and communicate back to the CP (this could result in partial config application)
 type: feature
 scope: Core

--- a/changelog/3.7.0/kong/feat-increase-ai-anthropic-regex-expression-length.yml
+++ b/changelog/3.7.0/kong/feat-increase-ai-anthropic-regex-expression-length.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI-Prompt-Guard**: increase the maximum length of regex expression to 500 for both allow and deny parameter
+  **AI Prompt Guard**: Increased the maximum length of regex expressions to 500 for the allow and deny parameters.
 scope: Plugin
 type: feature

--- a/changelog/3.7.0/kong/feat-wasm-general-shm-kv.yml
+++ b/changelog/3.7.0/kong/feat-wasm-general-shm-kv.yml
@@ -1,5 +1,5 @@
 message: |
-   Introduce `nginx_wasm_main_shm_kv` configuration entry, which enables
+   Introduced `nginx_wasm_main_shm_kv` configuration parameter, which enables
    Wasm filters to use the Proxy-Wasm operations `get_shared_data` and
    `set_shared_data` without namespaced keys.
 type: feature

--- a/changelog/3.7.0/kong/fix-aws-lambda-kong-latency.yml
+++ b/changelog/3.7.0/kong/fix-aws-lambda-kong-latency.yml
@@ -1,3 +1,3 @@
-message: "**AWS-Lambda**: fix an issue that the latency attributed to AWS Lambda API requests will be counted as part of the latency in Kong"
+message: "**AWS-Lambda**: Fixed an issue where the latency attributed to AWS Lambda API requests was counted as part of the latency in Kong."
 type: bugfix
 scope: Plugin

--- a/changelog/3.7.0/kong/fix-cjson-t-end.yml
+++ b/changelog/3.7.0/kong/fix-cjson-t-end.yml
@@ -1,3 +1,3 @@
 message: |
-  Improve the robustness of lua-cjson when handling unexpected input. 
+  Improved the robustness of lua-cjson when handling unexpected input.
 type: dependency

--- a/changelog/3.7.0/kong/fix-ctx-host-port.yml
+++ b/changelog/3.7.0/kong/fix-ctx-host-port.yml
@@ -1,5 +1,5 @@
 message: |
-  **PDK:** fix kong.request.get_forwarded_port to always return a number which was caused by an incorrectly
-  stored string value in ngx.ctx.host_port.
+  **PDK:** Fixed `kong.request.get_forwarded_port` to always return a number,
+  which was caused by an incorrectly stored string value in `ngx.ctx.host_port`.
 type: bugfix
 scope: PDK

--- a/changelog/3.7.0/kong/fix-dbless-duplicate-target-error.yml
+++ b/changelog/3.7.0/kong/fix-dbless-duplicate-target-error.yml
@@ -1,3 +1,3 @@
-message: "Fixed an issue wherein `POST /config?flatten_errors=1` could not return a proper response if the input included duplicate upstream targets"
+message: "Fixed an issue where `POST /config?flatten_errors=1` could not return a proper response if the input included duplicate upstream targets."
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-default-value-of-upstream-keepalive-max-requests.yml
+++ b/changelog/3.7.0/kong/fix-default-value-of-upstream-keepalive-max-requests.yml
@@ -1,5 +1,5 @@
 message: |
-    Fixed default value in kong.conf.default documentation from 1000 to 10000
-    for upstream_keepalive_max_requests option.
+  Fixed the default value in kong.conf.default documentation from 1000 to 10000
+  for the `upstream_keepalive_max_requests` option.
 type: bugfix
 scope: Configuration

--- a/changelog/3.7.0/kong/fix-external-plugin-instance.yml
+++ b/changelog/3.7.0/kong/fix-external-plugin-instance.yml
@@ -1,5 +1,5 @@
 message: |
-    Fix an issue where an external plugin (Go, Javascript, or Python) would fail to
+    Fixed an issue where an external plugin (Go, Javascript, or Python) would fail to
     apply a change to the plugin config via the Admin API.
 type: bugfix
 scope: Configuration

--- a/changelog/3.7.0/kong/fix-file-permission-of-logrotate.yml
+++ b/changelog/3.7.0/kong/fix-file-permission-of-logrotate.yml
@@ -1,3 +1,3 @@
-message: update file permission of kong.logrotate to 644
+message: Updated the file permission of `kong.logrotate` to 644.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-hybrid-dp-certificate-with-vault-not-refresh.yml
+++ b/changelog/3.7.0/kong/fix-hybrid-dp-certificate-with-vault-not-refresh.yml
@@ -1,3 +1,3 @@
-message: Fixed a problem that in hybrid DP mode a certificate entity configured with vault reference may not get refreshed on time
+message: Fixed a problem on hybrid mode DPs, where a certificate entity configured with a vault reference may not get refreshed on time.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-jwt-plugin-check.yml
+++ b/changelog/3.7.0/kong/fix-jwt-plugin-check.yml
@@ -1,3 +1,3 @@
-message: "**Jwt**: fix an issue where the plugin would fail when using invalid public keys for ES384 and ES512 algorithms."
+message: "**Jwt**: Fixed an issue where the plugin would fail when using invalid public keys for ES384 and ES512 algorithms."
 type: bugfix
 scope: Plugin

--- a/changelog/3.7.0/kong/fix-missing-router-section-of-request-debugging.yml
+++ b/changelog/3.7.0/kong/fix-missing-router-section-of-request-debugging.yml
@@ -1,3 +1,3 @@
-message: Fix the missing router section for the output of the request-debugging
+message: Fixed the missing router section for the output of the request-debugging.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-mlcache-renew-lock-leaks.yml
+++ b/changelog/3.7.0/kong/fix-mlcache-renew-lock-leaks.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue that leaking locks in the internal caching logic
+  Fixed an issue in the internal caching logic where mutexes could get never unlocked.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-router-rebuing-flag.yml
+++ b/changelog/3.7.0/kong/fix-router-rebuing-flag.yml
@@ -1,5 +1,5 @@
 message: |
-  Fixed an issue where router may not work correctly
-  when the routes configuration changed.
+  Fixed an issue where the router didn't work correctly
+  when the route's configuration changed.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-snis-tls-passthrough-in-trad-compat.yml
+++ b/changelog/3.7.0/kong/fix-snis-tls-passthrough-in-trad-compat.yml
@@ -1,5 +1,5 @@
 message: |
-  Fixed an issue where SNI-based routing does not work
-  using tls_passthrough and the traditional_compatible router flavor
+  Fixed an issue where SNI-based routing didn't work
+  using `tls_passthrough` and the `traditional_compatible` router flavor.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-upstream-status-unset.yml
+++ b/changelog/3.7.0/kong/fix-upstream-status-unset.yml
@@ -1,3 +1,3 @@
-message: fix a bug that `X-Kong-Upstream-Status` will not appear in the response headers even if it is set in the `headers` parameter in the kong.conf when the response is hit and returned by proxy cache plugin.
+message: Fixed a bug that `X-Kong-Upstream-Status` didn't appear in the response headers even if it was set in the `headers` parameter in the `kong.conf` file when the response was hit and returned by the Proxy Cache plugin.
 scope: Core
 type: bugfix

--- a/changelog/3.7.0/kong/fix-vault-init-worker.yml
+++ b/changelog/3.7.0/kong/fix-vault-init-worker.yml
@@ -1,3 +1,3 @@
-message: fix vault initialization by postponing vault reference resolving on init_worker
+message: Fixed vault initialization by postponing vault reference resolving on init_worker
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/fix-wasm-disable-pwm-lua-resolver.yml
+++ b/changelog/3.7.0/kong/fix-wasm-disable-pwm-lua-resolver.yml
@@ -1,4 +1,4 @@
 message: |
-   Disable usage of the Lua DNS resolver from proxy-wasm by default.
+   Disabled usage of the Lua DNS resolver from proxy-wasm by default.
 type: bugfix
 scope: Configuration

--- a/changelog/3.7.0/kong/flavor-expressions-supports-traditional-fields.yml
+++ b/changelog/3.7.0/kong/flavor-expressions-supports-traditional-fields.yml
@@ -1,7 +1,7 @@
 message: |
-  Supported fields `methods`, `hosts`, `paths`, `headers`,
-  `snis`, `sources`, `destinations` and `regex_priority`
-  for the `route` entity when the `router_flavor` is `expressions`.
+  The route entity now supports the following fields when the
+  `router_flavor` is `expressions`: `methods`, `hosts`, `paths`, `headers`,
+  `snis`, `sources`, `destinations`, and `regex_priority`.
   The meaning of these fields are consistent with the traditional route entity.
 type: feature
 scope: Core

--- a/changelog/3.7.0/kong/key_auth_www_authenticate.yml
+++ b/changelog/3.7.0/kong/key_auth_www_authenticate.yml
@@ -1,3 +1,3 @@
-message: Add WWW-Authenticate headers to all 401 response in key auth plugin.
+message: Added WWW-Authenticate headers to all 401 responses in the Key Auth plugin.
 type: bugfix
 scope: Plugin

--- a/changelog/3.7.0/kong/log-serializer-receive-latency.yml
+++ b/changelog/3.7.0/kong/log-serializer-receive-latency.yml
@@ -1,3 +1,3 @@
-message: 'Add `latencies.receive` property to log serializer'
+message: 'Added the `latencies.receive` property to the log serializer'
 type: feature
 scope: PDK

--- a/changelog/3.7.0/kong/otel-increase-queue-max-batch-size.yml
+++ b/changelog/3.7.0/kong/otel-increase-queue-max-batch-size.yml
@@ -1,3 +1,3 @@
-message: "**Opentelemetry**: increase queue max batch size to 200"
+message: "**Opentelemetry**: Increased queue max batch size to 200."
 type: performance
 scope: Plugin

--- a/changelog/3.7.0/kong/otel-sampling-panic-when-header-trace-id-enable.yml
+++ b/changelog/3.7.0/kong/otel-sampling-panic-when-header-trace-id-enable.yml
@@ -1,3 +1,3 @@
-message: "**Opentelemetry**: fix otel sampling mode lua panic bug when http_response_header_for_traceid option enable"
+message: "**Opentelemetry**: Fixed an OTEL sampling mode Lua panic bug, which happened when the `http_response_header_for_traceid` option was enabled."
 type: bugfix
 scope: Plugin

--- a/changelog/3.7.0/kong/plugin_server_restart.yml
+++ b/changelog/3.7.0/kong/plugin_server_restart.yml
@@ -1,3 +1,3 @@
-message: "**Plugin Server**: fix an issue where Kong fails to properly restart MessagePack-based pluginservers (used in Python and Javascript plugins, for example)"
+message: "**Plugin Server**: Fixed an issue where Kong failed to properly restart MessagePack-based pluginservers (used in Python and Javascript plugins, for example)."
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/propagation-module-rework.yml
+++ b/changelog/3.7.0/kong/propagation-module-rework.yml
@@ -1,5 +1,5 @@
 message: |
-  **OpenTelemetry, Zipkin**: the propagation module has been reworked, new
+  **OpenTelemetry, Zipkin**: The propagation module has been reworked. The new
   options allow better control over the configuration of tracing headers propagation.
 type: feature
 scope: Plugin

--- a/changelog/3.7.0/kong/revert-req-body-limitation-patch.yml
+++ b/changelog/3.7.0/kong/revert-req-body-limitation-patch.yml
@@ -1,3 +1,3 @@
-message: revert the hard-coded limitation of the ngx.read_body() API in OpenResty upstreams' new versions when downstream connections are in HTTP/2 or HTTP/3 stream modes.
+message: Reverted the hard-coded limitation of the `ngx.read_body()` API in OpenResty upstreams' new versions when downstream connections are in HTTP/2 or HTTP/3 stream modes.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/set_grpc_tls_seclevel.yml
+++ b/changelog/3.7.0/kong/set_grpc_tls_seclevel.yml
@@ -1,3 +1,3 @@
-message: Set security level of gRPC's TLS to 0 when ssl_cipher_suite is set to old
+message: Set security level of gRPC's TLS to 0 when `ssl_cipher_suite` is set to `old`.
 type: bugfix
 scope: Configuration

--- a/changelog/3.7.0/kong/speed_up_router.yml
+++ b/changelog/3.7.0/kong/speed_up_router.yml
@@ -1,3 +1,3 @@
-message: Speeded up the router matching when the `router_flavor` is `traditional_compatible` or `expressions`.
+message: Sped up the router matching when the `router_flavor` is `traditional_compatible` or `expressions`.
 type: performance
 scope: Performance

--- a/changelog/3.7.0/kong/update-ai-proxy-telemetry.yml
+++ b/changelog/3.7.0/kong/update-ai-proxy-telemetry.yml
@@ -1,3 +1,3 @@
-message: Update telemetry collection for AI Plugins to allow multiple plugins data to be set for the same request.
+message: Updated telemetry collection for AI Plugins to allow multiple plugins data to be set for the same request.
 type: bugfix
 scope: Core

--- a/changelog/3.7.0/kong/wasm-bundled-filters.yml
+++ b/changelog/3.7.0/kong/wasm-bundled-filters.yml
@@ -1,3 +1,3 @@
-message: Add `wasm_filters` configuration value for enabling individual filters
+message: Added the `wasm_filters` configuration parameter for enabling individual filters
 type: feature
 scope: Configuration


### PR DESCRIPTION
### Summary

During the review of the Changelog generation for release 3.7.0 (#12965), the changes from review suggestions were made only on `changelog/3.7.0/3.7.0.md` file, but should have been applied to all related `yml` files.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4422
