### PR TITLE
fix(ci): replace "cpio" rpm extraction

### DIFF
--- a/scripts/explain_manifest/main.py
+++ b/scripts/explain_manifest/main.py
@@ -84,9 +84,12 @@ def gather_files(path: str, image: str):
             code = os.system(
                 "ar p %s data.tar.gz | tar -C %s -xz" % (path, t.name))
         elif ext == ".rpm":
-            # GNU cpio and rpm2cpio is needed
+            # rpm2cpio is needed
+            # rpm2archive ships with rpm2cpio on debians
             code = os.system(
-                "rpm2cpio %s | cpio --no-preserve-owner --no-absolute-filenames -idm -D %s" % (path, t.name))
+                """
+                    rpm2archive %s && tar -C %s -xf %s.tgz
+                """ % (path, t.name, path))
         elif ext == ".gz":
             code = os.system("tar -C %s -xf %s" % (t.name, path))
 


### PR DESCRIPTION
cherry-pick from kong/kong-ee#9042

This PR doesn't need to be cherry-picked.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4775
