### PR TITLE
fix(core): should_warn checks if kong global has been defined

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -887,7 +887,7 @@ function Schema:validate_field(field, value)
 
   if field.deprecation then
     local old_default = field.deprecation.old_default
-    local should_warn = kong.configuration.role ~= "data_plane" and
+    local should_warn = kong and kong.configuration and kong.configuration.role ~= "data_plane" and
                           (old_default == nil
                             or not deepcompare(value, old_default))
     if should_warn then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

After merging: https://github.com/Kong/kong/pull/13069 it was revealed in some tests that `kong` global might not have been initialized yet. This PR checks first if kong global is defined as it's done in a few other places in this module. It's just to make sure unit test work.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
[KAG-4515](https://konghq.atlassian.net/browse/KAG-4515)


[KAG-4515]: https://konghq.atlassian.net/browse/KAG-4515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ