### PR TITLE
docs(changelog): documented dns client behavior revert

### DIFF
--- a/changelog/unreleased/kong/revert-dns-behavior.yml
+++ b/changelog/unreleased/kong/revert-dns-behavior.yml
@@ -1,0 +1,4 @@
+message: "Reverted DNS client to original behaviour of ignoring ADDITIONAL SECTION in DNS responses."
+type: bugfix
+scope: Core
+


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Add changelog to reverted PR.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-6039
