### PR TITLE
docs(changelog): assemble 2.8.5 changelog into CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Table of Contents
+- [2.8.5](#285)
 - [2.8.4](#284)
 - [2.8.3](#283)
 - [2.8.2](#282)
@@ -64,6 +65,24 @@
 - [0.10.1](#0101---20170327)
 - [0.10.0](#0100---20170307)
 - [0.9.9 and prior](#099---20170202)
+
+## [2.8.5]
+
+### Kong
+
+#### Performance
+##### Performance
+
+- Fixed an inefficiency issue in the Luajit hashing algorithm
+ [#13269](https://github.com/Kong/kong/issues/13269)
+
+
+#### Fixes
+##### Default
+
+- Added zlib1g-dev dependency to Ubuntu packages.
+ [#13269](https://github.com/Kong/kong/issues/13269)
+
 
 ## [2.8.4]
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
assemble 2.8.5 changelog into CHANGELOG.md

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4786
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
