### PR TITLE
feat(queue): implement functions `Quque.is_full` & `Queue.can_enqueue`

### DIFF
--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -539,8 +539,9 @@ local function enqueue(self, entry)
   -- The queue should not be full if we are running into this situation.
   -- Since the dropping logic is complcated,
   -- further maintenancers might introduce bugs,
-  -- so I added this assertion to detect this kind of bug early
-  -- (it's better to crash early than leak memory).
+  -- so I added this assertion to detect this kind of bug early.
+  -- It's better to crash early than leak memory
+  -- as analyze memory leak is hard.
   assert(
     -- bracing the function call to get the first return value only
     internal_is_full(self) == false,

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -102,18 +102,19 @@ end
 
 local function internal_remaining_capacity(self)
   local remaining_entries = self.max_entries - self:count()
+  local max_bytes = self.max_bytes
 
   -- we enqueue entries one by one,
   -- so it is impossible to have a negative value
   assert(remaining_entries >= 0, "queue should not be over capacity")
 
-  if self.max_bytes == nil then
+  if max_bytes == nil then
     return remaining_entries
   end
 
-  local remaining_bytes = self.max_bytes - self.bytes_queued
+  local remaining_bytes = max_bytes - self.bytes_queued
 
-  -- we check remaining_bytes before enqueuing an entry,
+  -- we check remaining_bytes before enqueueing an entry,
   -- so it is impossible to have a negative value
   assert(remaining_bytes >= 0, "queue should not be over capacity")
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -571,11 +571,8 @@ function Queue.enqueue(queue_conf, handler, handler_conf, value)
     "arg #2 (handler) must be a function")
   assert(handler_conf == nil or type(handler_conf) == "table",
     "arg #3 (handler_conf) must be a table or nil")
-
   assert(type(queue_conf.name) == "string",
     "arg #1 (queue_conf) must include a name")
-
-  local max_bytes_type = type(queue_conf.max_bytes)
 
   assert(
     type(queue_conf.max_batch_size) == "number",
@@ -590,10 +587,6 @@ function Queue.enqueue(queue_conf, handler, handler_conf, value)
     "arg #1 (queue_conf) max_entries must be a number"
   )
   assert(
-    max_bytes_type == "nil" or max_bytes_type == "number",
-    "arg #1 (queue_conf) max_bytes must be a number or nil"
-  )
-  assert(
     type(queue_conf.max_retry_time) == "number",
     "arg #1 (queue_conf) max_retry_time must be a number"
   )
@@ -604,6 +597,12 @@ function Queue.enqueue(queue_conf, handler, handler_conf, value)
   assert(
     type(queue_conf.max_retry_delay) == "number",
     "arg #1 (queue_conf) max_retry_delay must be a number"
+  )
+
+  local max_bytes_type = type(queue_conf.max_bytes)
+  assert(
+    max_bytes_type == "nil" or max_bytes_type == "number",
+    "arg #1 (queue_conf) max_bytes must be a number or nil"
   )
 
   local queue = get_or_create_queue(queue_conf, handler, handler_conf)

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -536,7 +536,7 @@ local function enqueue(self, entry)
 
   -- safety guard
   -- The queue should not be full if we are running into this situation.
-  -- Since the dropping logic is complcated,
+  -- Since the dropping logic is complicated,
   -- further maintenancers might introduce bugs,
   -- so I added this assertion to detect this kind of bug early.
   -- It's better to crash early than leak memory

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -533,9 +533,9 @@ local function enqueue(self, entry)
     self:log_err("byte capacity exceeded, %d queue entries were dropped", dropped)
   end
 
-  -- safe guard
+  -- safety guard
   -- this should never happen if the dropping logic is correct,
-  -- but it's better to be safe than memory leaky
+  -- but it's better to crash early than leak memory
   assert(
     -- bracing the function call to get the first return value only
     internal_is_full(self) == false,

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -536,7 +536,7 @@ local function enqueue(self, entry)
   -- safety guard
   -- The queue should not be full if we are running into this situation.
   -- Since the dropping logic is complcated,
-  -- further maintenance might introduce bugs,
+  -- further maintenancers might introduce bugs,
   -- so I added this assertion to detect this kind of bug early
   -- (it's better to crash early than leak memory).
   assert(

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -122,14 +122,14 @@ end
 
 
 local function internal_is_reaching_max_entries(self)
-  local remaining_entries = internal_remaining_capacity(self)
-  return remaining_entries == 0
+  -- `()` is used to get the first return value only
+  return (internal_remaining_capacity(self)) == 0
 end
 
 
 local function internal_will_exceed_max_entries(self)
-  local remaining_entries = internal_remaining_capacity(self)
-  return remaining_entries - 1 < 0
+   -- `()` is used to get the first return value only
+  return (internal_remaining_capacity(self)) - 1 < 0
 end
 
 
@@ -181,7 +181,7 @@ local function internal_is_full(self)
 end
 
 
-local function internal_will_full(self, entry)
+local function internal_can_enqueue(self, entry)
   return internal_is_full(self)                       or
          internal_is_entry_too_large(self, entry)     or
          internal_will_exceed_max_entries(self)       or
@@ -293,14 +293,14 @@ function Queue.is_full(queue_conf)
 end
 
 
-function Queue.will_full(queue_conf, entry)
+function Queue.can_enqueue(queue_conf, entry)
   local queue = queues[make_queue_key(queue_conf.name)]
   if not queue then
     -- treat non-existing queues as not full as they will be created on demand
     return false
   end
 
-  return internal_will_full(queue, entry)
+  return internal_can_enqueue(queue, entry)
 end
 
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -107,7 +107,7 @@ local function internal_remaining_capacity(self)
   -- so it is impossible to have a negative value
   assert(remaining_entries >= 0, "queue should not be over capacity")
 
-  if not self.max_bytes then
+  if self.max_bytes == nil then
     return remaining_entries
   end
 
@@ -161,7 +161,7 @@ end
 
 
 local function internal_will_exceed_max_bytes(self, entry)
-  if not self.max_bytes then
+  if self.max_bytes == nil then
     return false
   end
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -108,7 +108,7 @@ local function internal_remaining_capacity(self)
   -- so it is impossible to have a negative value
   assert(remaining_entries >= 0, "queue should not be over capacity")
 
-  if max_bytes == nil then
+  if not max_bytes then
     return remaining_entries
   end
 
@@ -137,7 +137,7 @@ end
 local function internal_is_entry_too_large(self, entry)
   local max_bytes = self.max_bytes
 
-  if max_bytes == nil then
+  if not max_bytes then
     return false
   end
 
@@ -151,18 +151,17 @@ end
 
 
 local function internal_is_reaching_max_bytes(self)
-  if self.max_bytes == nil then
+  if not self.max_bytes then
     return false
   end
 
   local _, remaining_bytes = internal_remaining_capacity(self)
-  assert(type(remaining_bytes) == "number", "remaining_bytes must be a number")
   return remaining_bytes == 0
 end
 
 
 local function internal_will_exceed_max_bytes(self, entry)
-  if self.max_bytes == nil then
+  if not self.max_bytes then
     return false
   end
 
@@ -172,7 +171,6 @@ local function internal_will_exceed_max_bytes(self, entry)
   end
 
   local _, remaining_bytes = internal_remaining_capacity(self)
-  assert(type(remaining_bytes) == "number", "remaining_bytes must be a number")
   return #entry > remaining_bytes
 end
 
@@ -572,10 +570,41 @@ function Queue.enqueue(queue_conf, handler, handler_conf, value)
   assert(type(handler) == "function",
     "arg #2 (handler) must be a function")
   assert(handler_conf == nil or type(handler_conf) == "table",
-    "arg #3 (handler_conf) must be a table")
+    "arg #3 (handler_conf) must be a table or nil")
 
   assert(type(queue_conf.name) == "string",
     "arg #1 (queue_conf) must include a name")
+
+  local max_bytes_type = type(queue_conf.max_bytes)
+
+  assert(
+    type(queue_conf.max_batch_size) == "number",
+    "arg #1 (queue_conf) max_batch_size must be a number"
+  )
+  assert(
+    type(queue_conf.max_coalescing_delay) == "number",
+    "arg #1 (queue_conf) max_coalescing_delay must be a number"
+  )
+  assert(
+    type(queue_conf.max_entries) == "number",
+    "arg #1 (queue_conf) max_entries must be a number"
+  )
+  assert(
+    max_bytes_type == "nil" or max_bytes_type == "number",
+    "arg #1 (queue_conf) max_bytes must be a number or nil"
+  )
+  assert(
+    type(queue_conf.max_retry_time) == "number",
+    "arg #1 (queue_conf) max_retry_time must be a number"
+  )
+  assert(
+    type(queue_conf.initial_retry_delay) == "number",
+    "arg #1 (queue_conf) initial_retry_delay must be a number"
+  )
+  assert(
+    type(queue_conf.max_retry_delay) == "number",
+    "arg #1 (queue_conf) max_retry_delay must be a number"
+  )
 
   local queue = get_or_create_queue(queue_conf, handler, handler_conf)
   return enqueue(queue, value)

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -113,7 +113,7 @@ local function internal_remaining_capacity(self)
 
   local remaining_bytes = self.max_bytes - self.bytes_queued
 
-  -- we checking remaining_bytes before enqueuing an entry,
+  -- we check remaining_bytes before enqueuing an entry,
   -- so it is impossible to have a negative value
   assert(remaining_bytes >= 0, "queue should not be over capacity")
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -182,10 +182,12 @@ end
 
 
 local function internal_can_enqueue(self, entry)
-  return internal_is_full(self)                       or
-         internal_is_entry_too_large(self, entry)     or
-         internal_will_exceed_max_entries(self)       or
-         internal_will_exceed_max_bytes(self, entry)
+  return not (
+    internal_is_full(self)                       or
+    internal_is_entry_too_large(self, entry)     or
+    internal_will_exceed_max_entries(self)       or
+    internal_will_exceed_max_bytes(self, entry)
+  )
 end
 
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -534,8 +534,11 @@ local function enqueue(self, entry)
   end
 
   -- safety guard
-  -- this should never happen if the dropping logic is correct,
-  -- but it's better to crash early than leak memory
+  -- The queue should not be full if we are running into this situation.
+  -- Since the dropping logic is complcated,
+  -- further maintenance might introduce bugs,
+  -- so I added this assertion to detect this kind of bug early
+  -- (it's better to crash early than leak memory).
   assert(
     -- bracing the function call to get the first return value only
     internal_is_full(self) == false,

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -543,7 +543,7 @@ local function enqueue(self, entry)
   -- as analyze memory leak is hard.
   assert(
     -- assert that enough space is available on the queue now
-    internal_can_enqueue(self, entry) == false,
+    internal_can_enqueue(self, entry),
     "queue should not be full after dropping entries"
   )
 

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -542,8 +542,8 @@ local function enqueue(self, entry)
   -- It's better to crash early than leak memory
   -- as analyze memory leak is hard.
   assert(
-    -- bracing the function call to get the first return value only
-    internal_is_full(self) == false,
+    -- assert that enough space is available on the queue now
+    internal_can_enqueue(self, entry) == false,
     "queue should not be full after dropping entries"
   )
 

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -788,4 +788,71 @@ describe("plugin queue", function()
     assert.match_re(log_messages, 'WARN \\[\\] queue continue-processing: handler could not process entries: .*: hard error')
     assert.match_re(log_messages, 'ERR \\[\\] queue continue-processing: could not send entries, giving up after \\d retries.  1 queue entries were lost')  
   end)
+
+  it("sanity check for function Queue.is_full() & Queue.will_full()", function()
+    local queue_conf = {
+      name = "queue-full-checking-too-many-entries",
+      max_batch_size = 99999, -- avoiding automatically flushing,
+      max_entries = 2,
+      max_bytes = nil, -- avoiding bytes limit
+      max_coalescing_delay = 99999, -- avoiding automatically flushing,
+    }
+
+    local function enqueue(queue_conf, entry)
+      Queue.enqueue(
+        queue_conf,
+        function()
+          return true
+        end,
+        nil,
+        entry
+      )
+    end
+
+    assert.is_false(Queue.is_full(queue_conf))
+    assert.is_false(Queue.will_full(queue_conf, "One"))
+    enqueue(queue_conf, "One")
+    assert.is_false(Queue.is_full(queue_conf))
+
+    assert.is_false(Queue.will_full(queue_conf, "Two"))
+    enqueue(queue_conf, "Two")
+    assert.is_true(Queue.is_full(queue_conf))
+
+    assert.is_true(Queue.will_full(queue_conf, "Three"))
+
+
+    queue_conf = {
+      name = "queue-full-checking-too-many-bytes",
+      max_batch_size = 99999, -- avoiding automatically flushing,
+      max_entries = 99999, -- big enough to avoid entries limit
+      max_bytes = 2,
+      max_coalescing_delay = 99999, -- avoiding automatically flushing,
+    }
+
+    assert.is_false(Queue.is_full(queue_conf))
+    assert.is_false(Queue.will_full(queue_conf, "1"))
+    enqueue(queue_conf, "1")
+    assert.is_false(Queue.is_full(queue_conf))
+
+    assert.is_false(Queue.will_full(queue_conf, "2"))
+    enqueue(queue_conf, "2")
+    assert.is_true(Queue.is_full(queue_conf))
+
+    assert.is_true(Queue.will_full(queue_conf, "3"))
+
+    queue_conf = {
+      name = "queue-full-checking-too-large-entry",
+      max_batch_size = 99999, -- avoiding automatically flushing,
+      max_entries = 99999, -- big enough to avoid entries limit
+      max_bytes = 3,
+      max_coalescing_delay = 99999, -- avoiding automatically flushing,
+    }
+
+    enqueue(queue_conf, "1")
+
+    assert.is_false(Queue.is_full(queue_conf))
+    assert.is_false(Queue.will_full(queue_conf, "1"))
+    assert.is_false(Queue.will_full(queue_conf, "11"))
+    assert.is_true(Queue.will_full(queue_conf, "111"))
+  end)
 end)

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -789,7 +789,7 @@ describe("plugin queue", function()
     assert.match_re(log_messages, 'ERR \\[\\] queue continue-processing: could not send entries, giving up after \\d retries.  1 queue entries were lost')  
   end)
 
-  it("sanity check for function Queue.is_full() & Queue.will_full()", function()
+  it("sanity check for function Queue.is_full() & Queue.can_enqueue()", function()
     local queue_conf = {
       name = "queue-full-checking-too-many-entries",
       max_batch_size = 99999, -- avoiding automatically flushing,
@@ -810,15 +810,15 @@ describe("plugin queue", function()
     end
 
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.will_full(queue_conf, "One"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "One"))
     enqueue(queue_conf, "One")
     assert.is_false(Queue.is_full(queue_conf))
 
-    assert.is_false(Queue.will_full(queue_conf, "Two"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "Two"))
     enqueue(queue_conf, "Two")
     assert.is_true(Queue.is_full(queue_conf))
 
-    assert.is_true(Queue.will_full(queue_conf, "Three"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "Three"))
 
 
     queue_conf = {
@@ -830,15 +830,15 @@ describe("plugin queue", function()
     }
 
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.will_full(queue_conf, "1"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "1"))
     enqueue(queue_conf, "1")
     assert.is_false(Queue.is_full(queue_conf))
 
-    assert.is_false(Queue.will_full(queue_conf, "2"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "2"))
     enqueue(queue_conf, "2")
     assert.is_true(Queue.is_full(queue_conf))
 
-    assert.is_true(Queue.will_full(queue_conf, "3"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "3"))
 
     queue_conf = {
       name = "queue-full-checking-too-large-entry",
@@ -851,8 +851,8 @@ describe("plugin queue", function()
     enqueue(queue_conf, "1")
 
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.will_full(queue_conf, "1"))
-    assert.is_false(Queue.will_full(queue_conf, "11"))
-    assert.is_true(Queue.will_full(queue_conf, "111"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "1"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "11"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "111"))
   end)
 end)

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -814,11 +814,11 @@ describe("plugin queue", function()
     enqueue(queue_conf, "One")
     assert.is_false(Queue.is_full(queue_conf))
 
-    assert.is_false(Queue.can_enqueue(queue_conf, "Two"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "Two"))
     enqueue(queue_conf, "Two")
     assert.is_true(Queue.is_full(queue_conf))
 
-    assert.is_true(Queue.can_enqueue(queue_conf, "Three"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "Three"))
 
 
     queue_conf = {
@@ -834,11 +834,11 @@ describe("plugin queue", function()
     enqueue(queue_conf, "1")
     assert.is_false(Queue.is_full(queue_conf))
 
-    assert.is_false(Queue.can_enqueue(queue_conf, "2"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "2"))
     enqueue(queue_conf, "2")
     assert.is_true(Queue.is_full(queue_conf))
 
-    assert.is_true(Queue.can_enqueue(queue_conf, "3"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "3"))
 
     queue_conf = {
       name = "queue-full-checking-too-large-entry",
@@ -851,8 +851,8 @@ describe("plugin queue", function()
     enqueue(queue_conf, "1")
 
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.can_enqueue(queue_conf, "1"))
-    assert.is_false(Queue.can_enqueue(queue_conf, "11"))
-    assert.is_true(Queue.can_enqueue(queue_conf, "111"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "1"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "11"))
+    assert.is_false(Queue.can_enqueue(queue_conf, "111"))
   end)
 end)

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -796,6 +796,9 @@ describe("plugin queue", function()
       max_entries = 2,
       max_bytes = nil, -- avoiding bytes limit
       max_coalescing_delay = 99999, -- avoiding automatically flushing,
+      max_retry_time = 60,
+      initial_retry_delay = 1,
+      max_retry_delay = 60,
     }
 
     local function enqueue(queue_conf, entry)
@@ -827,6 +830,9 @@ describe("plugin queue", function()
       max_entries = 99999, -- big enough to avoid entries limit
       max_bytes = 2,
       max_coalescing_delay = 99999, -- avoiding automatically flushing,
+      max_retry_time = 60,
+      initial_retry_delay = 1,
+      max_retry_delay = 60,
     }
 
     assert.is_false(Queue.is_full(queue_conf))
@@ -846,6 +852,9 @@ describe("plugin queue", function()
       max_entries = 99999, -- big enough to avoid entries limit
       max_bytes = 3,
       max_coalescing_delay = 99999, -- avoiding automatically flushing,
+      max_retry_time = 60,
+      initial_retry_delay = 1,
+      max_retry_delay = 60,
     }
 
     enqueue(queue_conf, "1")


### PR DESCRIPTION
# SQUASH AND MERGE

### Summary

Generating entries is expensive in some cases,
so we'd better have a way to observe the state of the Queue.
So we are able to skip generating if the Queue is already or will be full.

This is the pre-requirement of https://github.com/Kong/kong-ee/pull/9273.

### Checklist

- [x] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-4270]_


[KAG-4270]: https://konghq.atlassian.net/browse/KAG-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ