### PR TITLE
debug

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -1,24 +1,209 @@
-# please see matrix-full.yml for meaning of each field
 build-packages:
+# label: used to distinguish artifacts for later use
+# image: docker image name if the build is running in side a container
+# package: package type
+# package-type: the nfpm packaging target, //:kong_{package} target; only used when package is rpm
+# bazel-args: additional bazel build flags
+# check-manifest-suite: the check manifest suite as defined in scripts/explain_manifest/config.py
+
+# Ubuntu
+- label: ubuntu-20.04
+  image: ubuntu:20.04
+  package: deb
+  check-manifest-suite: ubuntu-20.04-amd64
 - label: ubuntu-22.04
-  os: ubuntu-22.04
   package: deb
   check-manifest-suite: ubuntu-22.04-amd64
+- label: ubuntu-22.04-arm64
+  package: deb
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
+  check-manifest-suite: ubuntu-22.04-arm64
+
+# Debian
+- label: debian-10
+  image: debian:10
+  package: deb
+  check-manifest-suite: debian-10-amd64
+- label: debian-11
+  image: debian:11
+  package: deb
+  check-manifest-suite: debian-11-amd64
+- label: debian-12
+  image: debian:12
+  package: deb
+  check-manifest-suite: debian-12-amd64
+
+# RHEL
+- label: rhel-7
+  image: centos:7
+  package: rpm
+  package-type: el7
+  bazel-args: --//:wasmx_el7_workaround=true --//:brotli=False
+  check-manifest-suite: el7-amd64
+- label: rhel-8
+  image: rockylinux:8
+  package: rpm
+  package-type: el8
+  check-manifest-suite: el8-amd64
+- label: rhel-9
+  image: rockylinux:9
+  package: rpm
+  package-type: el9
+  check-manifest-suite: el9-amd64
+- label: rhel-9-arm64
+  package: rpm
+  package-type: el9
+  bazel-args: --platforms=//:rhel9-crossbuild-aarch64 --//:brotli=False
+  check-manifest-suite: el9-arm64
+
+  # Amazon Linux
+- label: amazonlinux-2
+  image: amazonlinux:2
+  package: rpm
+  package-type: aws2
+  check-manifest-suite: amazonlinux-2-amd64
+- label: amazonlinux-2023
+  image: amazonlinux:2023
+  package: rpm
+  package-type: aws2023
+  check-manifest-suite: amazonlinux-2023-amd64
+- label: amazonlinux-2023-arm64
+  package: rpm
+  package-type: aws2023
+  bazel-args: --platforms=//:aws2023-crossbuild-aarch64 --//:brotli=False
+  check-manifest-suite: amazonlinux-2023-arm64
 
 build-images:
+# Only build images for the latest version of each major release.
+
+# label: used as compose docker image label ${github.sha}-${label}
+# base-image: docker image to use as base
+# package: package type
+# artifact-from: label of build-packages to use
+# artifact-from-alt: another label of build-packages to use for downloading package (to build multi-arch image)
+# docker-platforms: comma separated list of docker buildx platforms to build for
+
+# Ubuntu
 - label: ubuntu
   base-image: ubuntu:22.04
   package: deb
   artifact-from: ubuntu-22.04
+  artifact-from-alt: ubuntu-22.04-arm64
+  docker-platforms: linux/amd64, linux/arm64
+
+# Debian
+- label: debian
+  base-image: debian:12-slim
+  package: deb
+  artifact-from: debian-12
+
+# RHEL
+- label: rhel
+  base-image: registry.access.redhat.com/ubi9
+  package: rpm
+  rpm_platform: el9
+  artifact-from: rhel-9
+  artifact-from-alt: rhel-9-arm64
+  docker-platforms: linux/amd64, linux/arm64
 
 smoke-tests:
 - label: ubuntu
+- label: debian
+- label: rhel
 
 scan-vulnerabilities:
 - label: ubuntu
+- label: debian
+- label: rhel
 
 release-packages:
+# Ubuntu
+- label: ubuntu-20.04
+  package: deb
+  artifact-from: ubuntu-20.04
+  artifact-version: 20.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-22.04
+  package: deb
+  artifact-from: ubuntu-22.04
+  artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-22.04-arm64
+  package: deb
+  artifact-from: ubuntu-22.04-arm64
+  artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.arm64.deb
+
+# Debian
+- label: debian-10
+  package: deb
+  artifact-from: debian-10
+  artifact-version: 10
+  artifact-type: debian
+  artifact: kong.amd64.deb
+- label: debian-11
+  package: deb
+  artifact-from: debian-11
+  artifact-version: 11
+  artifact-type: debian
+  artifact: kong.amd64.deb
+- label: debian-12
+  package: deb
+  artifact-from: debian-12
+  artifact-version: 12
+  artifact-type: debian
+  artifact: kong.amd64.deb
+
+# RHEL
+- label: rhel-7
+  package: rpm
+  artifact-from: rhel-7
+  artifact-version: 7
+  artifact-type: rhel
+  artifact: kong.el7.amd64.rpm
+- label: rhel-8
+  package: rpm
+  artifact-from: rhel-8
+  artifact-version: 8
+  artifact-type: rhel
+  artifact: kong.el8.amd64.rpm
+- label: rhel-9
+  package: rpm
+  artifact-from: rhel-9
+  artifact-version: 9
+  artifact-type: rhel
+  artifact: kong.el9.amd64.rpm
+- label: rhel-9-arm64
+  package: rpm
+  artifact-from: rhel-9-arm64
+  artifact-version: 9
+  artifact-type: rhel
+  artifact: kong.el9.arm64.rpm
+
+# Amazon Linux
+- label: amazonlinux-2
+  package: rpm
+  artifact-from: amazonlinux-2
+  artifact-version: 2
+  artifact-type: amazonlinux
+  artifact: kong.aws2.amd64.rpm
+- label: amazonlinux-2023
+  package: rpm
+  artifact-from: amazonlinux-2023
+  artifact-version: 2023
+  artifact-type: amazonlinux
+  artifact: kong.aws2023.amd64.rpm
+- label: amazonlinux-2023-arm64
+  package: rpm
+  artifact-from: amazonlinux-2023-arm64
+  artifact-version: 2023
+  artifact-type: amazonlinux
+  artifact: kong.aws2023.arm64.rpm
 
 release-images:
 - label: ubuntu
-  package: deb
+- label: debian
+- label: rhel

--- a/scripts/explain_manifest/main.py
+++ b/scripts/explain_manifest/main.py
@@ -84,9 +84,12 @@ def gather_files(path: str, image: str):
             code = os.system(
                 "ar p %s data.tar.gz | tar -C %s -xz" % (path, t.name))
         elif ext == ".rpm":
-            # GNU cpio and rpm2cpio is needed
+            # rpm2cpio is needed
+            # rpm2archive ships with rpm2cpio on debians
             code = os.system(
-                "rpm2cpio %s | cpio --no-preserve-owner --no-absolute-filenames -idm -D %s" % (path, t.name))
+                """
+                    rpm2archive %s && tar -C %s -xf %s.tgz
+                """ % (path, t.name, path))
         elif ext == ".gz":
             code = os.system("tar -C %s -xf %s" % (t.name, path))
 


### PR DESCRIPTION
Github runner's "ubuntu-latest" will be bumped to ubuntu 24.04, thus build outside of docker results in artifacts targeting 24.04.

(cherry picked from commit 8fdfb46b497e6237af0d95b9c75587d5aa17d368)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
