### PR TITLE
chore(deps): bump luacheck from 1.1.2 to 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.2.0" "busted-hjtest 0.0.5" "luacheck 1.1.2" "lua-llthreads2 0.1.6" "ldoc 1.5.0" "luacov 0.15.0"
+DEV_ROCKS = "busted 2.2.0" "busted-hjtest 0.0.5" "luacheck 1.2.0" "lua-llthreads2 0.1.6" "ldoc 1.5.0" "luacov 0.15.0"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
@@ -209,4 +209,3 @@ install-legacy:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) YAML_DIR=$(YAML_DIR)
 
 dev-legacy: remove install-legacy dependencies
-


### PR DESCRIPTION
### Summary

#### Features

- Add builtin standards support for minetest — @BuckarooBanzay and @appgurueu

#### Performance

- Memoize results to addresses speed refression from new feature in v0.26 — @tomlau10

KAG-4615
KAG-4621