### PR TITLE
chore(release): bump version to 2.8.6

### DIFF
--- a/kong-2.8.6-0.rockspec
+++ b/kong-2.8.6-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong"
-version = "2.8.5-0"
+version = "2.8.6-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "https://github.com/Kong/kong.git",
-  tag = "2.8.5"
+  tag = "2.8.6"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 2,
   minor = 8,
-  patch = 5,
+  patch = 6,
   --suffix = "rc.1"
 }, {
   -- our Makefile during certain releases adjusts this line. Any changes to


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Bump version to 2.8.6 as part of the 2.8.5 release.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference
KAG-4786

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
