### PR TITLE
fix(package): add missing zlib1g-dev dependency

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -48,6 +48,7 @@ overrides:
     - libpcre3
     - perl
     - libyaml-0-2
+    - zlib1g-dev
   rpm:
     depends:
     - ca-certificates

--- a/changelog/unreleased/kong/add_zlib1g-dev.yml
+++ b/changelog/unreleased/kong/add_zlib1g-dev.yml
@@ -1,0 +1,2 @@
+message: Added zlib1g-dev dependency to Ubuntu packages. 
+type: bugfix 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Added missing zlib1g-dev dependency.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4786
