### PR TITLE
style(pdk/log): simplify buffer:put with vararg-style

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -152,29 +152,29 @@ local serializers = {
   end,
 
   [2] = function(buf, sep, to_string, ...)
-    buf:put(to_string((select(1, ...)))):put(sep)
-       :put(to_string((select(2, ...))))
+    buf:put(to_string((select(1, ...))), sep,
+            to_string((select(2, ...))))
   end,
 
   [3] = function(buf, sep, to_string, ...)
-    buf:put(to_string((select(1, ...)))):put(sep)
-       :put(to_string((select(2, ...)))):put(sep)
-       :put(to_string((select(3, ...))))
+    buf:put(to_string((select(1, ...))), sep,
+            to_string((select(2, ...))), sep,
+            to_string((select(3, ...))))
   end,
 
   [4] = function(buf, sep, to_string, ...)
-    buf:put(to_string((select(1, ...)))):put(sep)
-       :put(to_string((select(2, ...)))):put(sep)
-       :put(to_string((select(3, ...)))):put(sep)
-       :put(to_string((select(4, ...))))
+    buf:put(to_string((select(1, ...))), sep,
+            to_string((select(2, ...))), sep,
+            to_string((select(3, ...))), sep,
+            to_string((select(4, ...))))
   end,
 
   [5] = function(buf, sep, to_string, ...)
-    buf:put(to_string((select(1, ...)))):put(sep)
-       :put(to_string((select(2, ...)))):put(sep)
-       :put(to_string((select(3, ...)))):put(sep)
-       :put(to_string((select(4, ...)))):put(sep)
-       :put(to_string((select(5, ...))))
+    buf:put(to_string((select(1, ...))), sep,
+            to_string((select(2, ...))), sep,
+            to_string((select(3, ...))), sep,
+            to_string((select(4, ...))), sep,
+            to_string((select(5, ...))))
   end,
 }
 
@@ -334,7 +334,7 @@ local function gen_log_func(lvl_const, imm_buf, to_string, stack_level, sep)
 
     else
       for i = 1, n - 1 do
-        variadic_buf:put(to_string((select(i, ...)))):put(sep or "")
+        variadic_buf:put(to_string((select(i, ...))), sep or "")
       end
       variadic_buf:put(to_string((select(n, ...))))
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Using varags-style for `string.buffer:put()` will make the code easy to read.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
