### PR TITLE
feat(plugin/response-transformer): added support for json_body rename 

### DIFF
--- a/changelog/unreleased/kong/feat-response-transformer-json-rename.yml
+++ b/changelog/unreleased/kong/feat-response-transformer-json-rename.yml
@@ -1,0 +1,4 @@
+message: |
+  Added support for json_body rename in response-transformer plugin
+type: feature
+scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -140,6 +140,9 @@ return {
     },
     key_auth = {
       "realm"
+    },
+    response_transformer = {
+      "rename.json",
     }
   },
 }

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -141,8 +141,12 @@ return {
     key_auth = {
       "realm"
     },
+  },
+
+  -- Any dataplane older than 3.8.0
+  [3008000000] = {
     response_transformer = {
       "rename.json",
-    }
+    },
   },
 }

--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -123,6 +123,15 @@ function _M.transform_json_body(conf, buffered_data)
     json_body[name] = nil
   end
 
+  -- rename key to body
+  for _, old_name, new_name in iter(conf.rename.json) do
+    if json_body[old_name] ~= nil and new_name then
+      local value = json_body[old_name]
+      json_body[new_name] = value
+      json_body[old_name] = nil
+    end
+  end
+
   -- replace key:value to body
   local replace_json_types = conf.replace.json_types
   for i, name, value in iter(conf.replace.json) do

--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -64,6 +64,7 @@ end
 
 local function is_body_transform_set(conf)
   return not isempty(conf.add.json    ) or
+         not isempty(conf.rename.json ) or
          not isempty(conf.remove.json ) or
          not isempty(conf.replace.json) or
          not isempty(conf.append.json )

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -73,6 +73,7 @@ local colon_headers_array = {
 local colon_rename_strings_array_record = {
   type = "record",
   fields = {
+    { json = colon_string_array },
     { headers = colon_headers_array }
   },
 }

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -145,6 +145,7 @@ describe("plugins", function()
       },
       rename = {
         headers = {},
+        json = {}
       },
       replace = {
         headers = {},

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -662,13 +662,13 @@ describe("CP/DP config compat transformations #" .. strategy, function()
     end)
 
     describe("compatibility test for response-transformer plugin", function()
-      it("removes `config.rename.json` before sending them to older(less than 3.7.0.0) DP nodes", function()
+      it("removes `config.rename.json` before sending them to older(less than 3.8.0.0) DP nodes", function()
         local rt = admin.plugins:insert {
           name = "response-transformer",
           enabled = true,
           config = {
             rename = {
-              -- [[ new fields 3.7.0
+              -- [[ new fields 3.8.0
               json = {"old:new"}
               -- ]]
             }
@@ -678,7 +678,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         assert.not_nil(rt.config.rename.json)
         local expected_rt = utils.cycle_aware_deep_copy(rt)
         expected_rt.config.rename.json = nil
-        do_assert(utils.uuid(), "3.6.0", expected_rt)
+        do_assert(utils.uuid(), "3.7.0", expected_rt)
 
         -- cleanup
         admin.plugins:remove({ id = rt.id })
@@ -690,13 +690,13 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           enabled = true,
           config = {
             rename = {
-              -- [[ new fields 3.7.0
+              -- [[ new fields 3.8.0
               json = {"old:new"}
               -- ]]
             }
           }
         }
-        do_assert(utils.uuid(), "3.7.0", rt)
+        do_assert(utils.uuid(), "3.8.0", rt)
 
         -- cleanup
         admin.plugins:remove({ id = rt.id })

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -660,6 +660,48 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         admin.plugins:remove({ id = key_auth.id })
       end)
     end)
+
+    describe("compatibility test for response-transformer plugin", function()
+      it("removes `config.rename.json` before sending them to older(less than 3.7.0.0) DP nodes", function()
+        local rt = admin.plugins:insert {
+          name = "response-transformer",
+          enabled = true,
+          config = {
+            rename = {
+              -- [[ new fields 3.7.0
+              json = {"old:new"}
+              -- ]]
+            }
+          }
+        }
+
+        assert.not_nil(rt.config.rename.json)
+        local expected_rt = utils.cycle_aware_deep_copy(rt)
+        expected_rt.config.rename.json = nil
+        do_assert(utils.uuid(), "3.6.0", expected_rt)
+
+        -- cleanup
+        admin.plugins:remove({ id = rt.id })
+      end)
+
+      it("does not remove `config.rename.json` from DP nodes that are already compatible", function()
+        local rt = admin.plugins:insert {
+          name = "response-transformer",
+          enabled = true,
+          config = {
+            rename = {
+              -- [[ new fields 3.7.0
+              json = {"old:new"}
+              -- ]]
+            }
+          }
+        }
+        do_assert(utils.uuid(), "3.7.0", rt)
+
+        -- cleanup
+        admin.plugins:remove({ id = rt.id })
+      end)
+    end)
   end)
 end)
 

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -676,9 +676,9 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         }
 
         assert.not_nil(rt.config.rename.json)
-        local expected_rt = utils.cycle_aware_deep_copy(rt)
+        local expected_rt = cycle_aware_deep_copy(rt)
         expected_rt.config.rename.json = nil
-        do_assert(utils.uuid(), "3.7.0", expected_rt)
+        do_assert(uuid(), "3.7.0", expected_rt)
 
         -- cleanup
         admin.plugins:remove({ id = rt.id })
@@ -696,7 +696,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
             }
           }
         }
-        do_assert(utils.uuid(), "3.8.0", rt)
+        do_assert(uuid(), "3.8.0", rt)
 
         -- cleanup
         admin.plugins:remove({ id = rt.id })

--- a/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
@@ -108,10 +108,11 @@ describe("Plugin: response-transformer", function()
     describe("rename", function()
       local conf  = {
         remove    = {
-          json = {},
+          json    = {},
           headers = {}
         },
-        rename   = {
+        rename    = {
+          json    = {},
           headers = {"h1:h2", "h3:h4"}
         },
         replace   = {
@@ -295,7 +296,8 @@ describe("Plugin: response-transformer", function()
             json    = {"p1"},
             headers = {"h1", "h2"}
           },
-          rename   = {
+          rename    = {
+            json    = {},
             headers = {}
           },
           replace   = {
@@ -339,7 +341,8 @@ describe("Plugin: response-transformer", function()
             json    = {},
             headers = {}
           },
-          rename   = {
+          rename    = {
+            json    = {},
             headers = {}
           },
           replace   = {
@@ -383,7 +386,8 @@ describe("Plugin: response-transformer", function()
             json    = {},
             headers = {}
           },
-          rename   = {
+          rename    = {
+            json    = {},
             headers = {}
           },
           replace   = {
@@ -427,7 +431,8 @@ describe("Plugin: response-transformer", function()
             json    = {},
             headers = {}
           },
-          rename   = {
+          rename    = {
+            json    = {},
             headers = {}
           },
           replace   = {

--- a/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
@@ -9,6 +9,9 @@ describe("Plugin: response-transformer", function()
         remove   = {
           json   = {},
         },
+        rename   = {
+          json   = {}
+        },
         replace  = {
           json   = {}
         },
@@ -56,6 +59,9 @@ describe("Plugin: response-transformer", function()
     describe("append", function()
       local conf = {
         remove   = {
+          json   = {}
+        },
+        rename   = {
           json   = {}
         },
         replace  = {
@@ -113,6 +119,9 @@ describe("Plugin: response-transformer", function()
         remove   = {
           json   = {"p1", "p2"}
         },
+        rename   = {
+          json   = {}
+        },
         replace  = {
           json   = {}
         },
@@ -137,9 +146,57 @@ describe("Plugin: response-transformer", function()
       end)
     end)
 
+    describe("rename", function()
+      local conf = {
+        remove   = {
+          json   = {}
+        },
+        rename   = {
+          json   = {"p1:k1", "p2:k2", "p3:k3", "p4:k4", "p5:k5"},
+        },
+        replace  = {
+          json   = {}
+        },
+        add      = {
+          json   = {}
+        },
+        append   = {
+          json   = {}
+        }
+      }
+      it("parameter", function()
+        local json = [[{"p1" : "v1", "p2" : "v2"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({k1 = "v1", k2 = "v2"}, body_json)
+      end)
+      it("preserves empty arrays", function()
+        local json = [[{"p1" : "v1", "p2" : "v2", "p3": []}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({k1 = "v1", k2 = "v2", k3 = {}}, body_json)
+        assert.equals('[]', cjson.encode(body_json.k3))
+      end)
+      it("number", function()
+        local json = [[{"p3" : -1}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({k3 = -1}, body_json)
+      end)
+      it("boolean", function()
+        local json = [[{"p4" : false, "p5" : true}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({k4 = false, k5 = true}, body_json)
+      end)
+    end)
+
     describe("replace", function()
       local conf = {
         remove   = {
+          json   = {}
+        },
+        rename   = {
           json   = {}
         },
         replace  = {
@@ -192,10 +249,13 @@ describe("Plugin: response-transformer", function()
       end)
     end)
 
-    describe("remove, replace, add, append", function()
+    describe("remove, rename, replace, add, append", function()
       local conf = {
         remove   = {
           json   = {"p1"}
+        },
+        rename   = {
+          json   = {"p4:p2"}
         },
         replace  = {
           json   = {"p2:v2"}
@@ -208,13 +268,13 @@ describe("Plugin: response-transformer", function()
         },
       }
       it("combination", function()
-        local json = [[{"p1" : "v1", "p2" : "v1"}]]
+        local json = [[{"p1" : "v1", "p4" : "v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
         assert.same({p2 = "v2", p3 = {"v1", "v2"}}, body_json)
       end)
       it("preserves empty array", function()
-        local json = [[{"p1" : "v1", "p2" : "v1", "a" : []}]]
+        local json = [[{"p1" : "v1", "p4" : "v1", "a" : []}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
         assert.same({p2 = "v2", p3 = {"v1", "v2"}, a = {}}, body_json)
@@ -258,6 +318,10 @@ describe("Plugin: response-transformer", function()
         remove    = {
           headers = {"h1", "h2", "h3"},
           json    = {}
+        },
+        rename    = {
+          headers = {},
+          json    = {},
         },
         add       = {
           headers = {},
@@ -348,6 +412,10 @@ describe("Plugin: response-transformer", function()
         remove    = {
           headers = {},
           json    = { "foo" }
+        },
+        rename    = {
+          headers = {},
+          json    = {},
         },
         add       = {
           headers = {},

--- a/spec/03-plugins/15-response-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-response-transformer/03-api_spec.lua
@@ -56,6 +56,7 @@ for _, strategy in helpers.each_strategy() do
         end)
         it("rename succeeds with colons", function()
           local rename_header = "x-request-id:x-custom-request-id"
+          local rename_json = "old_key:new_key"
           local res = assert(admin_client:send {
             method  = "POST",
             path    = "/plugins",
@@ -64,6 +65,7 @@ for _, strategy in helpers.each_strategy() do
               config = {
                 rename = {
                   headers = { rename_header },
+                  json    = { rename_json },
                 },
               },
             },
@@ -74,6 +76,7 @@ for _, strategy in helpers.each_strategy() do
           assert.response(res).has.status(201)
           local body = assert.response(res).has.jsonbody()
           assert.equals(rename_header, body.config.rename.headers[1])
+          assert.equals(rename_json, body.config.rename.json[1])
 
           admin_client:send {
             method  = "DELETE",
@@ -201,6 +204,7 @@ for _, strategy in helpers.each_strategy() do
                 },
                 rename = {
                   headers    = cjson.null,
+                  json       = cjson.null,
                 },
                 replace = {
                   headers    = cjson.null,
@@ -232,6 +236,7 @@ for _, strategy in helpers.each_strategy() do
             },
             rename = {
               headers = "required field missing",
+              json = "required field missing",
             },
             replace = {
               headers = "required field missing",


### PR DESCRIPTION
### Summary

reopened: https://github.com/Kong/kong/pull/12888 (by: [zhongweikang](https://github.com/zhongweikang), closed by mistake)

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
