### PR TITLE
tests(cluster_events): fix flaky due to too close time for a delay timer

### DIFF
--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -315,8 +315,10 @@ for _, strategy in helpers.each_strategy() do
 
         ngx.sleep(delay) -- go past our desired `nbf` delay
 
-        assert(cluster_events_1:poll())
-        assert.spy(spy_func).was_called(1) -- called
+        helpers.wait_until(function()
+          assert(cluster_events_1:poll())
+          return pcall(assert.spy(spy_func).was_called, 1) -- called
+        end, 1) -- note that we have already waited for `delay` seconds
       end)
 
       it("broadcasts an event with a polling delay for subscribers", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

For the test scenario of broadcasting an event with a delay (`broadcast(..., ..., delay)`), we need to apply wait_until to stabilize the test. Note that https://github.com/Kong/kong/pull/12696 has fixed a similar issue, however, another one remains unresolved.


### Checklist

- [x] The Pull Request has tests
- [x] ~~N/A. A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)~~
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-4764
