### PR TITLE
feat(acl): added a config `always_use_authenticated_groups` to support using authenticated groups even when an authenticated consumer exists.

### DIFF
--- a/changelog/unreleased/kong/acl-always-use-authenticated-groups.yml
+++ b/changelog/unreleased/kong/acl-always-use-authenticated-groups.yml
@@ -1,0 +1,3 @@
+message: "**acl:** Added a new config `always_use_authenticated_groups` to support using authenticated groups even when an authenticated consumer already exists."
+type: feature
+scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -207,5 +207,8 @@ return {
     prometheus = {
       "ai_metrics",
     },
+    acl = {
+      "always_use_authenticated_groups",
+    },
   },
 }

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -80,7 +80,7 @@ function ACLHandler:access(conf)
   else
     local credential = kong.client.get_credential()
     local authenticated_groups
-    if not credential or conf.always_use_authenticated_groups then
+    if (not credential) or conf.always_use_authenticated_groups then
       -- authenticated groups overrides anonymous groups
       authenticated_groups = groups.get_authenticated_groups()
     end

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -80,7 +80,7 @@ function ACLHandler:access(conf)
   else
     local credential = kong.client.get_credential()
     local authenticated_groups
-    if not credential then
+    if not credential or conf.always_use_authenticated_groups then
       -- authenticated groups overrides anonymous groups
       authenticated_groups = groups.get_authenticated_groups()
     end

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -16,6 +16,7 @@ return {
               type = "array",
               elements = { type = "string" }, }, },
           { hide_groups_header = { type = "boolean", required = true, default = false, description = "If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service." }, },
+          { always_use_authenticated_groups = { type = "boolean", required = true, default = false, description = "If enabled (`true`), the authenticated groups will always be used even when an authenticated consumer already exists. If the authenticated groups don't exist, it will fallback to use the groups associated with the consumer. By default the authenticated groups will only be used when there is no consumer or the consumer is anonymous." } },
         },
       }
     }

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -132,6 +132,7 @@ for _, strategy in helpers.each_strategy() do
         deny = ngx.null,
         allow = { "*" },
         hide_groups_header = false,
+        always_use_authenticated_groups = false,
       }
     }
 
@@ -146,6 +147,7 @@ for _, strategy in helpers.each_strategy() do
         deny = ngx.null,
         allow = { "*" },
         hide_groups_header = false,
+        always_use_authenticated_groups = false,
       }
     }
 

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -1017,6 +1017,46 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         admin.plugins:remove({ id = rt.id })
       end)
     end)
+
+    describe("compatibility test for acl plugin", function()
+      it("removes `config.always_use_authenticated_groups` before sending them to older(less than 3.8.0.0) DP nodes", function()
+        local acl = admin.plugins:insert {
+          name = "acl",
+          enabled = true,
+          config = {
+            allow = { "admin" },
+            -- [[ new fields 3.8.0
+            always_use_authenticated_groups = true,
+            -- ]]
+          }
+        }
+
+        assert.not_nil(acl.config.always_use_authenticated_groups)
+        local expected_acl = cycle_aware_deep_copy(acl)
+        expected_acl.config.always_use_authenticated_groups = nil
+        do_assert(uuid(), "3.7.0", expected_acl)
+
+        -- cleanup
+        admin.plugins:remove({ id = acl.id })
+      end)
+
+      it("does not remove `config.always_use_authenticated_groups` from DP nodes that are already compatible", function()
+        local acl = admin.plugins:insert {
+          name = "acl",
+          enabled = true,
+          config = {
+            allow = { "admin" },
+            -- [[ new fields 3.8.0
+            always_use_authenticated_groups = true,
+            -- ]]
+          }
+        }
+        do_assert(uuid(), "3.8.0", acl)
+
+        -- cleanup
+        admin.plugins:remove({ id = acl.id })
+      end)
+    end)
   end)
 end)
 


### PR DESCRIPTION
### Summary

Currently, authenticated groups will only be used when there is no consumer or the consumer is anonymous. When there is an authenticated consumer, there is no way to use authenticated groups, only the groups associated with the consumer will be used.

This PR adds a config `always_use_authenticated_groups` to support using authenticated groups even when an authenticated consumer exists. If enabled, it will first try to use authenticated groups and will fallback to use the groups associated with the consumer if authenticated groups don't exist, which is consistent with the logic in the anonymous consumer case.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-5945
