### PR TITLE
refactor(router/atc): cache `ngx.var` result in stream routing

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -161,7 +161,12 @@ else  -- stream
   FIELDS_FUNCS["net.dst.ip"] =
   function(params)
     if not params.dst_ip then
-      if var.kong_tls_passthrough_block == "1" or var.ssl_protocol then
+      if params._need_proxy_protocol == nil then
+        params._need_proxy_protocol = var.kong_tls_passthrough_block == "1" or
+                                      var.ssl_protocol ~= nil
+      end
+
+      if params._need_proxy_protocol then
         params.dst_ip = var.proxy_protocol_server_addr
 
       else
@@ -175,8 +180,14 @@ else  -- stream
   FIELDS_FUNCS["net.dst.port"] =
   function(params, ctx)
     if not params.dst_port then
-      if var.kong_tls_passthrough_block == "1" or var.ssl_protocol then
+      if params._need_proxy_protocol == nil then
+        params._need_proxy_protocol = var.kong_tls_passthrough_block == "1" or
+                                      var.ssl_protocol ~= nil
+      end
+
+      if params._need_proxy_protocol then
         params.dst_port = tonumber(var.proxy_protocol_server_port, 10)
+
       else
         params.dst_port = (ctx or ngx.ctx).host_port or tonumber(var.server_port, 10)
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`ngx.var` is a relatively expensive operation in OpenResty, 
this PR tries to cache the result of `ngx.var` when we process TLS requests.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
