### PR TITLE
fix(vault): apply retry count maximum threshold for secret rotation

### DIFF
--- a/changelog/unreleased/kong/fix-vault-rotation-remove-refs-exceed-retry-count.yml
+++ b/changelog/unreleased/kong/fix-vault-rotation-remove-refs-exceed-retry-count.yml
@@ -1,0 +1,5 @@
+message: |
+  Fixed an issue where vault references that no longer used would still be rotated. A maximum retry count threshold is added
+  with a default value 60, to prevent the reference from being rotated indefinitely.
+type: bugfix
+scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -1248,6 +1248,7 @@ local function new(self)
     if not reference then
       -- invalid cache keys are removed (in general should never happen)
       SECRETS_CACHE:delete(old_cache_key)
+      SECRETS_CACHE:delete(SECRETS_RETRY_KEY_PREFIX .. old_cache_key)
       return nil, err
     end
 
@@ -1255,12 +1256,14 @@ local function new(self)
     if not strategy then
       -- invalid cache keys are removed (e.g. a vault entity could have been removed)
       SECRETS_CACHE:delete(old_cache_key)
+      SECRETS_CACHE:delete(SECRETS_RETRY_KEY_PREFIX .. old_cache_key)
       return nil, fmt("could not parse reference %s (%s)", reference, err)
     end
 
     if old_cache_key ~= new_cache_key then
       -- config has changed, thus the old cache key can be removed
       SECRETS_CACHE:delete(old_cache_key)
+      SECRETS_CACHE:delete(SECRETS_RETRY_KEY_PREFIX .. old_cache_key)
     end
 
     -- The ttl for this key, is the TTL + the resurrect time

--- a/spec/02-integration/13-vaults/07-resurrect_spec.lua
+++ b/spec/02-integration/13-vaults/07-resurrect_spec.lua
@@ -133,7 +133,7 @@ describe("vault resurrect_ttl and rotation (#" .. strategy .. ") #" .. vault.nam
   lazy_setup(function()
     helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
     helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
-    helpers.setenv("KONG_VAULT_SECRETS_RETRY_COUNT_THRESHOLD", "2")
+    helpers.setenv("KONG_VAULT_SECRETS_ROTATION_MAX_RETRIES", "2")
 
     vault:setup()
     vault:create_secret(secret, "init")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds a maximum threshold for secret rotation in the vault. If a secret has exceeded the threshold, vault will remove it from the shared dict and no longer rotate it in the future. Note that this is a solution that keeps simplicity for fixing this issue.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5775