### PR TITLE
fix(core): reduce uninitialized variable message when nginx return 400

### DIFF
--- a/changelog/unreleased/kong/fix-reports-uninitialized-variable-in-400.yml
+++ b/changelog/unreleased/kong/fix-reports-uninitialized-variable-in-400.yml
@@ -1,0 +1,4 @@
+message: |
+  Fixed an issue where trigger a report with an uninitialized variable in the 400 abnormal traffic.
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix-reports-uninitialized-variable-in-400.yml
+++ b/changelog/unreleased/kong/fix-reports-uninitialized-variable-in-400.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue where trigger a report with an uninitialized variable in the 400 abnormal traffic.
+  Fixed an issue where unnecessary uninitialized variable error log is reported when 400 bad requests were received.
 type: bugfix
 scope: Core

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -265,6 +265,11 @@ local get_current_suffix
 if subsystem == "http" then
 function get_current_suffix(ctx)
   local scheme = var.scheme
+  -- 400 case is for invalid requests, eg: if a client sends a HTTP
+  -- request to a HTTPS port, it does not initialized any Nginx variable
+  if kong.response.get_status() == 400 then
+    return nil
+  end
   local proxy_mode = var.kong_proxy_mode
   if scheme == "http" or scheme == "https" then
     if proxy_mode == "http" or proxy_mode == "unbuffered" then

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -265,11 +265,6 @@ local get_current_suffix
 if subsystem == "http" then
 function get_current_suffix(ctx)
   local scheme = var.scheme
-  -- 400 case is for invalid requests, eg: if a client sends a HTTP
-  -- request to a HTTPS port, it does not initialized any Nginx variable
-  if kong.response.get_status() == 400 then
-    return nil
-  end
   local proxy_mode = var.kong_proxy_mode
   if scheme == "http" or scheme == "https" then
     if proxy_mode == "http" or proxy_mode == "unbuffered" then
@@ -305,6 +300,12 @@ function get_current_suffix(ctx)
   end
 
   if ctx.KONG_UNEXPECTED then
+    return nil
+  end
+
+  -- 400 case is for invalid requests, eg: if a client sends a HTTP
+  -- request to a HTTPS port, it does not initialized any Nginx variables
+  if kong.response.get_status() == 400 and proxy_mode == "" then
     return nil
   end
 

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -305,7 +305,7 @@ function get_current_suffix(ctx)
 
   -- 400 case is for invalid requests, eg: if a client sends a HTTP
   -- request to a HTTPS port, it does not initialized any Nginx variables
-  if kong.response.get_status() == 400 and proxy_mode == "" then
+  if proxy_mode == "" and kong.response.get_status() == 400 then
     return nil
   end
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -39,6 +39,8 @@ ssl_ciphers ${{SSL_CIPHERS}};
 $(el.name) $(el.value);
 > end
 
+uninitialized_variable_warn  off;
+
 init_by_lua_block {
 > if test and coverage then
     require 'luacov'
@@ -79,21 +81,6 @@ upstream kong_upstream {
 }
 
 server {
-    set $ctx_ref                     '';
-    set $upstream_te                 '';
-    set $upstream_host               '';
-    set $upstream_upgrade            '';
-    set $upstream_connection         '';
-    set $upstream_scheme             '';
-    set $upstream_uri                '';
-    set $upstream_x_forwarded_for    '';
-    set $upstream_x_forwarded_proto  '';
-    set $upstream_x_forwarded_host   '';
-    set $upstream_x_forwarded_port   '';
-    set $upstream_x_forwarded_path   '';
-    set $upstream_x_forwarded_prefix '';
-    set $kong_proxy_mode             'http';
-
     server_name kong;
 > for _, entry in ipairs(proxy_listeners) do
     listen $(entry.listener);
@@ -401,7 +388,6 @@ server {
 
     location = /kong_error_handler {
         internal;
-        uninitialized_variable_warn  off;
 
         default_type                 '';
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -10,8 +10,6 @@ lua_socket_log_errors  off;
 lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
 
-uninitialized_variable_warn  off;
-
 include 'nginx-kong-inject.conf';
 
 lua_shared_dict kong                        5m;
@@ -81,6 +79,21 @@ upstream kong_upstream {
 }
 
 server {
+    set $ctx_ref                     '';
+    set $upstream_te                 '';
+    set $upstream_host               '';
+    set $upstream_upgrade            '';
+    set $upstream_connection         '';
+    set $upstream_scheme             '';
+    set $upstream_uri                '';
+    set $upstream_x_forwarded_for    '';
+    set $upstream_x_forwarded_proto  '';
+    set $upstream_x_forwarded_host   '';
+    set $upstream_x_forwarded_port   '';
+    set $upstream_x_forwarded_path   '';
+    set $upstream_x_forwarded_prefix '';
+    set $kong_proxy_mode             'http';
+
     server_name kong;
 > for _, entry in ipairs(proxy_listeners) do
     listen $(entry.listener);
@@ -388,6 +401,8 @@ server {
 
     location = /kong_error_handler {
         internal;
+        uninitialized_variable_warn  off;
+
         default_type                 '';
 
         rewrite_by_lua_block {;}

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -10,6 +10,8 @@ lua_socket_log_errors  off;
 lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
 
+uninitialized_variable_warn  off;
+
 include 'nginx-kong-inject.conf';
 
 lua_shared_dict kong                        5m;
@@ -387,8 +389,6 @@ server {
     location = /kong_error_handler {
         internal;
         default_type                 '';
-
-        uninitialized_variable_warn  off;
 
         rewrite_by_lua_block {;}
         access_by_lua_block  {;}

--- a/spec/02-integration/05-proxy/22-reports_spec.lua
+++ b/spec/02-integration/05-proxy/22-reports_spec.lua
@@ -242,6 +242,20 @@ for _, strategy in helpers.each_strategy() do
       proxy_ssl_client:close()
     end)
 
+    it("when send http request to https port, no other error in error.log", function()
+      local https_port = assert(helpers.get_proxy_port(true))
+      local proxy_client = assert(helpers.proxy_client(nil, https_port))
+      local res = proxy_client:get("/", {
+        headers = { host  = "http-service.test" }
+      })
+      reports_send_ping({port=constants.REPORTS.STATS_TLS_PORT})
+
+      assert.response(res).has_status(400)
+      assert.logfile().has.no.line("using uninitialized")
+      assert.logfile().has.no.line("could not determine log suffix (scheme=http, proxy_mode=)")
+      proxy_client:close()
+    end)
+
     it("reports h2c requests", function()
       local h2c_client = assert(helpers.proxy_client_h2c())
       local body, headers = h2c_client({


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

When Kong receives abnormal traffic, it will trigger 400 responses without initializing any Nginx variable, So it will trigger `report.lua`  error, which is unnecessary.

eg: send HTTP traffic to HTTPS port, Nginx will finalize the current request by 400 response in the TLS handshake, So it will never call any openresty HTTP processing phase, it also does not initialize any Nginx variable.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/Kong/kong/issues/13197
https://konghq.atlassian.net/browse/FTI-6025
