### PR TITLE
feat(ai-promp-guard) add config option to prompt guard for scanning "system" and "assistant" messages

### DIFF
--- a/changelog/unreleased/kong/feat-ai-prompt-guard-all-roles.yml
+++ b/changelog/unreleased/kong/feat-ai-prompt-guard-all-roles.yml
@@ -1,0 +1,3 @@
+message: "**AI-Prompt-Guard**: add `match_all_roles` option to allow match all roles in addition to `user`."
+type: feature
+scope: Plugin

--- a/changelog/unreleased/kong/fix-ai-prompt-guard-order.yml
+++ b/changelog/unreleased/kong/fix-ai-prompt-guard-order.yml
@@ -1,0 +1,3 @@
+message: "**AI-Prompt-Guard**: Fixed an issue when `allow_all_conversation_history` is set to false, the first user request is selected instead of the last one."
+type: bugfix
+scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -174,6 +174,7 @@ return {
       "max_request_body_size",
     },
     ai_prompt_guard = {
+      "match_all_roles",
       "max_request_body_size",
     },
     ai_prompt_template = {

--- a/kong/plugins/ai-prompt-guard/handler.lua
+++ b/kong/plugins/ai-prompt-guard/handler.lua
@@ -26,6 +26,7 @@ local execute do
   -- @tparam table request The deserialized JSON body of the request
   -- @tparam table conf The plugin configuration
   -- @treturn[1] table The decorated request (same table, content updated)
+  -- @treturn[2] nil
   -- @treturn[2] string The error message
   function execute(request, conf)
     local collected_prompts
@@ -44,7 +45,7 @@ local execute do
         if type(v.role) ~= "string" then
           return nil, bad_format_error
         end
-        if v.role == "user" then
+        if v.role == "user" or conf.match_all_roles then
           if type(v.content) ~= "string" then
             return nil, bad_format_error
           end

--- a/kong/plugins/ai-prompt-guard/handler.lua
+++ b/kong/plugins/ai-prompt-guard/handler.lua
@@ -26,16 +26,21 @@ local execute do
   -- @tparam table request The deserialized JSON body of the request
   -- @tparam table conf The plugin configuration
   -- @treturn[1] table The decorated request (same table, content updated)
-  -- @treturn[2] nil
   -- @treturn[2] string The error message
   function execute(request, conf)
-    local user_prompt
+    local collected_prompts
+    local messages = request.messages
 
-    -- concat all 'user' prompts into one string, if conversation history must be checked
-    if type(request.messages) == "table" and not conf.allow_all_conversation_history then
+    -- concat all prompts into one string, if conversation history must be checked
+    if type(messages) == "table" then
       local buf = buffer.new()
+      -- Note allow_all_conversation_history means ignores history
+      local just_pick_latest = conf.allow_all_conversation_history
 
-      for _, v in ipairs(request.messages) do
+      -- iterate in reverse so we get the latest user prompt first
+      -- instead of the oldest one in history
+      for i=#messages, 1, -1 do
+        local v = messages[i]
         if type(v.role) ~= "string" then
           return nil, bad_format_error
         end
@@ -44,33 +49,25 @@ local execute do
             return nil, bad_format_error
           end
           buf:put(v.content)
-        end
-      end
 
-      user_prompt = buf:get()
-
-    elseif type(request.messages) == "table" then
-      -- just take the trailing 'user' prompt
-      for _, v in ipairs(request.messages) do
-        if type(v.role) ~= "string" then
-          return nil, bad_format_error
-        end
-        if v.role == "user" then
-          if type(v.content) ~= "string" then
-            return nil, bad_format_error
+          if just_pick_latest then
+            break
           end
-          user_prompt = v.content
+
+          buf:put(" ") -- put a seperator to avoid adhension of words
         end
       end
+
+      collected_prompts = buf:get()
 
     elseif type(request.prompt) == "string" then
-      user_prompt = request.prompt
+      collected_prompts = request.prompt
 
     else
       return nil, bad_format_error
     end
 
-    if not user_prompt then
+    if not collected_prompts then
       return nil, "no 'prompt' or 'messages' received"
     end
 
@@ -78,7 +75,7 @@ local execute do
     -- check the prompt for explcit ban patterns
     for _, v in ipairs(conf.deny_patterns or EMPTY) do
       -- check each denylist; if prompt matches it, deny immediately
-      local m, _, err = ngx_re_find(user_prompt, v, "jo")
+      local m, _, err = ngx_re_find(collected_prompts, v, "jo")
       if err then
         -- regex failed, that's an error by the administrator
         kong.log.err("bad regex pattern '", v ,"', failed to execute: ", err)
@@ -98,7 +95,7 @@ local execute do
     -- if any allow_patterns specified, make sure the prompt matches one of them
     for _, v in ipairs(conf.allow_patterns or EMPTY) do
       -- check each denylist; if prompt matches it, deny immediately
-      local m, _, err = ngx_re_find(user_prompt, v, "jo")
+      local m, _, err = ngx_re_find(collected_prompts, v, "jo")
 
       if err then
         -- regex failed, that's an error by the administrator

--- a/kong/plugins/ai-prompt-guard/schema.lua
+++ b/kong/plugins/ai-prompt-guard/schema.lua
@@ -36,8 +36,12 @@ return {
               type = "integer",
               default = 8 * 1024,
               gt = 0,
-              description = "max allowed body size allowed to be introspected",}
-          },
+              description = "max allowed body size allowed to be introspected" } },
+          { match_all_roles = {
+              description = "If true, will match all roles in addition to 'user' role in conversation history.",
+              type = "boolean",
+              required = true,
+              default = false } },
         }
       }
     }
@@ -45,6 +49,10 @@ return {
   entity_checks = {
     {
       at_least_one_of = { "config.allow_patterns", "config.deny_patterns" },
-    }
+    },
+    { conditional = {
+      if_field = "config.match_all_roles", if_match = { eq = true },
+      then_field = "config.allow_all_conversation_history", then_match = { eq = false },
+    } },
   }
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -649,6 +649,30 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         -- cleanup
         admin.plugins:remove({ id = ai_response_transformer.id })
       end)
+
+      it("[ai-prompt-guard] sets unsupported match_all_roles to nil or defaults", function()
+        -- [[ 3.8.x ]] --
+        local ai_prompt_guard = admin.plugins:insert {
+          name = "ai-prompt-guard",
+          enabled = true,
+          config = {
+            allow_patterns = { "a" },
+            allow_all_conversation_history = false,
+            match_all_roles = true,
+            max_request_body_size = 8192,
+          },
+        }
+        -- ]]
+
+        local expected = cycle_aware_deep_copy(ai_prompt_guard)
+        expected.config.match_all_roles = nil
+        expected.config.max_request_body_size = nil
+
+        do_assert(uuid(), "3.7.0", expected)
+
+        -- cleanup
+        admin.plugins:remove({ id = ai_prompt_guard.id })
+      end)
     end)
 
     describe("www-authenticate header in plugins (realm config)", function()

--- a/spec/03-plugins/42-ai-prompt-guard/00-config_spec.lua
+++ b/spec/03-plugins/42-ai-prompt-guard/00-config_spec.lua
@@ -84,4 +84,22 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     assert.same({ config = {allow_patterns = "length must be at most 10" }}, err)
   end)
 
+  it("allow_all_conversation_history needs to be false if match_all_roles is set to true", function()
+    local config = {
+      allow_patterns = { "wat" },
+      allow_all_conversation_history = true,
+      match_all_roles = true,
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.not_nil(err)
+    assert.same({
+    ["@entity"] = {
+      [1] = 'failed conditional validation given value of field \'config.match_all_roles\'' },
+    ["config"] = {
+      ["allow_all_conversation_history"] = 'value must be false' }}, err)
+  end)
+
 end)

--- a/spec/03-plugins/42-ai-prompt-guard/01-unit_spec.lua
+++ b/spec/03-plugins/42-ai-prompt-guard/01-unit_spec.lua
@@ -1,119 +1,57 @@
 local PLUGIN_NAME = "ai-prompt-guard"
 
+local message_fixtures = {
+  user = "this is a user request",
+  system = "this is a system message",
+  assistant = "this is an assistant reply",
+}
 
-
-local general_chat_request = {
-  messages = {
-    [1] = {
+local _M = {}
+local function create_request(typ)
+  local messages = {
+    {
       role = "system",
-      content = "You are a mathematician."
-    },
-    [2] = {
-      role = "user",
-      content = "What is 1 + 1?"
-    },
-  },
-}
+      content = message_fixtures.system,
+    }
+  }
 
-local general_chat_request_with_history = {
-  messages = {
-    [1] = {
-      role = "system",
-      content = "You are a mathematician."
-    },
-    [2] = {
-      role = "user",
-      content = "What is 12 + 1?"
-    },
-    [3] = {
-      role = "assistant",
-      content = "The answer is 13.",
-    },
-    [4] = {
-      role = "user",
-      content = "Now double the previous answer.",
-    },
-  },
-}
+  if typ ~= "chat" and typ ~= "completions" then
+    error("type must be one of 'chat' or 'completions'", 2)
+  end
+  
+  return setmetatable({
+    messages = messages,
+    type = typ,
+  }, {
+    __index = _M,
+  })
+end
 
-local denied_chat_request = {
-  messages = {
-    [1] = {
-      role = "system",
-      content = "You are a mathematician."
-    },
-    [2] = {
-      role = "user",
-      content = "What is 22 + 1?"
-    },
-  },
-}
+function _M:append_message(role, custom)
+  if not message_fixtures[role] then
+    assert("role must be one of: user, system or assistant")
+  end
 
-local neither_allowed_nor_denied_chat_request = {
-  messages = {
-    [1] = {
-      role = "system",
-      content = "You are a mathematician."
-    },
-    [2] = {
-      role = "user",
-      content = "What is 55 + 55?"
-    },
-  },
-}
+  if self.type == "completion" then
+    self.prompt = "this is a completions request"
+    if custom then
+      self.prompt = self.prompt .. " with custom content " .. custom
+    end
+    return
+  end
 
+  local message = message_fixtures[role]
+  if custom then
+    message = message .. " with custom content " .. custom
+  end
 
-local general_completions_request = {
-  prompt = "You are a mathematician. What is 1 + 1?"
-}
+  self.messages[#self.messages+1] = {
+    role = "user",
+    content = message
+  }
 
-
-local denied_completions_request = {
-  prompt = "You are a mathematician. What is 22 + 1?"
-}
-
-local neither_allowed_nor_denied_completions_request = {
-  prompt = "You are a mathematician. What is 55 + 55?"
-}
-
-local allow_patterns_no_history = {
-  allow_patterns = {
-    [1] = ".*1 \\+ 1.*"
-  },
-  allow_all_conversation_history = true,
-}
-
-local allow_patterns_with_history = {
-  allow_patterns = {
-    [1] = ".*1 \\+ 1.*"
-  },
-  allow_all_conversation_history = false,
-}
-
-local deny_patterns_with_history = {
-  deny_patterns = {
-    [1] = ".*12 \\+ 1.*"
-  },
-  allow_all_conversation_history = false,
-}
-
-local deny_patterns_no_history = {
-  deny_patterns = {
-    [1] = ".*22 \\+ 1.*"
-  },
-  allow_all_conversation_history = true,
-}
-
-local both_patterns_no_history = {
-  allow_patterns = {
-    [1] = ".*1 \\+ 1.*"
-  },
-  deny_patterns = {
-    [1] = ".*99 \\+ 99.*"
-  },
-  allow_all_conversation_history = true,
-}
-
+  return self
+end
 
 
 describe(PLUGIN_NAME .. ": (unit)", function()
@@ -132,115 +70,123 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
 
 
-  describe("chat operations", function()
+  for _, request_type in ipairs({"chat", "completions"}) do
+    describe(request_type .. " operations", function()
+      it("allows a user request when nothing is set", function()
+        -- deny_pattern in this case should be made to have no effect
+        local ctx = create_request(request_type):append_message("user", "pattern")
+        local ok, err = access_handler._execute(ctx, {
+        })
 
-    it("allows request when only conf.allow_patterns is set", function()
-      local ok, err = access_handler._execute(general_chat_request, allow_patterns_no_history)
+        assert.is_truthy(ok)
+        assert.is_nil(err)
+      end)
 
-      assert.is_truthy(ok)
-      assert.is_nil(err)
+      for _, has_history in ipairs({false, request_type == "chat" and true or nil}) do
+
+        describe("conf.allow_patterns is set", function()
+          for _, has_deny_patterns in ipairs({true, false}) do
+
+            local test_description = has_history and " in history" or " only the last"
+            test_description = test_description .. (has_deny_patterns and ", conf.deny_patterns is also set" or "")
+
+            it("allows a matching user request" .. test_description, function()
+              -- deny_pattern in this case should be made to have no effect
+              local ctx = create_request(request_type):append_message("user", "pattern")
+
+              if has_history then
+                ctx:append_message("user", "no match")
+              end
+              local ok, err = access_handler._execute(ctx, {
+                allow_patterns = {
+                  "pa..ern"
+                },
+                deny_patterns = has_deny_patterns and {"deny match"} or nil,
+                allow_all_conversation_history = not has_history,
+              })
+
+              assert.is_truthy(ok)
+              assert.is_nil(err)
+            end)
+
+            it("denies an unmatched user request" .. test_description, function()
+              -- deny_pattern in this case should be made to have no effect
+              local ctx = create_request(request_type):append_message("user", "no match")
+
+              if has_history then
+                ctx:append_message("user", "no match")
+              else
+                -- if we are ignoring history, actually put a matched message in history to test edge case
+                ctx:append_message("user", "pattern"):append_message("user", "no match")
+              end
+
+              local ok, err = access_handler._execute(ctx, {
+                allow_patterns = {
+                  "pa..ern"
+                },
+                deny_patterns = has_deny_patterns and {"deny match"} or nil,
+                allow_all_conversation_history = not has_history,
+              })
+
+              assert.is_falsy(ok)
+              assert.equal("prompt doesn't match any allowed pattern", err)
+            end)
+
+          end -- for _, has_deny_patterns in ipairs({true, false}) do
+        end)
+
+        describe("conf.deny_patterns is set", function()
+          for _, has_allow_patterns in ipairs({true, false}) do
+
+            local test_description = has_history and " in history" or " only the last"
+            test_description = test_description .. (has_allow_patterns and ", conf.allow_patterns is also set" or "")
+
+            it("denies a matching user request" .. test_description, function()
+              -- allow_pattern in this case should be made to have no effect
+              local ctx = create_request(request_type):append_message("user", "pattern")
+
+              if has_history then
+                ctx:append_message("user", "no match")
+              end
+              local ok, err = access_handler._execute(ctx, {
+                deny_patterns = {
+                  "pa..ern"
+                },
+                allow_patterns = has_allow_patterns and {"allow match"} or nil,
+                allow_all_conversation_history = not has_history,
+              })
+
+              assert.is_falsy(ok)
+              assert.equal("prompt pattern is blocked", err)
+            end)
+
+            it("allows unmatched user request" .. test_description, function()
+              -- allow_pattern in this case should be made to have no effect
+              local ctx = create_request(request_type):append_message("user", "allow match")
+
+              if has_history then
+                ctx:append_message("user", "no match")
+              else
+                -- if we are ignoring history, actually put a matched message in history to test edge case
+                ctx:append_message("user", "pattern"):append_message("user", "allow match")
+              end
+
+              local ok, err = access_handler._execute(ctx, {
+                deny_patterns = {
+                  "pa..ern"
+                },
+                allow_patterns = has_allow_patterns and {"allow match"} or nil,
+                allow_all_conversation_history = not has_history,
+              })
+
+              assert.is_truthy(ok)
+              assert.is_nil(err)
+            end)
+          end -- for for _, has_allow_patterns in ipairs({true, false}) do
+        end)
+
+      end -- for _, has_history in ipairs({true, false}) do
     end)
-
-
-    it("allows request when only conf.deny_patterns is set, and pattern should not match", function()
-      local ok, err = access_handler._execute(general_chat_request, deny_patterns_no_history)
-
-      assert.is_truthy(ok)
-      assert.is_nil(err)
-    end)
-
-
-    it("denies request when only conf.allow_patterns is set, and pattern should not match", function()
-      local ok, err = access_handler._execute(denied_chat_request, allow_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt doesn't match any allowed pattern")
-    end)
-
-
-    it("denies request when only conf.deny_patterns is set, and pattern should match", function()
-      local ok, err = access_handler._execute(denied_chat_request, deny_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt pattern is blocked")
-    end)
-
-
-    it("allows request when both conf.allow_patterns and conf.deny_patterns are set, and pattern matches allow", function()
-      local ok, err = access_handler._execute(general_chat_request, both_patterns_no_history)
-
-      assert.is_truthy(ok)
-      assert.is_nil(err)
-    end)
-
-
-    it("denies request when both conf.allow_patterns and conf.deny_patterns are set, and pattern matches neither", function()
-      local ok, err = access_handler._execute(neither_allowed_nor_denied_chat_request, both_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt doesn't match any allowed pattern")
-    end)
-
-
-    it("denies request when only conf.allow_patterns is set and previous chat history should not match", function()
-      local ok, err = access_handler._execute(general_chat_request_with_history, allow_patterns_with_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt doesn't match any allowed pattern")
-    end)
-
-
-    it("denies request when only conf.deny_patterns is set and previous chat history should match", function()
-      local ok, err = access_handler._execute(general_chat_request_with_history, deny_patterns_with_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt pattern is blocked")
-    end)
-
-  end)
-
-
-  describe("completions operations", function()
-
-    it("allows request when only conf.allow_patterns is set", function()
-      local ok, err = access_handler._execute(general_completions_request, allow_patterns_no_history)
-
-      assert.is_truthy(ok)
-      assert.is_nil(err)
-    end)
-
-
-    it("allows request when only conf.deny_patterns is set, and pattern should not match", function()
-      local ok, err = access_handler._execute(general_completions_request, deny_patterns_no_history)
-
-      assert.is_truthy(ok)
-      assert.is_nil(err)
-    end)
-
-
-    it("denies request when only conf.allow_patterns is set, and pattern should not match", function()
-      local ok, err = access_handler._execute(denied_completions_request, allow_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt doesn't match any allowed pattern")
-    end)
-
-
-    it("denies request when only conf.deny_patterns is set, and pattern should match", function()
-      local ok, err = access_handler._execute(denied_completions_request, deny_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal("prompt pattern is blocked", err)
-    end)
-
-
-    it("denies request when both conf.allow_patterns and conf.deny_patterns are set, and pattern matches neither", function()
-      local ok, err = access_handler._execute(neither_allowed_nor_denied_completions_request, both_patterns_no_history)
-
-      assert.is_falsy(ok)
-      assert.equal(err, "prompt doesn't match any allowed pattern")
-    end)
-
-  end)
+  end --   for _, request_type in ipairs({"chat", "completions"}) do
 
 end)

--- a/spec/03-plugins/42-ai-prompt-guard/01-unit_spec.lua
+++ b/spec/03-plugins/42-ai-prompt-guard/01-unit_spec.lua
@@ -71,6 +71,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
 
   for _, request_type in ipairs({"chat", "completions"}) do
+
     describe(request_type .. " operations", function()
       it("allows a user request when nothing is set", function()
         -- deny_pattern in this case should be made to have no effect
@@ -82,7 +83,13 @@ describe(PLUGIN_NAME .. ": (unit)", function()
         assert.is_nil(err)
       end)
 
+      -- only chat has history
+      -- match_all_roles require history
       for _, has_history in ipairs({false, request_type == "chat" and true or nil}) do
+      for _, match_all_roles in ipairs({false, has_history and true or nil}) do
+
+        -- we only have user or not user, so testing "assistant" is not necessary
+        local role = match_all_roles and "system" or "user"
 
         describe("conf.allow_patterns is set", function()
           for _, has_deny_patterns in ipairs({true, false}) do
@@ -92,7 +99,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
             it("allows a matching user request" .. test_description, function()
               -- deny_pattern in this case should be made to have no effect
-              local ctx = create_request(request_type):append_message("user", "pattern")
+              local ctx = create_request(request_type):append_message(role, "pattern")
 
               if has_history then
                 ctx:append_message("user", "no match")
@@ -103,6 +110,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
                 },
                 deny_patterns = has_deny_patterns and {"deny match"} or nil,
                 allow_all_conversation_history = not has_history,
+                match_all_roles = match_all_roles,
               })
 
               assert.is_truthy(ok)
@@ -117,7 +125,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
                 ctx:append_message("user", "no match")
               else
                 -- if we are ignoring history, actually put a matched message in history to test edge case
-                ctx:append_message("user", "pattern"):append_message("user", "no match")
+                ctx:append_message(role, "pattern"):append_message("user", "no match")
               end
 
               local ok, err = access_handler._execute(ctx, {
@@ -126,6 +134,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
                 },
                 deny_patterns = has_deny_patterns and {"deny match"} or nil,
                 allow_all_conversation_history = not has_history,
+                match_all_roles = match_all_roles,
               })
 
               assert.is_falsy(ok)
@@ -143,7 +152,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
             it("denies a matching user request" .. test_description, function()
               -- allow_pattern in this case should be made to have no effect
-              local ctx = create_request(request_type):append_message("user", "pattern")
+              local ctx = create_request(request_type):append_message(role, "pattern")
 
               if has_history then
                 ctx:append_message("user", "no match")
@@ -162,13 +171,13 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
             it("allows unmatched user request" .. test_description, function()
               -- allow_pattern in this case should be made to have no effect
-              local ctx = create_request(request_type):append_message("user", "allow match")
+              local ctx = create_request(request_type):append_message(role, "allow match")
 
               if has_history then
                 ctx:append_message("user", "no match")
               else
                 -- if we are ignoring history, actually put a matched message in history to test edge case
-                ctx:append_message("user", "pattern"):append_message("user", "allow match")
+                ctx:append_message(role, "pattern"):append_message(role, "allow match")
               end
 
               local ok, err = access_handler._execute(ctx, {
@@ -185,6 +194,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
           end -- for for _, has_allow_patterns in ipairs({true, false}) do
         end)
 
+      end -- for _, match_all_role in ipairs(false, true)) do
       end -- for _, has_history in ipairs({true, false}) do
     end)
   end --   for _, request_type in ipairs({"chat", "completions"}) do


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR also fixes an issue when allow_all_conversation_history
is set to false, the first user request is selected instead of the last
one.

Unit tests are refactored to so that it's cleaner and has wider coverage.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

AG-58
