### PR TITLE
fix(http-log): add port information to the host header

### DIFF
--- a/changelog/unreleased/kong/fix-http-log-host-header.yml
+++ b/changelog/unreleased/kong/fix-http-log-host-header.yml
@@ -1,0 +1,4 @@
+message: "**HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server."
+type: bugfix
+scope: Plugin
+

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -114,7 +114,6 @@ local function send_entries(conf, entries)
   httpc:set_timeout(timeout)
 
   local headers = {
-    ["Host"] = host,
     ["Content-Type"] = content_type,
     ["Content-Length"] = content_length,
     ["Authorization"] = userinfo and "Basic " .. encode_base64(userinfo) or nil


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Add port to host header when non-default port is used.The log server receives requests with a host header that does not include the port number.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #13067 
