### PR TITLE
chore(deps): bump bazelisk from 1.19.0 to 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KONG_SOURCE_LOCATION ?= $(ROOT_DIR)
 GRPCURL_VERSION ?= 1.8.5
-BAZLISK_VERSION ?= 1.19.0
+BAZLISK_VERSION ?= 1.20.0
 H2CLIENT_VERSION ?= 0.4.4
 BAZEL := $(shell command -v bazel 2> /dev/null)
 VENV = /dev/null # backward compatibility when no venv is built
@@ -209,4 +209,3 @@ install-legacy:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) YAML_DIR=$(YAML_DIR)
 
 dev-legacy: remove install-legacy dependencies
-


### PR DESCRIPTION
### Summary

#### New Features
- The Go version now supports BAZELISK_NOJDK

#### Bug Fixes & Improvements
- It's now easier to use Bazelisk programmatically
- Bazelisk will retry more connection errors
- A display bug in the download progress bar has been fixed

KAG-4615
KAG-4624