### PR TITLE
tests(hybrid): reset schema for correct bootstrap

### DIFF
--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -10,6 +10,16 @@ local function reset_fields()
 end
 
 describe("kong.clustering.compat", function()
+  -- The truncate() in the following teardown() will clean all tables' records,
+  -- which may cause some other tests to fail because the number of records
+  -- in the truncated table differs from the number of records after bootstrap.
+  -- So we need this to reset schema.
+  lazy_teardown(function()
+    if _G.kong.db then
+      _G.kong.db:schema_reset()
+    end
+  end)
+
   describe("calculating fields to remove", function()
     before_each(reset_fields)
     after_each(reset_fields)


### PR DESCRIPTION
KAG-4440

This is a follow up of #13008.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
