### PR TITLE
refactor(pdk): simplify private RL pdk

### DIFF
--- a/kong/pdk/private/rate_limiting.lua
+++ b/kong/pdk/private/rate_limiting.lua
@@ -1,5 +1,4 @@
 local table_new    = require("table.new")
-local buffer       = require("string.buffer")
 
 local type         = type
 local pairs        = pairs
@@ -7,80 +6,8 @@ local assert       = assert
 local tostring     = tostring
 local resp_header  = ngx.header
 
-local tablex_keys  = require("pl.tablex").keys
-
-local RL_LIMIT     = "RateLimit-Limit"
-local RL_REMAINING = "RateLimit-Remaining"
-local RL_RESET     = "RateLimit-Reset"
-local RETRY_AFTER  = "Retry-After"
-
-
 -- determine the number of pre-allocated fields at runtime
 local max_fields_n = 4
-local buf = buffer.new(64)
-
-local LIMIT_BY = {
-  second = {
-    limit = "X-RateLimit-Limit-Second",
-    remain = "X-RateLimit-Remaining-Second",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Second",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Second",
-  },
-  minute = {
-    limit = "X-RateLimit-Limit-Minute",
-    remain = "X-RateLimit-Remaining-Minute",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Minute",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Minute",
-  },
-  hour = {
-    limit = "X-RateLimit-Limit-Hour",
-    remain = "X-RateLimit-Remaining-Hour",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Hour",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Hour",
-  },
-  day = {
-    limit = "X-RateLimit-Limit-Day",
-    remain = "X-RateLimit-Remaining-Day",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Day",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Day",
-  },
-  month = {
-    limit = "X-RateLimit-Limit-Month",
-    remain = "X-RateLimit-Remaining-Month",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Month",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Month",
-  },
-  year = {
-    limit = "X-RateLimit-Limit-Year",
-    remain = "X-RateLimit-Remaining-Year",
-    limit_segment_0 = "X-",
-    limit_segment_1 = "RateLimit-Limit-",
-    limit_segment_3 = "-Year",
-    remain_segment_0 = "X-",
-    remain_segment_1 = "RateLimit-Remaining-",
-    remain_segment_3 = "-Year",
-  },
-}
 
 local _M = {}
 
@@ -114,201 +41,39 @@ local function _get_or_create_rl_ctx(ngx_ctx)
 end
 
 
-function _M.set_basic_limit(ngx_ctx, limit, remaining, reset)
-  local rl_ctx = _get_or_create_rl_ctx(ngx_ctx or ngx.ctx)
-
+function _M.store_response_header(ngx_ctx, key, value)
   assert(
-    type(limit) == "number",
-    "arg #2 `limit` for `set_basic_limit` must be a number"
-  )
-  assert(
-    type(remaining) == "number",
-    "arg #3 `remaining` for `set_basic_limit` must be a number"
-  )
-  assert(
-    type(reset) == "number",
-    "arg #4 `reset` for `set_basic_limit` must be a number"
+    type(key) == "string",
+    "arg #2 `key` for function `store_response_header` must be a string"
   )
 
-  rl_ctx[RL_LIMIT] = limit
-  rl_ctx[RL_REMAINING] = remaining
-  rl_ctx[RL_RESET] = reset
+  local value_type = type(value)
+  assert(
+    value_type == "string" or value_type == "number",
+    "arg #3 `value` for function `store_response_header` must be a string or a number"
+  )
+
+  local rl_ctx = _get_or_create_rl_ctx(ngx_ctx)
+  rl_ctx[key] = value
 end
 
-function _M.set_retry_after(ngx_ctx, reset)
-  local rl_ctx = _get_or_create_rl_ctx(ngx_ctx or ngx.ctx)
 
+function _M.get_stored_response_header(ngx_ctx, key)
   assert(
-    type(reset) == "number",
-    "arg #2 `reset` for `set_retry_after` must be a number"
+    type(key) == "string",
+    "arg #2 `key` for function `get_stored_response_header` must be a string"
   )
 
-  rl_ctx[RETRY_AFTER] = reset
-end
-
-function _M.set_limit_by(ngx_ctx, limit_by, limit, remaining)
-  local rl_ctx = _get_or_create_rl_ctx(ngx_ctx or ngx.ctx)
-
-  assert(
-    type(limit_by) == "string",
-    "arg #2 `limit_by` for `set_limit_by` must be a string"
-  )
-  assert(
-    type(limit) == "number",
-    "arg #3 `limit` for `set_limit_by` must be a number"
-  )
-  assert(
-    type(remaining) == "number",
-    "arg #4 `remaining` for `set_limit_by` must be a number"
-  )
-
-  limit_by = LIMIT_BY[limit_by]
-  assert(limit_by, "invalid limit_by")
-
-  rl_ctx[limit_by.limit] = limit
-  rl_ctx[limit_by.remain] = remaining
-end
-
-function _M.set_limit_by_with_identifier(ngx_ctx, limit_by, limit, remaining, id_seg_1, id_seg_2)
-  local rl_ctx = _get_or_create_rl_ctx(ngx_ctx or ngx.ctx)
-
-  assert(
-    type(limit_by) == "string",
-    "arg #2 `limit_by` for `set_limit_by_with_identifier` must be a string"
-  )
-  assert(
-    type(limit) == "number",
-    "arg #3 `limit` for `set_limit_by_with_identifier` must be a number"
-  )
-  assert(
-    type(remaining) == "number",
-    "arg #4 `remaining` for `set_limit_by_with_identifier` must be a number"
-  )
-
-  local id_seg_1_typ = type(id_seg_1)
-  local id_seg_2_typ = type(id_seg_2)
-  assert(
-    id_seg_1_typ == "nil" or id_seg_1_typ == "string",
-    "arg #5 `id_seg_1` for `set_limit_by_with_identifier` must be a string or nil"
-  )
-  assert(
-    id_seg_2_typ == "nil" or id_seg_2_typ == "string",
-    "arg #6 `id_seg_2` for `set_limit_by_with_identifier` must be a string or nil"
-  )
-
-  limit_by = LIMIT_BY[limit_by]
-  if not limit_by then
-    local valid_limit_bys = tablex_keys(LIMIT_BY)
-    local msg = string.format(
-      "arg #2 `limit_by` for `set_limit_by_with_identifier` must be one of: %s",
-      table.concat(valid_limit_bys, ", ")
-    )
-    error(msg)
+  if not _has_rl_ctx(ngx_ctx) then
+    return nil
   end
 
-  id_seg_1 = id_seg_1 or ""
-  id_seg_2 = id_seg_2 or ""
-
-  -- construct the key like X-<id_seg_1>-RateLimit-Limit-<id_seg_2>-<limit_by>
-  local limit_key = buf:reset():put(
-    limit_by.limit_segment_0,
-    id_seg_1,
-    limit_by.limit_segment_1,
-    id_seg_2,
-    limit_by.limit_segment_3
-  ):get()
-
-  -- construct the key like X-<id_seg_1>-RateLimit-Remaining-<id_seg_2>-<limit_by>
-  local remain_key = buf:reset():put(
-    limit_by.remain_segment_0,
-    id_seg_1,
-    limit_by.remain_segment_1,
-    id_seg_2,
-    limit_by.remain_segment_3
-  ):get()
-
-  rl_ctx[limit_key] = limit
-  rl_ctx[remain_key] = remaining
+  local rl_ctx = _get_rl_ctx(ngx_ctx)
+  return rl_ctx[key]
 end
 
-function _M.get_basic_limit(ngx_ctx)
-  local rl_ctx = _get_rl_ctx(ngx_ctx or ngx.ctx)
-  return rl_ctx[RL_LIMIT], rl_ctx[RL_REMAINING], rl_ctx[RL_RESET]
-end
 
-function _M.get_retry_after(ngx_ctx)
-  local rl_ctx = _get_rl_ctx(ngx_ctx or ngx.ctx)
-  return rl_ctx[RETRY_AFTER]
-end
-
-function _M.get_limit_by(ngx_ctx, limit_by)
-  local rl_ctx = _get_rl_ctx(ngx_ctx or ngx.ctx)
-
-  assert(
-    type(limit_by) == "string",
-    "arg #2 `limit_by` for `get_limit_by` must be a string"
-  )
-
-  limit_by = LIMIT_BY[limit_by]
-  assert(limit_by, "invalid limit_by")
-
-  return rl_ctx[limit_by.limit], rl_ctx[limit_by.remain]
-end
-
-function _M.get_limit_by_with_identifier(ngx_ctx, limit_by, id_seg_1, id_seg_2)
-  local rl_ctx = _get_rl_ctx(ngx_ctx or ngx.ctx)
-
-  assert(
-    type(limit_by) == "string",
-    "arg #2 `limit_by` for `get_limit_by_with_identifier` must be a string"
-  )
-
-  local id_seg_1_typ = type(id_seg_1)
-  local id_seg_2_typ = type(id_seg_2)
-  assert(
-    id_seg_1_typ == "nil" or id_seg_1_typ == "string",
-    "arg #3 `id_seg_1` for `get_limit_by_with_identifier` must be a string or nil"
-  )
-  assert(
-    id_seg_2_typ == "nil" or id_seg_2_typ == "string",
-    "arg #4 `id_seg_2` for `get_limit_by_with_identifier` must be a string or nil"
-  )
-
-  limit_by = LIMIT_BY[limit_by]
-  if not limit_by then
-    local valid_limit_bys = tablex_keys(LIMIT_BY)
-    local msg = string.format(
-      "arg #2 `limit_by` for `get_limit_by_with_identifier` must be one of: %s",
-      table.concat(valid_limit_bys, ", ")
-    )
-    error(msg)
-  end
-
-  id_seg_1 = id_seg_1 or ""
-  id_seg_2 = id_seg_2 or ""
-
-  -- construct the key like X-<id_seg_1>-RateLimit-Limit-<id_seg_2>-<limit_by>
-  local limit_key = buf:reset():put(
-    limit_by.limit_segment_0,
-    id_seg_1,
-    limit_by.limit_segment_1,
-    id_seg_2,
-    limit_by.limit_segment_3
-  ):get()
-
-  -- construct the key like X-<id_seg_1>-RateLimit-Remaining-<id_seg_2>-<limit_by>
-  local remain_key = buf:reset():put(
-    limit_by.remain_segment_0,
-    id_seg_1,
-    limit_by.remain_segment_1,
-    id_seg_2,
-    limit_by.remain_segment_3
-  ):get()
-
-  return rl_ctx[limit_key], rl_ctx[remain_key]
-end
-
-function _M.set_response_headers(ngx_ctx)
+function _M.apply_response_headers(ngx_ctx)
   if not _has_rl_ctx(ngx_ctx) then
     return
   end

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -14,15 +14,40 @@ local pairs = pairs
 local error = error
 local tostring = tostring
 local timer_at = ngx.timer.at
-local pdk_rl_set_basic_limit = pdk_private_rl.set_basic_limit
-local pdk_rl_set_retry_after = pdk_private_rl.set_retry_after
-local pdk_rl_set_limit_by = pdk_private_rl.set_limit_by
-local pdk_rl_set_response_headers = pdk_private_rl.set_response_headers
 local SYNC_RATE_REALTIME = -1
+
+
+local pdk_rl_store_response_header = pdk_private_rl.store_response_header
+local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
 
 local EMPTY = {}
 local EXPIRATION = require "kong.plugins.rate-limiting.expiration"
+
+
+local RATELIMIT_LIMIT     = "RateLimit-Limit"
+local RATELIMIT_REMAINING = "RateLimit-Remaining"
+local RATELIMIT_RESET     = "RateLimit-Reset"
+local RETRY_AFTER         = "Retry-After"
+
+
+local X_RATELIMIT_LIMIT = {
+  second = "X-RateLimit-Limit-Second",
+  minute = "X-RateLimit-Limit-Minute",
+  hour   = "X-RateLimit-Limit-Hour",
+  day    = "X-RateLimit-Limit-Day",
+  month  = "X-RateLimit-Limit-Month",
+  year   = "X-RateLimit-Limit-Year",
+}
+
+local X_RATELIMIT_REMAINING = {
+  second = "X-RateLimit-Remaining-Second",
+  minute = "X-RateLimit-Remaining-Minute",
+  hour   = "X-RateLimit-Remaining-Hour",
+  day    = "X-RateLimit-Remaining-Day",
+  month  = "X-RateLimit-Remaining-Month",
+  year   = "X-RateLimit-Remaining-Year",
+}
 
 
 local RateLimitingHandler = {}
@@ -126,7 +151,6 @@ function RateLimitingHandler:access(conf)
 
   if usage then
     local ngx_ctx = ngx.ctx
-    -- Adding headers
     local reset
     if not conf.hide_client_headers then
       local timestamps
@@ -157,21 +181,23 @@ function RateLimitingHandler:access(conf)
           reset = max(1, window - floor((current_timestamp - timestamps[k]) / 1000))
         end
 
-        pdk_rl_set_limit_by(ngx_ctx, k, limit, current_remaining)
+        pdk_rl_store_response_header(ngx_ctx, X_RATELIMIT_LIMIT[k], current_limit)
+        pdk_rl_store_response_header(ngx_ctx, X_RATELIMIT_REMAINING[k], current_remaining)
       end
 
-      pdk_rl_set_basic_limit(ngx_ctx, limit, remaining, reset)
+      pdk_rl_store_response_header(ngx_ctx, RATELIMIT_LIMIT, limit)
+      pdk_rl_store_response_header(ngx_ctx, RATELIMIT_REMAINING, remaining)
+      pdk_rl_store_response_header(ngx_ctx, RATELIMIT_RESET, reset)
     end
 
     -- If limit is exceeded, terminate the request
     if stop then
-      pdk_rl_set_retry_after(ngx_ctx, reset)
-      pdk_rl_set_response_headers(ngx_ctx)
+      pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
+      pdk_rl_apply_response_headers(ngx_ctx)
       return kong.response.error(conf.error_code, conf.error_message)
     end
 
-    -- Set rate-limiting response headers
-    pdk_rl_set_response_headers(ngx_ctx)
+    pdk_rl_apply_response_headers(ngx_ctx)
   end
 
   if conf.sync_rate ~= SYNC_RATE_REALTIME and conf.policy == "redis" then

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -1,5 +1,6 @@
 local policies = require "kong.plugins.response-ratelimiting.policies"
 local timestamp = require "kong.tools.timestamp"
+local pdk_private_rl = require "kong.pdk.private.rate_limiting"
 
 
 local kong = kong
@@ -7,6 +8,10 @@ local next = next
 local pairs = pairs
 local error = error
 local tostring = tostring
+
+
+local pdk_rl_store_response_header = pdk_private_rl.store_response_header
+local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
 
 local EMPTY = {}
@@ -84,6 +89,7 @@ function _M.execute(conf)
   end
 
   -- Append usage headers to the upstream request. Also checks "block_on_first_violation".
+  local ngx_ctx = ngx.ctx
   for k in pairs(conf.limits) do
     local remaining
     for _, lv in pairs(usage[k]) do
@@ -97,8 +103,10 @@ function _M.execute(conf)
       end
     end
 
-    kong.service.request.set_header(RATELIMIT_REMAINING .. "-" .. k, remaining)
+    pdk_rl_store_response_header(ngx_ctx, RATELIMIT_REMAINING .. "-" .. k, remaining)
   end
+
+  pdk_rl_apply_response_headers(ngx_ctx)
 
   kong.ctx.plugin.usage = usage -- For later use
 end

--- a/t/01-pdk/16-rl-ctx.t
+++ b/t/01-pdk/16-rl-ctx.t
@@ -1,0 +1,200 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+do "./t/Util.pm";
+
+plan tests => repeat_each() * (blocks() * 4) - 1;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: should work in rewrite phase
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        rewrite_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+            pdk_rl.store_response_header(ngx.ctx, "X-1", 1)
+            pdk_rl.store_response_header(ngx.ctx, "X-2", 2)
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+
+            pdk_rl.apply_response_headers(ngx.ctx)
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+        }
+    }
+--- request
+GET /t
+--- response_headers
+X-1: 1
+X-2: 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: should work in access phase
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+            pdk_rl.store_response_header(ngx.ctx, "X-1", 1)
+            pdk_rl.store_response_header(ngx.ctx, "X-2", 2)
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+
+            pdk_rl.apply_response_headers(ngx.ctx)
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+        }
+    }
+--- request
+GET /t
+--- response_headers
+X-1: 1
+X-2: 2
+--- no_error_log
+[error]
+
+
+=== TEST 3: should work in header_filter phase
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        header_filter_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+            pdk_rl.store_response_header(ngx.ctx, "X-1", 1)
+            pdk_rl.store_response_header(ngx.ctx, "X-2", 2)
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+
+            pdk_rl.apply_response_headers(ngx.ctx)
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+
+            local value = pdk_rl.get_stored_response_header(ngx.ctx, "X-1")
+            assert(value == 1, "unexpected value: " .. value)
+
+            value = pdk_rl.get_stored_response_header(ngx.ctx, "X-2")
+            assert(value == 2, "unexpected value: " .. value)
+        }
+    }
+--- request
+GET /t
+--- response_headers
+X-1: 1
+X-2: 2
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: should not accept invalid arguments
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        rewrite_by_lua_block {
+            local pdk_rl = require("kong.pdk.private.rate_limiting")
+            local ok, err
+
+            ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, nil, 1)
+            assert(not ok, "pcall should fail")
+            assert(
+                err:find("arg #2 `key` for function `store_response_header` must be a string", nil, true),
+                "unexpected error message: " .. err
+            )
+            for _k, v in ipairs({ 1, true, {}, function() end, ngx.null }) do
+                ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, v, 1)
+                assert(not ok, "pcall should fail")
+                assert(
+                    err:find("arg #2 `key` for function `store_response_header` must be a string", nil, true),
+                    "unexpected error message: " .. err
+                )
+            end
+
+            ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, "X-1", nil)
+            assert(not ok, "pcall should fail")
+            assert(
+                err:find("arg #3 `value` for function `store_response_header` must be a string or a number", nil, true),
+                "unexpected error message: " .. err
+            )
+            for _k, v in ipairs({ true, {}, function() end, ngx.null }) do
+                ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, "X-1", v)
+                assert(not ok, "pcall should fail")
+                assert(
+                    err:find("arg #3 `value` for function `store_response_header` must be a string or a number", nil, true),
+                    "unexpected error message: " .. err
+                )
+            end
+
+            ok, err = pcall(pdk_rl.get_stored_response_header, ngx.ctx, nil)
+            assert(not ok, "pcall should fail")
+            assert(
+                err:find("arg #2 `key` for function `get_stored_response_header` must be a string", nil, true),
+                "unexpected error message: " .. err
+            )
+            for _k, v in ipairs({ 1, true, {}, function() end, ngx.null }) do
+                ok, err = pcall(pdk_rl.get_stored_response_header, ngx.ctx, v)
+                assert(not ok, "pcall should fail")
+                assert(
+                    err:find("arg #2 `key` for function `get_stored_response_header` must be a string", nil, true),
+                    "unexpected error message: " .. err
+                )
+            end
+        }
+
+        content_by_lua_block {
+            ngx.print("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+"ok"
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

The rate-limiting-related headers have no fixed format, different plugins have different formats.

The goal of this private PDK is only to retrieve the RL context in a central place, so it should be enough.

### Checklist

- [X] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-4679](https://konghq.atlassian.net/browse/KAG-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[KAG-4679]: https://konghq.atlassian.net/browse/KAG-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ