### PR TITLE
refactor(tools/http): simplify check_https() with ngx.var

### DIFF
--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -211,7 +211,6 @@ _M.check_https = function(trusted_ip, allow_terminated)
   -- (which was either validated earlier, or we fall through this block)
   if trusted_ip then
     local scheme = ngx.var.http_x_forwarded_proto
-
     if not scheme then
       return false
     end

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -212,6 +212,10 @@ _M.check_https = function(trusted_ip, allow_terminated)
   if trusted_ip then
     local scheme = ngx.var.http_x_forwarded_proto
 
+    if not scheme then
+      return false
+    end
+
     -- we could use the first entry (lower security), or check the contents of
     -- each of them (slow). So for now defensive, and error
     -- out on multiple entries for the x-forwarded-proto header.

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -210,16 +210,16 @@ _M.check_https = function(trusted_ip, allow_terminated)
   -- otherwise, we fall back to relying on the client scheme
   -- (which was either validated earlier, or we fall through this block)
   if trusted_ip then
-    local scheme = ngx.req.get_headers()["x-forwarded-proto"]
+    local scheme = ngx.var.http_x_forwarded_proto
 
     -- we could use the first entry (lower security), or check the contents of
     -- each of them (slow). So for now defensive, and error
     -- out on multiple entries for the x-forwarded-proto header.
-    if type(scheme) == "table" then
+    if scheme:find(",", 1, true) then
       return nil, "Only one X-Forwarded-Proto header allowed"
     end
 
-    return tostring(scheme):lower() == "https"
+    return scheme:lower() == "https"
   end
 
   return false

--- a/t/01-pdk/05-client/08-get_protocol.t
+++ b/t/01-pdk/05-client/08-get_protocol.t
@@ -301,3 +301,34 @@ qq{
 protocol=tls
 --- no_error_log
 [error]
+
+
+
+=== TEST 11: client.get_protocol() fails when kong receives an http request with multiple x-forwarded-proto headers
+
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            ngx.ctx.route = {
+              protocols = { "http", "https" }
+            }
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+            pdk.ip.is_trusted = function() return true end -- mock
+
+            local ok, err = pdk.client.get_protocol(true)
+            assert(not ok)
+            ngx.say("err=", err)
+        }
+    }
+--- request
+GET /t
+--- more_headers
+X-Forwarded-Proto: https
+X-Forwarded-Proto: http
+--- response_body
+err=Only one X-Forwarded-Proto header allowed
+--- no_error_log
+[error]

--- a/t/01-pdk/05-client/08-get_protocol.t
+++ b/t/01-pdk/05-client/08-get_protocol.t
@@ -319,7 +319,7 @@ protocol=tls
             pdk.ip.is_trusted = function() return true end -- mock
 
             local ok, err = pdk.client.get_protocol(true)
-            assert(not ok)
+            assert(ok == nil)
             ngx.say("err=", err)
         }
     }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

We used to call `ngx.req.get_headers()` to get all possible header values,
but since nginx 1.23.0 or OpenResty 1.25.3.1 `ngx.var` can get a combined value for all header values
with identical name (joined by comma), so I think that we could simplify these code.

There is one concern:
If header `X-Forwarded-Proto` has a comma separated value like `http, https`, 
This PR will think it is a multiple header request and report an error `Only one X-Forwarded-Proto header allowed`.
But I think that it is an unlikely case in the real world.

KAG-4673

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
