### PR TITLE
feat(prometheus): update grafana dashboard

### DIFF
--- a/changelog/unreleased/kong/feat-new-panels-grafana-dashboard.yml
+++ b/changelog/unreleased/kong/feat-new-panels-grafana-dashboard.yml
@@ -1,0 +1,4 @@
+message: |
+  Added new panels to the Grafana dashboard
+type: feature
+scope: Plugin

--- a/kong/plugins/prometheus/grafana/kong-official.json
+++ b/kong/plugins/prometheus/grafana/kong-official.json
@@ -1,3406 +1,7433 @@
 {
-  "__inputs":[
-     {
-        "name":"DS_PROMETHEUS",
-        "label":"Prometheus",
-        "description":"",
-        "type":"datasource",
-        "pluginId":"prometheus",
-        "pluginName":"Prometheus"
-     }
-  ],
-  "__requires":[
-     {
-        "type":"panel",
-        "id":"gauge",
-        "name":"Gauge",
-        "version":""
-     },
-     {
-        "type":"grafana",
-        "id":"grafana",
-        "name":"Grafana",
-        "version":"8.4.5"
-     },
-     {
-        "type":"panel",
-        "id":"graph",
-        "name":"Graph",
-        "version":""
-     },
-     {
-        "type":"panel",
-        "id":"heatmap",
-        "name":"Heatmap",
-        "version":""
-     },
-     {
-        "type":"datasource",
-        "id":"prometheus",
-        "name":"Prometheus",
-        "version":"1.0.0"
-     },
-     {
-        "type":"panel",
-        "id":"singlestat",
-        "name":"Singlestat",
-        "version":""
-     },
-     {
-        "type":"panel",
-        "id":"table",
-        "name":"Table",
-        "version":""
-     }
-  ],
-  "annotations":{
-     "list":[
-        {
-           "builtIn":1,
-           "datasource":"${DS_PROMETHEUS}",
-           "enable":true,
-           "hide":true,
-           "iconColor":"rgba(0, 211, 255, 1)",
-           "name":"Annotations & Alerts",
-           "type":"dashboard"
-        }
-     ]
-  },
-  "description":"Dashboard that graphs metrics exported via Prometheus plugin in Kong (http://github.com/kong/kong)",
-  "editable":true,
-  "gnetId":7424,
-  "graphTooltip":0,
-  "id":null,
-  "iteration":1662693484232,
-  "links":[
-     {
-        "asDropdown":false,
-        "icon":"info",
-        "includeVars":false,
-        "keepTime":false,
-        "tags":[
-
-        ],
-        "targetBlank":true,
-        "title":"Prometheus Plugin Config",
-        "tooltip":"",
-        "type":"link",
-        "url":"https://docs.konghq.com/hub/kong-inc/prometheus/"
-     }
-  ],
-  "panels":[
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":0
-        },
-        "id":38,
-        "panels":[
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"reqps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":24,
-                 "x":0,
-                 "y":1
-              },
-              "hiddenSeries":false,
-              "id":1,
-              "legend":{
-                 "alignAsTable":false,
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "rightSide":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "legend":{
-                    "calcs":[
-
-                    ],
-                    "displayMode":"hidden",
-                    "placement":"bottom"
-                 },
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(rate(kong_http_requests_total{instance=~\"$instance\"}[1m]))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "refId":"A",
-                    "legendFormat":"Requests/second"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Total requests per second (RPS)",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"s",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"reqps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":24,
-                 "x":0,
-                 "y":8
-              },
-              "hiddenSeries":false,
-              "id":16,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "legend":{
-                    "calcs":[
-
-                    ],
-                    "placement":"bottom"
-                 },
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\"}[1m])) by (service)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"service:{{service}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\"}[1m])) by (route)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"route:{{route}}",
-                    "refId":"B"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"RPS per route/service ($service)",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"reqps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":24,
-                 "x":0,
-                 "y":15
-              },
-              "hiddenSeries":false,
-              "id":39,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "legend":{
-                    "calcs":[
-
-                    ],
-                    "placement":"bottom"
-                 },
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\"}[1m])) by (service,code)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"service:{{service}}-{{code}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\"}[1m])) by (route,code)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"route:{{route}}-{{code}}",
-                    "refId":"B"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"RPS per route/service by status code",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           }
-        ],
-        "title":"Request rate",
-        "type":"row"
-     },
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":1
-        },
-        "id":36,
-        "panels":[
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":0,
-                 "y":2
-              },
-              "hiddenSeries":false,
-              "id":10,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Kong Proxy Latency across all services",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":8,
-                 "y":2
-              },
-              "hiddenSeries":false,
-              "id":11,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{service}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{service}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{service}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Kong Proxy Latency per Service",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":16,
-                 "y":2
-              },
-              "hiddenSeries":false,
-              "id":42,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{route}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{route}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{route}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Kong Proxy Latency per Route",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":0,
-                 "y":9
-              },
-              "hiddenSeries":false,
-              "id":12,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Request Time across all services",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":8,
-                 "y":9
-              },
-              "hiddenSeries":false,
-              "id":13,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{service}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{service}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{service}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Request Time per service",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":16,
-                 "y":9
-              },
-              "hiddenSeries":false,
-              "id":41,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{route}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{route}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{route}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Request Time per Route",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":0,
-                 "y":16
-              },
-              "height":"250",
-              "hiddenSeries":false,
-              "id":14,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "interval":"",
-                    "intervalFactor":2,
-                    "legendFormat":"p90",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{}[1m])) by (le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Upstream time across all services",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":8,
-                 "y":16
-              },
-              "height":"250",
-              "hiddenSeries":false,
-              "id":15,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "interval":"",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{service}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{service}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{service}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Upstream Time across per service",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"ms"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":16,
-                 "y":16
-              },
-              "height":"250",
-              "hiddenSeries":false,
-              "id":40,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "interval":"",
-                    "intervalFactor":2,
-                    "legendFormat":"p90-{{route}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p95-{{route}}",
-                    "refId":"B"
-                 },
-                 {
-                    "expr":"histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route,le))",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"p99-{{route}}",
-                    "refId":"C"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Upstream Time across per Route",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"ms",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           }
-        ],
-        "title":"Latencies",
-        "type":"row"
-     },
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":2
-        },
-        "id":34,
-        "panels":[
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"Bps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":24,
-                 "x":0,
-                 "y":3
-              },
-              "hiddenSeries":false,
-              "id":3,
-              "legend":{
-                 "alignAsTable":true,
-                 "avg":true,
-                 "current":true,
-                 "max":true,
-                 "min":true,
-                 "rightSide":true,
-                 "show":true,
-                 "total":false,
-                 "values":true
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "legend":{
-                    "calcs":[
-                       "min",
-                       "max",
-                       "mean",
-                       "lastNotNull"
-                    ],
-                    "displayMode":"table",
-                    "placement":"right"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(irate(kong_bandwidth_bytes{instance=~\"$instance\"}[1m])) by (type)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"{{type}}",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Total Bandwidth",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"Bps",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":false
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"Bps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":12,
-                 "x":0,
-                 "y":10
-              },
-              "hiddenSeries":false,
-              "id":2,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(irate(kong_bandwidth_bytes{direction=\"egress\", service =~\"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (service)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"service:{{service}}",
-                    "refId":"A"
-                 },
-                 {
-                    "expr":"sum(irate(kong_bandwidth_bytes{direction=\"egress\", service =~\"$service\",route=~\"$route\",instance=~\"$instance\"}[1m])) by (route)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"route:{{route}}",
-                    "refId":"B"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Egress per service/route",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"Bps",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"Bps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":12,
-                 "x":12,
-                 "y":10
-              },
-              "hiddenSeries":false,
-              "id":9,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(irate(kong_bandwidth_bytes{direction=\"ingress\", service =~\"$service\"}[1m])) by (service)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"{{service}}",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Ingress per service/route",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"Bps",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           }
-        ],
-        "title":"Bandwidth",
-        "type":"row"
-     },
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":3
-        },
-        "id":28,
-        "panels":[
-           {
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "color":{
-                       "mode":"thresholds"
-                    },
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "mappings":[
-                       {
-                          "from":"",
-                          "id":1,
-                          "operator":"",
-                          "text":"",
-                          "to":"",
-                          "type":1,
-                          "value":""
-                       }
-                    ],
-                    "max":100,
-                    "min":0,
-                    "thresholds":{
-                       "mode":"absolute",
-                       "steps":[
-                          {
-                             "color":"green",
-                             "value":null
-                          },
-                          {
-                             "color":"yellow",
-                             "value":70
-                          },
-                          {
-                             "color":"red",
-                             "value":90
-                          }
-                       ]
-                    },
-                    "unit":"percent"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "gridPos":{
-                 "h":6,
-                 "w":24,
-                 "x":0,
-                 "y":4
-              },
-              "id":22,
-              "options":{
-                 "fieldOptions":{
-                    "calcs":[
-                       "mean"
-                    ],
-                    "defaults":{
-                       "mappings":[
-
-                       ],
-                       "thresholds":{
-                          "mode":"absolute",
-                          "steps":[
-                             {
-                                "color":"green",
-                                "value":null
-                             },
-                             {
-                                "color":"red",
-                                "value":80
-                             }
-                          ]
-                       },
-                       "unit":"percent"
-                    },
-                    "overrides":[
-
-                    ],
-                    "values":false
-                 },
-                 "orientation":"auto",
-                 "reduceOptions":{
-                    "calcs":[
-                       "lastNotNull"
-                    ],
-                    "fields":"",
-                    "values":false
-                 },
-                 "showThresholdLabels":false,
-                 "showThresholdMarkers":true,
-                 "text":{
-
-                 }
-              },
-              "pluginVersion":"8.4.5",
-              "repeat":"instance",
-              "repeatDirection":"v",
-              "targets":[
-                 {
-                    "exemplar":true,
-                    "expr":"(kong_memory_lua_shared_dict_bytes{instance=~\"$instance\"}/kong_memory_lua_shared_dict_total_bytes{instance=~\"$instance\"})*100",
-                    "format":"time_series",
-                    "instant":false,
-                    "interval":"",
-                    "legendFormat":"{{shared_dict}} ({{kong_subsystem}})",
-                    "refId":"A"
-                 }
-              ],
-              "timeFrom":null,
-              "timeShift":null,
-              "title":"Kong shared memory usage by Node ($instance)",
-              "type":"gauge",
-              "xaxis":{
-                 "mode":"time",
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"bytes",
-                    "logBase":1,
-                    "show":true
-                 },
-                 {
-                    "format":"bytes",
-                    "logBase":1,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false
-              }
-           },
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "color":{
-                       "mode":"palette-classic"
-                    },
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "mappings":[
-
-                    ],
-                    "unit":"bytes"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":6,
-                 "w":24,
-                 "x":0,
-                 "y":10
-              },
-              "hiddenSeries":false,
-              "id":43,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "nullPointMode":"null",
-              "options":{
-                 "dataLinks":[
-
-                 ],
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":2,
-              "points":false,
-              "renderer":"flot",
-              "repeat":"instance",
-              "repeatDirection":"v",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "exemplar":true,
-                    "expr":"kong_memory_workers_lua_vms_bytes{instance=~\"$instance\"}",
-                    "format":"time_series",
-                    "instant":false,
-                    "interval":"",
-                    "legendFormat":"PID:{{pid}} ({{kong_subsystem}})",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Kong worker Lua VM usage by Node ($instance)",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "mode":"time",
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"bytes",
-                    "logBase":1,
-                    "show":true
-                 },
-                 {
-                    "format":"bytes",
-                    "logBase":1,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           }
-        ],
-        "title":"Caching",
-        "type":"row"
-     },
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":16
-        },
-        "id":45,
-        "panels":[
-           {
-              "cards":{
-                 "cardPadding":null,
-                 "cardRound":null
-              },
-              "color":{
-                 "cardColor":"#b4ff00",
-                 "colorScale":"sqrt",
-                 "colorScheme":"interpolateRdYlGn",
-                 "exponent":0.5,
-                 "mode":"spectrum"
-              },
-              "dataFormat":"tsbuckets",
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "gridPos":{
-                 "h":8,
-                 "w":12,
-                 "x":0,
-                 "y":17
-              },
-              "heatmap":{
-
-              },
-              "hideZeroBuckets":false,
-              "highlightCards":true,
-              "id":49,
-              "legend":{
-                 "show":false
-              },
-              "pluginVersion":"7.5.4",
-              "reverseYBuckets":false,
-              "targets":[
-                 {
-                    "exemplar":true,
-                    "expr":"sum(kong_upstream_target_health{state=\"healthy\",upstream=~\"$upstream\"}) by (upstream,target,address) * -1  + sum(kong_upstream_target_health{state=~\"(unhealthy|dns_error)\",upstream=~\"$upstream\"}) by (upstream,target,address)",
-                    "format":"heatmap",
-                    "hide":false,
-                    "instant":false,
-                    "interval":"",
-                    "legendFormat":"{{upstream}}:{{target}}",
-                    "refId":"A"
-                 }
-              ],
-              "title":"Healthy status",
-              "tooltip":{
-                 "show":true,
-                 "showHistogram":false
-              },
-              "transformations":[
-                 {
-                    "id":"seriesToColumns",
-                    "options":{
-
-                    }
-                 }
-              ],
-              "type":"heatmap",
-              "xAxis":{
-                 "show":true
-              },
-              "xBucketNumber":null,
-              "xBucketSize":null,
-              "yAxis":{
-                 "decimals":null,
-                 "format":"short",
-                 "logBase":1,
-                 "max":null,
-                 "min":null,
-                 "show":true,
-                 "splitFactor":null
-              },
-              "yBucketBound":"auto",
-              "yBucketNumber":null,
-              "yBucketSize":null
-           },
-           {
-              "columns":[
-
-              ],
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "color":{
-                       "mode":"fixed"
-                    },
-                    "custom":{
-                       "displayMode":"auto",
-                       "filterable":false
-                    },
-                    "mappings":[
-
-                    ],
-                    "thresholds":{
-                       "mode":"absolute",
-                       "steps":[
-                          {
-                             "color":"red",
-                             "value":null
-                          }
-                       ]
-                    },
-                    "unit":"short"
-                 },
-                 "overrides":[
-                    {
-                       "matcher":{
-                          "id":"byName",
-                          "options":"state"
-                       },
-                       "properties":[
-                          {
-                             "id":"custom.displayMode",
-                             "value":"color-background"
-                          },
-                          {
-                             "id":"color",
-                             "value":{
-                                "mode":"thresholds"
-                             }
-                          },
-                          {
-                             "id":"thresholds",
-                             "value":{
-                                "mode":"absolute",
-                                "steps":[
-                                   {
-                                      "color":"red",
-                                      "value":null
-                                   },
-                                   {
-                                      "color":"yellow",
-                                      "value":0
-                                   },
-                                   {
-                                      "color":"green",
-                                      "value":1
-                                   }
-                                ]
-                             }
-                          },
-                          {
-                             "id":"mappings",
-                             "value":[
-                                {
-                                   "from":"",
-                                   "id":1,
-                                   "text":"healthchecks_off",
-                                   "to":"",
-                                   "type":1,
-                                   "value":"0"
-                                },
-                                {
-                                   "from":"",
-                                   "id":2,
-                                   "text":"healthy",
-                                   "to":"",
-                                   "type":1,
-                                   "value":"1"
-                                },
-                                {
-                                   "from":"",
-                                   "id":3,
-                                   "text":"unhealthy",
-                                   "to":"",
-                                   "type":1,
-                                   "value":"-1"
-                                }
-                             ]
-                          }
-                       ]
-                    }
-                 ]
-              },
-              "fontSize":"100%",
-              "gridPos":{
-                 "h":8,
-                 "w":12,
-                 "x":12,
-                 "y":17
-              },
-              "id":47,
-              "options":{
-                 "frameIndex":0,
-                 "showHeader":true
-              },
-              "pageSize":null,
-              "pluginVersion":"7.5.4",
-              "showHeader":true,
-              "sort":{
-                 "col":0,
-                 "desc":true
-              },
-              "styles":[
-                 {
-                    "alias":"",
-                    "align":"auto",
-                    "colorMode":null,
-                    "colors":[
-                       "rgba(245, 54, 54, 0.9)",
-                       "rgba(237, 129, 40, 0.89)",
-                       "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat":"YYYY-MM-DD HH:mm:ss",
-                    "decimals":2,
-                    "mappingType":1,
-                    "pattern":"Time",
-                    "thresholds":[
-
-                    ],
-                    "type":"hidden",
-                    "unit":"short"
-                 },
-                 {
-                    "alias":"",
-                    "align":"auto",
-                    "colorMode":null,
-                    "colors":[
-                       "rgba(245, 54, 54, 0.9)",
-                       "rgba(237, 129, 40, 0.89)",
-                       "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat":"YYYY-MM-DD HH:mm:ss",
-                    "decimals":2,
-                    "mappingType":1,
-                    "pattern":"state",
-                    "thresholds":[
-
-                    ],
-                    "type":"hidden",
-                    "unit":"short"
-                 },
-                 {
-                    "alias":"state",
-                    "align":"auto",
-                    "colorMode":"cell",
-                    "colors":[
-                       "rgba(245, 54, 54, 0.9)",
-                       "#FADE2A",
-                       "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat":"YYYY-MM-DD HH:mm:ss",
-                    "decimals":2,
-                    "mappingType":1,
-                    "pattern":"state_value",
-                    "thresholds":[
-                       "0",
-                       "1"
-                    ],
-                    "type":"string",
-                    "unit":"short",
-                    "valueMaps":[
-                       {
-                          "text":"healthy",
-                          "value":"1"
-                       },
-                       {
-                          "text":"healthchecks_off",
-                          "value":"0"
-                       },
-                       {
-                          "text":"unhealthy",
-                          "value":"-1"
-                       }
-                    ]
-                 },
-                 {
-                    "alias":"",
-                    "align":"auto",
-                    "colorMode":null,
-                    "colors":[
-                       "rgba(245, 54, 54, 0.9)",
-                       "rgba(237, 129, 40, 0.89)",
-                       "rgba(50, 172, 45, 0.97)"
-                    ],
-                    "dateFormat":"YYYY-MM-DD HH:mm:ss",
-                    "decimals":2,
-                    "mappingType":1,
-                    "pattern":"Value",
-                    "thresholds":[
-
-                    ],
-                    "type":"hidden",
-                    "unit":"short"
-                 }
-              ],
-              "targets":[
-                 {
-                    "exemplar":false,
-                    "expr":"sum(\n# map state to a numeric value\n# since grafana doesn't support value mapping yet\n  label_replace(\n    label_replace(\n      label_replace(\n       kong_upstream_target_health{upstream=~\"$upstream\"}\n       # healthy is positive number\n       , \"state_value\", \"1\", \"state\", \"healthy\"\n       # healthchecks_off is 0\n      ), \"state_value\", \"0\", \"state\", \"healthchecks_off\"\n      # unhealthy is negative number\n    ), \"state_value\", \"-1\", \"state\", \"(dns_error|unhealthy)\"\n  )\n)\nby (upstream, target, address, state, state_value) > 0",
-                    "format":"table",
-                    "instant":true,
-                    "interval":"",
-                    "legendFormat":"",
-                    "refId":"A"
-                 }
-              ],
-              "timeFrom":null,
-              "timeShift":null,
-              "transform":"table",
-              "transformations":[
-                 {
-                    "id":"organize",
-                    "options":{
-                       "excludeByName":{
-                          "Time":true,
-                          "Value":true,
-                          "state":true
-                       },
-                       "indexByName":{
-                          "Time":0,
-                          "Value":5,
-                          "address":3,
-                          "state":4,
-                          "target":2,
-                          "upstream":1
-                       },
-                       "renameByName":{
-                          "Value":"report node count",
-                          "state":"state_original",
-                          "state_value":"state"
-                       }
-                    }
-                 }
-              ],
-              "type":"table"
-           }
-        ],
-        "title":"Upstream",
-        "type":"row"
-     },
-     {
-        "collapsed":true,
-        "datasource":"${DS_PROMETHEUS}",
-        "gridPos":{
-           "h":1,
-           "w":24,
-           "x":0,
-           "y":25
-        },
-        "id":25,
-        "panels":[
-           {
-              "aliasColors":{
-
-              },
-              "bars":false,
-              "dashLength":10,
-              "dashes":false,
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-                    "links":[
-
-                    ],
-                    "custom":{
-                       "fillOpacity":10,
-                       "showPoints":"never",
-                       "spanNulls":true
-                    },
-                    "unit":"reqps"
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "fill":1,
-              "fillGradient":0,
-              "gridPos":{
-                 "h":7,
-                 "w":24,
-                 "x":0,
-                 "y":6
-              },
-              "hiddenSeries":false,
-              "id":17,
-              "legend":{
-                 "avg":false,
-                 "current":false,
-                 "max":false,
-                 "min":false,
-                 "show":true,
-                 "total":false,
-                 "values":false
-              },
-              "lines":true,
-              "linewidth":1,
-              "links":[
-
-              ],
-              "nullPointMode":"null",
-              "options":{
-                 "alertThreshold":true,
-                 "tooltip":{
-                    "mode":"multi",
-                    "sort":"none"
-                 }
-              },
-              "paceLength":10,
-              "percentage":false,
-              "pluginVersion":"8.4.5",
-              "pointradius":5,
-              "points":false,
-              "renderer":"flot",
-              "seriesOverrides":[
-
-              ],
-              "spaceLength":10,
-              "stack":false,
-              "steppedLine":false,
-              "targets":[
-                 {
-                    "expr":"sum(kong_nginx_connections_total{state=~\"active|reading|writing|waiting\", instance=~\"$instance\"}) by (state)",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"{{state}}",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":[
-
-              ],
-              "timeFrom":null,
-              "timeRegions":[
-
-              ],
-              "timeShift":null,
-              "title":"Nginx connection state",
-              "tooltip":{
-                 "shared":true,
-                 "sort":0,
-                 "value_type":"individual"
-              },
-              "type":"timeseries",
-              "xaxis":{
-                 "buckets":null,
-                 "mode":"time",
-                 "name":null,
-                 "show":true,
-                 "values":[
-
-                 ]
-              },
-              "yaxes":[
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 },
-                 {
-                    "format":"short",
-                    "label":null,
-                    "logBase":1,
-                    "max":null,
-                    "min":null,
-                    "show":true
-                 }
-              ],
-              "yaxis":{
-                 "align":false,
-                 "alignLevel":null
-              }
-           },
-           {
-              "cacheTimeout":null,
-              "colorBackground":false,
-              "colorValue":false,
-              "colors":[
-                 "#299c46",
-                 "rgba(237, 129, 40, 0.89)",
-                 "#d44a3a"
-              ],
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "format":"none",
-              "gauge":{
-                 "maxValue":100,
-                 "minValue":0,
-                 "show":false,
-                 "thresholdLabels":false,
-                 "thresholdMarkers":true
-              },
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":0,
-                 "y":13
-              },
-              "id":18,
-              "interval":null,
-              "links":[
-
-              ],
-              "mappingType":1,
-              "mappingTypes":[
-                 {
-                    "name":"value to text",
-                    "value":1
-                 },
-                 {
-                    "name":"range to text",
-                    "value":2
-                 }
-              ],
-              "maxDataPoints":100,
-              "nullPointMode":"connected",
-              "nullText":null,
-              "postfix":"",
-              "postfixFontSize":"50%",
-              "prefix":"",
-              "prefixFontSize":"50%",
-              "rangeMaps":[
-                 {
-                    "from":"null",
-                    "text":"N/A",
-                    "to":"null"
-                 }
-              ],
-              "sparkline":{
-                 "fillColor":"#3f6833",
-                 "full":true,
-                 "lineColor":"rgb(31, 120, 193)",
-                 "show":true
-              },
-              "tableColumn":"",
-              "targets":[
-                 {
-                    "exemplar":true,
-                    "expr":"sum(kong_nginx_connections_total{state=\"total\", instance=~\"$instance\"})",
-                    "format":"time_series",
-                    "interval":"",
-                    "intervalFactor":2,
-                    "legendFormat":"Total",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":"",
-              "title":"Total Connections",
-              "type":"singlestat",
-              "valueFontSize":"80%",
-              "valueMaps":[
-                 {
-                    "op":"=",
-                    "text":"N/A",
-                    "value":"null"
-                 }
-              ],
-              "valueName":"current"
-           },
-           {
-              "cacheTimeout":null,
-              "colorBackground":false,
-              "colorValue":false,
-              "colors":[
-                 "#299c46",
-                 "rgba(237, 129, 40, 0.89)",
-                 "#d44a3a"
-              ],
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "format":"none",
-              "gauge":{
-                 "maxValue":100,
-                 "minValue":0,
-                 "show":false,
-                 "thresholdLabels":false,
-                 "thresholdMarkers":true
-              },
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":8,
-                 "y":13
-              },
-              "id":19,
-              "interval":null,
-              "links":[
-
-              ],
-              "mappingType":1,
-              "mappingTypes":[
-                 {
-                    "name":"value to text",
-                    "value":1
-                 },
-                 {
-                    "name":"range to text",
-                    "value":2
-                 }
-              ],
-              "maxDataPoints":100,
-              "nullPointMode":"connected",
-              "nullText":null,
-              "postfix":"",
-              "postfixFontSize":"50%",
-              "prefix":"",
-              "prefixFontSize":"50%",
-              "rangeMaps":[
-                 {
-                    "from":"null",
-                    "text":"N/A",
-                    "to":"null"
-                 }
-              ],
-              "sparkline":{
-                 "fillColor":"#3f6833",
-                 "full":true,
-                 "lineColor":"rgb(31, 120, 193)",
-                 "show":true
-              },
-              "tableColumn":"",
-              "targets":[
-                 {
-                    "expr":"sum(kong_nginx_connections_total{state=\"handled\", instance=~\"$instance\"})",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"Handled",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":"",
-              "title":"Handled Connections",
-              "type":"singlestat",
-              "valueFontSize":"80%",
-              "valueMaps":[
-                 {
-                    "op":"=",
-                    "text":"N/A",
-                    "value":"null"
-                 }
-              ],
-              "valueName":"current"
-           },
-           {
-              "cacheTimeout":null,
-              "colorBackground":false,
-              "colorValue":false,
-              "colors":[
-                 "#299c46",
-                 "rgba(237, 129, 40, 0.89)",
-                 "#d44a3a"
-              ],
-              "datasource":"${DS_PROMETHEUS}",
-              "fieldConfig":{
-                 "defaults":{
-
-                 },
-                 "overrides":[
-
-                 ]
-              },
-              "format":"none",
-              "gauge":{
-                 "maxValue":100,
-                 "minValue":0,
-                 "show":false,
-                 "thresholdLabels":false,
-                 "thresholdMarkers":true
-              },
-              "gridPos":{
-                 "h":7,
-                 "w":8,
-                 "x":16,
-                 "y":13
-              },
-              "id":20,
-              "interval":null,
-              "links":[
-
-              ],
-              "mappingType":1,
-              "mappingTypes":[
-                 {
-                    "name":"value to text",
-                    "value":1
-                 },
-                 {
-                    "name":"range to text",
-                    "value":2
-                 }
-              ],
-              "maxDataPoints":100,
-              "nullPointMode":"connected",
-              "nullText":null,
-              "postfix":"",
-              "postfixFontSize":"50%",
-              "prefix":"",
-              "prefixFontSize":"50%",
-              "rangeMaps":[
-                 {
-                    "from":"null",
-                    "text":"N/A",
-                    "to":"null"
-                 }
-              ],
-              "sparkline":{
-                 "fillColor":"#3f6833",
-                 "full":true,
-                 "lineColor":"rgb(31, 120, 193)",
-                 "show":true
-              },
-              "tableColumn":"",
-              "targets":[
-                 {
-                    "expr":"sum(kong_nginx_connections_total{state=\"accepted\", instance=~\"$instance\"})",
-                    "format":"time_series",
-                    "intervalFactor":2,
-                    "legendFormat":"Accepted",
-                    "refId":"A"
-                 }
-              ],
-              "thresholds":"",
-              "title":"Accepted Connections",
-              "type":"singlestat",
-              "valueFontSize":"80%",
-              "valueMaps":[
-                 {
-                    "op":"=",
-                    "text":"N/A",
-                    "value":"null"
-                 }
-              ],
-              "valueName":"current"
-           }
-        ],
-        "title":"Nginx",
-        "type":"row"
-     }
-  ],
-  "refresh":false,
-  "schemaVersion":22,
-  "style":"dark",
-  "tags":[
-
-  ],
-  "templating":{
-     "list":[
-        {
-           "allValue":".*",
-           "current":{
-
-           },
-           "datasource":"${DS_PROMETHEUS}",
-           "definition":"label_values(kong_http_requests_total,service)",
-           "description":null,
-           "error":null,
-           "hide":0,
-           "includeAll":true,
-           "index":-1,
-           "label":"",
-           "multi":true,
-           "name":"service",
-           "options":[
-
-           ],
-           "query":"label_values(kong_http_requests_total,service)",
-           "refresh":1,
-           "regex":"",
-           "skipUrlSync":false,
-           "sort":1,
-           "tagValuesQuery":"",
-           "tags":[
-
-           ],
-           "tagsQuery":"",
-           "type":"query",
-           "useTags":false
-        },
-        {
-           "allValue":".*",
-           "current":{
-
-           },
-           "datasource":"${DS_PROMETHEUS}",
-           "definition":"label_values(kong_nginx_connections_total,instance)",
-           "description":null,
-           "error":null,
-           "hide":0,
-           "includeAll":true,
-           "index":-1,
-           "label":"",
-           "multi":true,
-           "name":"instance",
-           "options":[
-
-           ],
-           "query":"label_values(kong_nginx_connections_total,instance)",
-           "refresh":2,
-           "regex":".*",
-           "skipUrlSync":false,
-           "sort":1,
-           "tagValuesQuery":"",
-           "tags":[
-
-           ],
-           "tagsQuery":"",
-           "type":"query",
-           "useTags":false
-        },
-        {
-           "allValue":".*",
-           "current":{
-
-           },
-           "datasource":"${DS_PROMETHEUS}",
-           "definition":"label_values(kong_http_requests_total,route)",
-           "description":"Ingress",
-           "error":null,
-           "hide":0,
-           "includeAll":true,
-           "index":-1,
-           "label":"",
-           "multi":true,
-           "name":"route",
-           "options":[
-
-           ],
-           "query":"label_values(kong_http_requests_total,route)",
-           "refresh":1,
-           "regex":"",
-           "skipUrlSync":false,
-           "sort":1,
-           "tagValuesQuery":"",
-           "tags":[
-
-           ],
-           "tagsQuery":"",
-           "type":"query",
-           "useTags":false
-        },
-        {
-           "allValue":null,
-           "current":{
-
-           },
-           "datasource":"${DS_PROMETHEUS}",
-           "definition":"label_values(kong_upstream_target_health, upstream)",
-           "hide":0,
-           "includeAll":true,
-           "index":-1,
-           "label":null,
-           "multi":true,
-           "name":"upstream",
-           "options":[
-
-           ],
-           "query":"label_values(kong_upstream_target_health, upstream)",
-           "refresh":1,
-           "regex":"",
-           "skipUrlSync":false,
-           "sort":0,
-           "tagValuesQuery":"",
-           "tags":[
-
-           ],
-           "tagsQuery":"",
-           "type":"query",
-           "useTags":false
-        },
-        {
-           "current":{
-              "selected":false,
-              "text":"Prometheus",
-              "value":"Prometheus"
-           },
-           "description":null,
-           "error":null,
-           "hide":0,
-           "includeAll":false,
-           "label":"Datasource",
-           "multi":false,
-           "name":"DS_PROMETHEUS",
-           "options":[
-
-           ],
-           "query":"prometheus",
-           "refresh":1,
-           "regex":"",
-           "skipUrlSync":false,
-           "type":"datasource"
-        }
-     ]
-  },
-  "time":{
-     "from":"now-15m",
-     "to":"now"
-  },
-  "timepicker":{
-     "refresh_intervals":[
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-     ],
-     "time_options":[
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-     ]
-  },
-  "timezone":"",
-  "title":"Kong (official)",
-  "uid":"mY9p7dQmz",
-  "variables":{
-     "list":[
-
-     ]
-  },
-  "version":9
+   "annotations": {
+      "list": [
+         {
+            "builtIn": 1,
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+         }
+      ]
+   },
+   "description": "Dashboard that graphs metrics exported via Prometheus plugin in Kong (http://github.com/kong/kong)",
+   "editable": true,
+   "fiscalYearStartMonth": 0,
+   "gnetId": 7424,
+   "graphTooltip": 0,
+   "id": 3,
+   "links": [
+      {
+         "asDropdown": false,
+         "icon": "info",
+         "includeVars": false,
+         "keepTime": false,
+         "tags": [],
+         "targetBlank": true,
+         "title": "Prometheus Plugin Config",
+         "tooltip": "",
+         "type": "link",
+         "url": "https://docs.konghq.com/hub/kong-inc/prometheus/"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 38,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Request rate - no cousumer filtering",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 1
+         },
+         "hiddenSeries": false,
+         "id": 56,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (host)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{host}} Requests/second",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per host - stacked",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 8
+         },
+         "hiddenSeries": false,
+         "id": 1,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\", namespace=~\"$namespace\"}[$range])) by (consumer)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 15
+         },
+         "hiddenSeries": false,
+         "id": 16,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (service)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{service}}",
+               "range": true,
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (route)",
+               "format": "time_series",
+               "hide": true,
+               "intervalFactor": 2,
+               "legendFormat": "route:{{route}}",
+               "range": true,
+               "refId": "B"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per service",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 22
+         },
+         "hiddenSeries": false,
+         "id": 68,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (service, route)",
+               "format": "time_series",
+               "hide": true,
+               "intervalFactor": 2,
+               "legendFormat": "service:{{service}} {{route}}",
+               "range": true,
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (route)",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "{{route}}",
+               "range": true,
+               "refId": "B"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 29
+         },
+         "id": 70,
+         "panels": [],
+         "title": "Request rate per status code",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 30
+         },
+         "hiddenSeries": false,
+         "id": 69,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", code =~\"$code\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by  (code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{code}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per status code",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 37
+         },
+         "hiddenSeries": false,
+         "id": 73,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", code =~\"$code\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (service, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{service}} {{code}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per service and code",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 44
+         },
+         "hiddenSeries": false,
+         "id": 71,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", code =~\"$code\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (route, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{route}} {{code}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per route and code",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 51
+         },
+         "id": 77,
+         "panels": [],
+         "title": "RPS success and error",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 52
+         },
+         "hiddenSeries": false,
+         "id": 74,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", code =~\"$code\", code =~\"2..|3..\", instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (route, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{route}} {{code}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per route and code - success 2xx and 3xx",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 59
+         },
+         "hiddenSeries": false,
+         "id": 75,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\", code =~\"$code\", code =~\"4..|5..\", instance=~\"$instance\", namespace=~\"$namespace\", source=\"service\"}[$range])) by (route, code, source)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{route}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per route and code - error 4xx and 5xx - from upstream service",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisWidth": -1,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 66
+         },
+         "hiddenSeries": false,
+         "id": 76,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{service=~\"$service\", route=~\"$route\",  code =~\"$code\", code =~\"4..|5..\", instance=~\"$instance\", namespace=~\"$namespace\", source!=\"service\"}[$range])) by (route, code, source)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{route}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "RPS per route and code - error 4xx and 5xx - from upstream kong",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 73
+         },
+         "id": 72,
+         "panels": [],
+         "title": "RPS per consumer",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 74
+         },
+         "hiddenSeries": false,
+         "id": 67,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\",code =~\"$code\",  namespace=~\"$namespace\", code =~\"2..|3..\", source=\"service\"}[$range])) by (consumer, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer per code from Upstream service - SUCCESS 2xx and 3xx",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 81
+         },
+         "hiddenSeries": false,
+         "id": 82,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\",code =~\"$code\",  namespace=~\"$namespace\", code =~\"4..|5..\", source=\"service\"}[$range])) by (consumer, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer per code from Upstream service - ERROR 4xx and 5xx",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 88
+         },
+         "hiddenSeries": false,
+         "id": 81,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\",code =~\"$code\", code =~\"2..|3..\", namespace=~\"$namespace\", source=\"service\"}[$range])) by (consumer, route, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{route}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer/route per code from Upstream service - SUCCESS 2xx and 3xx",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 95
+         },
+         "hiddenSeries": false,
+         "id": 83,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\",code =~\"$code\", code =~\"4..|5..\", namespace=~\"$namespace\", source=\"service\"}[$range])) by (consumer, route, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{route}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer/route per code from Upstream service - ERROR 4xx and 5xx",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 102
+         },
+         "hiddenSeries": false,
+         "id": 79,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", consumer=~\"$consumer\",code =~\"$code\",  namespace=~\"$namespace\", source!=\"service\"}[$range])) by (consumer, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer per code from Kong",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 109
+         },
+         "hiddenSeries": false,
+         "id": 80,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": false
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(kong_http_requests_total{instance=~\"$instance\", route=~\"$route\", consumer=~\"$consumer\",code =~\"$code\",  namespace=~\"$namespace\", source!=\"service\"}[$range])) by (consumer, route, source, code)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{consumer}} {{route}} {{code}} {{source}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total requests per second (RPS) per consumer/route/code per code from Kong",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "s",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 116
+         },
+         "id": 36,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Latencies",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 117
+         },
+         "hiddenSeries": false,
+         "id": 10,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{instance=~\"$instance\"}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Kong Proxy Latency across all services",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 117
+         },
+         "hiddenSeries": false,
+         "id": 11,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{service}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{service}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{service}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Kong Proxy Latency per Service",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 117
+         },
+         "hiddenSeries": false,
+         "id": 42,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{route}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{route}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_kong_latency_ms_bucket{ service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{route}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Kong Proxy Latency per Route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 124
+         },
+         "hiddenSeries": false,
+         "id": 12,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Request Time across all services",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 124
+         },
+         "hiddenSeries": false,
+         "id": 13,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{service}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{service}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{service}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Request Time per service",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 124
+         },
+         "hiddenSeries": false,
+         "id": 41,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{route}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{route}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_request_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{route}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Request Time per Route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 131
+         },
+         "height": "250",
+         "hiddenSeries": false,
+         "id": 14,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "interval": "",
+               "intervalFactor": 2,
+               "legendFormat": "p90",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{}[$range])) by (le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Upstream time across all services",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 131
+         },
+         "height": "250",
+         "hiddenSeries": false,
+         "id": 15,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "interval": "",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{service}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{service}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (service,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{service}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Upstream Time across per service",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "ms"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 131
+         },
+         "height": "250",
+         "hiddenSeries": false,
+         "id": 40,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.90, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "interval": "",
+               "intervalFactor": 2,
+               "legendFormat": "p90-{{route}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p95-{{route}}",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(kong_upstream_latency_ms_bucket{service =~ \"$service\",route=~\"$route\",instance=~\"$instance\"}[$range])) by (route,le))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "p99-{{route}}",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Upstream Time across per Route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "ms",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 138
+         },
+         "id": 34,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Bandwidth",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 139
+         },
+         "hiddenSeries": false,
+         "id": 3,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [
+                  "min",
+                  "max",
+                  "mean",
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "single",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(irate(kong_bandwidth_bytes{instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (type)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{type}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Total Bandwidth",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "Bps",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": false
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 146
+         },
+         "hiddenSeries": false,
+         "id": 2,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(irate(kong_bandwidth_bytes{direction=\"egress\", service =~\"$service\",route=~\"$route\",instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (service)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "service:{{service}}",
+               "range": true,
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(irate(kong_bandwidth_bytes{direction=\"egress\", service =~\"$service\",route=~\"$route\",instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (route)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "route:{{route}}",
+               "range": true,
+               "refId": "B"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Egress per service/route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "Bps",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 146
+         },
+         "hiddenSeries": false,
+         "id": 9,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "single",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(irate(kong_bandwidth_bytes{direction=\"ingress\", service =~\"$service\", namespace=~\"$namespace\"}[$range])) by (service)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{service}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Ingress per service/route",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "Bps",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 153
+         },
+         "id": 28,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Caching",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "mappings": [
+                  {
+                     "options": {
+                        "": {
+                           "text": ""
+                        }
+                     },
+                     "type": "value"
+                  }
+               ],
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 70
+                     },
+                     {
+                        "color": "red",
+                        "value": 90
+                     }
+                  ]
+               },
+               "unit": "percent"
+            },
+            "overrides": []
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 154
+         },
+         "id": 22,
+         "options": {
+            "fieldOptions": {
+               "calcs": [
+                  "mean"
+               ],
+               "defaults": {
+                  "mappings": [],
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "green"
+                        },
+                        {
+                           "color": "red",
+                           "value": 80
+                        }
+                     ]
+                  },
+                  "unit": "percent"
+               },
+               "overrides": [],
+               "values": false
+            },
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto",
+            "text": {}
+         },
+         "pluginVersion": "11.0.0",
+         "repeat": "instance",
+         "repeatDirection": "v",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "exemplar": true,
+               "expr": "(kong_memory_lua_shared_dict_bytes{instance=~\"$instance\",shared_dict!~\"kong_process_events\", namespace=~\"$namespace\"}/kong_memory_lua_shared_dict_total_bytes{instance=~\"$instance\",shared_dict!~\"kong_process_events\", namespace=~\"$namespace\"})*100",
+               "format": "time_series",
+               "instant": false,
+               "interval": "",
+               "legendFormat": "{{shared_dict}} ({{kong_subsystem}})",
+               "refId": "A"
+            }
+         ],
+         "title": "Kong shared memory usage by Node ($instance)",
+         "type": "gauge",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "bytes",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "bytes",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "bytes"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 166
+         },
+         "hiddenSeries": false,
+         "id": 43,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "dataLinks": [],
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 2,
+         "points": false,
+         "renderer": "flot",
+         "repeat": "instance",
+         "repeatDirection": "v",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "exemplar": true,
+               "expr": "kong_memory_workers_lua_vms_bytes{instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "instant": false,
+               "interval": "",
+               "legendFormat": "PID:{{pid}} ({{kong_subsystem}})",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Kong worker Lua VM usage by Node ($instance)",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "bytes",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "bytes",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 178
+         },
+         "id": 45,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Upstream",
+         "type": "row"
+      },
+      {
+         "cards": {},
+         "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateRdYlGn",
+            "exponent": 0.5,
+            "mode": "spectrum"
+         },
+         "dataFormat": "tsbuckets",
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "scaleDistribution": {
+                     "type": "linear"
+                  }
+               }
+            },
+            "overrides": []
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 179
+         },
+         "heatmap": {},
+         "hideZeroBuckets": false,
+         "highlightCards": true,
+         "id": 49,
+         "legend": {
+            "show": false
+         },
+         "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+               "exponent": 0.5,
+               "fill": "#b4ff00",
+               "mode": "scheme",
+               "reverse": false,
+               "scale": "exponential",
+               "scheme": "RdYlGn",
+               "steps": 128
+            },
+            "exemplars": {
+               "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+               "le": 1e-9
+            },
+            "legend": {
+               "show": false
+            },
+            "rowsFrame": {
+               "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "single",
+               "showColorScale": false,
+               "yHistogram": false
+            },
+            "yAxis": {
+               "axisPlacement": "left",
+               "reverse": false,
+               "unit": "short"
+            }
+         },
+         "pluginVersion": "11.0.0",
+         "reverseYBuckets": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "exemplar": true,
+               "expr": "sum(kong_upstream_target_health{state=\"healthy\",upstream=~\"$upstream\", namespace=~\"$namespace\"}) by (upstream,target,address) * -1  + sum(kong_upstream_target_health{state=~\"(unhealthy|dns_error)\",upstream=~\"$upstream\", namespace=~\"$namespace\"}) by (upstream,target,address)",
+               "format": "heatmap",
+               "hide": false,
+               "instant": false,
+               "interval": "",
+               "legendFormat": "{{upstream}}:{{target}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Healthy status",
+         "tooltip": {
+            "show": true,
+            "showHistogram": false
+         },
+         "transformations": [
+            {
+               "id": "seriesToColumns",
+               "options": {}
+            }
+         ],
+         "type": "heatmap",
+         "xAxis": {
+            "show": true
+         },
+         "yAxis": {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+         },
+         "yBucketBound": "auto"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "inspect": false
+               },
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Time"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.hidden",
+                        "value": true
+                     },
+                     {
+                        "id": "custom.align"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "state"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.hidden",
+                        "value": true
+                     },
+                     {
+                        "id": "custom.align"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "state_value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "state"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-background"
+                        }
+                     },
+                     {
+                        "id": "custom.align"
+                     },
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "rgba(245, 54, 54, 0.9)",
+                                 "value": null
+                              },
+                              {
+                                 "color": "#FADE2A",
+                                 "value": 0
+                              },
+                              {
+                                 "color": "rgba(50, 172, 45, 0.97)",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.hidden",
+                        "value": true
+                     },
+                     {
+                        "id": "custom.align"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 179
+         },
+         "id": 47,
+         "options": {
+            "cellHeight": "sm",
+            "footer": {
+               "countRows": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "showHeader": true
+         },
+         "pluginVersion": "11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "exemplar": false,
+               "expr": "sum(\n# map state to a numeric value\n# since grafana doesn't support value mapping yet\n  label_replace(\n    label_replace(\n      label_replace(\n       kong_upstream_target_health{upstream=~\"$upstream\"}\n       # healthy is positive number\n       , \"state_value\", \"1\", \"state\", \"healthy\"\n       # healthchecks_off is 0\n      ), \"state_value\", \"0\", \"state\", \"healthchecks_off\"\n      # unhealthy is negative number\n    ), \"state_value\", \"-1\", \"state\", \"(dns_error|unhealthy)\"\n  )\n)\nby (upstream, target, address, state, state_value) > 0",
+               "format": "table",
+               "instant": true,
+               "interval": "",
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true,
+                     "state": true
+                  },
+                  "indexByName": {
+                     "Time": 0,
+                     "Value": 5,
+                     "address": 3,
+                     "state": 4,
+                     "target": 2,
+                     "upstream": 1
+                  },
+                  "renameByName": {
+                     "Value": "report node count",
+                     "state": "state_original",
+                     "state_value": "state"
+                  }
+               }
+            },
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": []
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 187
+         },
+         "id": 25,
+         "panels": [],
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "refId": "A"
+            }
+         ],
+         "title": "Nginx",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 188
+         },
+         "hiddenSeries": false,
+         "id": 17,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(kong_nginx_connections_total{state=~\"active|reading|writing|waiting\", instance=~\"$instance\", namespace=~\"$namespace\"}) by (state)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{state}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "Nginx connection state",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "rgb(31, 120, 193)",
+                  "mode": "fixed"
+               },
+               "mappings": [
+                  {
+                     "options": {
+                        "match": "null",
+                        "result": {
+                           "text": "N/A"
+                        }
+                     },
+                     "type": "special"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "none"
+            },
+            "overrides": []
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 195
+         },
+         "id": 18,
+         "maxDataPoints": 100,
+         "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "pluginVersion": "11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "exemplar": true,
+               "expr": "sum(kong_nginx_connections_total{state=\"total\", instance=~\"$instance\", namespace=~\"$namespace\"})",
+               "format": "time_series",
+               "interval": "",
+               "intervalFactor": 2,
+               "legendFormat": "Total",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "title": "Total Connections",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "rgb(31, 120, 193)",
+                  "mode": "fixed"
+               },
+               "mappings": [
+                  {
+                     "options": {
+                        "match": "null",
+                        "result": {
+                           "text": "N/A"
+                        }
+                     },
+                     "type": "special"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "none"
+            },
+            "overrides": []
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 195
+         },
+         "id": 19,
+         "maxDataPoints": 100,
+         "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "pluginVersion": "11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(kong_nginx_connections_total{state=\"handled\", instance=~\"$instance\", namespace=~\"$namespace\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Handled",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "title": "Handled Connections",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "rgb(31, 120, 193)",
+                  "mode": "fixed"
+               },
+               "mappings": [
+                  {
+                     "options": {
+                        "match": "null",
+                        "result": {
+                           "text": "N/A"
+                        }
+                     },
+                     "type": "special"
+                  }
+               ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "none"
+            },
+            "overrides": []
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 195
+         },
+         "id": 20,
+         "maxDataPoints": 100,
+         "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+         },
+         "pluginVersion": "11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(kong_nginx_connections_total{state=\"accepted\", instance=~\"$instance\", namespace=~\"$namespace\"})",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Accepted",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "title": "Accepted Connections",
+         "type": "stat"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 202
+         },
+         "id": 59,
+         "panels": [],
+         "title": "Container",
+         "type": "row"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 203
+         },
+         "hiddenSeries": false,
+         "id": 60,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(container_cpu_usage_seconds_total{ instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (host)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "CPU usage",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "CPU load",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "bytes"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 203
+         },
+         "hiddenSeries": false,
+         "id": 61,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_rss{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory RSS {{host}}",
+               "range": true,
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_working_set_bytes{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory working set {{host}}",
+               "range": true,
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_usage_bytes{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory usage {{host}}",
+               "range": true,
+               "refId": "C"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "container rss and working set and usage",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "s"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 210
+         },
+         "hiddenSeries": false,
+         "id": 62,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "time() - container_start_time_seconds{instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{host}} start time",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "container uptime",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "bytes"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 210
+         },
+         "hiddenSeries": false,
+         "id": 64,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_cache{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory cache {{host}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "container memory cache",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "bytes"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 217
+         },
+         "hiddenSeries": false,
+         "id": 66,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_mapped_file{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory mapped file{{host}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "container_memory mapped file",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "bytes"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 7,
+            "x": 8,
+            "y": 217
+         },
+         "hiddenSeries": false,
+         "id": 65,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "container_memory_swap{ instance=~\"$instance\", namespace=~\"$namespace\"}",
+               "format": "time_series",
+               "hide": false,
+               "intervalFactor": 2,
+               "legendFormat": "memory swap {{host}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "containercontainer_memory_swap",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "links": [],
+               "mappings": [],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            },
+            "overrides": []
+         },
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 7,
+            "w": 9,
+            "x": 15,
+            "y": 217
+         },
+         "hiddenSeries": false,
+         "id": 63,
+         "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "nullPointMode": "null",
+         "options": {
+            "alertThreshold": true,
+            "legend": {
+               "calcs": [],
+               "displayMode": "list",
+               "placement": "bottom",
+               "showLegend": true
+            },
+            "tooltip": {
+               "maxHeight": 600,
+               "mode": "multi",
+               "sort": "none"
+            }
+         },
+         "paceLength": 10,
+         "percentage": false,
+         "pluginVersion": "8.4.5",
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "PBFA97CFB590B2093"
+               },
+               "editorMode": "code",
+               "expr": "sum(rate(container_fs_writes_bytes_total{ instance=~\"$instance\", namespace=~\"$namespace\"}[$range])) by (host)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "CPU usage",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "thresholds": [],
+         "timeRegions": [],
+         "title": "container_fs_writes_bytes per second",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "timeseries",
+         "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            },
+            {
+               "format": "short",
+               "logBase": 1,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false
+         }
+      }
+   ],
+   "refresh": "",
+   "schemaVersion": 39,
+   "tags": [],
+   "templating": {
+      "list": [
+         {
+            "allValue": ".*",
+            "current": {
+               "isNone": true,
+               "selected": false,
+               "text": "None",
+               "value": ""
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_http_requests_total,namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+               "qryType": 1,
+               "query": "label_values(kong_http_requests_total,namespace)",
+               "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_http_requests_total,service)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "service",
+            "options": [],
+            "query": "label_values(kong_http_requests_total,service)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_nginx_connections_total,instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "instance",
+            "options": [],
+            "query": "label_values(kong_nginx_connections_total,instance)",
+            "refresh": 2,
+            "regex": ".*",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_http_requests_total,route)",
+            "description": "Ingress",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "route",
+            "options": [],
+            "query": "label_values(kong_http_requests_total,route)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_upstream_target_health, upstream)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "upstream",
+            "options": [],
+            "query": "label_values(kong_upstream_target_health, upstream)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "current": {
+               "selected": false,
+               "text": "Prometheus",
+               "value": "PBFA97CFB590B2093"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "DS_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+         },
+         {
+            "auto": false,
+            "auto_count": 30,
+            "auto_min": "10s",
+            "current": {
+               "selected": false,
+               "text": "2m",
+               "value": "2m"
+            },
+            "hide": 0,
+            "name": "range",
+            "options": [
+               {
+                  "selected": true,
+                  "text": "2m",
+                  "value": "2m"
+               },
+               {
+                  "selected": false,
+                  "text": "3m",
+                  "value": "3m"
+               },
+               {
+                  "selected": false,
+                  "text": "5m",
+                  "value": "5m"
+               },
+               {
+                  "selected": false,
+                  "text": "10m",
+                  "value": "10m"
+               },
+               {
+                  "selected": false,
+                  "text": "15m",
+                  "value": "15m"
+               },
+               {
+                  "selected": false,
+                  "text": "30m",
+                  "value": "30m"
+               },
+               {
+                  "selected": false,
+                  "text": "1h",
+                  "value": "1h"
+               },
+               {
+                  "selected": false,
+                  "text": "2h",
+                  "value": "2h"
+               },
+               {
+                  "selected": false,
+                  "text": "4h",
+                  "value": "4h"
+               },
+               {
+                  "selected": false,
+                  "text": "6h",
+                  "value": "6h"
+               },
+               {
+                  "selected": false,
+                  "text": "12h",
+                  "value": "12h"
+               },
+               {
+                  "selected": false,
+                  "text": "1d",
+                  "value": "1d"
+               },
+               {
+                  "selected": false,
+                  "text": "4d",
+                  "value": "4d"
+               },
+               {
+                  "selected": false,
+                  "text": "7d",
+                  "value": "7d"
+               },
+               {
+                  "selected": false,
+                  "text": "14d",
+                  "value": "14d"
+               },
+               {
+                  "selected": false,
+                  "text": "30d",
+                  "value": "30d"
+               },
+               {
+                  "selected": false,
+                  "text": "1m",
+                  "value": "1m"
+               },
+               {
+                  "selected": false,
+                  "text": "90s",
+                  "value": "90s"
+               }
+            ],
+            "query": "2m,3m,5m,10m,15m,30m,1h,2h,4h,6h,12h,1d,4d,7d,14d,30d, 1m, 90s",
+            "queryValue": "",
+            "refresh": 2,
+            "skipUrlSync": false,
+            "type": "interval"
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_http_requests_total,code)",
+            "description": "code / status",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "code",
+            "options": [],
+            "query": {
+               "qryType": 1,
+               "query": "label_values(kong_http_requests_total,code)",
+               "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "selected": true,
+               "text": [
+                  "All"
+               ],
+               "value": [
+                  "$__all"
+               ]
+            },
+            "datasource": {
+               "type": "prometheus",
+               "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(kong_http_requests_total,consumer)",
+            "description": "consumer",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "consumer",
+            "options": [],
+            "query": {
+               "qryType": 1,
+               "query": "label_values(kong_http_requests_total,consumer)",
+               "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-15m",
+      "to": "now"
+   },
+   "timeRangeUpdatedDuringEditOrView": false,
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "",
+   "title": "Nordea Kong (official)",
+   "uid": "mY9p7dQma",
+   "version": 5,
+   "weekStart": ""
 }


### PR DESCRIPTION
### Summary

- new codes (http status) panel
- new consumer panel created
- panels showing 4xx/5xx from kong or upstream
- range 1m not working if Prometheus scrape is 30s. Better to create template variable range, type interval and set values like 2m,3m,5m,10m,15m,30m,1h,2h,4h,6h,12h,1d,4d,7d,14d,30d, 1m, 90s, plus auto tick most variables should be loaded 
- using “on time range change” instead of “on dashboards load. In reality variables are not available when panel is loaded. 
- missing variables for code and status.

### Checklist

- [ ] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
