### PR TITLE
chore(ci): skip uploading centos packages to cloudsmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,7 +618,12 @@ jobs:
         CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         CLOUDSMITH_DRY_RUN: ''
         IGNORE_CLOUDSMITH_FAILURES: ${{ vars.IGNORE_CLOUDSMITH_FAILURES }}
-        USE_CLOUDSMITH: ${{ vars.USE_CLOUDSMITH }}
+        # skip CentOS package uploads for Cloudsmith
+        #
+        # Cloudsmith doesn't support CentOS as a unique distribution
+        # there is only "el" (enterprise linux) distributions that cover all
+        # RedHat-family OSs and that distribution is covered by the rhel label
+        USE_CLOUDSMITH: ${{ ! startsWith(matrix.label, 'centos') || '' && vars.USE_CLOUDSMITH }}
       run: |
         sha256sum bazel-bin/pkg/*
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Skip uploading centos packages to cloudsmith as cloudsmith doesn't support centos. Users should use rhel packages instead.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4786

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
