### PR TITLE
fix(core/balancer): fix a bug that the `host_header` not set correctly

### DIFF
--- a/changelog/unreleased/host_header.yml
+++ b/changelog/unreleased/host_header.yml
@@ -1,0 +1,3 @@
+message: fix a bug that the `host_header` attribute of upstream entity can not be set correctly in requests to upstream as Host header when retries to upstream happen.
+scope: Core
+type: bugfix

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -307,7 +307,6 @@ local function execute(balancer_data, ctx)
     -- retry, so balancer is already set if there was one
     balancer   = balancer_data.balancer
     upstream   = balancer_data.upstream
-    hash_value = balancer_data.hash_value
 
   else
     -- first try, so try and find a matching balancer/upstream object

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -305,8 +305,8 @@ local function execute(balancer_data, ctx)
 
   if dns_cache_only then
     -- retry, so balancer is already set if there was one
-    balancer   = balancer_data.balancer
-    upstream   = balancer_data.upstream
+    balancer = balancer_data.balancer
+    upstream = balancer_data.upstream
 
   else
     -- first try, so try and find a matching balancer/upstream object

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -305,8 +305,9 @@ local function execute(balancer_data, ctx)
 
   if dns_cache_only then
     -- retry, so balancer is already set if there was one
-    balancer = balancer_data.balancer
-    upstream = balancer_data.upstream
+    balancer   = balancer_data.balancer
+    upstream   = balancer_data.upstream
+    hash_value = balancer_data.hash_value
 
   else
     -- first try, so try and find a matching balancer/upstream object

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -306,6 +306,7 @@ local function execute(balancer_data, ctx)
   if dns_cache_only then
     -- retry, so balancer is already set if there was one
     balancer = balancer_data.balancer
+    upstream = balancer_data.upstream
 
   else
     -- first try, so try and find a matching balancer/upstream object

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -1218,7 +1218,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("host_header should be set correctly #h", function()
+  describe("host_header should be set correctly", function()
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "routes",

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -1242,7 +1242,7 @@ for _, strategy in helpers.each_strategy() do
         retries         = 5,
       }
 
-      local route = bp.routes:insert {
+      bp.routes:insert {
         service    = service,
         paths      = { "/hello" },
         strip_path = false,

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -1217,4 +1217,78 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
   end)
+
+  describe("host_header should be set correctly #h", function()
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
+
+      local upstream = assert(bp.upstreams:insert {
+        name               = "foo",
+        host_header        = "foo.com",
+      })
+
+      assert(bp.targets:insert {
+        target   = "127.0.0.1:62351",
+        upstream = upstream,
+        weight   = 50,
+      })
+
+      local service = bp.services:insert {
+        name            = "retry_service",
+        host            = "foo",
+        retries         = 5,
+      }
+
+      local route = bp.routes:insert {
+        service    = service,
+        paths      = { "/hello" },
+        strip_path = false,
+      }
+
+      local fixtures = {
+        http_mock = {}
+      }
+
+      fixtures.http_mock.my_server_block = [[
+        server {
+          listen 0.0.0.0:62351;
+          location /hello {
+            content_by_lua_block {
+              local shd = ngx.shared.request_counter
+              local request_counter = shd:incr("counter", 1, 0)
+              if request_counter % 2 ~= 0 then
+                ngx.exit(ngx.HTTP_CLOSE)
+              else
+                ngx.say(ngx.var.host)
+              end
+            }
+          }
+        }
+      ]]
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        nginx_http_lua_shared_dict = "request_counter 1m",
+      }, nil, nil, fixtures))
+    end)
+
+    lazy_teardown(function()
+      assert(helpers.stop_kong())
+    end)
+
+    it("when retries to upstream happen", function()
+      local proxy_client = helpers.proxy_client()
+      local res = assert(proxy_client:send {
+        method = "GET",
+        path = "/hello",
+      })
+
+      local body = assert.res_status(200, res)
+      assert.equal("foo.com", body)
+    end)
+  end)
 end


### PR DESCRIPTION
### Summary

fix a bug that the `host_header` can not be set correctly as Host header in requests to upstream when retries happen 

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5987