### PR TITLE
fix(ai-plugins): remove no_consumer and no_service restriction on AI plugins

### DIFF
--- a/changelog/unreleased/kong/fix-ai-plugin-no-consumer.yml
+++ b/changelog/unreleased/kong/fix-ai-plugin-no-consumer.yml
@@ -1,0 +1,4 @@
+message: "Fix certain AI plugins cannot be applied per consumer or per service."
+type: bugfix
+scope: Plugin
+

--- a/changelog/unreleased/kong/fix-ai-plugin-no-consumer.yml
+++ b/changelog/unreleased/kong/fix-ai-plugin-no-consumer.yml
@@ -1,4 +1,4 @@
-message: "Fix certain AI plugins cannot be applied per consumer or per service."
+message: "Fixed certain AI plugins cannot be applied per consumer or per service."
 type: bugfix
 scope: Plugin
 

--- a/kong/plugins/ai-prompt-template/schema.lua
+++ b/kong/plugins/ai-prompt-template/schema.lua
@@ -23,7 +23,6 @@ return {
   name = "ai-prompt-template",
   fields = {
     { protocols = typedefs.protocols_http },
-    { consumer = typedefs.no_consumer },
     { config = {
       type = "record",
       fields = {

--- a/kong/plugins/ai-proxy/schema.lua
+++ b/kong/plugins/ai-proxy/schema.lua
@@ -23,8 +23,6 @@ return {
   name = "ai-proxy",
   fields = {
     { protocols = typedefs.protocols_http },
-    { consumer = typedefs.no_consumer },
-    { service = typedefs.no_service },
     { config = this_schema },
   },
 }

--- a/kong/plugins/ai-response-transformer/schema.lua
+++ b/kong/plugins/ai-response-transformer/schema.lua
@@ -7,7 +7,6 @@ return {
   name = "ai-response-transformer",
   fields = {
     { protocols = typedefs.protocols_http },
-    { consumer = typedefs.no_consumer },
     { config = {
       type = "record",
       fields = {


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

AG-2
