### PR TITLE
refactor(*): use kong.tools.string whenever possible 

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -8,7 +8,6 @@ local config_helper = require("kong.clustering.config_helper")
 local clustering_utils = require("kong.clustering.utils")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local pl_stringx = require("pl.stringx")
 local inspect = require("inspect")
 
 local assert = assert
@@ -37,7 +36,7 @@ local PING_WAIT = PING_INTERVAL * 1.5
 local _log_prefix = "[clustering] "
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
-local endswith = pl_stringx.endswith
+local endswith = require("pl.stringx").endswith
 
 local function is_timeout(err)
   return err and sub(err, -7) == "timeout"

--- a/kong/clustering/rpc/utils.lua
+++ b/kong/clustering/rpc/utils.lua
@@ -1,5 +1,4 @@
 local _M = {}
-local pl_stringx = require("pl.stringx")
 local cjson = require("cjson")
 local snappy = require("resty.snappy")
 
@@ -8,7 +7,7 @@ local string_sub = string.sub
 local assert = assert
 local cjson_encode = cjson.encode
 local cjson_decode = cjson.decode
-local rfind = pl_stringx.rfind
+local rfind = require("pl.stringx").rfind
 local snappy_compress = snappy.compress
 local snappy_uncompress = snappy.uncompress
 

--- a/kong/cmd/health.lua
+++ b/kong/cmd/health.lua
@@ -2,8 +2,9 @@ local log = require "kong.cmd.utils.log"
 local kill = require "kong.cmd.utils.kill"
 local pl_path = require "pl.path"
 local pl_tablex = require "pl.tablex"
-local pl_stringx = require "pl.stringx"
 local conf_loader = require "kong.conf_loader"
+
+local ljust = require("pl.stringx").ljust
 
 local function execute(args)
   log.disable()
@@ -27,7 +28,7 @@ local function execute(args)
   local count = 0
   for k, v in pairs(pids) do
     local running = kill.is_running(v)
-    local msg = pl_stringx.ljust(k, 12, ".") .. (running and "running" or "not running")
+    local msg = ljust(k, 12, ".") .. (running and "running" or "not running")
     if running then
       count = count + 1
     end

--- a/kong/cmd/utils/inject_confs.lua
+++ b/kong/cmd/utils/inject_confs.lua
@@ -1,8 +1,8 @@
 local conf_loader = require "kong.conf_loader"
 local pl_path = require "pl.path"
-local pl_stringx = require "pl.stringx"
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local log = require "kong.cmd.utils.log"
+local strip = require("kong.tools.string").strip
 local fmt = string.format
 
 local compile_nginx_main_inject_conf = prefix_handler.compile_nginx_main_inject_conf
@@ -42,7 +42,7 @@ local function convert_directive_path_to_absolute(prefix, nginx_conf, paths)
       return nil, err
 
     elseif m then
-      local path = pl_stringx.strip(m[2])
+      local path = strip(m[2])
 
       if path:sub(1, 1) ~= '/' then
         local absolute_path = prefix .. "/" .. path

--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -5,8 +5,10 @@ local meta = require "kong.meta"
 local pl_path = require "pl.path"
 local version = require "version"
 local pl_utils = require "pl.utils"
-local pl_stringx = require "pl.stringx"
 local process_secrets = require "kong.cmd.utils.process_secrets"
+
+
+local strip = require("kong.tools.string").strip
 
 
 local fmt = string.format
@@ -115,7 +117,7 @@ function _M.find_nginx_bin(kong_conf)
         log.debug("finding executable absolute path from $PATH...")
         local ok, code, stdout, stderr = pl_utils.executeex("command -v nginx")
         if ok and code == 0 then
-          path_to_check = pl_stringx.strip(stdout)
+          path_to_check = strip(stdout)
 
         else
           log.error("could not find executable absolute path: %s", stderr)

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -15,7 +15,6 @@ local x509 = require "resty.openssl.x509"
 local x509_extension = require "resty.openssl.x509.extension"
 local x509_name = require "resty.openssl.x509.name"
 local pl_template = require "pl.template"
-local pl_stringx = require "pl.stringx"
 local pl_tablex = require "pl.tablex"
 local pl_utils = require "pl.utils"
 local pl_file = require "pl.file"
@@ -25,6 +24,10 @@ local log = require "kong.cmd.utils.log"
 local ffi = require "ffi"
 local bit = require "bit"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
+
+
+local strip = require("kong.tools.string").strip
+local split = require("kong.tools.string").split
 
 
 local getmetatable = getmetatable
@@ -229,7 +232,7 @@ local function get_ulimit()
   if not ok then
     return nil, stderr
   end
-  local sanitized_limit = pl_stringx.strip(stdout)
+  local sanitized_limit = strip(stdout)
   if sanitized_limit:lower():match("unlimited") then
     return 65536
   else
@@ -725,7 +728,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
   end
 
   local template_env = {}
-  nginx_conf_flags = nginx_conf_flags and pl_stringx.split(nginx_conf_flags, ",") or {}
+  nginx_conf_flags = nginx_conf_flags and split(nginx_conf_flags, ",") or {}
   for _, flag in ipairs(nginx_conf_flags) do
     template_env[flag] = true
   end

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -4,7 +4,6 @@ local require = require
 local kong_default_conf = require "kong.templates.kong_defaults"
 local process_secrets = require "kong.cmd.utils.process_secrets"
 local pl_stringio = require "pl.stringio"
-local pl_stringx = require "pl.stringx"
 local socket_url = require "socket.url"
 local conf_constants = require "kong.conf_loader.constants"
 local listeners = require "kong.conf_loader.listeners"
@@ -16,9 +15,12 @@ local pl_config = require "pl.config"
 local pl_file = require "pl.file"
 local pl_path = require "pl.path"
 local tablex = require "pl.tablex"
-local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 local log = require "kong.cmd.utils.log"
 local env = require "kong.cmd.utils.env"
+
+
+local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
+local strip = require("kong.tools.string").strip
 
 
 local fmt = string.format
@@ -27,7 +29,6 @@ local type = type
 local sort = table.sort
 local find = string.find
 local gsub = string.gsub
-local strip = pl_stringx.strip
 local lower = string.lower
 local match = string.match
 local pairs = pairs

--- a/kong/conf_loader/listeners.lua
+++ b/kong/conf_loader/listeners.lua
@@ -1,5 +1,5 @@
-local pl_stringx = require "pl.stringx"
 local tools_ip = require "kong.tools.ip"
+local strip = require("kong.tools.string").strip
 
 
 local type = type
@@ -73,7 +73,7 @@ local function parse_option_flags(value, flags)
     end
   end
 
-  return pl_stringx.strip(value), result, pl_stringx.strip(sanitized)
+  return strip(value), result, strip(sanitized)
 end
 
 
@@ -98,7 +98,7 @@ local function parse_listeners(values, flags)
     return nil, usage
   end
 
-  if pl_stringx.strip(values[1]) == "off" then
+  if strip(values[1]) == "off" then
     return list
   end
 

--- a/kong/conf_loader/parse.lua
+++ b/kong/conf_loader/parse.lua
@@ -1,7 +1,6 @@
 local require = require
 
 
-local pl_stringx = require "pl.stringx"
 local pl_path = require "pl.path"
 local socket_url = require "socket.url"
 local tablex = require "pl.tablex"
@@ -10,15 +9,15 @@ local openssl_pkey = require "resty.openssl.pkey"
 local log = require "kong.cmd.utils.log"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local conf_constants = require "kong.conf_loader.constants"
-
-
-local tools_system = require("kong.tools.system")   -- for unit-testing
-local tools_ip = require("kong.tools.ip")
+local tools_system = require "kong.tools.system" -- for unit-testing
+local tools_ip = require "kong.tools.ip"
 
 
 local normalize_ip = tools_ip.normalize_ip
 local is_valid_ip_or_cidr = tools_ip.is_valid_ip_or_cidr
 local try_decode_base64 = require("kong.tools.string").try_decode_base64
+local strip = require("kong.tools.string").strip
+local split = require("kong.tools.string").split
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 local is_valid_uuid = require("kong.tools.uuid").is_valid_uuid
 
@@ -40,7 +39,6 @@ local insert = table.insert
 local concat = table.concat
 local getenv = os.getenv
 local re_match = ngx.re.match
-local strip = pl_stringx.strip
 local exists = pl_path.exists
 local isdir = pl_path.isdir
 
@@ -93,7 +91,7 @@ local function parse_value(value, typ)
     -- must check type because pl will already convert comma
     -- separated strings to tables (but not when the arr has
     -- only one element)
-    value = setmetatable(pl_stringx.split(value, ","), nil) -- remove List mt
+    value = setmetatable(split(value, ","), nil) -- remove List mt
 
     for i = 1, #value do
       value[i] = strip(value[i])

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -1,11 +1,10 @@
 local logger       = require "kong.cmd.utils.log"
 local pgmoon       = require "pgmoon"
 local arrays       = require "pgmoon.arrays"
-local stringx      = require "pl.stringx"
 local semaphore    = require "ngx.semaphore"
-local kong_global = require "kong.global"
-local constants = require "kong.constants"
-local db_utils  = require "kong.db.utils"
+local kong_global  = require "kong.global"
+local constants    = require "kong.constants"
+local db_utils     = require "kong.db.utils"
 
 
 local setmetatable = setmetatable
@@ -31,6 +30,7 @@ local sub          = string.sub
 local utils_toposort = db_utils.topological_sort
 local insert       = table.insert
 local table_merge  = require("kong.tools.table").table_merge
+local strip        = require("kong.tools.string").strip
 
 
 local WARN                          = ngx.WARN
@@ -867,7 +867,7 @@ function _mt:run_up_migration(name, up_sql)
     error("no connection")
   end
 
-  local sql = stringx.strip(up_sql)
+  local sql = strip(up_sql)
   if sub(sql, -1) ~= ";" then
     sql = sql .. ";"
   end

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -3,14 +3,13 @@ local ngx_encode_base64 = ngx.encode_base64
 local ngx_decode_base64 = ngx.decode_base64
 local cjson = require "cjson.safe"
 
-local pl_stringx = require("pl.stringx")
 local date = require("date")
 local get_request_id = require("kong.tracing.request_id").get
 
 local EMPTY = {}
 
 local isempty = require "table.isempty"
-local split = pl_stringx.split
+local split = require("kong.tools.string").split
 local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_get_http_version = ngx.req.http_version

--- a/kong/plugins/oauth2/secret.lua
+++ b/kong/plugins/oauth2/secret.lua
@@ -1,6 +1,3 @@
-local kong_string = require "kong.tools.string"
-
-
 local type = type
 local fmt = string.format
 local find = string.find
@@ -11,8 +8,8 @@ local assert = assert
 local tonumber = tonumber
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
-local strip = kong_string.strip
-local split = kong_string.split
+local strip = require("kong.tools.string").strip
+local split = require("kong.tools.string").split
 local get_rand_bytes = require("kong.tools.rand").get_rand_bytes
 
 

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -1,6 +1,6 @@
 -- Copyright (C) Kong Inc.
 
-local strip = require("pl.stringx").strip
+local strip = require("kong.tools.string").strip
 local kong_meta = require "kong.meta"
 local tonumber = tonumber
 

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -1,6 +1,3 @@
-local kong_string = require "kong.tools.string"
-
-
 local kong = kong
 local next = next
 local type = type
@@ -8,8 +5,8 @@ local pairs = pairs
 local ipairs = ipairs
 local tonumber = tonumber
 local math_max = math.max
-local strip = kong_string.strip
-local split = kong_string.split
+local strip = require("kong.tools.string").strip
+local split = require("kong.tools.string").split
 
 
 local RATELIMIT_LIMIT = "X-RateLimit-Limit"

--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -1,7 +1,7 @@
 local isempty = require "table.isempty"
 local mime_type = require "kong.tools.mime_type"
 local ngx_re = require "ngx.re"
-local pl_stringx = require "pl.stringx"
+
 
 local kong = kong
 local type = type
@@ -10,8 +10,8 @@ local noop = function() end
 local ipairs = ipairs
 local parse_mime_type = mime_type.parse_mime_type
 local mime_type_includes = mime_type.includes
-local split = ngx_re.split
-local strip = pl_stringx.strip
+local re_split = ngx_re.split
+local strip = require("kong.tools.string").strip
 
 
 local _M = {}
@@ -44,7 +44,7 @@ local function is_json_body(content_type)
   if not content_type then
     return false
   end
-  local content_types = split(content_type, ",")
+  local content_types = re_split(content_type, ",")
   local expected_media_type = { type = "application", subtype = "json" }
   for _, content_type in ipairs(content_types) do
     local t, subtype = parse_mime_type(strip(content_type))

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -1,6 +1,5 @@
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
-local tools_str = require "kong.tools.string"
 
 
 local type          = type
@@ -13,9 +12,9 @@ local sort          = table.sort
 local concat        = table.concat
 local fmt           = string.format
 local re_match      = ngx.re.match
-local join          = tools_str.join
-local split         = tools_str.split
-local strip         = tools_str.strip
+local join          = require("kong.tools.string").join
+local split         = require("kong.tools.string").split
+local strip         = require("kong.tools.string").strip
 
 
 local _M = {}

--- a/kong/tools/ip.lua
+++ b/kong/tools/ip.lua
@@ -1,5 +1,5 @@
 local ipmatcher  = require "resty.ipmatcher"
-local pl_stringx = require "pl.stringx"
+
 
 
 local type     = type
@@ -11,7 +11,7 @@ local sub      = string.sub
 local fmt      = string.format
 local lower    = string.lower
 local find     = string.find
-local split    = pl_stringx.split
+local split    = require("kong.tools.string").split
 
 
 local _M = {}

--- a/spec/02-integration/02-cmd/04-version_spec.lua
+++ b/spec/02-integration/02-cmd/04-version_spec.lua
@@ -1,11 +1,14 @@
-local pl_stringx = require "pl.stringx"
 local helpers = require "spec.helpers"
 local meta = require "kong.meta"
+
+
+local strip = require("kong.tools.string").strip
+
 
 describe("kong version", function()
   it("outputs Kong version", function()
     local _, _, stdout = assert(helpers.kong_exec("version"))
-    assert.equal(meta._VERSION, pl_stringx.strip(stdout))
+    assert.equal(meta._VERSION, strip(stdout))
   end)
   it("--all outputs all deps versions", function()
     local _, _, stdout = assert(helpers.kong_exec("version -a"))

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 local DB = require "kong.db.init"
 local tb_clone = require "table.clone"
 local shell = require "resty.shell"
-local strip = require "kong.tools.string".strip
+local strip = require("kong.tools.string").strip
 
 
 -- Current number of migrations to execute in a new install
@@ -445,4 +445,3 @@ for _, strategy in helpers.each_strategy() do
   end)
 
 end
-

--- a/spec/02-integration/04-admin_api/01-admin_api_spec.lua
+++ b/spec/02-integration/04-admin_api/01-admin_api_spec.lua
@@ -1,7 +1,9 @@
 local helpers = require "spec.helpers"
 local utils = require "pl.utils"
-local stringx = require "pl.stringx"
 local http = require "resty.http"
+
+
+local strip = require("kong.tools.string").strip
 
 
 local function count_server_blocks(filename)
@@ -16,10 +18,10 @@ local function get_listeners(filename)
   local result = {}
   for block in file:gmatch("[%\n%s]+server%s+(%b{})") do
     local server = {}
-    local server_name = stringx.strip(block:match("[%\n%s]server_name%s(.-);"))
+    local server_name = strip(block:match("[%\n%s]server_name%s(.-);"))
     result[server_name] = server
     for listen in block:gmatch("[%\n%s]listen%s(.-);") do
-      listen = stringx.strip(listen)
+      listen = strip(listen)
       table.insert(server, listen)
       server[listen] = #server
     end

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -1,7 +1,9 @@
 local helpers = require "spec.helpers"
 local utils = require "pl.utils"
-local stringx = require "pl.stringx"
 local http = require "resty.http"
+
+
+local strip = require("kong.tools.string").strip
 
 
 local function count_server_blocks(filename)
@@ -16,11 +18,11 @@ local function get_listeners(filename)
   local result = {}
   for block in file:gmatch("[%\n%s]+server%s+(%b{})") do
     local server_name = block:match("[%\n%s]server_name%s(.-);")
-    server_name = server_name and stringx.strip(server_name) or "stream"
+    server_name = server_name and strip(server_name) or "stream"
     local server = result[server_name] or {}
     result[server_name] = server
     for listen in block:gmatch("[%\n%s]listen%s(.-);") do
-      listen = stringx.strip(listen)
+      listen = strip(listen)
       table.insert(server, listen)
       server[listen] = #server
     end

--- a/spec/02-integration/14-tracing/04-trace-ids-log_spec.lua
+++ b/spec/02-integration/14-tracing/04-trace-ids-log_spec.lua
@@ -1,7 +1,8 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson.safe"
 local pl_file = require "pl.file"
-local pl_stringx = require "pl.stringx"
+
+local strip = require("kong.tools.string").strip
 
 local FILE_LOG_PATH = os.tmpname()
 
@@ -10,7 +11,6 @@ local fmt = string.format
 local trace_id_hex_128 = "4bf92000000000000000000000000001"
 local span_id = "0000000000000003"
 local trace_id_hex_pattern = "^%x+$"
-
 
 local tracing_headers = {
   {
@@ -85,7 +85,7 @@ local function wait_json_log()
       .eventually(function()
         local data = assert(pl_file.read(FILE_LOG_PATH))
 
-        data = pl_stringx.strip(data)
+        data = strip(data)
         assert(#data > 0, "log file is empty")
 
         data = data:match("%b{}")

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -1,11 +1,11 @@
 local cjson         = require "cjson"
 local helpers       = require "spec.helpers"
 local pl_file       = require "pl.file"
-local pl_stringx    = require "pl.stringx"
 local pl_path       = require "pl.path"
 local fmt           = string.format
 local random_string = require("kong.tools.rand").random_string
 local uuid          = require("kong.tools.uuid").uuid
+local strip         = require("kong.tools.string").strip
 
 
 local FILE_LOG_PATH = os.tmpname()
@@ -85,7 +85,7 @@ local function wait_for_json_log_entry()
     .eventually(function()
       local data = assert(pl_file.read(FILE_LOG_PATH))
 
-      data = pl_stringx.strip(data)
+      data = strip(data)
       assert(#data > 0, "log file is empty")
 
       data = data:match("%b{}")

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -1,7 +1,10 @@
 local helpers    = require "spec.helpers"
 local uuid       = require "kong.tools.uuid"
 local cjson      = require "cjson"
-local pl_stringx = require "pl.stringx"
+
+
+local strip = require("kong.tools.string").strip
+local split = require("kong.tools.string").split
 
 
 for _, strategy in helpers.each_strategy() do
@@ -138,7 +141,7 @@ for _, strategy in helpers.each_strategy() do
 
       local ok, _, stdout = helpers.execute("uname")
       assert(ok, "failed to retrieve platform name")
-      platform = pl_stringx.strip(stdout)
+      platform = strip(stdout)
 
       assert(helpers.start_kong({
         database   = strategy,
@@ -207,7 +210,7 @@ for _, strategy in helpers.each_strategy() do
           local _, _, stdout = assert(helpers.execute("sudo find /var/log -type f -mmin -5 | grep syslog"))
           assert.True(#stdout > 0)
 
-          local files = pl_stringx.split(stdout, "\n")
+          local files = split(stdout, "\n")
           assert.True(#files > 0)
 
           if files[#files] == "" then

--- a/spec/03-plugins/11-correlation-id/01-access_spec.lua
+++ b/spec/03-plugins/11-correlation-id/01-access_spec.lua
@@ -1,7 +1,10 @@
 local helpers    = require "spec.helpers"
 local cjson      = require "cjson"
 local pl_file    = require "pl.file"
-local pl_stringx = require "pl.stringx"
+
+
+local strip = require("kong.tools.string").strip
+
 
 local UUID_PATTERN         = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 local UUID_COUNTER_PATTERN = UUID_PATTERN .. "#%d"
@@ -18,7 +21,7 @@ local function wait_json_log()
       .eventually(function()
         local data = assert(pl_file.read(FILE_LOG_PATH))
 
-        data = pl_stringx.strip(data)
+        data = strip(data)
         assert(#data > 0, "log file is empty")
 
         data = data:match("%b{}")

--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -1,7 +1,10 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local pl_file = require "pl.file"
-local pl_stringx = require "pl.stringx"
+
+
+local strip = require("kong.tools.string").strip
+
 
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
@@ -21,7 +24,7 @@ local function wait_for_json_log_entry(FILE_LOG_PATH)
     .eventually(function()
       local data = assert(pl_file.read(FILE_LOG_PATH))
 
-      data = pl_stringx.strip(data)
+      data = strip(data)
       assert(#data > 0, "log file is empty")
 
       data = data:match("%b{}")

--- a/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
@@ -1,7 +1,8 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local pl_file = require "pl.file"
-local pl_stringx = require "pl.stringx"
+
+local strip = require("kong.tools.string").strip
 
 local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-request-transformer"
@@ -17,7 +18,7 @@ local function wait_for_json_log_entry(FILE_LOG_PATH)
     .eventually(function()
       local data = assert(pl_file.read(FILE_LOG_PATH))
 
-      data = pl_stringx.strip(data)
+      data = strip(data)
       assert(#data > 0, "log file is empty")
 
       data = data:match("%b{}")

--- a/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
@@ -1,7 +1,8 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local pl_file = require "pl.file"
-local pl_stringx = require "pl.stringx"
+
+local strip = require("kong.tools.string").strip
 
 local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-response-transformer"
@@ -17,7 +18,7 @@ local function wait_for_json_log_entry(FILE_LOG_PATH)
     .eventually(function()
       local data = assert(pl_file.read(FILE_LOG_PATH))
 
-      data = pl_stringx.strip(data)
+      data = strip(data)
       assert(#data > 0, "log file is empty")
 
       data = data:match("%b{}")

--- a/spec/fixtures/https_server.lua
+++ b/spec/fixtures/https_server.lua
@@ -9,11 +9,13 @@ local pl_dir = require "pl.dir"
 local pl_file = require "pl.file"
 local pl_template = require "pl.template"
 local pl_path = require "pl.path"
-local pl_stringx = require "pl.stringx"
 local uuid = require "resty.jit-uuid"
 local http_client = require "resty.http"
 local cjson = require "cjson"
 local shell = require "resty.shell"
+
+
+local Template = require("pl.stringx").Template
 
 
 -- we need this to get random UUIDs
@@ -62,7 +64,7 @@ local function create_conf(params)
     return nil, err
   end
 
-  local compiled_tpl = pl_stringx.Template(tpl:render(params, { ipairs = ipairs }))
+  local compiled_tpl = Template(tpl:render(params, { ipairs = ipairs }))
   local conf_filename = params.base_path .. "/nginx.conf"
   local conf, err = io.open (conf_filename, "w")
   if err then

--- a/spec/fixtures/mock_upstream.lua
+++ b/spec/fixtures/mock_upstream.lua
@@ -1,8 +1,8 @@
 local cjson_safe = require "cjson.safe"
 local cjson      = require "cjson"
 local ws_server  = require "resty.websocket.server"
-local pl_stringx = require "pl.stringx"
 local pl_file    = require "pl.file"
+local strip      = require("kong.tools.string").strip
 local split      = require("kong.tools.string").split
 
 
@@ -28,7 +28,7 @@ local function parse_multipart_form_params(body, content_type)
   local params      = {}
   local part, from, to, part_value, part_name, part_headers, first_header
   for i = 1, #parts_split do
-    part = pl_stringx.strip(parts_split[i])
+    part = strip(parts_split[i])
 
     if part ~= '' and part ~= '--' then
       from, to, err = ngx.re.find(part, '^\\r$', 'ojm')
@@ -39,7 +39,7 @@ local function parse_multipart_form_params(body, content_type)
       part_value   = part:sub(to + 2, #part) -- +2: trim leading line jump
       part_headers = part:sub(1, from - 1)
       first_header = split(part_headers, '\\n')[1]
-      if pl_stringx.startswith(first_header:lower(), "content-disposition") then
+      if first_header:lower():sub(1, 19) == "content-disposition" then
         local m, err = ngx.re.match(first_header, 'name="(.*?)"', "oj")
 
         if err or not m or not m[1] then

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -49,7 +49,6 @@ local dc_blueprints = require "spec.fixtures.dc_blueprints"
 local conf_loader = require "kong.conf_loader"
 local kong_global = require "kong.global"
 local Blueprints = require "spec.fixtures.blueprints"
-local pl_stringx = require "pl.stringx"
 local constants = require "kong.constants"
 local pl_tablex = require "pl.tablex"
 local pl_utils = require "pl.utils"
@@ -79,6 +78,8 @@ local lfs = require "lfs"
 local luassert = require "luassert.assert"
 local uuid = require("kong.tools.uuid").uuid
 local colors = require "ansicolors"
+local strip = require("kong.tools.string").strip
+local splitlines = require("pl.stringx").splitlines
 
 ffi.cdef [[
   int setenv(const char *name, const char *value, int overwrite);
@@ -2527,7 +2528,7 @@ local function res_status(state, args)
   if expected ~= res.status then
     local body, err = res:read_body()
     if not body then body = "Error reading body: " .. err end
-    table.insert(args, 1, pl_stringx.strip(body))
+    table.insert(args, 1, strip(body))
     table.insert(args, 1, res.status)
     table.insert(args, 1, expected)
     args.n = 3
@@ -2542,7 +2543,7 @@ local function res_status(state, args)
         return false -- no err logs to read in this prefix
       end
 
-      local lines_t = pl_stringx.splitlines(str)
+      local lines_t = splitlines(str)
       local str_t = {}
       -- filter out debugs as they are not usually useful in this context
       for i = 1, #lines_t do
@@ -2566,12 +2567,12 @@ local function res_status(state, args)
     local body, err = res:read_body()
     local output = body
     if not output then output = "Error reading body: " .. err end
-    output = pl_stringx.strip(output)
+    output = strip(output)
     table.insert(args, 1, output)
     table.insert(args, 1, res.status)
     table.insert(args, 1, expected)
     args.n = 3
-    return true, {pl_stringx.strip(body)}
+    return true, { strip(body) }
   end
 end
 say:set("assertion.res_status.negative", [[
@@ -3375,7 +3376,7 @@ function kong_exec(cmd, env, returns, env_vars)
   do
     local function cleanup(t)
       if t then
-        t = pl_stringx.strip(t)
+        t = strip(t)
         if t:sub(-1,-1) == ";" then
           t = t:sub(1, -2)
         end


### PR DESCRIPTION
### Summary

`kong.tools.string` has a faster implementation of e.g. `strip`. This makes our code use
the `kong.tools.string` whenever possible and removes `pl.stringx` usage in those cases.

This is a follow-up PR to:
https://github.com/Kong/kong/pull/13168

KAG-4684