### PR TITLE
[backport -> release/3.6.x] fix(plugins): add realm to removed fields

### DIFF
--- a/changelog/unreleased/kong/fix-realm-compat-changes-basic-auth.yml
+++ b/changelog/unreleased/kong/fix-realm-compat-changes-basic-auth.yml
@@ -1,0 +1,3 @@
+message: "**Basic-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.6)"
+type: bugfix
+scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -115,5 +115,8 @@ return {
     opentelemetry = {
       "sampling_rate",
     },
+    basic_auth = {
+      "realm"
+    },
   },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -468,6 +468,22 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         end)
       end)
     end)
+
+    describe("www-authenticate header in plugins (realm config)", function()
+      it("[basic-auth] removes realm for versions below 3.6", function()
+        local basic_auth = admin.plugins:insert {
+          name = "basic-auth",
+        }
+
+        local expected_basic_auth_prior_36 = utils.cycle_aware_deep_copy(basic_auth)
+        expected_basic_auth_prior_36.config.realm = nil
+
+        do_assert(utils.uuid(), "3.5.0", expected_basic_auth_prior_36)
+
+        -- cleanup
+        admin.plugins:remove({ id = basic_auth.id })
+      end)
+    end)
   end)
 end)
 


### PR DESCRIPTION
Manual backport of https://github.com/Kong/kong/pull/13042 to `release/3.6.x` due to the fact that the original PR fixed basic-auth and key-auth but key-auth changes were introduced in newer (3.7) version.

## Original description

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Basic-auth and key-auth added new field "realm" but it was not added to "removed_fields" which breaks backwards compat between new CPs and old DPs. Adding realm to removed fields fixes the issue.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4516

