### PR TITLE
feat(dao): add ability to select and delete expired entities

### DIFF
--- a/changelog/unreleased/kong/ttl_expires.yml
+++ b/changelog/unreleased/kong/ttl_expires.yml
@@ -1,3 +1,0 @@
-message: Fixed an issue where can't be deleted or selected an entity after TTL expires.
-type: bugfix
-scope: Core

--- a/changelog/unreleased/kong/ttl_expires.yml
+++ b/changelog/unreleased/kong/ttl_expires.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where can't be deleted or selected an entity after TTL expires.
+type: bugfix
+scope: Core

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -424,7 +424,7 @@ local function execute(strategy, statement_name, attributes, options)
 
   local is_update = options and options.update
   local has_ttl   = strategy.schema.ttl
-
+  local is_skip_ttl = options and options.skip_ttl
   if has_ws_id then
     assert(ws_id == nil or type(ws_id) == "string")
     argv[0] = escape_literal(connector, ws_id, "ws_id")
@@ -433,7 +433,7 @@ local function execute(strategy, statement_name, attributes, options)
   for i = 1, argc do
     local name = argn[i]
     local value
-    if has_ttl and name == "ttl" then
+    if has_ttl and name == "ttl" and not is_skip_ttl then
       value = (options and options.ttl)
               and get_ttl_value(strategy, attributes, options)
 
@@ -576,7 +576,12 @@ end
 
 
 function _mt:select(primary_key, options)
-  local res, err = execute(self, "select", self.collapse(primary_key), options)
+  local statement_name = "select"
+  if self.schema.ttl and options and options.skip_ttl then
+    statement_name = "select_skip_ttl"
+  end
+
+  local res, err = execute(self, statement_name, self.collapse(primary_key), options)
   if res then
     local row = res[1]
     if row then
@@ -592,6 +597,11 @@ end
 
 function _mt:select_by_field(field_name, unique_value, options)
   local statement_name = "select_by_" .. field_name
+
+  if self.schema.ttl and options and options.skip_ttl then
+    statement_name = statement_name .. "_skip_ttl"
+  end
+
   local filter = {
     [field_name] = unique_value,
   }
@@ -695,7 +705,11 @@ end
 
 
 function _mt:delete(primary_key, options)
-  local res, err = execute(self, "delete", self.collapse(primary_key), options)
+  local statement_name = "delete"
+  if self.schema.ttl and options and options.skip_ttl then
+    statement_name = "delete_skip_ttl"
+  end
+  local res, err = execute(self, statement_name, self.collapse(primary_key), options)
   if res then
     if res.affected_rows == 0 then
       return nil, nil
@@ -710,6 +724,9 @@ end
 
 function _mt:delete_by_field(field_name, unique_value, options)
   local statement_name = "delete_by_" .. field_name
+  if self.schema.ttl and options and options.skip_ttl then
+    statement_name = statement_name .. "_skip_ttl"
+  end
   local filter = {
     [field_name] = unique_value,
   }
@@ -1189,6 +1206,19 @@ function _M.new(connector, schema, errors)
     }
   })
 
+  add_statement("delete_skip_ttl", {
+    operation = "write",
+    argn = primary_key_names,
+    argv = primary_key_args,
+    code = {
+      "DELETE\n",
+      "  FROM ", table_name_escaped, "\n",
+      where_clause(
+        " WHERE ", "(" .. pk_escaped .. ") = (" .. primary_key_placeholders .. ")",
+        ws_id_select_where), ";"
+    }
+  })
+
   add_statement("select", {
     operation = "read",
     expr = select_expressions,
@@ -1201,6 +1231,21 @@ function _M.new(connector, schema, errors)
       " WHERE ", "(" .. pk_escaped .. ") = (" .. primary_key_placeholders .. ")",
                  ttl_select_where,
                  ws_id_select_where),
+      " LIMIT 1;"
+    }
+  })
+
+  add_statement("select_skip_ttl", {
+    operation = "read",
+    expr = select_expressions,
+    argn = primary_key_names,
+    argv = primary_key_args,
+    code = {
+      "SELECT ", select_expressions, "\n",
+      "  FROM ", table_name_escaped, "\n",
+      where_clause(
+        " WHERE ", "(" .. pk_escaped .. ") = (" .. primary_key_placeholders .. ")",
+        ws_id_select_where),
       " LIMIT 1;"
     }
   })
@@ -1387,6 +1432,20 @@ function _M.new(connector, schema, errors)
         },
       })
 
+      add_statement("select_by_" .. field_name .. "_skip_ttl", {
+        operation = "read",
+        argn = single_names,
+        argv = single_args,
+        code = {
+          "SELECT ", select_expressions, "\n",
+          "  FROM ", table_name_escaped, "\n",
+          where_clause(
+            " WHERE ", unique_escaped .. " = $1",
+            ws_id_select_where),
+          " LIMIT 1;"
+        },
+      })
+
       local update_by_args_names = {}
       for _, update_name in ipairs(update_names) do
         insert(update_by_args_names, update_name)
@@ -1440,6 +1499,19 @@ function _M.new(connector, schema, errors)
           " WHERE ",  unique_escaped .. " = $1",
                       ttl_select_where,
                       ws_id_select_where), ";"
+        }
+      })
+
+      add_statement("delete_by_" .. field_name .. "_skip_ttl", {
+        operation = "write",
+        argn = single_names,
+        argv = single_args,
+        code = {
+          "DELETE\n",
+          "  FROM ", table_name_escaped, "\n",
+          where_clause(
+            " WHERE ", unique_escaped .. " = $1",
+            ws_id_select_where), ";"
         }
       })
     end

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1215,7 +1215,7 @@ function _M.new(connector, schema, errors)
       "  FROM ", table_name_escaped, "\n",
       where_clause(
         " WHERE ", "(" .. pk_escaped .. ") = (" .. primary_key_placeholders .. ")",
-        ws_id_select_where), ";"
+                   ws_id_select_where), ";"
     }
   })
 
@@ -1245,7 +1245,7 @@ function _M.new(connector, schema, errors)
       "  FROM ", table_name_escaped, "\n",
       where_clause(
         " WHERE ", "(" .. pk_escaped .. ") = (" .. primary_key_placeholders .. ")",
-        ws_id_select_where),
+                   ws_id_select_where),
       " LIMIT 1;"
     }
   })
@@ -1441,7 +1441,7 @@ function _M.new(connector, schema, errors)
           "  FROM ", table_name_escaped, "\n",
           where_clause(
             " WHERE ", unique_escaped .. " = $1",
-            ws_id_select_where),
+                       ws_id_select_where),
           " LIMIT 1;"
         },
       })
@@ -1511,7 +1511,7 @@ function _M.new(connector, schema, errors)
           "  FROM ", table_name_escaped, "\n",
           where_clause(
             " WHERE ", unique_escaped .. " = $1",
-            ws_id_select_where), ";"
+                       ws_id_select_where), ";"
         }
       })
     end

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -424,7 +424,7 @@ local function execute(strategy, statement_name, attributes, options)
 
   local is_update = options and options.update
   local has_ttl   = strategy.schema.ttl
-  local is_skip_ttl = options and options.skip_ttl
+  local skip_ttl = options and options.skip_ttl
   if has_ws_id then
     assert(ws_id == nil or type(ws_id) == "string")
     argv[0] = escape_literal(connector, ws_id, "ws_id")
@@ -433,7 +433,7 @@ local function execute(strategy, statement_name, attributes, options)
   for i = 1, argc do
     local name = argn[i]
     local value
-    if has_ttl and name == "ttl" and not is_skip_ttl then
+    if has_ttl and name == "ttl" and not skip_ttl then
       value = (options and options.ttl)
               and get_ttl_value(strategy, attributes, options)
 

--- a/spec/02-integration/03-db/14-dao_spec.lua
+++ b/spec/02-integration/03-db/14-dao_spec.lua
@@ -16,6 +16,7 @@ for _, strategy in helpers.all_strategies() do
         "services",
         "consumers",
         "acls",
+        "keyauth_credentials",
       })
       _G.kong.db = db
 
@@ -98,6 +99,7 @@ for _, strategy in helpers.all_strategies() do
       db.consumers:truncate()
       db.plugins:truncate()
       db.services:truncate()
+      db.keyauth_credentials:truncate()
     end)
 
     it("select_by_cache_key()", function()
@@ -184,6 +186,36 @@ for _, strategy in helpers.all_strategies() do
       assert.same(new_plugin_config.config.minute, read_plugin.config.minute)
       assert.same(new_plugin_config.config.redis.host, read_plugin.config.redis.host)
       assert.same(new_plugin_config.config.redis.host, read_plugin.config.redis_host) -- legacy field is included
+    end)
+
+    it("keyauth_credentials can be deleted or selected before run ttl cleanup in background timer", function()
+      local key = uuid()
+      local original_keyauth_credentials = bp.keyauth_credentials:insert({
+        consumer = { id = consumer.id },
+        key = key,
+      }, { ttl = 5 })
+
+      -- wait for 5 seconds.
+      ngx.sleep(5)
+
+      -- select or delete keyauth_credentials after ttl expired.
+      local expired_keyauth_credentials
+      helpers.wait_until(function()
+        expired_keyauth_credentials = kong.db.keyauth_credentials:select_by_key(key)
+        return not expired_keyauth_credentials
+      end, 1)
+      assert.is_nil(expired_keyauth_credentials)
+      kong.db.keyauth_credentials:delete_by_key(key)
+
+      -- select or delete keyauth_credentials with skip_ttl=true after ttl expired.
+      expired_keyauth_credentials = kong.db.keyauth_credentials:select_by_key(key, { skip_ttl = true })
+      assert.not_nil(expired_keyauth_credentials)
+      assert.same(expired_keyauth_credentials.id, original_keyauth_credentials.id)
+      kong.db.keyauth_credentials:delete_by_key(key, { skip_ttl = true })
+
+      -- check again
+      expired_keyauth_credentials = kong.db.keyauth_credentials:select_by_key(key, { skip_ttl = true })
+      assert.is_nil(expired_keyauth_credentials)
     end)
   end)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Before running the TTL cleanup in the background timer. it can't delete or select an entity after the TTL expires.
The context of this PR has been written in KAG-4833.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KM-111, [KAG-4833](https://konghq.atlassian.net/browse/KAG-4833)


[KAG-4833]: https://konghq.atlassian.net/browse/KAG-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ