### PR TITLE
 fix(queue): function `Queue.can_enqueue` should handle non-existing queue instance correctly

### DIFF
--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -302,8 +302,8 @@ function Queue.can_enqueue(queue_conf, entry)
     --          and also the `#entry` is larger than `queue.max_bytes`,
     --          this function will incorrectly return `true` instead of `false`.
     --          This is a limitation of the current implementation.
-    --          All capacity checking functions needs a Queue instance to work correctly.
-    --          consturcting a Queue instance just for this function is not efficient,
+    --          All capacity checking functions need a Queue instance to work correctly.
+    --          constructing a Queue instance just for this function is not efficient,
     --          so we just return `true` here.
     --          This limitation should not happen in normal usage,
     --          as user should be aware of the queue capacity settings

--- a/kong/tools/queue.lua
+++ b/kong/tools/queue.lua
@@ -297,8 +297,18 @@ end
 function Queue.can_enqueue(queue_conf, entry)
   local queue = queues[_make_queue_key(queue_conf.name)]
   if not queue then
-    -- treat non-existing queues as not full as they will be created on demand
-    return false
+    -- treat non-existing queues having enough capacity.
+    -- WARNING: The limitation is that if the `entry` is a string and the `queue.max_bytes` is set,
+    --          and also the `#entry` is larger than `queue.max_bytes`,
+    --          this function will incorrectly return `true` instead of `false`.
+    --          This is a limitation of the current implementation.
+    --          All capacity checking functions needs a Queue instance to work correctly.
+    --          consturcting a Queue instance just for this function is not efficient,
+    --          so we just return `true` here.
+    --          This limitation should not happen in normal usage,
+    --          as user should be aware of the queue capacity settings
+    --          to avoid such situation.
+    return true
   end
 
   return _can_enqueue(queue, entry)

--- a/spec/01-unit/27-queue_spec.lua
+++ b/spec/01-unit/27-queue_spec.lua
@@ -812,8 +812,11 @@ describe("plugin queue", function()
       )
     end
 
+    -- should be true if the queue does not exist
+    assert.is_true(Queue.can_enqueue(queue_conf))
+
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.can_enqueue(queue_conf, "One"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "One"))
     enqueue(queue_conf, "One")
     assert.is_false(Queue.is_full(queue_conf))
 
@@ -835,8 +838,11 @@ describe("plugin queue", function()
       max_retry_delay = 60,
     }
 
+    -- should be true if the queue does not exist
+    assert.is_true(Queue.can_enqueue(queue_conf))
+
     assert.is_false(Queue.is_full(queue_conf))
-    assert.is_false(Queue.can_enqueue(queue_conf, "1"))
+    assert.is_true(Queue.can_enqueue(queue_conf, "1"))
     enqueue(queue_conf, "1")
     assert.is_false(Queue.is_full(queue_conf))
 
@@ -856,6 +862,9 @@ describe("plugin queue", function()
       initial_retry_delay = 1,
       max_retry_delay = 60,
     }
+
+    -- should be true if the queue does not exist
+    assert.is_true(Queue.can_enqueue(queue_conf))
 
     enqueue(queue_conf, "1")
 


### PR DESCRIPTION
### Summary

Treating the non-existing queue instance has enough capacity for enqueueing (fixup https://github.com/Kong/kong/pull/13164)

### Checklist

- [X] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-4270]_


[KAG-4270]: https://konghq.atlassian.net/browse/KAG-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ