### PR TITLE
feat(admin_api): support map brackets syntax

### DIFF
--- a/changelog/unreleased/kong/admin-api-map-brackets-syntax.yml
+++ b/changelog/unreleased/kong/admin-api-map-brackets-syntax.yml
@@ -1,0 +1,3 @@
+message: "Added support for brackets syntax for map fields configuration via the Admin API"
+type: feature
+scope: Admin API

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -147,6 +147,7 @@ build = {
     ["kong.api"] = "kong/api/init.lua",
     ["kong.api.api_helpers"] = "kong/api/api_helpers.lua",
     ["kong.api.arguments"] = "kong/api/arguments.lua",
+    ["kong.api.arguments_decoder"] = "kong/api/arguments_decoder.lua",
     ["kong.api.endpoints"] = "kong/api/endpoints.lua",
     ["kong.api.routes.cache"] = "kong/api/routes/cache.lua",
     ["kong.api.routes.certificates"] = "kong/api/routes/certificates.lua",

--- a/kong/api/arguments_decoder.lua
+++ b/kong/api/arguments_decoder.lua
@@ -1,0 +1,287 @@
+local getmetatable = getmetatable
+local tonumber     = tonumber
+local rawget       = rawget
+local insert       = table.insert
+local unpack       = table.unpack       -- luacheck: ignore table
+local ipairs       = ipairs
+local pairs        = pairs
+local type         = type
+local ngx          = ngx
+local req          = ngx.req
+local log          = ngx.log
+local re_match     = ngx.re.match
+local re_gmatch    = ngx.re.gmatch
+local re_gsub      = ngx.re.gsub
+local get_method   = req.get_method
+
+
+local NOTICE       = ngx.NOTICE
+
+local ENC_LEFT_SQUARE_BRACKET = "%5B"
+local ENC_RIGHT_SQUARE_BRACKET = "%5D"
+
+
+local multipart_mt = {}
+
+
+function multipart_mt:__tostring()
+  return self.data
+end
+
+
+function multipart_mt:__index(name)
+  local json = rawget(self, "json")
+  if json then
+    return json[name]
+  end
+
+  return nil
+end
+
+
+-- Extracts keys from a string representing a nested table
+-- e.g. [foo][bar][21].key => ["foo", "bar", 21, "key"].
+-- is_map is meant to label patterns that use the bracket map syntax.
+local function extract_param_keys(keys_string)
+  local is_map = false
+
+  -- iterate through keys (split by dots or square brackets)
+  local iterator, err = re_gmatch(keys_string, [=[\.([^\[\.]+)|\[([^\]]*)\]]=], "jos")
+  if not iterator then
+    return nil, err
+  end
+
+  local keys = {}
+  for captures, it_err in iterator do
+    if it_err then
+      log(NOTICE, it_err)
+
+    else
+      local key_name
+      if captures[1] then
+        -- The first capture: `\.([^\[\.]+)` matches dot-separated keys
+        key_name = captures[1]
+
+      else
+        -- The second capture: \[([^\]]*)\] matches bracket-separated keys
+        key_name = captures[2]
+
+        -- If a bracket-separated key is non-empty and non-numeric, set
+        -- is_map to true: foo[test] is a map, foo[] and bar[42] are arrays
+        local map_key_found = key_name ~= "" and tonumber(key_name) == nil
+        if map_key_found then
+          is_map = true
+        end
+      end
+
+      insert(keys, key_name)
+    end
+  end
+
+  return keys, nil, is_map
+end
+
+
+-- Extracts the parameter name and keys from a string
+-- e.g. myparam[foo][bar][21].key => myparam, ["foo", "bar", 21, "key"]
+local function get_param_name_and_keys(name_and_keys)
+  -- key delimiter must appear after the first character
+  -- e.g. for `[5][foo][bar].key`, `[5]` is the parameter name
+  local first_key_delimiter = name_and_keys:find('[%[%.]', 2)
+  if not first_key_delimiter then
+    return nil, "keys not found"
+  end
+
+  local param_name = name_and_keys:sub(1, first_key_delimiter - 1)
+  local keys_string = name_and_keys:sub(first_key_delimiter)
+
+  local keys, err, is_map = extract_param_keys(keys_string)
+  if not keys then
+    return nil, err
+  end
+
+  return param_name, nil, keys, is_map
+end
+
+
+-- Nests the provided path into container
+-- e.g. nest_path({}, {"foo", "bar", 21, "key"}, 42) => { foo = { bar = { [21] = { key = 42 } } } }
+local function nest_path(container, path, value)
+  container = container or {}
+
+  if type(path) ~= "table" then
+    return nil, "path must be a table"
+  end
+
+  for i = 1, #path do
+    local segment = path[i]
+
+    local arr_index = tonumber(segment)
+    -- if it looks like: foo[] or bar[42], it's an array
+    local isarray = segment == "" or arr_index ~= nil
+
+    if isarray then
+      if i == #path then
+
+        if arr_index then
+          insert(container, arr_index, value)
+          return container[arr_index]
+        end
+
+        if type(value) == "table" and getmetatable(value) ~= multipart_mt then
+          for j, v in ipairs(value) do
+            insert(container, j, v)
+          end
+
+          return container
+        end
+
+        container[#container + 1] = value
+        return container
+
+      else
+        local position = arr_index or 1
+        if not container[position] then
+          container[position] = {}
+          container = container[position]
+        end
+      end
+
+    else -- it's a map
+      if i == #path then
+        container[segment] = value
+        return container[segment]
+
+      elseif not container[segment] then
+        container[segment] = {}
+        container = container[segment]
+      end
+    end
+  end
+end
+
+
+-- Decodes a complex argument (map, array or mixed), into a nested table
+-- e.g. foo[bar][21].key, 42 => { foo = { bar = { [21] = { key = 42 } } } }
+local function decode_map_array_arg(name, value, container)
+  local param_name, err, keys, is_map = get_param_name_and_keys(name)
+  if not param_name or not keys or #keys == 0 then
+    return nil, err or "not a map or array"
+  end
+
+  -- the meaning of square brackets varies depending on the http method.
+  -- It is considered a map when a non numeric value exists between brackets
+  -- if the method is POST, PUT, or PATCH, otherwise it is interpreted as LHS
+  -- brackets used for search capabilities (only in EE).
+  if is_map then
+    local method = get_method()
+    if method ~= "POST" and method ~= "PUT" and method ~= "PATCH" then
+      return nil, "map not supported for this method"
+    end
+  end
+
+  local path = {param_name, unpack(keys)}
+  return nest_path(container, path, value)
+end
+
+
+local function decode_complex_arg(name, value, container)
+  container = container or {}
+
+  if type(name) ~= "string" then
+    container[name] = value
+    return container[name]
+  end
+
+  local decoded = decode_map_array_arg(name, value, container)
+  if not decoded then
+    container[name] = value
+    return container[name]
+  end
+
+  return decoded
+end
+
+
+local function decode_arg(raw_name, value)
+  if type(raw_name) ~= "string" or re_match(raw_name, [[^\.+|\.$]], "jos") then
+    return { name = value }
+  end
+
+  -- unescape `[` and `]` characters when the array / map syntax is detected
+  local array_map_pattern = ENC_LEFT_SQUARE_BRACKET .. "(.*?)" .. ENC_RIGHT_SQUARE_BRACKET
+  local name = re_gsub(raw_name, array_map_pattern, "[$1]", "josi")
+
+  -- treat test[foo.bar] as a single match instead of splitting on the dot
+  local iterator, err = re_gmatch(name, [=[([^.](?:\[[^\]]*\])*)+]=], "jos")
+  if not iterator then
+    if err then
+      log(NOTICE, err)
+    end
+
+    return decode_complex_arg(name, value)
+  end
+
+  local names = {}
+  local count = 0
+
+  while true do
+    local captures, err = iterator()
+    if captures then
+      count = count + 1
+      names[count] = captures[0]
+
+    elseif err then
+      log(NOTICE, err)
+      break
+
+    else
+      break
+    end
+  end
+
+  if count == 0 then
+    return decode_complex_arg(name, value)
+  end
+
+  local container = {}
+  local bucket = container
+
+  for i = 1, count do
+    if i == count then
+      decode_complex_arg(names[i], value, bucket)
+      return container
+
+    else
+      bucket = decode_complex_arg(names[i], {}, bucket)
+    end
+  end
+end
+
+
+local function decode(args)
+  local i = 0
+  local r = {}
+
+  if type(args) ~= "table" then
+    return r
+  end
+
+  for name, value in pairs(args) do
+    i = i + 1
+    r[i] = decode_arg(name, value)
+  end
+
+  return r
+end
+
+
+return {
+  decode       = decode,
+  multipart_mt = multipart_mt,
+  _decode_arg  = decode_arg,
+  _extract_param_keys = extract_param_keys,
+  _get_param_name_and_keys = get_param_name_and_keys,
+  _nest_path = nest_path,
+  _decode_map_array_arg = decode_map_array_arg,
+}

--- a/spec/01-unit/01-db/03-arguments_spec.lua
+++ b/spec/01-unit/01-db/03-arguments_spec.lua
@@ -1,366 +1,512 @@
-local arguments    = require "kong.api.arguments"
 local Schema       = require "kong.db.schema"
 local helpers      = require "spec.helpers"
 
+local deep_sort = helpers.deep_sort
 
-local infer_value = arguments.infer_value
-local infer       = arguments.infer
-local decode_arg  = arguments.decode_arg
-local decode      = arguments.decode
-local combine     = arguments.combine
-local deep_sort   = helpers.deep_sort
+describe("arguments tests", function()
 
+  local arguments, infer_value, infer, decode_arg, decode, combine, old_get_method
 
-describe("arguments.infer_value", function()
-  it("infers numbers", function()
-    assert.equal(2, infer_value("2", { type = "number" }))
-    assert.equal(2, infer_value("2", { type = "integer" }))
-    assert.equal(2.5, infer_value("2.5", { type = "number" }))
-    assert.equal(2.5, infer_value("2.5", { type = "integer" })) -- notice that integers are not rounded
+  lazy_setup(function()
+    old_get_method = _G.ngx.req.get_method
+    _G.ngx.req.get_method = function() return "POST" end
+
+    package.loaded["kong.api.arguments"] = nil
+    arguments = require "kong.api.arguments"
+    infer_value = arguments.infer_value
+    infer       = arguments.infer
+    decode_arg  = arguments.decode_arg
+    decode      = arguments.decode
+    combine     = arguments.combine
   end)
 
-  it("infers booleans", function()
-    assert.equal(false, infer_value("false", { type = "boolean" }))
-    assert.equal(true, infer_value("true", { type = "boolean" }))
+  lazy_teardown(function()
+    _G.ngx.req.get_method = old_get_method
   end)
 
-  it("infers arrays and sets", function()
-    assert.same({ "a" }, infer_value("a",   { type = "array", elements = { type = "string" } }))
-    assert.same({ 2 },   infer_value("2",   { type = "array", elements = { type = "number" } }))
-    assert.same({ "a" }, infer_value({"a"}, { type = "array", elements = { type = "string" } }))
-    assert.same({ 2 },   infer_value({"2"}, { type = "array", elements = { type = "number" } }))
+  describe("arguments.infer_value", function()
+    it("infers numbers", function()
+      assert.equal(2, infer_value("2", { type = "number" }))
+      assert.equal(2, infer_value("2", { type = "integer" }))
+      assert.equal(2.5, infer_value("2.5", { type = "number" }))
+      assert.equal(2.5, infer_value("2.5", { type = "integer" })) -- notice that integers are not rounded
+    end)
 
-    assert.same({ "a" }, infer_value("a",   { type = "set", elements = { type = "string" } }))
-    assert.same({ 2 },   infer_value("2",   { type = "set", elements = { type = "number" } }))
-    assert.same({ "a" }, infer_value({"a"}, { type = "set", elements = { type = "string" } }))
-    assert.same({ 2 },   infer_value({"2"}, { type = "set", elements = { type = "number" } }))
+    it("infers booleans", function()
+      assert.equal(false, infer_value("false", { type = "boolean" }))
+      assert.equal(true, infer_value("true", { type = "boolean" }))
+    end)
+
+    it("infers arrays and sets", function()
+      assert.same({ "a" }, infer_value("a",   { type = "array", elements = { type = "string" } }))
+      assert.same({ 2 },   infer_value("2",   { type = "array", elements = { type = "number" } }))
+      assert.same({ "a" }, infer_value({"a"}, { type = "array", elements = { type = "string" } }))
+      assert.same({ 2 },   infer_value({"2"}, { type = "array", elements = { type = "number" } }))
+
+      assert.same({ "a" }, infer_value("a",   { type = "set", elements = { type = "string" } }))
+      assert.same({ 2 },   infer_value("2",   { type = "set", elements = { type = "number" } }))
+      assert.same({ "a" }, infer_value({"a"}, { type = "set", elements = { type = "string" } }))
+      assert.same({ 2 },   infer_value({"2"}, { type = "set", elements = { type = "number" } }))
+    end)
+
+    it("infers nulls from empty strings", function()
+      assert.equal(ngx.null, infer_value("", { type = "string" }))
+      assert.equal(ngx.null, infer_value("", { type = "array" }))
+      assert.equal(ngx.null, infer_value("", { type = "set" }))
+      assert.equal(ngx.null, infer_value("", { type = "number" }))
+      assert.equal(ngx.null, infer_value("", { type = "integer" }))
+      assert.equal(ngx.null, infer_value("", { type = "boolean" }))
+      assert.equal(ngx.null, infer_value("", { type = "foreign" }))
+      assert.equal(ngx.null, infer_value("", { type = "map" }))
+      assert.equal(ngx.null, infer_value("", { type = "record" }))
+    end)
+
+    it("doesn't infer nulls from empty strings on unknown types", function()
+      assert.equal("", infer_value(""))
+    end)
+
+    it("infers maps", function()
+      assert.same({ x = "1" }, infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "string" } }))
+      assert.same({ x = 1 },   infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "number" } }))
+    end)
+
+    it("infers records", function()
+      assert.same({ age = "1" }, infer_value({ age = "1" },
+                                             { type = "record", fields = {{ age = { type = "string" } } }}))
+      assert.same({ age = 1 },   infer_value({ age = "1" },
+                                             { type = "record", fields = {{ age = { type = "number" } } }}))
+    end)
+
+    it("returns the provided value when inferring is not possible", function()
+      assert.equal("not number", infer_value("not number", { type = "number" }))
+      assert.equal("not integer", infer_value("not integer", { type = "integer" }))
+      assert.equal("not boolean", infer_value("not boolean", { type = "boolean" }))
+    end)
   end)
 
-  it("infers nulls from empty strings", function()
-    assert.equal(ngx.null, infer_value("", { type = "string" }))
-    assert.equal(ngx.null, infer_value("", { type = "array" }))
-    assert.equal(ngx.null, infer_value("", { type = "set" }))
-    assert.equal(ngx.null, infer_value("", { type = "number" }))
-    assert.equal(ngx.null, infer_value("", { type = "integer" }))
-    assert.equal(ngx.null, infer_value("", { type = "boolean" }))
-    assert.equal(ngx.null, infer_value("", { type = "foreign" }))
-    assert.equal(ngx.null, infer_value("", { type = "map" }))
-    assert.equal(ngx.null, infer_value("", { type = "record" }))
-  end)
 
-  it("doesn't infer nulls from empty strings on unknown types", function()
-    assert.equal("", infer_value(""))
-  end)
+  describe("arguments.infer", function()
+    it("returns nil for nil args", function()
+      assert.is_nil(infer())
+    end)
 
-  it("infers maps", function()
-    assert.same({ x = "1" }, infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "string" } }))
-    assert.same({ x = 1 },   infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "number" } }))
-  end)
+    it("does no inferring without schema", function()
+      assert.same("args", infer("args"))
+    end)
 
-  it("infers records", function()
-    assert.same({ age = "1" }, infer_value({ age = "1" },
-                                           { type = "record", fields = {{ age = { type = "string" } } }}))
-    assert.same({ age = 1 },   infer_value({ age = "1" },
-                                           { type = "record", fields = {{ age = { type = "number" } } }}))
-  end)
-
-  it("returns the provided value when inferring is not possible", function()
-    assert.equal("not number", infer_value("not number", { type = "number" }))
-    assert.equal("not integer", infer_value("not integer", { type = "integer" }))
-    assert.equal("not boolean", infer_value("not boolean", { type = "boolean" }))
-  end)
-end)
-
-
-describe("arguments.infer", function()
-  it("returns nil for nil args", function()
-    assert.is_nil(infer())
-  end)
-
-  it("does no inferring without schema", function()
-    assert.same("args", infer("args"))
-  end)
-
-  it("infers every field using the schema", function()
-    local schema = Schema.new({
-      fields = {
-        { name = { type = "string" } },
-        { age  = { type = "number" } },
-        { has_license = { type = "boolean" } },
-        { aliases = { type = "set", elements = { type = { "string" } } } },
-        { comments = { type = "string" } },
-      }
-    })
-
-    local args = { name = "peter",
-                   age = "45",
-                   has_license = "true",
-                   aliases = "peta",
-                   comments = "" }
-    assert.same({
-      name = "peter",
-      age = 45,
-      has_license = true,
-      aliases = { "peta" },
-      comments = ngx.null
-    }, infer(args, schema))
-  end)
-
-  it("infers shorthand_fields but does not run the func", function()
-    local schema = Schema.new({
-      fields = {
-        { name = { type = "string" } },
-        { another_array = { type = "array", elements = { type = { "string" } } } },
-      },
-      shorthand_fields = {
-        { an_array = {
-            type = "array",
-            elements = { type = { "string" } },
-            func = function(value)
-              return { another_array = value:upper() }
-            end,
-          }
-        },
-      }
-    })
-
-    local args = { name = "peter",
-                   an_array = "something" }
-    assert.same({
-      name = "peter",
-      an_array = { "something" },
-    }, infer(args, schema))
-  end)
-
-end)
-
-describe("arguments.combine", function()
-  it("merges arguments together, creating arrays when finding repeated names, recursively", function()
-    local monster = {
-      { a = { [99] = "wayne", }, },
-      { a = { "first", }, },
-      { a = { b = { c = { "true", }, }, }, },
-      { a = { "a", "b", "c" }, },
-      { a = { b = { c = { d = "" }, }, }, },
-      { c = "test", },
-      { a = { "1", "2", "3", }, },
-    }
-
-    local combined_monster = {
-      a = {
-        { "first", "a", "1" }, { "b", "2" }, { "c", "3" },
-        [99] = "wayne",
-        b = { c = { "true", d = "", }, }
-      },
-      c = "test",
-    }
-
-    assert.same(combined_monster, combine(monster))
-  end)
-end)
-
-
-describe("arguments.decode_arg", function()
-  it("does not infer numbers, booleans or nulls from strings", function()
-    assert.same({ x = "" }, decode_arg("x", ""))
-    assert.same({ x = "true" }, decode_arg("x", "true"))
-    assert.same({ x = "false" }, decode_arg("x", "false"))
-    assert.same({ x = "10" }, decode_arg("x", "10"))
-  end)
-
-  it("decodes arrays", function()
-    assert.same({ x = { "a" } }, decode_arg("x[]", "a"))
-    assert.same({ x = { "a" } }, decode_arg("x[1]", "a"))
-    assert.same({ x = { nil, "a" } }, decode_arg("x[2]", "a"))
-  end)
-
-  it("decodes nested arrays", function()
-    assert.same({ x = { { "a" } } }, decode_arg("x[1][1]", "a"))
-    assert.same({ x = { nil, { "a" } } }, decode_arg("x[2][1]", "a"))
-  end)
-end)
-
-describe("arguments.decode", function()
-
-  it("decodes complex nested parameters", function()
-    assert.same(deep_sort{
-      c = "test",
-      a = {
-        {
-          "first",
-          "a",
-          "1",
-        },
-        {
-          "b",
-          "2",
-        },
-        {
-          "c",
-          "3",
-        },
-        [99] = "wayne",
-        b = {
-          c = {
-            "true",
-            d = ""
-          }
+    it("infers every field using the schema", function()
+      local schema = Schema.new({
+        fields = {
+          { name = { type = "string" } },
+          { age  = { type = "number" } },
+          { has_license = { type = "boolean" } },
+          { aliases = { type = "set", elements = { type = { "string" } } } },
+          { comments = { type = "string" } },
         }
-      },
-    },
-    deep_sort(decode{
-      ["a.b.c.d"] = "",
-      ["a"]       = { "1", "2", "3" },
-      ["c"]       = "test",
-      ["a.b.c"]   = { "true" },
-      ["a[]"]     = { "a", "b", "c" },
-      ["a[99]"]   = "wayne",
-      ["a[1]"]    = "first",
-    }))
-  end)
+      })
 
-  it("decodes complex nested parameters combinations", function()
-    assert.same({
-      a = {
-        {
-          "a",
-          cat = "tommy"
+      local args = { name = "peter",
+                     age = "45",
+                     has_license = "true",
+                     aliases = "peta",
+                     comments = "" }
+      assert.same({
+        name = "peter",
+        age = 45,
+        has_license = true,
+        aliases = { "peta" },
+        comments = ngx.null
+      }, infer(args, schema))
+    end)
+
+    it("infers shorthand_fields but does not run the func", function()
+      local schema = Schema.new({
+        fields = {
+          { name = { type = "string" } },
+          { another_array = { type = "array", elements = { type = { "string" } } } },
         },
-        {
-          "b1",
-          "b2",
-          dog = "jake"
+        shorthand_fields = {
+          { an_array = {
+              type = "array",
+              elements = { type = { "string" } },
+              func = function(value)
+                return { another_array = value:upper() }
+              end,
+            }
+          },
+        }
+      })
+
+      local args = { name = "peter",
+                     an_array = "something" }
+      assert.same({
+        name = "peter",
+        an_array = { "something" },
+      }, infer(args, schema))
+    end)
+
+  end)
+
+  describe("arguments.combine", function()
+    it("merges arguments together, creating arrays when finding repeated names, recursively", function()
+      local monster = {
+        { a = { [99] = "wayne", }, },
+        { a = { "first", }, },
+        { a = { b = { c = { "true", }, }, }, },
+        { a = { "a", "b", "c" }, },
+        { a = { b = { c = { d = "" }, }, }, },
+        { c = "test", },
+        { a = { "1", "2", "3", }, },
+      }
+
+      local combined_monster = {
+        a = {
+          { "first", "a", "1" }, { "b", "2" }, { "c", "3" },
+          [99] = "wayne",
+          b = { c = { "true", d = "", }, }
         },
-        {
-          "c",
-          cat = { "tommy", "the", "cat" },
+        c = "test",
+      }
+
+      assert.same(combined_monster, combine(monster))
+    end)
+  end)
+
+
+  describe("arguments.decode_arg", function()
+    it("does not infer numbers, booleans or nulls from strings", function()
+      assert.same({ x = "" }, decode_arg("x", ""))
+      assert.same({ x = "true" }, decode_arg("x", "true"))
+      assert.same({ x = "false" }, decode_arg("x", "false"))
+      assert.same({ x = "10" }, decode_arg("x", "10"))
+    end)
+
+    it("decodes arrays", function()
+      assert.same({ x = { "a" } }, decode_arg("x[]", "a"))
+      assert.same({ x = { "a" } }, decode_arg("x[1]", "a"))
+      assert.same({ x = { nil, "a" } }, decode_arg("x[2]", "a"))
+    end)
+
+    it("decodes nested arrays", function()
+      assert.same({ x = { { "a" } } }, decode_arg("x[1][1]", "a"))
+      assert.same({ x = { nil, { "a" } } }, decode_arg("x[2][1]", "a"))
+    end)
+  end)
+
+  describe("arguments.decode", function()
+
+    it("decodes complex nested parameters", function()
+      assert.same(deep_sort{
+        c = "test",
+        a = {
+          {
+            "first",
+            "a",
+            "1",
+          },
+          {
+            "b",
+            "2",
+          },
+          {
+            "c",
+            "3",
+          },
+          [99] = "wayne",
+          b = {
+            [1] = "x",
+            [2] = "y",
+            [3] = "z",
+            [98] = "wayne",
+            c = {
+              "true",
+              d = "",
+              ["test.key"] = {
+                "d",
+                "e",
+                "f",
+              },
+              ["escaped.k.2"] = {
+                "d",
+                "e",
+                "f",
+              }
+            }
+          },
+          foo = "bar",
+          escaped_k_1 = "bar",
         },
-        {
-          "d1",
-          "d2",
-          dog = { "jake", "the", "dog" }
-        }
-      }
-    },
-    decode{
-      ["a[1]"] = "a",
-      ["a[1].cat"] = "tommy",
-      ["a[2]"] = { "b1", "b2" },
-      ["a[2].dog"] = "jake",
-      ["a[3]"] = "c",
-      ["a[3].cat"] = { "tommy", "the", "cat" },
-      ["a[4]"] = { "d1", "d2" },
-      ["a[4].dog"] = { "jake", "the", "dog" },
-    })
-  end)
-
-  it("decodes multidimensional arrays", function()
-    assert.same({
-      key = {
-        { "value" }
-      }
-    },
-    decode{
-      ["key[][]"] = "value",
-    })
-
-    assert.same({
-      key = {
-        [5] = { [4] = "value" }
-      }
-    },
-    decode{
-      ["key[5][4]"] = "value",
-    })
-
-    assert.same({
-      key = {
-        [5] = { [4] = { key = "value" } }
-      }
-    },
-    decode{
-      ["key[5][4].key"] = "value",
-    })
-
-    assert.same({
-      ["[5]"] = {{ [4] = { key = "value" } }}
-    },
-    decode{
-      ["[5][1][4].key"] = "value"
-    })
-  end)
-
-  pending("decodes different array representations", function()
-    -- undefined:  the result depends on whether `["a"]` or `["a[2]"]` is applied first
-    -- but there's no way to guarantee order without adding a "presort keys" step.
-    -- but it's unlikely that a real-world client uses both forms in the same request,
-    -- instead of making `decode()` slower, split test in two
-    local decoded = decode{
-      ["a"]    = { "1", "2" },
-      ["a[]"]  = "3",
-      ["a[1]"] = "4",
-      ["a[2]"] = { "5", "6" },
-    }
-
-    assert.same(
-      deep_sort{ a = {
-          { "4", "1", "3" },
-          { "5", "6", "2" },
-        }
-      },
-      deep_sort(decoded)
-    )
-  end)
-
-  it("decodes different array representations", function()
-    -- same as previous test, but split to reduce ordering dependency
-    assert.same(
-      { a = {
-        "2",
-        { "1", "3", "4" },
-        }
       },
       deep_sort(decode{
+        ["a.b.c.d"]   = "",
+        ["a"]         = { "1", "2", "3" },
+        ["c"]         = "test",
+        ["a.b.c"]     = { "true" },
+        ["a[]"]       = { "a", "b", "c" },
+        ["a[99]"]     = "wayne",
+        ["a[1]"]      = "first",
+        ["a[foo]"]    = "bar",
+        ["a.b%5B%5D"]   = { "x", "y", "z" },
+        ["a.b%5B98%5D"] = "wayne",
+        ["a.b.c[test.key]"]        = { "d", "e", "f" },
+        ["a%5Bescaped_k_1%5D"]     = "bar",
+        ["a.b.c%5Bescaped.k.2%5D"] = { "d", "e", "f" },
+      }))
+
+      assert.same(deep_sort{
+        a = {
+          b = {
+            c = {
+              ["escaped.k.3"] = {
+                "d",
+                "e",
+                "f",
+              }
+            }
+          },
+          escaped_k_1 = "bar",
+          ESCAPED_K_2 = "baz",
+          ["escaped%5B_k_4"] = "vvv",
+          ["escaped.k_5"] = {
+            nested = "ww",
+          }
+        },
+      },
+      deep_sort(decode{
+        ["a%5Bescaped_k_1%5D"]        = "bar",
+        ["a%5BESCAPED_K_2%5D"]        = "baz",
+        ["a.b.c%5Bescaped.k.3%5D"]    = { "d", "e", "f" },
+        ["a%5Bescaped%5B_k_4%5D"]     = "vvv",
+        ["a%5Bescaped.k_5%5D.nested"] = "ww",
+      }))
+    end)
+
+    it("decodes complex nested parameters combinations", function()
+      assert.same({
+        a = {
+          {
+            "a",
+            cat = "tommy"
+          },
+          {
+            "b1",
+            "b2",
+            dog = "jake"
+          },
+          {
+            "c",
+            cat = { "tommy", "the", "cat" },
+          },
+          {
+            "d1",
+            "d2",
+            dog = { "jake", "the", "dog" }
+          },
+          {
+            "e1",
+            "e2",
+            dog = { "finn", "the", "human" }
+          },
+          one = {
+            "a",
+            cat = "tommy"
+          },
+          two = {
+            "b1",
+            "b2",
+            dog = "jake"
+          },
+          three = {
+            "c",
+            cat = { "tommy", "the", "cat" },
+          },
+          four = {
+            "d1",
+            "d2",
+            dog = { "jake", "the", "dog" }
+          },
+          five = {
+            "e1",
+            "e2",
+            dog = { "finn", "the", "human" }
+          },
+        }
+      },
+      decode{
+        ["a[1]"] = "a",
+        ["a[1].cat"] = "tommy",
+        ["a[2]"] = { "b1", "b2" },
+        ["a[2].dog"] = "jake",
+        ["a[3]"] = "c",
+        ["a[3].cat"] = { "tommy", "the", "cat" },
+        ["a[4]"] = { "d1", "d2" },
+        ["a[4].dog"] = { "jake", "the", "dog" },
+        ["a%5B5%5D"] = { "e1", "e2" },
+        ["a%5B5%5D.dog"] = { "finn", "the", "human" },
+        ["a[one]"] = "a",
+        ["a[one].cat"] = "tommy",
+        ["a[two]"] = { "b1", "b2" },
+        ["a[two].dog"] = "jake",
+        ["a[three]"] = "c",
+        ["a[three].cat"] = { "tommy", "the", "cat" },
+        ["a[four]"] = { "d1", "d2" },
+        ["a[four].dog"] = { "jake", "the", "dog" },
+        ["a%5Bfive%5D"] = { "e1", "e2" },
+        ["a%5Bfive%5D.dog"] = { "finn", "the", "human" },
+      })
+    end)
+
+    it("decodes multidimensional arrays and maps", function()
+      assert.same({
+        key = {
+          { "value" }
+        }
+      },
+      decode{
+        ["key[][]"] = "value",
+      })
+
+      assert.same({
+        key = {
+          [5] = { [4] = "value" }
+        }
+      },
+      decode{
+        ["key[5][4]"] = "value",
+      })
+
+      assert.same({
+        key = {
+          foo = { bar = "value" }
+        }
+      },
+      decode{
+        ["key[foo][bar]"] = "value",
+      })
+
+      assert.same({
+        key = {
+          [5] = { [4] = { key = "value" } }
+        }
+      },
+      decode{
+        ["key[5][4].key"] = "value",
+      })
+
+      assert.same({
+        key = {
+          [5] = { [4] = { key = "value" } }
+        }
+      },
+      decode{
+        ["key%5B5%5D%5B4%5D.key"] = "value",
+      })
+
+      assert.same({
+        key = {
+          foo = { bar = { key = "value" } }
+        }
+      },
+      decode{
+        ["key[foo][bar].key"] = "value",
+      })
+
+      assert.same({
+        ["[5]"] = {{ [4] = { key = "value" } }}
+      },
+      decode{
+        ["[5][1][4].key"] = "value"
+      })
+
+      assert.same({
+        ["[5]"] = { foo = { bar = { key = "value" } }}
+      },
+      decode{
+        ["[5][foo][bar].key"] = "value"
+      })
+
+      assert.same({
+        key = {
+          foo = { bar = { key = "value" } }
+        }
+      },
+      decode{
+        ["key%5Bfoo%5D%5Bbar%5D.key"] = "value",
+      })
+    end)
+
+    pending("decodes different array representations", function()
+      -- undefined:  the result depends on whether `["a"]` or `["a[2]"]` is applied first
+      -- but there's no way to guarantee order without adding a "presort keys" step.
+      -- but it's unlikely that a real-world client uses both forms in the same request,
+      -- instead of making `decode()` slower, split test in two
+      local decoded = decode{
         ["a"]    = { "1", "2" },
         ["a[]"]  = "3",
         ["a[1]"] = "4",
-      }))
-
-    assert.same(
-      { a = {
-          { "3", "4" },
-          { "5", "6" },
-        }
-      },
-      deep_sort(decode{
-        ["a[]"]  = "3",
-        ["a[1]"] = "4",
         ["a[2]"] = { "5", "6" },
-      }))
-  end)
-
-  it("infers values when provided with a schema", function()
-    local schema = Schema.new({
-      fields = {
-        { name = { type = "string" } },
-        { age  = { type = "number" } },
-        { has_license = { type = "boolean" } },
-        { aliases = { type = "set", elements = { type = { "string" } } } },
-        { comments = { type = "string" } },
       }
-    })
 
-    local args = { name = "peter",
-                   age = "45",
-                   has_license = "true",
-                   ["aliases[]"] = "peta",
-                   comments = "" }
-    assert.same({
-      name = "peter",
-      age = 45,
-      has_license = true,
-      aliases = { "peta" },
-      comments = ngx.null
-    }, decode(args, schema))
+      assert.same(
+        deep_sort{ a = {
+            { "4", "1", "3" },
+            { "5", "6", "2" },
+          }
+        },
+        deep_sort(decoded)
+      )
+    end)
+
+    it("decodes different array representations", function()
+      -- same as previous test, but split to reduce ordering dependency
+      assert.same(
+        { a = {
+          "2",
+          { "1", "3", "4" },
+          }
+        },
+        deep_sort(decode{
+          ["a"]    = { "1", "2" },
+          ["a[]"]  = "3",
+          ["a[1]"] = "4",
+        }))
+
+      assert.same(
+        { a = {
+            { "3", "4" },
+            { "5", "6" },
+          }
+        },
+        deep_sort(decode{
+          ["a[]"]  = "3",
+          ["a[1]"] = "4",
+          ["a[2]"] = { "5", "6" },
+        }))
+    end)
+
+    it("infers values when provided with a schema", function()
+      local schema = Schema.new({
+        fields = {
+          { name = { type = "string" } },
+          { age  = { type = "number" } },
+          { has_license = { type = "boolean" } },
+          { aliases = { type = "set", elements = { type = { "string" } } } },
+          { comments = { type = "string" } },
+        }
+      })
+
+      local args = { name = "peter",
+                     age = "45",
+                     has_license = "true",
+                     ["aliases[]"] = "peta",
+                     comments = "" }
+      assert.same({
+        name = "peter",
+        age = 45,
+        has_license = true,
+        aliases = { "peta" },
+        comments = ngx.null
+      }, decode(args, schema))
+    end)
   end)
 end)


### PR DESCRIPTION
## Note for reviewers: use hide whitespace if reviewing from gh

### Summary

This commit adds support for configuring maps using brackets syntax to
enclose the key:

```
http -f post :8001/plugins/                       \
name=opentelemetry                                \
config.endpoint=http://test.test/                 \
config.resource_attributes[service.name]=kong-dev
```

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4827
