### PR TITLE
fix(propagation): remove redundant warning messages

### DIFF
--- a/changelog/unreleased/kong/fix-propagation-remove-redundant-warnings.yml
+++ b/changelog/unreleased/kong/fix-propagation-remove-redundant-warnings.yml
@@ -1,0 +1,3 @@
+message: "**OpenTelemetry / Zipkin**: remove redundant deprecation warnings"
+type: bugfix
+scope: Plugin

--- a/kong/tracing/propagation/init.lua
+++ b/kong/tracing/propagation/init.lua
@@ -33,11 +33,6 @@ local function get_plugin_params(config)
 
   if (config.default_header_type or null) ~= null then
     propagation_config.default_format = config.default_header_type
-
-    kong.log.warn(
-      "the default_header_type parameter is deprecated, please update your "
-      .. "configuration to use the propagation.default_format, "
-      .. "propagation.extract and propagation.inject options instead")
   end
 
   if (config.header_type or null) ~= null then
@@ -75,10 +70,6 @@ local function get_plugin_params(config)
         config.header_type
       }
     end
-
-    kong.log.warn(
-      "the header_type parameter is deprecated, please update your "
-      .. "configuration to use propagation.extract and propagation.inject instead")
   end
 
   return propagation_config


### PR DESCRIPTION
### Summary

The propagation module logs some redundant warning messages that [are already printed](https://github.com/Kong/kong/blob/master/kong/plugins/opentelemetry/schema.lua#L75), when necessary, during schema validation, with logic that also checks the "old default" value. This commit removes the unnecessary messages.

### Checklist

- [x] (no) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4744
