### PR TITLE
chore(deps): bump resty.openssl from 1.3.1 to 1.4.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-openssl.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-openssl.yml
@@ -1,3 +1,3 @@
-message: Bumped lua-resty-openssl from 1.2.0 to 1.3.1
+message: Bumped lua-resty-openssl to 1.4.0
 type: dependency
 scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.0.2",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.4.1",
-  "lua-resty-openssl == 1.3.1",
+  "lua-resty-openssl == 1.4.0",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.13.0",


### PR DESCRIPTION
### Summary

#### bug fixes
- **ec:** add missing cdef for EC_POINT_free [2093e88](https://github.com/fffonion/lua-resty-openssl/commit/2093e8814ccfbe830ba594a71f05870cac208e9c)

#### features
- **pkey:** allow pkey.new to compose from parameters [91a30f6](https://github.com/fffonion/lua-resty-openssl/commit/91a30f6988e3fc696363ce1445b49a3f6ee8f35e)
- **pkey:** add pkey:verify_raw [0016308](https://github.com/fffonion/lua-resty-openssl/commit/0016308c9e3a2ccfdfe674ede64e462060f7b13b)

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)

KAG-4615
KAG-4620