### PR TITLE
tests: add uninstall test case

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,6 +447,18 @@ jobs:
           DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
         fi
 
+    - name: Uninstall Tests
+      run: |
+        cd scripts/explain_manifest
+        IMAGE=${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
+        BUILD_LABEL=${{ matrix.label }}
+        ./test-uninstall.sh $IMAGE $BUILD_LABEL
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+          echo "Uninstall test failed for $IMAGE"
+          exit $exit_code
+        fi
+
   scan-images:
     name: Scan Images - ${{ matrix.label }}
     needs: [metadata, build-images]

--- a/scripts/explain_manifest/test-uninstall.sh
+++ b/scripts/explain_manifest/test-uninstall.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+image=$1
+label=$2
+
+container_id=$(docker run -d --entrypoint "/bin/bash" "$image" -c "tail -f /dev/null")
+
+remove_kong_command() {
+    local remove_cmd=""
+
+    case "$label" in
+        "ubuntu"| "debian")
+            remove_cmd="apt-get remove -y kong"
+            ;;
+        "rhel")
+            remove_cmd="yum remove -y kong"
+            ;;
+        *)
+            echo "Unsupported operating system: $label" >&2
+            return 1
+    esac
+    echo "$remove_cmd"
+}
+
+if ! remove_cmd=$(remove_kong_command); then
+    echo "Failed to get remove command"
+    exit 1
+fi
+
+if ! docker exec -u root "$container_id" bash -c "$remove_cmd" > /dev/null 2>&1; then
+    echo "Failed to remove Kong"
+    docker stop --time 1 "$container_id" > /dev/null 2>&1
+    docker rm "$container_id" > /dev/null 2>&1
+    exit 1
+fi
+
+dir=(
+  "/usr/local/kong/include"
+  "/usr/local/kong/lib"
+  "/usr/local/share/lua/5.1"
+  "/usr/local/openresty"
+)
+
+for d in "${dir[@]}"
+do
+  docker exec -u root "$container_id" bash -c "test -d $d"
+  result=$?
+  if [ $result -eq 0 ]; then
+    echo "Failed to uninstall Kong, $d still exists"
+    break
+  fi
+done
+
+docker stop --time 1 "$container_id" > /dev/null 2>&1
+docker rm "$container_id" > /dev/null 2>&1


### PR DESCRIPTION
legacy smoke tests step has been removed, which include uninstall test, this commit move uninstall test to verify manifest test.

Fix[FTI-5678](https://konghq.atlassian.net/browse/FTI-5678)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
