### PR TITLE
fix(ci): edit the pattern in changelog requirement checker

### DIFF
--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           files_yaml: |
             changelogs:
-              - 'changelog/unreleased/**/*.yml'
+              - 'changelog/unreleased/*/*.yml'
             upper_case:
               - 'CHANGELOG/**'
             numbered:
-              - 'changelog/unreleased/**/[0-9]+.yml'
+              - 'changelog/unreleased/*/[0-9]+.yml'
 
       - name: Check changelog existence
         if: steps.changelog-list.outputs.changelogs_any_changed == 'false'


### PR DESCRIPTION
### Summary

changelog files put directly under `kong/unreleased/` cannot be recognized when generating changelog entries, therefore in this PR, edit the location pattern in changelog requirement

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
