### PR TITLE
tests(cmd): match kong version in cmd verbose test should use plain match

### DIFF
--- a/spec/02-integration/02-cmd/16-verbose_spec.lua
+++ b/spec/02-integration/02-cmd/16-verbose_spec.lua
@@ -6,6 +6,6 @@ describe("kong cli verbose output", function()
     local _, stderr, stdout = assert(helpers.kong_exec("version --vv"))
     -- globalpatches debug log will be printed by upper level resty command that runs kong.cmd
     assert.matches("installing the globalpatches", stderr)
-    assert.matches("Kong: " .. meta._VERSION, stdout)
+    assert.matches("Kong: " .. meta._VERSION, stdout, nil, true)
   end)
 end)


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fixed the CI failure when cherry-picking https://github.com/Kong/kong-ee/pull/9382

When `meta._VERSION` contains `-`, it will be regarded as magic character which is not expected.

This PR fixes the test to let it use plain matches. Note that CE does not have this issue because CE's `meta._VERSION` does not contain magic character

<!--- Why is this change required? What problem does it solve? -->

