### PR TITLE
test(ci):kong migrations can't up in sometimes

### DIFF
--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -166,7 +166,7 @@ function run_tests() {
         echo ">> Setting up tests"
         docker exec -w /upgrade-test $OLD_CONTAINER $BUSTED_ENV /kong/bin/busted -t setup $TEST
         echo ">> Running migrations"
-        kong migrations up
+        kong migrations up --force
         echo ">> Testing old_after_up,all_phases"
         docker exec -w /upgrade-test $OLD_CONTAINER $BUSTED_ENV /kong/bin/busted -t old_after_up,all_phases $TEST
         echo ">> Testing new_after_up,all_phases"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
It has created a PR base branch `next/3.4.x.x`.  Add migration scripts to the existing script file, such as `kong/enterprise_edition/db/migrations/enterprise/021_3435_to_3436.lua`. It will be ignored when executing `kong migrations up`.

case 1: upgrade next/2.8.x.x to the current PR of the next/3.4.x.x. the migration `021_3435_to_3436.lua` is always new.
The upgrade_tests are work well.

case 2: Upgrade `next/3.4.x.x` to the current PR of `next/3.4.x.x`. When starting the `next/3.4.x.x` container, the migration script `021_3435_to_3436.lua` will be bootstrapped for the first time. Then, upgrade to this PR. The second time using `kong migrations up` to bootstrap the script will not execute the migration script `021_3435_to_3436.lua`.

There is an example. https://github.com/Kong/kong-ee/actions/runs/9310936847/job/25629308613

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

