### PR TITLE
fix(wasm): disable jit for set_host_properties_handlers()

### DIFF
--- a/kong/runloop/wasm.lua
+++ b/kong/runloop/wasm.lua
@@ -836,6 +836,7 @@ local function enable(kong_config)
 
   if not ngx.IS_CLI then
     proxy_wasm = proxy_wasm or require "resty.wasmx.proxy_wasm"
+    jit.off(proxy_wasm.set_host_properties_handlers)
 
     register_property_handlers()
   end


### PR DESCRIPTION
This function can trigger a segfault if it is jit-compiled due to the semantics of making an FFI call to a C land function which in turn calls back into a Lua land function.

Fixes a condition introduced in https://github.com/Kong/kong/pull/13222.

No changelog entry required--the bug fixed by this change has not been released anywhere.

KAG-4671