### PR TITLE
fix(core): validation against header regex match

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -196,10 +196,7 @@ local routes = {
             },
           },
         },
-        values = {
-          type = "array",
-          elements = typedefs.regex_or_plain_pattern,
-        }
+        values = typedefs.header_regex_or_plain_pattern,
       } },
 
       { regex_priority = { description = "A number used to choose which route resolves a given request when several routes match it using regexes simultaneously.", type = "integer", default = 0 }, },

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -112,7 +112,6 @@ local OP_IN       = "in"
 
 
 local DOT              = byte(".")
-local TILDE            = byte("~")
 local ASTERISK         = byte("*")
 
 
@@ -424,12 +423,13 @@ local function get_expression(route)
     for h, v in pairs(headers) do
       single_header_buf:reset():put("(")
 
+      local num_v = #v
       for i, value in ipairs(v) do
         local name = "any(lower(http.headers." .. replace_dashes_lower(h) .. "))"
         local op = OP_EQUAL
 
-        -- value starts with "~*"
-        if byte(value, 1) == TILDE and byte(value, 2) == ASTERISK then
+        -- the condition: only 1 value and it starts with `~*`
+        if num_v == 1 and is_regex_magic(value) then
           value = value:sub(3)
           op = OP_REGEX
         end

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -262,8 +262,9 @@ do
   local get_phase = ngx.get_phase
 
   local TILDE = byte("~")
+  local ASTERISK = byte("*")
   is_regex_magic = function(path)
-    return byte(path) == TILDE
+    return byte(path) == TILDE and byte(path, 2) == ASTERISK
   end
 
   local empty_table = {}

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -622,16 +622,29 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
       assert.equal("length must be at least 1", err.headers[1])
     end)
 
-    it("value must be a plain pattern or a valid regex pattern", function()
-      local route = {
-        headers = { location = { "~[" } },
-        protocols = { "http" },
-      }
+    if flavor == "traditional_compatible" then
+      it("value must be a plain pattern or a valid regex pattern", function()
+        local route = {
+          headers = { location = { "~*[" } },
+          protocols = { "http" },
+        }
 
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.match("invalid regex", err.headers[1])
-    end)
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.match("invalid regex", err.headers)
+      end)
+
+      it("multiple patterns are treated as plain patterns", function()
+        local route = {
+          headers = { location = { "~*[", "~*" } },
+          protocols = { "http" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.is_nil(err)
+        assert.truthy(ok)
+      end)
+    end
   end)
 
   describe("methods attribute", function()


### PR DESCRIPTION
### Summary

The regex pattern for header should starts with "\~*" instead of "\~"

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

fixup #12365
fix KAG-4788
