### PR TITLE
fix(cmd): fix kong cli not printing some debug level error log

### DIFF
--- a/bin/kong
+++ b/bin/kong
@@ -141,9 +141,17 @@ package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.
 require("kong.cmd.init")("%s", %s)
 ]], cmd_name, args_str)
 
+local resty_ngx_log_level
+if arg.vv then
+  resty_ngx_log_level = "debug"
+elseif arg.v then
+  resty_ngx_log_level = "info"
+end
+
 local resty_cmd = string.format(
-  "resty --main-conf \"%s\" --http-conf \"%s\" --stream-conf \"%s\" -e '%s'",
-  main_conf, http_conf, stream_conf, inline_code)
+  "resty %s --main-conf \"%s\" --http-conf \"%s\" --stream-conf \"%s\" -e '%s'",
+  resty_ngx_log_level and ("--errlog-level " .. resty_ngx_log_level) or "", main_conf,
+  http_conf, stream_conf, inline_code)
 
 local _, code = pl_utils.execute(resty_cmd)
 os.exit(code)

--- a/changelog/unreleased/kong/fix-cmd-error-log.yml
+++ b/changelog/unreleased/kong/fix-cmd-error-log.yml
@@ -1,0 +1,4 @@
+message: |
+  Fixed an issue where some debug level error logs were not being displayed by the CLI.
+type: bugfix
+scope: CLI Command

--- a/spec/02-integration/02-cmd/16-verbose_spec.lua
+++ b/spec/02-integration/02-cmd/16-verbose_spec.lua
@@ -1,0 +1,11 @@
+local helpers = require "spec.helpers"
+local meta = require "kong.meta"
+
+describe("kong cli verbose output", function()
+  it("--vv outputs debug level log", function()
+    local _, stderr, stdout = assert(helpers.kong_exec("version --vv"))
+    -- globalpatches debug log will be printed by upper level resty command that runs kong.cmd
+    assert.matches("installing the globalpatches", stderr)
+    assert.matches("Kong: " .. meta._VERSION, stdout)
+  end)
+end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3312,7 +3312,8 @@ luassert:register("assertion", "partial_match", partial_match,
 -- (ok, code, stdout, stderr); if `returns` is false,
 -- returns either (false, stderr) or (true, stderr, stdout).
 function exec(cmd, returns)
-  local ok, stdout, stderr, _, code = shell.run(cmd, nil, 0)
+  --100MB for retrieving stdout & stderr
+  local ok, stdout, stderr, _, code = shell.run(cmd, nil, 0, 1024*1024*100)
   if returns then
     return ok, code, stdout, stderr
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR fixes a problem that running `kong` CLI command will not print some of the debug level error logs. Those error logs may be triggered by `ngx.log` before the actual `kong.cmd` module gets called. 

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

The issue in this PR was discovered when debugging FTI-5995, but it is not related to the ticket's problem at all.
