### PR TITLE
docs(changelog): typofix for #13021

### DIFF
--- a/changelog/unreleased/kong/feat-dont-allow-priority-with-others.yml
+++ b/changelog/unreleased/kong/feat-dont-allow-priority-with-others.yml
@@ -1,5 +1,5 @@
 message: |
   Do not allow setting priority field in traditional mode route
-  When 'router_flavor' is configrued as 'expressions'.
+  When 'router_flavor' is configured as 'expressions'.
 type: feature
 scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-4411

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
