### PR TITLE
refactor(pdk): show more friendly error msg when passing invalid arguments

### DIFF
--- a/t/01-pdk/16-rl-ctx.t
+++ b/t/01-pdk/16-rl-ctx.t
@@ -140,49 +140,85 @@ X-2: 2
     location = /t {
         rewrite_by_lua_block {
             local pdk_rl = require("kong.pdk.private.rate_limiting")
-            local ok, err
+            local ok, err, errmsg
 
             ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, nil, 1)
             assert(not ok, "pcall should fail")
+            errmsg = string.format(
+                "arg #%d `key` for function `%s` must be a string, got %s",
+                2,
+                "store_response_header",
+                type(nil)
+            )
             assert(
-                err:find("arg #2 `key` for function `store_response_header` must be a string", nil, true),
+                err:find(errmsg, nil, true),
                 "unexpected error message: " .. err
             )
             for _k, v in ipairs({ 1, true, {}, function() end, ngx.null }) do
                 ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, v, 1)
                 assert(not ok, "pcall should fail")
+                errmsg = string.format(
+                    "arg #%d `key` for function `%s` must be a string, got %s",
+                    2,
+                    "store_response_header",
+                    type(v)
+                )
                 assert(
-                    err:find("arg #2 `key` for function `store_response_header` must be a string", nil, true),
+                    err:find(errmsg, nil, true),
                     "unexpected error message: " .. err
                 )
             end
 
             ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, "X-1", nil)
             assert(not ok, "pcall should fail")
+            errmsg = string.format(
+                "arg #%d `value` for function `%s` must be a string or a number, got %s",
+                3,
+                "store_response_header",
+                type(nil)
+            )
             assert(
-                err:find("arg #3 `value` for function `store_response_header` must be a string or a number", nil, true),
+                err:find(errmsg, nil, true),
                 "unexpected error message: " .. err
             )
             for _k, v in ipairs({ true, {}, function() end, ngx.null }) do
                 ok, err = pcall(pdk_rl.store_response_header, ngx.ctx, "X-1", v)
                 assert(not ok, "pcall should fail")
+                errmsg = string.format(
+                    "arg #%d `value` for function `%s` must be a string or a number, got %s",
+                    3,
+                    "store_response_header",
+                    type(v)
+                )
                 assert(
-                    err:find("arg #3 `value` for function `store_response_header` must be a string or a number", nil, true),
+                    err:find(errmsg, nil, true),
                     "unexpected error message: " .. err
                 )
             end
 
             ok, err = pcall(pdk_rl.get_stored_response_header, ngx.ctx, nil)
             assert(not ok, "pcall should fail")
+            errmsg = string.format(
+                "arg #%d `key` for function `%s` must be a string, got %s",
+                2,
+                "get_stored_response_header",
+                type(nil)
+            )
             assert(
-                err:find("arg #2 `key` for function `get_stored_response_header` must be a string", nil, true),
+                err:find(errmsg, nil, true),
                 "unexpected error message: " .. err
             )
             for _k, v in ipairs({ 1, true, {}, function() end, ngx.null }) do
                 ok, err = pcall(pdk_rl.get_stored_response_header, ngx.ctx, v)
                 assert(not ok, "pcall should fail")
+                errmsg = string.format(
+                    "arg #%d `key` for function `%s` must be a string, got %s",
+                    2,
+                    "get_stored_response_header",
+                    type(v)
+                )
                 assert(
-                    err:find("arg #2 `key` for function `get_stored_response_header` must be a string", nil, true),
+                    err:find(errmsg, nil, true),
                     "unexpected error message: " .. err
                 )
             end


### PR DESCRIPTION
### Summary

The function `assert` doesn't show the caller of the PDK function when failed to validate incoming arguments. Invoking function `error` when unable to validate an argument can get a better error message.

### Checklist

- [X] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-4679]_


[KAG-4679]: https://konghq.atlassian.net/browse/KAG-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ