### PR TITLE
chore(deps): bump resty.aws from 1.4.1 to 1.5.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-aws.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-aws.yml
@@ -1,3 +1,3 @@
-message: "Bumped lua-resty-aws from 1.3.6 to 1.4.1"
+message: "Bumped lua-resty-aws to 1.5.0"
 type: dependency
 scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.0.2",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.4.1",
+  "lua-resty-aws == 1.5.0",
   "lua-resty-openssl == 1.3.1",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
### Summary

- feat: decode AWS api response json body with array metatable
- fix: do not inject region info for sts service with VPC endpoint hostname

### Checklist

- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)


KAG-4615
KAG-4622