### PR TITLE
fix(tracing): ensure sampling decisions apply to correct trace ID

### DIFF
--- a/changelog/unreleased/kong/fix-tracing-sampling-rate.yml
+++ b/changelog/unreleased/kong/fix-tracing-sampling-rate.yml
@@ -1,3 +1,3 @@
-message: "**OpenTelemetry:** improved accuracy of sampling decisions."
+message: "**OpenTelemetry:** Improved accuracy of sampling decisions."
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/fix-tracing-sampling-rate.yml
+++ b/changelog/unreleased/kong/fix-tracing-sampling-rate.yml
@@ -1,0 +1,3 @@
+message: "**OpenTelemetry:** improved accuracy of sampling decisions."
+type: bugfix
+scope: Plugin

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -243,6 +243,80 @@ for _, strategy in helpers.each_strategy() do
       end)
     end
 
+
+    describe("With config.sampling_rate unset, using global sampling rate: 0.5", function ()
+      local mock
+      local sampling_rate = 0.5
+       -- this trace_id is always sampled with 0.5 rate
+      local sampled_trace_id = "92a54b3e1a7c4f2da9e44b8a6f3e1dab"
+       -- this trace_id is never sampled with 0.5 rate
+      local non_sampled_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+      lazy_setup(function()
+        bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { "opentelemetry" }))
+
+        setup_instrumentations("all", {}, nil, nil, nil, nil, sampling_rate)
+        mock = helpers.http_mock(HTTP_SERVER_PORT, { timeout = HTTP_MOCK_TIMEOUT })
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+        if mock then
+          mock("close", true)
+        end
+      end)
+
+      it("does not sample spans when trace_id == non_sampled_trace_id", function()
+        local cli = helpers.proxy_client(7000, PROXY_PORT)
+        local r = assert(cli:send {
+          method  = "GET",
+          path    = "/",
+          headers = {
+            traceparent = "00-" .. non_sampled_trace_id .. "-0123456789abcdef-01"
+          }
+        })
+        assert.res_status(200, r)
+
+        cli:close()
+
+        ngx.sleep(2)
+        local lines = mock()
+        assert.is_falsy(lines)
+      end)
+
+      it("samples spans when trace_id == sampled_trace_id", function ()
+        for _ = 1, 10 do
+          local body
+          helpers.wait_until(function()
+            local cli = helpers.proxy_client(7000, PROXY_PORT)
+            local r = assert(cli:send {
+              method  = "GET",
+              path    = "/",
+              headers = {
+                traceparent = "00-" .. sampled_trace_id .. "-0123456789abcdef-01"
+              }
+            })
+            assert.res_status(200, r)
+
+            cli:close()
+
+            local lines
+            lines, body = mock()
+            return lines
+          end, 10)
+
+          local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
+          assert.not_nil(decoded)
+          local scope_spans = decoded.resource_spans[1].scope_spans
+          assert.is_true(#scope_spans > 0, scope_spans)
+        end
+      end)
+    end)
+
     for _, case in ipairs{
       {true, true, true},
       {true, true, nil},


### PR DESCRIPTION
### Summary

Kong generates a temporary trace ID when spans are created, this trace ID can be overwritten if tracing headers are passed in the request. Before this change, the global sampling rate from kong.conf was applied to the temporary trace ID, which was only valid for traces created by Kong, and not in distributed tracing scenarios.

This commit ensures the sampling decision always happens during the OTel plugin's access phase so that it is taken after headers have been read, when the trace id is final, to ensure Kong's sampling decision matches that of other tracing systems and therefore guarantee that traces are not broken when sampling rates are set to the same values.
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-4785](https://konghq.atlassian.net/browse/KAG-4785)

[KAG-4785]: https://konghq.atlassian.net/browse/KAG-4785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ