### PR TITLE
feat(aws-lambda): add new configuration field `empty_arrays_mode` to control empty array decoding behavior

### DIFF
--- a/changelog/unreleased/kong/feat-aws-lambda-decode-empty-array.yml
+++ b/changelog/unreleased/kong/feat-aws-lambda-decode-empty-array.yml
@@ -1,0 +1,4 @@
+message: |
+    **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays(returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
+type: feature
+scope: Plugin

--- a/changelog/unreleased/kong/feat-aws-lambda-decode-empty-array.yml
+++ b/changelog/unreleased/kong/feat-aws-lambda-decode-empty-array.yml
@@ -1,4 +1,4 @@
 message: |
-    **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays(returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
+    **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
 type: feature
 scope: Plugin

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.0.2",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.4.1",
+  "lua-resty-aws == 1.5.0",
   "lua-resty-openssl == 1.4.0",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -148,5 +148,8 @@ return {
     response_transformer = {
       "rename.json",
     },
+    aws_lambda = {
+      "empty_arrays_mode",
+    }
   },
 }

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -246,9 +246,11 @@ function AWSLambdaHandler:access(conf)
   -- This is just a backward compatibility code to keep a
   -- long-lived behavior that Kong responsed JSON objects
   -- instead of JSON arrays for empty arrays.
-  local ct = headers["Content-Type"]
-  if ct and ct:lower():match("application/.*json") and conf.empty_arrays_mode == "legacy" then
-    content = remove_array_mt_for_empty_table(content)
+  if conf.empty_arrays_mode == "legacy" then
+    local ct = headers["Content-Type"]
+    if ct and ct:lower():match("application/.*json") then
+      content = remove_array_mt_for_empty_table(content)
+    end
   end
 
   return kong.response.exit(status, content, headers)

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -116,6 +116,13 @@ return {
           default = "v1",
           one_of = { "v1", "v2" }
         } },
+        { empty_arrays_mode = { -- TODO: this config field is added for backward compatibility and will be removed in next major version
+          description = "An optional value that defines whether Kong should send empty arrays(returned by Lambda function) as `[]` arrays or `{}` objects in JSON responses. The value `legacy` means Kong will send empty arrays as `{}` objects in response",
+          type = "string",
+          required = true,
+          default = "legacy",
+          one_of = { "legacy", "correct" }
+        } },
       }
     },
   } },

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -117,7 +117,7 @@ return {
           one_of = { "v1", "v2" }
         } },
         { empty_arrays_mode = { -- TODO: this config field is added for backward compatibility and will be removed in next major version
-          description = "An optional value that defines whether Kong should send empty arrays(returned by Lambda function) as `[]` arrays or `{}` objects in JSON responses. The value `legacy` means Kong will send empty arrays as `{}` objects in response",
+          description = "An optional value that defines whether Kong should send empty arrays (returned by Lambda function) as `[]` arrays or `{}` objects in JSON responses. The value `legacy` means Kong will send empty arrays as `{}` objects in response",
           type = "string",
           required = true,
           default = "legacy",

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -961,7 +961,7 @@ for _, strategy in helpers.each_strategy() do
         end, 10)
       end)
 
-      it("#testme invokes a Lambda function with empty array", function()
+      it("invokes a Lambda function with empty array", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/get",

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -176,6 +176,18 @@ for _, strategy in helpers.each_strategy() do
         service     = null,
       }
 
+      local route26 = bp.routes:insert {
+        hosts       = { "lambda26.test" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
+      local route27 = bp.routes:insert {
+        hosts       = { "lambda27.test" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
       bp.plugins:insert {
         name     = "aws-lambda",
         route    = { id = route1.id },
@@ -519,6 +531,32 @@ for _, strategy in helpers.each_strategy() do
         name = "http-log",
         config   = {
           http_endpoint = "http://localhost:" .. mock_http_server_port,
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route26.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithEmptyArray",
+          empty_arrays_mode    = "legacy",
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route27.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithEmptyArray",
+          empty_arrays_mode    = "correct",
         }
       }
 
@@ -921,6 +959,30 @@ for _, strategy in helpers.each_strategy() do
           local _, count = logs:gsub([[%[aws%-lambda%].+lambda%.ab%-cdef%-1%.amazonaws%.com.+name error"]], "")
           return count >= 1
         end, 10)
+      end)
+
+      it("#testme invokes a Lambda function with empty array", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get",
+          headers = {
+            ["Host"] = "lambda26.test"
+          }
+        })
+
+        local body = assert.res_status(200, res)
+        assert.matches("\"testbody\":{}", body)
+
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get",
+          headers = {
+            ["Host"] = "lambda27.test"
+          }
+        })
+
+        local body = assert.res_status(200, res)
+        assert.matches("\"testbody\":%[%]", body)
       end)
 
       describe("config.is_proxy_integration = true", function()

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -65,6 +65,11 @@ local fixtures = {
                       ngx.sleep(2)
                       ngx.say("{\"statusCodge\": 200, \"body\": \"dGVzdA=\", \"isBase64Encoded\": false}")
 
+                    elseif string.match(ngx.var.uri, "functionWithEmptyArray") then
+                      ngx.header["Content-Type"] = "application/json"
+                      local str = "{\"statusCode\": 200, \"testbody\": [], \"isBase64Encoded\": false}"
+                      ngx.say(str)
+
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds a new configuration field `empty_arrays_mode` to control the behaviour that whether Kong will transform an empty array `[]`(returned by Lambda function) into an empty object `{}` when enabled aws-lambda plugin in the response.

**Essentially** this PR is just a small bugfix for not previously enabling `decode_array_with_array_mt` when decoding Lambda function's response. However, enabling `decode_array_with_array_mt` may bring unexpected behaviour changes on the user side(since the wrong behaviour itself has existed for long), so we decided to add a new field to keep backward compatibility, and remove this field in the next major version to let the correct behaviour(keep empty arrrays as is) to become the default behaviour in the next major version.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5937
