### PR TITLE
chore(ci): disable package upload to Pulp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,13 +608,10 @@ jobs:
       env:
         ARCHITECTURE: ${{ steps.pkg-arch.outputs.arch }}
         OFFICIAL_RELEASE: ${{ github.event.inputs.official }}
-        PULP_HOST: https://api.download.konghq.com
-        PULP_USERNAME: admin
-        # PULP_PASSWORD: ${{ secrets.PULP_DEV_PASSWORD }}
-        PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
         ARTIFACT_VERSION: ${{ matrix.artifact-version }}
         ARTIFACT_TYPE: ${{ matrix.artifact-type }}
         ARTIFACT: ${{ matrix.artifact }}
+        INPUT_VERSION: ${{ github.event.inputs.version }}
         PACKAGE_TYPE: ${{ matrix.package }}
         KONG_RELEASE_LABEL: ${{ needs.metadata.outputs.release-label }}
         VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
@@ -622,9 +619,19 @@ jobs:
         CLOUDSMITH_DRY_RUN: ''
         IGNORE_CLOUDSMITH_FAILURES: ${{ vars.IGNORE_CLOUDSMITH_FAILURES }}
         USE_CLOUDSMITH: ${{ vars.USE_CLOUDSMITH }}
-        USE_PULP: ${{ vars.USE_PULP }}
       run: |
         sha256sum bazel-bin/pkg/*
+
+        # set the version input as tags passed to release-scripts
+        # note: release-scripts rejects user tags if missing internal flag
+        #
+        # this can be a comma-sepratated list of tags to apply
+        if [[ "$OFFICIAL_RELEASE" == 'false' ]]; then
+          if echo "$INPUT_VERSION" | grep -qs -E 'rc|alpha|beta|nightly'; then
+            PACKAGE_TAGS="$INPUT_VERSION"
+            export PACKAGE_TAGS
+          fi
+        fi
 
         scripts/release-kong.sh
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Disable package upload to Pulp.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4776
