### PR TITLE
feat: Ubuntu 24.04 (Noble Numbat)

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -1,15 +1,16 @@
 # please see matrix-full.yml for meaning of each field
 build-packages:
-- label: ubuntu-22.04
-  os: ubuntu-22.04
+- label: ubuntu-24.04
+  os: ubuntu-24.04
   package: deb
-  check-manifest-suite: ubuntu-22.04-amd64
+  check-manifest-suite: ubuntu-24.04-amd64
 
 build-images:
 - label: ubuntu
-  base-image: ubuntu:22.04
+  base-image: ubuntu:24.04
   package: deb
-  artifact-from: ubuntu-22.04
+  artifact-from: ubuntu-24.04
+  check-manifest-suite: docker-image-ubuntu-24.04
 
 smoke-tests:
 - label: ubuntu

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -18,6 +18,13 @@ build-packages:
   package: deb
   bazel-args: --platforms=//:generic-crossbuild-aarch64
   check-manifest-suite: ubuntu-22.04-arm64
+- label: ubuntu-24.04
+  package: deb
+  check-manifest-suite: ubuntu-24.04-amd64
+- label: ubuntu-24.04-arm64
+  package: deb
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
+  check-manifest-suite: ubuntu-24.04-arm64
 
 # Debian
 - label: debian-10
@@ -85,11 +92,12 @@ build-images:
 
 # Ubuntu
 - label: ubuntu
-  base-image: ubuntu:22.04
+  base-image: ubuntu:24.04
   package: deb
-  artifact-from: ubuntu-22.04
-  artifact-from-alt: ubuntu-22.04-arm64
+  artifact-from: ubuntu-24.04
+  artifact-from-alt: ubuntu-24.04-arm64
   docker-platforms: linux/amd64, linux/arm64
+  check-manifest-suite: docker-image-ubuntu-24.04
 
 # Debian
 - label: debian
@@ -134,6 +142,18 @@ release-packages:
   package: deb
   artifact-from: ubuntu-22.04-arm64
   artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.arm64.deb
+- label: ubuntu-24.04
+  package: deb
+  artifact-from: ubuntu-24.04
+  artifact-version: 24.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-24.04-arm64
+  package: deb
+  artifact-from: ubuntu-24.04-arm64
+  artifact-version: 24.04
   artifact-type: ubuntu
   artifact: kong.arm64.deb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       matrix:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-packages'] }}"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
       options: --privileged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,15 +436,22 @@ jobs:
     - name: Verify
       run: |
         cd scripts/explain_manifest
+
+        SUITE='docker-image'
+        if [ -n '${{ matrix.check-manifest-suite }}' ]; then
+          SUITE='${{ matrix.check-manifest-suite }}'
+        fi
+
         # docker image verify requires sudo to set correct permissions, so we
         # also install deps for root
-        sudo -E pip install -r requirements.txt
+        sudo -H -E pip install -r requirements.txt
+
         IMAGE=${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
 
-        sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
+        sudo -H -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
 
         if [[ ! -z "${{ matrix.docker-platforms }}" ]]; then
-          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
+          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
         fi
 
   scan-images:

--- a/build/README.md
+++ b/build/README.md
@@ -222,7 +222,7 @@ time to control how the ngx_wasm_module repository is sourced:
 
 ## Cross compiling
 
-Cross compiling is currently only tested on Ubuntu 22.04 x86_64 with following targeting platforms:
+Cross compiling is currently only tested on Ubuntu 22.04/24.04 x86_64 with following targeting platforms:
 
 - **//:generic-crossbuild-aarch64** Use the system installed aarch64 toolchain.
   - Requires user to manually install `crossbuild-essential-arm64` on Debian/Ubuntu.

--- a/build/cross_deps/libxcrypt/repositories.bzl
+++ b/build/cross_deps/libxcrypt/repositories.bzl
@@ -9,10 +9,11 @@ def libxcrypt_repositories():
     # thus crypt.h and libcrypt.so.1 are missing from cross tool chain
     # ubuntu2004: 4.4.10
     # ubuntu2204: 4.4.27
+    # ubuntu2204: 4.4.36
     http_archive(
         name = "cross_deps_libxcrypt",
-        url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.27/libxcrypt-4.4.27.tar.xz",
-        sha256 = "500898e80dc0d027ddaadb5637fa2bf1baffb9ccd73cd3ab51d92ef5b8a1f420",
-        strip_prefix = "libxcrypt-4.4.27",
+        url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.36/libxcrypt-4.4.36.tar.xz",
+        sha256 = "e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943",
+        strip_prefix = "libxcrypt-4.4.36",
         build_file = "//build/cross_deps/libxcrypt:BUILD.libxcrypt.bazel",
     )

--- a/changelog/unreleased/kong/add-noble-numbat.yml
+++ b/changelog/unreleased/kong/add-noble-numbat.yml
@@ -1,0 +1,2 @@
+message: "Add Ubuntu 24.04 (Noble Numbat) to build"
+type: dependency

--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -150,6 +150,19 @@ targets = {
             },
         }
     ),
+    "ubuntu-24.04-amd64": ExpectSuite(
+        name="Ubuntu 24.04 (amd64)",
+        manifest="fixtures/ubuntu-24.04-amd64.txt",
+        tests={
+            common_suites: {},
+            libc_libcpp_suites: {
+                "libc_max_version": "2.39",
+                # gcc 13.2.0
+                "libcxx_max_version": "3.4.32",
+                "cxxabi_max_version": "1.3.14",
+            },
+        },
+    ),
     "debian-10-amd64": ExpectSuite(
         name="Debian 10 (amd64)",
         manifest="fixtures/debian-10-amd64.txt",
@@ -194,6 +207,16 @@ targets = {
         manifest=None,
         tests={
             docker_suites: {},
+        }
+    ),
+    "docker-image-ubuntu-24.04": ExpectSuite(
+        name="Ubuntu 24.04 Docker Image",
+        manifest=None,
+        tests={
+            docker_suites: {
+                "kong_uid": 1001,
+                "kong_gid": 1001,
+            },
         }
     ),
 }

--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
@@ -1,0 +1,195 @@
+- Path      : /etc/kong/kong.logrotate
+
+- Path      : /lib/systemd/system/kong.service
+
+- Path      : /usr/local/kong/gui
+  Type      : directory
+
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/kong/lib/libsnappy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lxp.so
+  Needed    :
+  - libexpat.so.1
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasmx_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libcrypt.so.1
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  - ngx_brotli
+  - ngx_wasmx_module
+  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+
+- Path      : /usr/local/openresty/site/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libm.so.6
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  - libstdc++.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
@@ -1,0 +1,193 @@
+- Path      : /etc/kong/kong.logrotate
+
+- Path      : /lib/systemd/system/kong.service
+
+- Path      : /usr/local/kong/gui
+  Type      : directory
+
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/kong/lib/libsnappy.so
+  Needed    :
+  - libstdc++.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lxp.so
+  Needed    :
+  - libexpat.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasmx_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libcrypt.so.1
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  - ngx_brotli
+  - ngx_wasmx_module
+  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+
+- Path      : /usr/local/openresty/site/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libc.so.6

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -127,10 +127,7 @@ def arm64_suites(expect):
     expect("/usr/local/openresty/nginx/sbin/nginx", "Nginx is arm64 arch") \
         .arch.equals("AARCH64")
 
-def docker_suites(expect):
-    kong_uid = 1000
-    kong_gid = 1000
-
+def docker_suites(expect, kong_uid: int = 1000, kong_gid: int = 1000):
     expect("/etc/passwd", "kong user exists") \
         .text_content.matches("kong:x:%d" % kong_uid)
 

--- a/scripts/release-kong.sh
+++ b/scripts/release-kong.sh
@@ -100,6 +100,9 @@ function push_package () {
   if [ "$ARTIFACT_VERSION" == "22.04" ]; then
     dist_version="--dist-version jammy"
   fi
+  if [ "$ARTIFACT_VERSION" == "24.04" ]; then
+    dist_version="--dist-version noble"
+  fi
 
   # test for sanitized github actions input
   if [[ -n "$(echo "$PACKAGE_TAGS" | tr -d 'a-zA-Z0-9._,')" ]]; then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR introduces the next LTS version of Ubuntu, and makes it the default Ubuntu version used for building PRs, the `-ubuntu` tagged docker images, etc.

The biggest change I've noticed so far is that the `ubuntu/noble` docker image has an `ubuntu` user pre-populated in it. Making the `kong` user created by our postinstall.sh script, UID `1001` (vs. the `ubuntu` user's `1000`). The `jammy` image has/had no such initial user.

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - [PUT DOCS PR HERE](https://github.com/Kong/docs.konghq.com/pull/7471)

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-4672]_


[KAG-4672]: https://konghq.atlassian.net/browse/KAG-4672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ