### PR TITLE
style(pdk): get hostname with `string.strip`

### DIFF
--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -4,21 +4,23 @@
 
 local ffi = require "ffi"
 local private_node = require "kong.pdk.private.node"
+local tools_string = require("kong.tools.string")
 local uuid = require("kong.tools.uuid").uuid
-local bytes_to_str = require("kong.tools.string").bytes_to_str
 
 
 local floor = math.floor
 local lower = string.lower
 local match = string.match
-local gsub = string.gsub
 local sort = table.sort
 local insert = table.insert
+local strip = tools_string.strip
+local bytes_to_str = tools_string.bytes_to_str
 local ngx = ngx
 local shared = ngx.shared
 local C             = ffi.C
 local ffi_new       = ffi.new
 local ffi_str       = ffi.string
+
 
 local NODE_ID_KEY = "kong:node_id"
 
@@ -254,13 +256,13 @@ local function new(self)
 
     if res == 0 then
       local hostname = ffi_str(buf, SIZE)
-      return gsub(hostname, "%z+$", "")
+      return strip(hostname)
     end
 
     local f = io.popen("/bin/hostname")
     local hostname = f:read("*a") or ""
     f:close()
-    return gsub(hostname, "\n$", "")
+    return strip(hostname)
   end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

`tools.string.strip()` has better performance than `gsub`, and it is easy to understand.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
