### PR TITLE
fix(plugins/request-size-limiting): Check the file size when the request body buffered to a temporary file

### DIFF
--- a/changelog/unreleased/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
+++ b/changelog/unreleased/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
@@ -1,0 +1,3 @@
+message: "request-size-limiting check the file size when the request body buffered to a temporary file."
+type: bugfix
+scope: "Plugin"

--- a/changelog/unreleased/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
+++ b/changelog/unreleased/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
@@ -1,3 +1,3 @@
-message: "request-size-limiting check the file size when the request body buffered to a temporary file."
+message: "**Request Size Limiting**: Fixed an issue where the body size doesn't get checked when the request body is buffered to a temporary file."
 type: bugfix
-scope: "Plugin"
+scope: Plugin

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -3,6 +3,7 @@
 local strip = require("kong.tools.string").strip
 local kong_meta = require "kong.meta"
 local tonumber = tonumber
+local lfs = require "lfs"
 
 
 local RequestSizeLimitingHandler = {}
@@ -52,6 +53,15 @@ function RequestSizeLimitingHandler:access(conf)
     local data = kong.request.get_raw_body()
     if data then
       check_size(#data, conf.allowed_payload_size, headers, conf.size_unit)
+    else
+      -- Check the file size when the request body buffered to a temporary file
+      local body_filepath = ngx.req.get_body_file()
+      if body_filepath then
+        local file_size = lfs.attributes(body_filepath, "size")
+        check_size(file_size, conf.allowed_payload_size, headers, conf.size_unit)
+      else 
+        kong.log.warn("missing request body")
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Firstly enable request-size-limiting plugin with below config
```
    plugins:
    - config:
        allowed_payload_size: 512
        require_content_length: false
        size_unit: kilobytes
      enabled: true
      name: request-size-limiting
```

When client send request without content-length and request body chunked with Transfer-Encoding,
then kong.request.get_raw_body() become nil, and request-size-limiting plugin do not work anymore and return 200 directly.

Below curl command could trigger the error:
```
dd if=/dev/urandom of=1m.dat bs=1m count=1
curl -v --data-binary @1m.dat http://kong:8000/test -H "Content-Length:" -H "Transfer-Encoding: chunked"
```

This PR will check the file size when the request body buffered to a temporary file.
Then request-size-limiting plugin still able to get the request body size and work as expected.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #FTI-6034
