### PR TITLE
Clean up kong.conf.default for better output to doc site

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -43,17 +43,12 @@
                                           # `prefix` location.
 
 
-#proxy_error_log = logs/error.log         # Path for proxy port request error
-                                          # logs. The granularity of these logs
-                                          # is adjusted by the `log_level`
-                                          # property.
+#proxy_error_log = logs/error.log         # Path for proxy port request error logs.
+                                          # The granularity of these logs is adjusted by the `log_level` property.
 
-#proxy_stream_access_log = logs/access.log basic # Path for tcp streams proxy port access
-                                                 # logs. Set this value to `off` to
-                                                 # disable logging proxy requests.
-                                                 # If this value is a relative path,
-                                                 # it will be placed under the
-                                                 # `prefix` location.
+#proxy_stream_access_log = logs/access.log basic # Path for TCP streams proxy port access logs.
+                                                 # Set to `off` to disable logging proxy requests.
+                                                 # If this value is a relative path, it will be placed under the `prefix` location.
                                                  # `basic` is defined as `'$remote_addr [$time_local] '
                                                  # '$protocol $status $bytes_sent $bytes_received '
                                                  # '$session_time'`
@@ -63,124 +58,95 @@
                                                  # is adjusted by the `log_level`
                                                  # property.
 
-#admin_access_log = logs/admin_access.log # Path for Admin API request access
-                                          # logs. If Hybrid Mode is enabled
-                                          # and the current node is set to be
-                                          # the Control Plane, then the
-                                          # connection requests from Data Planes
-                                          # are also written to this file with
+#admin_access_log = logs/admin_access.log # Path for Admin API request access logs.
+                                          # If hybrid mode is enabled and the current node is set
+                                          # to be the control plane, then the connection requests
+                                          # from data planes are also written to this file with
                                           # server name "kong_cluster_listener".
                                           #
-                                          # Set this value to `off` to
-                                          # disable logging Admin API requests.
-                                          # If this value is a relative path,
-                                          # it will be placed under the
-                                          # `prefix` location.
+                                          # Set this value to `off` to disable logging Admin API requests.
+                                          # If this value is a relative path, it will be placed under the `prefix` location.
 
-#admin_error_log = logs/error.log         # Path for Admin API request error
-                                          # logs. The granularity of these logs
-                                          # is adjusted by the `log_level`
-                                          # property.
 
-#status_access_log = off                  # Path for Status API request access
-                                          # logs. The default value of `off`
-                                          # implies that logging for this API
+#admin_error_log = logs/error.log         # Path for Admin API request error logs.
+                                          # The granularity of these logs is adjusted by the `log_level` property.
+
+#status_access_log = off                  # Path for Status API request access logs.
+                                          # The default value of `off` implies that logging for this API
                                           # is disabled by default.
-                                          # If this value is a relative path,
-                                          # it will be placed under the
-                                          # `prefix` location.
+                                          # If this value is a relative path, it will be placed under the `prefix` location.
 
-#status_error_log = logs/status_error.log # Path for Status API request error
-                                          # logs. The granularity of these logs
-                                          # is adjusted by the `log_level`
-                                          # property.
+#status_error_log = logs/status_error.log # Path for Status API request error logs.
+                                          # The granularity of these logs is adjusted by the `log_level` property.
 
-#vaults = bundled                # Comma-separated list of vaults this node
-                                 # should load. By default, all the bundled
-                                 # vaults are enabled.
+#vaults = bundled                # Comma-separated list of vaults this node should load.
+                                 # By default, all the bundled vaults are enabled.
                                  #
                                  # The specified name(s) will be substituted as
                                  # such in the Lua namespace:
                                  # `kong.vaults.{name}.*`.
 
-#opentelemetry_tracing = off                # Deprecated: use tracing_instrumentations instead
+#opentelemetry_tracing = off                # Deprecated: use `tracing_instrumentations` instead.
 
-#tracing_instrumentations = off             # Comma-separated list of tracing instrumentations
-                                            # this node should load. By default, no instrumentations
-                                            # are enabled.
+#tracing_instrumentations = off             # Comma-separated list of tracing instrumentations this node should load.
+                                            # By default, no instrumentations are enabled.
                                             #
-                                            # Valid values to this setting are:
+                                            # Valid values for this setting are:
                                             #
                                             # - `off`: do not enable instrumentations.
                                             # - `request`: only enable request-level instrumentations.
                                             # - `all`: enable all the following instrumentations.
-                                            # - `db_query`: trace database query
-                                            # - `dns_query`: trace DNS query.
-                                            # - `router`: trace router execution, including
-                                            #   router rebuilding.
+                                            # - `db_query`: trace database queries.
+                                            # - `dns_query`: trace DNS queries.
+                                            # - `router`: trace router execution, including router rebuilding.
                                             # - `http_client`: trace OpenResty HTTP client requests.
                                             # - `balancer`: trace balancer retries.
-                                            # - `plugin_rewrite`: trace plugins iterator
-                                            #   execution with rewrite phase.
-                                            # - `plugin_access`: trace plugins iterator
-                                            #   execution with access phase.
-                                            # - `plugin_header_filter`: trace plugins iterator
-                                            #   execution with header_filter phase.
+                                            # - `plugin_rewrite`: trace plugin iterator execution with rewrite phase.
+                                            # - `plugin_access`: trace plugin iterator execution with access phase.
+                                            # - `plugin_header_filter`: trace plugin iterator execution with header_filter phase.
                                             #
-                                            # **Note:** In the current implementation,
-                                            # tracing instrumentations are not enabled in
-                                            # stream mode.
+                                            # **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode.
 
-#opentelemetry_tracing_sampling_rate = 1.0  # Deprecated: use tracing_sampling_rate instead
+#opentelemetry_tracing_sampling_rate = 1.0  # Deprecated: use `tracing_sampling_rate` instead.
 #tracing_sampling_rate = 0.01               # Tracing instrumentation sampling rate.
                                             # Tracer samples a fixed percentage of all spans
                                             # following the sampling rate.
                                             #
-                                            # Example: `0.25`, this should account for 25% of all traces.
+                                            # Example: `0.25`, this accounts for 25% of all traces.
 
 
-#plugins = bundled               # Comma-separated list of plugins this node
-                                 # should load. By default, only plugins
-                                 # bundled in official distributions are
-                                 # loaded via the `bundled` keyword.
+#plugins = bundled               # Comma-separated list of plugins this node should load.
+                                 # By default, only plugins bundled in official distributions
+                                 # are loaded via the `bundled` keyword.
                                  #
-                                 # Loading a plugin does not enable it by
-                                 # default, but only instructs Kong to load its
-                                 # source code, and allows to configure the
-                                 # plugin via the various related Admin API
-                                 # endpoints.
+                                 # Loading a plugin does not enable it by default, but only
+                                 # instructs Kong to load its source code and allows
+                                 # configuration via the various related Admin API endpoints.
                                  #
-                                 # The specified name(s) will be substituted as
-                                 # such in the Lua namespace:
-                                 # `kong.plugins.{name}.*`.
+                                 # The specified name(s) will be substituted as such in the
+                                 # Lua namespace: `kong.plugins.{name}.*`.
                                  #
-                                 # When the `off` keyword is specified as the
-                                 # only value, no plugins will be loaded.
+                                 # When the `off` keyword is specified as the only value,
+                                 # no plugins will be loaded.
                                  #
-                                 # `bundled` and plugin names can be mixed
-                                 # together, as the following examples suggest:
+                                 # `bundled` and plugin names can be mixed together, as the
+                                 # following examples suggest:
                                  #
                                  # - `plugins = bundled,custom-auth,custom-log`
-                                 #   will include the bundled plugins plus two
-                                 #   custom ones
+                                 #   will include the bundled plugins plus two custom ones.
                                  # - `plugins = custom-auth,custom-log` will
-                                 #   *only* include the `custom-auth` and
-                                 #   `custom-log` plugins.
-                                 # - `plugins = off` will not include any
-                                 #   plugins
+                                 #   *only* include the `custom-auth` and `custom-log` plugins.
+                                 # - `plugins = off` will not include any plugins.
                                  #
-                                 # **Note:** Kong will not start if some
-                                 # plugins were previously configured (i.e.
-                                 # have rows in the database) and are not
-                                 # specified in this list.  Before disabling a
-                                 # plugin, ensure all instances of it are
-                                 # removed before restarting Kong.
+                                 # **Note:** Kong will not start if some plugins were previously
+                                 # configured (i.e. have rows in the database) and are not
+                                 # specified in this list. Before disabling a plugin, ensure
+                                 # all instances of it are removed before restarting Kong.
                                  #
-                                 # **Note:** Limiting the amount of available
-                                 # plugins can improve P99 latency when
-                                 # experiencing LRU churning in the database
-                                 # cache (i.e. when the configured
-                                 # `mem_cache_size`) is full.
+                                 # **Note:** Limiting the amount of available plugins can
+                                 # improve P99 latency when experiencing LRU churning in the
+                                 # database cache (i.e. when the configured `mem_cache_size`) is full.
+
 
 #dedicated_config_processing = on  # Enables or disables a special worker
                                    # process for configuration processing. This process
@@ -192,7 +158,7 @@
                                    # Currently this has effect only on data planes.
 
 #pluginserver_names =            # Comma-separated list of names for pluginserver
-                                 # processes.  The actual names are used for
+                                 # processes. The actual names are used for
                                  # log messages and to relate the actual settings.
 
 #pluginserver_XXX_socket = <prefix>/<XXX>.socket            # Path to the unix socket
@@ -207,7 +173,7 @@
                                                             # manages
 
 #port_maps =                     # With this configuration parameter, you can
-                                 # let the Kong to know about the port from
+                                 # let Kong Gateway know the port from
                                  # which the packets are forwarded to it. This
                                  # is fairly common when running Kong in a
                                  # containerized or virtualized environment.
@@ -234,8 +200,8 @@
 
 
 #proxy_server =                  # Proxy server defined as a URL. Kong will only use this
-                                 # option if any component is explicitly configured
-                                 # to use proxy.
+                                 # option if a component is explicitly configured
+                                 # to use a proxy.
 
 
 #proxy_server_ssl_verify = off   # Toggles server certificate verification if
@@ -295,16 +261,16 @@
 # HYBRID MODE
 #------------------------------------------------------------------------------
 
-#role = traditional              # Use this setting to enable Hybrid Mode,
+#role = traditional              # Use this setting to enable hybrid mode,
                                  # This allows running some Kong nodes in a
                                  # control plane role with a database and
                                  # have them deliver configuration updates
                                  # to other nodes running to DB-less running in
-                                 # a Data Plane role.
+                                 # a data plane role.
                                  #
-                                 # Valid values to this setting are:
+                                 # Valid values for this setting are:
                                  #
-                                 # - `traditional`: do not use Hybrid Mode.
+                                 # - `traditional`: do not use hybrid mode.
                                  # - `control_plane`: this node runs in a
                                  #   control plane role. It can use a database
                                  #   and will deliver configuration updates
@@ -313,23 +279,21 @@
                                  #   It runs DB-less and receives configuration
                                  #   updates from a control plane node.
 
-#cluster_mtls = shared           # Sets the verification between nodes of the
-                                 # cluster.
+#cluster_mtls = shared           # Sets the verification method between nodes of the cluster.
                                  #
-                                 # Valid values to this setting are:
+                                 # Valid values for this setting are:
                                  #
-                                 # - `shared`: use a shared certificate/key
-                                 #   pair specified with the `cluster_cert`
-                                 #   and `cluster_cert_key` settings.
-                                 #   Note that CP and DP nodes have to present
-                                 #   the same certificate to establish mTLS
-                                 #   connections.
-                                 # - `pki`: use `cluster_ca_cert`,
-                                 #   `cluster_server_name` and `cluster_cert`
-                                 #   for verification.
-                                 #   These are different certificates for each
-                                 #   DP node, but issued by a cluster-wide
+                                 # - `shared`: use a shared certificate/key pair specified with
+                                 #   the `cluster_cert` and `cluster_cert_key` settings.
+                                 #   Note that CP and DP nodes must present the same certificate
+                                 #   to establish mTLS connections.
+                                 # - `pki`: use `cluster_ca_cert`, `cluster_server_name`, and
+                                 #   `cluster_cert` for verification. These are different
+                                 #   certificates for each DP node, but issued by a cluster-wide
                                  #   common CA certificate: `cluster_ca_cert`.
+                                 # - `pki_check_cn`: similar to `pki` but additionally checks
+                                 #   for the common name of the data plane certificate specified
+                                 #   in `cluster_allowed_common_names`.
 
 #cluster_cert =                  # Cluster certificate to use
                                  # when establishing secure communication
@@ -359,29 +323,24 @@
                                  #
                                  # The certificate key can be configured on this
                                  # property with either of the following values:
-                                 # * absolute path to the certificate key
-                                 # * certificate key content
-                                 # * base64 encoded certificate key content
+                                 # - absolute path to the certificate key
+                                 # - certificate key content
+                                 # - base64 encoded certificate key content
 
-#cluster_ca_cert =               # The trusted CA certificate file in PEM
-                                 # format used for Control Plane to verify
-                                 # Data Plane's certificate and Data Plane
-                                 # to verify Control Plane's certificate.
-                                 # Required on data plane if `cluster_mtls`
-                                 # is set to `pki`.
-                                 # If Control Plane certificate is issued
-                                 # by a well known CA, user can set
-                                 # `lua_ssl_trusted_certificate=system`
-                                 # on Data Plane and leave this field empty.
+#cluster_ca_cert =               # The trusted CA certificate file in PEM format used for:
+                                 # - Control plane to verify data plane's certificate
+                                 # - Data plane to verify control plane's certificate
                                  #
-                                 # This field is ignored if `cluster_mtls` is
-                                 # set to `shared`.
+                                 # Required on data plane if `cluster_mtls` is set to `pki`.
+                                 # If the control plane certificate is issued by a well-known CA,
+                                 # set `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.
                                  #
-                                 # The certificate can be configured on this property
-                                 # with either of the following values:
-                                 # * absolute path to the certificate
-                                 # * certificate content
-                                 # * base64 encoded certificate content
+                                 # This field is ignored if `cluster_mtls` is set to `shared`.
+                                 #
+                                 # The certificate can be configured on this property with any of the following values:
+                                 # - absolute path to the certificate
+                                 # - certificate content
+                                 # - base64 encoded certificate content
 
 #------------------------------------------------------------------------------
 # HYBRID MODE DATA PLANE
@@ -397,8 +356,8 @@
                                  # `kong_clustering` is used.
 
 #cluster_control_plane =         # To be used by data plane nodes only:
-                                 # address of the control plane node from
-                                 # which configuration updates will be fetched,
+                                 # address of the control plane node from which
+                                 # configuration updates will be fetched,
                                  # in `host:port` format.
 
 #cluster_max_payload = 16777216
@@ -406,15 +365,15 @@
                                  # to be sent across from CP to DP in Hybrid mode
                                  # Default is 16MB - 16 * 1024 * 1024.
 
-#cluster_dp_labels =             # Comma separated list of Labels for the data plane.
+#cluster_dp_labels =             # Comma-separated list of labels for the data plane.
                                  # Labels are key-value pairs that provide additional
                                  # context information for each DP.
                                  # Each label must be configured as a string in the
                                  # format `key:value`.
                                  #
                                  # Labels are only compatible with hybrid mode
-                                 # deployments with Kong Konnect (SaaS),
-                                 # this configuration doesn't work with
+                                 # deployments with Kong Konnect (SaaS).
+                                 # This configuration doesn't work with
                                  # self-hosted deployments.
                                  #
                                  # Keys and values follow the AIP standards:
@@ -439,7 +398,7 @@
                          # This setting has no effect if `role` is not set to
                          # `control_plane`.
                          #
-                         # Connection made to this endpoint are logged
+                         # Connections made to this endpoint are logged
                          # to the same location as Admin API access logs.
                          # See `admin_access_log` config description for more
                          # information.
@@ -452,7 +411,7 @@
                          #
                          # This is to prevent the cluster data plane table from
                          # growing indefinitely. The default is set to
-                         # 14 days. That is, if CP haven't heard from a DP for
+                         # 14 days. That is, if the CP hasn't heard from a DP for
                          # 14 days, its entry will be removed.
 
 #cluster_ocsp = off
@@ -466,7 +425,7 @@
                          # OCSP checks are only performed on CP nodes, it has no
                          # effect on DP nodes.
                          #
-                         # Valid values to this setting are:
+                         # Valid values for this setting are:
                          #
                          # - `on`: OCSP revocation check is enabled and DP
                          #   must pass the check in order to establish
@@ -474,13 +433,14 @@
                          # - `off`: OCSP revocation check is disabled.
                          # - `optional`: OCSP revocation check will be attempted,
                          #   however, if the required extension is not
-                         #   found inside DP provided certificate
+                         #   found inside DP-provided certificate
                          #   or communication with the OCSP responder
                          #   failed, then DP is still allowed through.
+
 #cluster_use_proxy = off
                          # Whether to turn on HTTP CONNECT proxy support for
                          # hybrid mode connections. `proxy_server` will be used
-                         # for Hybrid mode connections if this option is turned on.
+                         # for hybrid mode connections if this option is turned on.
 #------------------------------------------------------------------------------
 # NGINX
 #------------------------------------------------------------------------------
@@ -504,42 +464,42 @@
                          # - `proxy_protocol` will enable usage of the
                          #   PROXY protocol for a given address/port.
                          # - `deferred` instructs to use a deferred accept on
-                         #   Linux (the TCP_DEFER_ACCEPT socket option).
+                         #   Linux (the `TCP_DEFER_ACCEPT` socket option).
                          # - `bind` instructs to make a separate bind() call
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
-                         #   listening socket for each worker process
-                         #   allowing the Kernel to better distribute incoming
-                         #   connections between worker processes
+                         #   listening socket for each worker process,
+                         #   allowing the kernel to better distribute incoming
+                         #   connections between worker processes.
                          # - `backlog=N` sets the maximum length for the queue
                          #   of pending TCP connections. This number should
-                         #   not be too small in order to prevent clients
-                         #   seeing "Connection refused" error connecting to
+                         #   not be too small to prevent clients
+                         #   seeing "Connection refused" errors when connecting to
                          #   a busy Kong instance.
-                         #   **Note:** on Linux, this value is limited by the
-                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   **Note:** On Linux, this value is limited by the
+                         #   setting of the `net.core.somaxconn` kernel parameter.
                          #   In order for the larger `backlog` set here to take
-                         #   effect it is necessary to raise
+                         #   effect, it is necessary to raise
                          #   `net.core.somaxconn` at the same time to match or
                          #   exceed the `backlog` number set.
-                         # - `ipv6only=on|off` whether an IPv6 socket listening
+                         # - `ipv6only=on|off` specifies whether an IPv6 socket listening
                          #   on a wildcard address [::] will accept only IPv6
-                         #   connections or both IPv6 and IPv4 connections
-                         # - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]
-                         #   configures the "TCP keepalive" behavior for the listening
-                         #   socket. If this parameter is omitted then the operating
+                         #   connections or both IPv6 and IPv4 connections.
+                         # - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`
+                         #   configures the `TCP keepalive` behavior for the listening
+                         #   socket. If this parameter is omitted, the operating
                          #   system’s settings will be in effect for the socket. If it
-                         #   is set to the value "on", the SO_KEEPALIVE option is turned
-                         #   on for the socket. If it is set to the value "off", the
-                         #   SO_KEEPALIVE option is turned off for the socket. Some
+                         #   is set to the value `on`, the `SO_KEEPALIVE` option is turned
+                         #   on for the socket. If it is set to the value `off`, the
+                         #   `SO_KEEPALIVE` option is turned off for the socket. Some
                          #   operating systems support setting of TCP keepalive parameters
-                         #   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,
-                         #   and TCP_KEEPCNT socket options.
+                         #   on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,
+                         #   and `TCP_KEEPCNT` socket options.
                          #
                          # This value can be set to `off`, thus disabling
                          # the HTTP/HTTPS proxy port for this node.
-                         # If stream_listen is also set to `off`, this enables
-                         # 'control-plane' mode for this node
+                         # If `stream_listen` is also set to `off`, this enables
+                         # control plane mode for this node
                          # (in which all traffic proxying capabilities are
                          # disabled). This node can then be used only to
                          # configure a cluster of Kong
@@ -573,33 +533,33 @@
                          # - `bind` instructs to make a separate bind() call
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
-                         #   listening socket for each worker process
-                         #   allowing the Kernel to better distribute incoming
-                         #   connections between worker processes
+                         #   listening socket for each worker process,
+                         #   allowing the kernel to better distribute incoming
+                         #   connections between worker processes.
                          # - `backlog=N` sets the maximum length for the queue
                          #   of pending TCP connections. This number should
-                         #   not be too small in order to prevent clients
-                         #   seeing "Connection refused" error connecting to
+                         #   not be too small to prevent clients
+                         #   seeing "Connection refused" errors when connecting to
                          #   a busy Kong instance.
-                         #   **Note:** on Linux, this value is limited by the
-                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   **Note:** On Linux, this value is limited by the
+                         #   setting of the `net.core.somaxconn` kernel parameter.
                          #   In order for the larger `backlog` set here to take
-                         #   effect it is necessary to raise
+                         #   effect, it is necessary to raise
                          #   `net.core.somaxconn` at the same time to match or
                          #   exceed the `backlog` number set.
-                         # - `ipv6only=on|off` whether an IPv6 socket listening
+                         # - `ipv6only=on|off` specifies whether an IPv6 socket listening
                          #   on a wildcard address [::] will accept only IPv6
-                         #   connections or both IPv6 and IPv4 connections
-                         # - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]
-                         #   configures the "TCP keepalive" behavior for the listening
-                         #   socket. If this parameter is omitted then the operating
+                         #   connections or both IPv6 and IPv4 connections.
+                         # - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`
+                         #   configures the `TCP keepalive` behavior for the listening
+                         #   socket. If this parameter is omitted, the operating
                          #   system’s settings will be in effect for the socket. If it
-                         #   is set to the value "on", the SO_KEEPALIVE option is turned
-                         #   on for the socket. If it is set to the value "off", the
-                         #   SO_KEEPALIVE option is turned off for the socket. Some
+                         #   is set to the value `on`, the `SO_KEEPALIVE` option is turned
+                         #   on for the socket. If it is set to the value `off`, the
+                         #   `SO_KEEPALIVE` option is turned off for the socket. Some
                          #   operating systems support setting of TCP keepalive parameters
-                         #   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,
-                         #   and TCP_KEEPCNT socket options.
+                         #   on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,
+                         #   and `TCP_KEEPCNT` socket options.
                          #
                          # Examples:
                          #
@@ -609,7 +569,7 @@
                          # stream_listen = [::1]:1234 backlog=16384
                          # ```
                          #
-                         # By default this value is set to `off`, thus
+                         # By default, this value is set to `off`, thus
                          # disabling the stream proxy port for this node.
 
 # See http://nginx.org/en/docs/stream/ngx_stream_core_module.html#listen
@@ -625,10 +585,10 @@
                          # IPv4, IPv6, and hostnames.
                          #
                          # It is highly recommended to avoid exposing the Admin API to public
-                         # interface(s), by using values such as 0.0.0.0:8001
+                         # interfaces, by using values such as `0.0.0.0:8001`
                          #
                          # See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/
-                         # for more information about how to secure your Admin API
+                         # for more information about how to secure your Admin API.
                          #
                          # Some suffixes can be specified for each pair:
                          #
@@ -640,41 +600,41 @@
                          # - `proxy_protocol` will enable usage of the
                          #   PROXY protocol for a given address/port.
                          # - `deferred` instructs to use a deferred accept on
-                         #   Linux (the TCP_DEFER_ACCEPT socket option).
+                         #   Linux (the `TCP_DEFER_ACCEPT` socket option).
                          # - `bind` instructs to make a separate bind() call
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
-                         #   listening socket for each worker process
+                         #   listening socket for each worker process,
                          #   allowing the Kernel to better distribute incoming
-                         #   connections between worker processes
+                         #   connections between worker processes.
                          # - `backlog=N` sets the maximum length for the queue
                          #   of pending TCP connections. This number should
-                         #   not be too small in order to prevent clients
-                         #   seeing "Connection refused" error connecting to
+                         #   not be too small to prevent clients
+                         #   seeing "Connection refused" errors when connecting to
                          #   a busy Kong instance.
-                         #   **Note:** on Linux, this value is limited by the
-                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   **Note:** On Linux, this value is limited by the
+                         #   setting of the `net.core.somaxconn` kernel parameter.
                          #   In order for the larger `backlog` set here to take
-                         #   effect it is necessary to raise
+                         #   effect, it is necessary to raise
                          #   `net.core.somaxconn` at the same time to match or
                          #   exceed the `backlog` number set.
-                         # - `ipv6only=on|off` whether an IPv6 socket listening
+                         # - `ipv6only=on|off` specifies whether an IPv6 socket listening
                          #   on a wildcard address [::] will accept only IPv6
-                         #   connections or both IPv6 and IPv4 connections
-                         # - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]
-                         #   configures the "TCP keepalive" behavior for the listening
-                         #   socket. If this parameter is omitted then the operating
+                         #   connections or both IPv6 and IPv4 connections.
+                         # - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`
+                         #   configures the “TCP keepalive” behavior for the listening
+                         #   socket. If this parameter is omitted, the operating
                          #   system’s settings will be in effect for the socket. If it
-                         #   is set to the value "on", the SO_KEEPALIVE option is turned
-                         #   on for the socket. If it is set to the value "off", the
-                         #   SO_KEEPALIVE option is turned off for the socket. Some
+                         #   is set to the value `on`, the `SO_KEEPALIVE` option is turned
+                         #   on for the socket. If it is set to the value `off`, the
+                         #   `SO_KEEPALIVE` option is turned off for the socket. Some
                          #   operating systems support setting of TCP keepalive parameters
-                         #   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,
-                         #   and TCP_KEEPCNT socket options.
+                         #   on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,
+                         #   and `TCP_KEEPCNT` socket options.
                          #
                          # This value can be set to `off`, thus disabling
                          # the Admin interface for this node, enabling a
-                         # 'data-plane' mode (without configuration
+                         # data plane mode (without configuration
                          # capabilities) pulling its configuration changes
                          # from the database.
                          #
@@ -694,7 +654,7 @@
                          #   through a particular address/port be made with TLS
                          #   enabled.
                          # - `http2` will allow for clients to open HTTP/2
-                         #   connections to Kong's proxy server.
+                         #   connections to Kong's Status API server.
                          # - `proxy_protocol` will enable usage of the PROXY protocol.
                          #
                          # This value can be set to `off`, disabling
@@ -743,7 +703,7 @@
                                  # uses to cache entities might be double this value.
                                  # The created zones are shared by all worker
                                  # processes and do not become larger when more
-                                 # worker is used.
+                                 # workers are used.
 
 #ssl_cipher_suite = intermediate # Defines the TLS ciphers served by Nginx.
                                  # Accepted values are `modern`,
@@ -790,7 +750,7 @@
                                  #
                                  # This value is ignored if `ssl_cipher_suite`
                                  # is `modern` or `intermediate`. The reason is
-                                 # that `modern` has no ciphers that needs this,
+                                 # that `modern` has no ciphers that need this,
                                  # and `intermediate` uses `ffdhe2048`.
                                  #
                                  # See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
@@ -811,27 +771,27 @@
                                  #
                                  # See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
 
-#ssl_session_cache_size = 10m    # Sets the size of the caches that store session parameters
+#ssl_session_cache_size = 10m    # Sets the size of the caches that store session parameters.
                                  #
                                  # See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
 
 #ssl_cert =                      # Comma-separated list of certificates for `proxy_listen` values with TLS enabled.
                                  #
-                                 # If more than one certificates are specified, it can be used to provide
-                                 # alternate type of certificate (for example, ECC certificate) that will be served
-                                 # to clients that supports them. Note to properly serve using ECC certificates,
+                                 # If more than one certificate is specified, it can be used to provide
+                                 # alternate types of certificates (for example, ECC certificates) that will be served
+                                 # to clients that support them. Note that to properly serve using ECC certificates,
                                  # it is recommended to also set `ssl_cipher_suite` to
                                  # `modern` or `intermediate`.
                                  #
                                  # Unless this option is explicitly set, Kong will auto-generate
-                                 # a pair of default certificates (RSA + ECC) first time it starts up and use
-                                 # it for serving TLS requests.
+                                 # a pair of default certificates (RSA + ECC) the first time it starts up and use
+                                 # them for serving TLS requests.
                                  #
-                                 # Certificates can be configured on this property with either of the following
+                                 # Certificates can be configured on this property with any of the following
                                  # values:
-                                 # * absolute path to the certificate
-                                 # * certificate content
-                                 # * base64 encoded certificate content
+                                 # - absolute path to the certificate
+                                 # - certificate content
+                                 # - base64 encoded certificate content
 
 #ssl_cert_key =                  # Comma-separated list of keys for `proxy_listen` values with TLS enabled.
                                  #
@@ -840,14 +800,14 @@
                                  # provided in the same order.
                                  #
                                  # Unless this option is explicitly set, Kong will auto-generate
-                                 # a pair of default private keys (RSA + ECC) first time it starts up and use
-                                 # it for serving TLS requests.
+                                 # a pair of default private keys (RSA + ECC) the first time it starts up and use
+                                 # them for serving TLS requests.
                                  #
-                                 # Keys can be configured on this property with either of the following
+                                 # Keys can be configured on this property with any of the following
                                  # values:
-                                 # * absolute path to the certificate key
-                                 # * certificate key content
-                                 # * base64 encoded certificate key content
+                                 # - absolute path to the certificate key
+                                 # - certificate key content
+                                 # - base64 encoded certificate key content
 
 #client_ssl = off                # Determines if Nginx should attempt to send client-side
                                  # TLS certificates and perform Mutual TLS Authentication
@@ -859,11 +819,11 @@
                                  # This value can be overwritten dynamically with the `client_certificate`
                                  # attribute of the `Service` object.
                                  #
-                                 # The certificate can be configured on this property with either of the following
+                                 # The certificate can be configured on this property with any of the following
                                  # values:
-                                 # * absolute path to the certificate
-                                 # * certificate content
-                                 # * base64 encoded certificate content
+                                 # - absolute path to the certificate
+                                 # - certificate content
+                                 # - base64 encoded certificate content
 
 #client_ssl_cert_key =           # If `client_ssl` is enabled, the client TLS key
                                  # for the `proxy_ssl_certificate_key` directive.
@@ -871,11 +831,11 @@
                                  # This value can be overwritten dynamically with the `client_certificate`
                                  # attribute of the `Service` object.
                                  #
-                                 # The certificate key can be configured on this property with either of the following
+                                 # The certificate key can be configured on this property with any of the following
                                  # values:
-                                 # * absolute path to the certificate key
-                                 # * certificate key content
-                                 # * base64 encoded certificate key content
+                                 # - absolute path to the certificate key
+                                 # - certificate key content
+                                 # - base64 encoded certificate key content
 
 #admin_ssl_cert =                # Comma-separated list of certificates for `admin_listen` values with TLS enabled.
                                  #
@@ -893,13 +853,21 @@
                                  #
                                  # See docs for `ssl_cert_key` for detailed usage.
 
+#debug_ssl_cert =                # Comma-separated list of certificates for `debug_listen` values with TLS enabled.
+                                 #
+                                 # See docs for `ssl_cert` for detailed usage.
+
+#debug_ssl_cert_key =            # Comma-separated list of keys for `debug_listen` values with TLS enabled.
+                                 #
+                                 # See docs for `ssl_cert_key` for detailed usage.
+
 #headers = server_tokens, latency_tokens, X-Kong-Request-Id
                                  # Comma-separated list of headers Kong should
                                  # inject in client responses.
                                  #
                                  # Accepted values are:
                                  # - `Server`: Injects `Server: kong/x.y.z`
-                                 #   on Kong-produced response (e.g. Admin
+                                 #   on Kong-produced responses (e.g., Admin
                                  #   API, rejected requests from auth plugin).
                                  # - `Via`: Injects `Via: kong/x.y.z` for
                                  #   successfully proxied requests.
@@ -907,11 +875,11 @@
                                  #   (in milliseconds) by Kong to process
                                  #   a request and run all plugins before
                                  #   proxying the request upstream.
-                                 # - `X-Kong-Response-Latency`: time taken
-                                 #   (in millisecond) by Kong to produce
-                                 #   a response in case of e.g. plugin
+                                 # - `X-Kong-Response-Latency`: Time taken
+                                 #   (in milliseconds) by Kong to produce
+                                 #   a response in case of, e.g., a plugin
                                  #   short-circuiting the request, or in
-                                 #   in case of an error.
+                                 #   case of an error.
                                  # - `X-Kong-Upstream-Latency`: Time taken
                                  #   (in milliseconds) by the upstream
                                  #   service to send response headers.
@@ -930,16 +898,17 @@
                                  # - `latency_tokens`: Same as specifying
                                  #   `X-Kong-Proxy-Latency`,
                                  #   `X-Kong-Response-Latency`,
-                                 #   `X-Kong-Admin-Latency` and
-                                 #   `X-Kong-Upstream-Latency`
+                                 #   `X-Kong-Admin-Latency`, and
+                                 #   `X-Kong-Upstream-Latency`.
                                  #
-                                 # In addition to those, this value can be set
+                                 # In addition to these, this value can be set
                                  # to `off`, which prevents Kong from injecting
                                  # any of the above headers. Note that this
                                  # does not prevent plugins from injecting
                                  # headers of their own.
                                  #
                                  # Example: `headers = via, latency_tokens`
+
 
 #headers_upstream = X-Kong-Request-Id
                                  # Comma-separated list of headers Kong should
@@ -955,7 +924,7 @@
                                  # does not prevent plugins from injecting
                                  # headers of their own.
 
-#trusted_ips =                   # Defines trusted IP addresses blocks that are
+#trusted_ips =                   # Defines trusted IP address blocks that are
                                  # known to send correct `X-Forwarded-*`
                                  # headers.
                                  # Requests from trusted IPs make Kong forward
@@ -969,7 +938,7 @@
                                  # values (CIDR blocks) but as a
                                  # comma-separated list.
                                  #
-                                 # To trust *all* /!\ IPs, set this value to
+                                 # To trust *all* IPs, set this value to
                                  # `0.0.0.0/0,::/0`.
                                  #
                                  # If the special value `unix:` is specified,
@@ -1021,7 +990,7 @@
                                      # connection.
 
 #upstream_keepalive_max_requests = 10000 # Sets the default maximum number of
-                                         # requests than can be proxied upstream
+                                         # requests that can be proxied upstream
                                          # through one keepalive connection.
                                          # After the maximum number of requests
                                          # is reached, the connection will be
@@ -1043,9 +1012,9 @@
                                         # indefinitely.
 
 #allow_debug_header = off               # Enable the `Kong-Debug` header function.
-                                        # if it is `on`, kong will add
-                                        # `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`
-                                        # `Kong-Service-Name` debug headers to response when
+                                        # If it is `on`, Kong will add
+                                        # `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`,
+                                        # and `Kong-Service-Name` debug headers to the response when
                                         # the client request header `Kong-Debug: 1` is present.
 
 #------------------------------------------------------------------------------
@@ -1055,7 +1024,7 @@
 # Nginx directives can be dynamically injected in the runtime nginx.conf file
 # without requiring a custom Nginx configuration template.
 #
-# All configuration properties respecting the naming scheme
+# All configuration properties following the naming scheme
 # `nginx_<namespace>_<directive>` will result in `<directive>` being injected in
 # the Nginx configuration block corresponding to the property's `<namespace>`.
 # Example:
@@ -1070,18 +1039,21 @@
 # - `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration
 #   `main` context.
 # - `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`
-#    block.
+#   block.
 # - `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.
 # - `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy
 #   `server {}` block.
 # - `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`
-#    location block (nested under Kong's proxy server {} block).
+#   location block (nested under Kong's proxy `server {}` block).
 # - `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy
 #   `upstream {}` block.
 # - `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API
 #   `server {}` block.
 # - `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API
-#   `server {}` block  (only effective if `status_listen` is enabled).
+#   `server {}` block (only effective if `status_listen` is enabled).
+# - `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API
+#   `server{}` block (only effective if `debug_listen` or `debug_listen_local`
+#   is enabled).
 # - `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module
 #   `stream {}` block (only effective if `stream_listen` is enabled).
 # - `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module
@@ -1100,7 +1072,7 @@
 #
 #   If different sets of protocols are desired between the proxy and Admin API
 #   server, you may specify `nginx_proxy_ssl_protocols` and/or
-#   `nginx_admin_ssl_protocols`, both of which taking precedence over the
+#   `nginx_admin_ssl_protocols`, both of which take precedence over the
 #   `http {}` block.
 
 #nginx_main_worker_rlimit_nofile = auto
@@ -1131,8 +1103,8 @@
 
 #nginx_http_large_client_header_buffers = 4 8k  # Sets the maximum number and
                                                 # size of buffers used for
-                                                # reading large clients
-                                                # requests headers.
+                                                # reading large client
+                                                # request headers.
                                                 # See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
 
 #nginx_http_client_max_body_size = 0  # Defines the maximum request body size
@@ -1148,13 +1120,13 @@
 #nginx_admin_client_max_body_size = 10m  # Defines the maximum request body size for
                                          # Admin API.
 
-#nginx_http_charset = UTF-8  # Adds the specified charset to the "Content-Type"
+#nginx_http_charset = UTF-8  # Adds the specified charset to the “Content-Type”
                              # response header field. If this charset is different
-                             # from the charset specified in the source_charset
+                             # from the charset specified in the `source_charset`
                              # directive, a conversion is performed.
                              #
                              # The parameter `off` cancels the addition of
-                             # charset to the "Content-Type" response header field.
+                             # charset to the “Content-Type” response header field.
                              # See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
 
 #nginx_http_client_body_buffer_size = 8k  # Defines the buffer size for reading
@@ -1188,7 +1160,7 @@
                                                 # in the worker process level PCRE JIT compiled regex cache.
                                                 # It is recommended to set it to at least (number of regex paths * 2)
                                                 # to avoid high CPU usages if you manually specified `router_flavor` to
-                                                # `traditional`. `expressions` and `traditional_compat` router does
+                                                # `traditional`. `expressions` and `traditional_compat` router do
                                                 # not make use of the PCRE library and their behavior
                                                 # is unaffected by this setting.
 
@@ -1196,10 +1168,9 @@
                                        # keep-alive connection. After the maximum number of requests are made,
                                        # the connection is closed.
                                        # Closing connections periodically is necessary to free per-connection
-                                       # memory allocations. Therefore, using too high maximum number of requests
-                                       # could result in excessive memory usage and not recommended.
+                                       # memory allocations. Therefore, using too high a maximum number of requests
+                                       # could result in excessive memory usage and is not recommended.
                                        # See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests
-
 
 
 #------------------------------------------------------------------------------
@@ -1211,9 +1182,8 @@
 # independently in memory.
 #
 # When using a database, Kong will store data for all its entities (such as
-# Routes, Services, Consumers, and Plugins) in PostgreSQL,
-# and all Kong nodes belonging to the same cluster must connect themselves
-# to the same database.
+# routes, services, consumers, and plugins) in PostgreSQL,
+# and all Kong nodes belonging to the same cluster must connect to the same database.
 #
 # Kong supports PostgreSQL versions 9.5 and above.
 #
@@ -1230,13 +1200,13 @@
 # reduce the latency jitter if the Kong proxy node's latency to the main
 # Postgres instance is high.
 #
-# The read-only Postgres instance only serves read queries and write
-# queries still goes to the main connection. The read-only Postgres instance
+# The read-only Postgres instance only serves read queries, and write
+# queries still go to the main connection. The read-only Postgres instance
 # can be eventually consistent while replicating changes from the main
 # instance.
 #
 # At least the `pg_ro_host` config is needed to enable this feature.
-# By default, all other database config for the read-only connection are
+# By default, all other database config for the read-only connection is
 # inherited from the corresponding main connection config described above but
 # may be optionally overwritten explicitly using the `pg_ro_*` config below.
 
@@ -1371,7 +1341,7 @@
 
 #declarative_config =           # The path to the declarative configuration
                                 # file which holds the specification of all
-                                # entities (Routes, Services, Consumers, etc.)
+                                # entities (routes, services, consumers, etc.)
                                 # to be used when the `database` is set to
                                 # `off`.
                                 #
@@ -1380,32 +1350,32 @@
                                 # allocated to it via the `lmdb_map_size`
                                 # property.
                                 #
-                                # If the Hybrid mode `role` is set to `data_plane`
+                                # If the hybrid mode `role` is set to `data_plane`
                                 # and there's no configuration cache file,
                                 # this configuration is used before connecting
-                                # to the Control Plane node as a user-controlled
+                                # to the control plane node as a user-controlled
                                 # fallback.
 
 #declarative_config_string =    # The declarative configuration as a string
 
 #lmdb_environment_path = dbless.lmdb  # Directory where the LMDB database files used by
-                                      # DB-less and Hybrid mode to store Kong
+                                      # DB-less and hybrid mode to store Kong
                                       # configurations reside.
                                       #
                                       # This path is relative under the Kong `prefix`.
 
 #lmdb_map_size = 2048m                # Maximum size of the LMDB memory map, used to store the
-                                      # DB-less and Hybird mode configurations. Default is 2048m.
+                                      # DB-less and hybrid mode configurations. Default is 2048m.
                                       #
-                                      # This config defines the limit of LMDB file size, the
+                                      # This config defines the limit of LMDB file size; the
                                       # actual file size growth will be on-demand and
                                       # proportional to the actual config size.
                                       #
-                                      # Note this value can be set very large, say a couple of GBs
+                                      # Note this value can be set very large, say a couple of GBs,
                                       # to accommodate future database growth and
-                                      # Multi Version Concurrency Control (MVCC) headroom needs.
+                                      # Multi-Version Concurrency Control (MVCC) headroom needs.
                                       # The file size of the LMDB database file should stabilize
-                                      # after a few config reload/Hybrid mode syncs and the actual
+                                      # after a few config reloads/hybrid mode syncs, and the actual
                                       # memory used by the LMDB database will be smaller than
                                       # the file size due to dynamic swapping of database pages by
                                       # the OS.
@@ -1415,12 +1385,11 @@
 #------------------------------------------------------------------------------
 
 # In order to avoid unnecessary communication with the datastore, Kong caches
-# entities (such as APIs, Consumers, Credentials...) for a configurable period
+# entities (such as APIs, consumers, credentials...) for a configurable period
 # of time. It also handles invalidations if such an entity is updated.
 #
 # This section allows for configuring the behavior of Kong regarding the
 # caching of such configuration entities.
-
 #db_update_frequency = 5         # Frequency (in seconds) at which to check for
                                  # updated entities with the datastore.
                                  #
@@ -1442,7 +1411,7 @@
                                  # servers should suffer no such delays, and
                                  # this value can be safely set to 0.
                                  # Postgres setups with read replicas should
-                                 # set this value to maximum expected replication
+                                 # set this value to the maximum expected replication
                                  # lag between the writer and reader instances.
 
 #db_cache_ttl = 0                # Time-to-live (in seconds) of an entity from
@@ -1464,7 +1433,7 @@
                                  # If set to 0, misses will never expire.
 
 #db_resurrect_ttl = 30           # Time (in seconds) for which stale entities
-                                 # from the datastore should be resurrected for
+                                 # from the datastore should be resurrected
                                  # when they cannot be refreshed (e.g., the
                                  # datastore is unreachable). When this TTL
                                  # expires, a new attempt to refresh the stale
@@ -1498,22 +1467,22 @@
 #
 # Kong will resolve hostnames as either `SRV` or `A` records (in that order, and
 # `CNAME` records will be dereferenced in the process).
-# In case a name was resolved as an `SRV` record it will also override any given
-# port number by the `port` field contents received from the DNS server.
+# In case a name is resolved as an `SRV` record, it will also override any given
+# port number with the `port` field contents received from the DNS server.
 #
 # The DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will
 # be used to expand short names to fully qualified ones. So it will first try
 # the entire `SEARCH` list for the `SRV` type, if that fails it will try the
 # `SEARCH` list for `A`, etc.
 #
-# For the duration of the `ttl`, the internal DNS resolver will loadbalance each
-# request it gets over the entries in the DNS record. For `SRV` records the
+# For the duration of the `ttl`, the internal DNS resolver will load balance each
+# request it gets over the entries in the DNS record. For `SRV` records, the
 # `weight` fields will be honored, but it will only use the lowest `priority`
 # field entries in the record.
 
-#dns_resolver =                  # Comma separated list of nameservers, each
+#dns_resolver =                  # Comma-separated list of nameservers, each
                                  # entry in `ip[:port]` format to be used by
-                                 # Kong. If not specified the nameservers in
+                                 # Kong. If not specified, the nameservers in
                                  # the local `resolv.conf` file will be used.
                                  # Port defaults to 53 if omitted. Accepts
                                  # both IPv4 and IPv6 addresses.
@@ -1527,7 +1496,7 @@
                                  # record types. The `LAST` type means the
                                  # type of the last successful lookup (for the
                                  # specified name). The format is a (case
-                                 # insensitive) comma separated list.
+                                 # insensitive) comma-separated list.
 
 #dns_valid_ttl =                 # By default, DNS records are cached using
                                  # the TTL value of a response. If this
@@ -1549,7 +1518,7 @@
                                  # DNS records stored in memory cache.
                                  # Least recently used DNS records are discarded
                                  # from cache if it is full. Both errors and
-                                 # data are cached, therefore a single name query
+                                 # data are cached; therefore, a single name query
                                  # can easily take up 10-15 slots.
 
 #dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
@@ -1558,9 +1527,9 @@
 #dns_error_ttl = 1               # TTL in seconds for error responses.
 
 #dns_no_sync = off               # If enabled, then upon a cache-miss every
-                                 # request will trigger its own dns query.
-                                 # When disabled multiple requests for the
-                                 # same name/type will be synchronised to a
+                                 # request will trigger its own DNS query.
+                                 # When disabled, multiple requests for the
+                                 # same name/type will be synchronized to a
                                  # single query.
 
 #------------------------------------------------------------------------------
@@ -1598,8 +1567,8 @@
                                  # Defines whether this node should rebuild its
                                  # state synchronously or asynchronously (the
                                  # balancers and the router are rebuilt on
-                                 # updates that affects them, e.g., updates to
-                                 # Routes, Services or Upstreams, via the Admin
+                                 # updates that affect them, e.g., updates to
+                                 # routes, services, or upstreams via the admin
                                  # API or loading a declarative configuration
                                  # file). (This option is deprecated and will be
                                  # removed in future releases. The new default
@@ -1619,18 +1588,18 @@
                                  #
                                  # Note that `strict` ensures that all workers
                                  # of a given node will always proxy requests
-                                 # with an identical router, but that increased
-                                 # long tail latency can be observed if
-                                 # frequent Routes and Services updates are
+                                 # with an identical router, but increased
+                                 # long-tail latency can be observed if
+                                 # frequent routes and services updates are
                                  # expected.
-                                 # Using `eventual` will help preventing long
-                                 # tail latency issues in such cases, but may
+                                 # Using `eventual` will help prevent long-tail
+                                 # latency issues in such cases, but may
                                  # cause workers to route requests differently
-                                 # for a short period of time after Routes and
-                                 # Services updates.
+                                 # for a short period of time after routes and
+                                 # services updates.
 
 #worker_state_update_frequency = 5
-                                 # Defines (in seconds) how often the worker state changes are
+                                 # Defines how often the worker state changes are
                                  # checked with a background job. When a change
                                  # is detected, a new router or balancer will be
                                  # built, as needed. Raising this value will
@@ -1644,40 +1613,40 @@
                                  # performing request routing. Incremental router
                                  # rebuild is available when the flavor is set
                                  # to either `expressions` or
-                                 # `traditional_compatible` which could
-                                 # significantly shorten rebuild time for large
+                                 # `traditional_compatible`, which could
+                                 # significantly shorten rebuild time for a large
                                  # number of routes.
                                  #
                                  # Accepted values are:
                                  #
-                                 # - `traditional_compatible`: the DSL based expression
-                                 #   router engine will be used under the hood. However
+                                 # - `traditional_compatible`: the DSL-based expression
+                                 #   router engine will be used under the hood. However,
                                  #   the router config interface will be the same
-                                 #   as `traditional` and expressions are
+                                 #   as `traditional`, and expressions are
                                  #   automatically generated at router build time.
-                                 #   The `expression` field on the `Route` object
+                                 #   The `expression` field on the `route` object
                                  #   is not visible.
-                                 # - `expressions`: the DSL based expression router engine
-                                 #   will be used under the hood. Traditional router
-                                 #   config interface is still visible, and you could also write
-                                 #   Router Expression manually and provide them in the
-                                 #   `expression` field on the `Route` object.
-                                 # - `traditional`: the pre-3.0 Router engine will be
-                                 #   used. Config interface will be the same as
-                                 #   pre-3.0 Kong and the `expression` field on the
-                                 #   `Route` object is not visible.
+                                 # - `expressions`: the DSL-based expression router engine
+                                 #   will be used under the hood. The traditional router
+                                 #   config interface is still visible, and you can also write
+                                 #   router Expressions manually and provide them in the
+                                 #   `expression` field on the `route` object.
+                                 # - `traditional`: the pre-3.0 router engine will be
+                                 #   used. The config interface will be the same as
+                                 #   pre-3.0 Kong, and the `expression` field on the
+                                 #   `route` object is not visible.
                                  #
                                  #   Deprecation warning: In Kong 3.0, `traditional`
-                                 #   mode should be avoided and only be used in case
-                                 #   `traditional_compatible` did not work as expected.
-                                 #   This flavor of router will be removed in the next
+                                 #   mode should be avoided and only be used if
+                                 #   `traditional_compatible` does not work as expected.
+                                 #   This flavor of the router will be removed in the next
                                  #   major release of Kong.
 
 #lua_max_req_headers = 100       # Maximum number of request headers to parse by default.
                                  #
                                  # This argument can be set to an integer between 1 and 1000.
                                  #
-                                 # When proxying the Kong sends all the request headers
+                                 # When proxying, Kong sends all the request headers,
                                  # and this setting does not have any effect. It is used
                                  # to limit Kong and its plugins from reading too many
                                  # request headers.
@@ -1686,18 +1655,18 @@
                                  #
                                  # This argument can be set to an integer between 1 and 1000.
                                  #
-                                 # When proxying, Kong returns all the response headers
+                                 # When proxying, Kong returns all the response headers,
                                  # and this setting does not have any effect. It is used
                                  # to limit Kong and its plugins from reading too many
                                  # response headers.
 
-#lua_max_uri_args = 100          # Maximum number of request uri arguments to parse by
+#lua_max_uri_args = 100          # Maximum number of request URI arguments to parse by
                                  # default.
                                  #
                                  # This argument can be set to an integer between 1 and 1000.
                                  #
                                  # When proxying, Kong sends all the request query
-                                 # arguments and this setting does not have any effect.
+                                 # arguments, and this setting does not have any effect.
                                  # It is used to limit Kong and its plugins from reading
                                  # too many query arguments.
 
@@ -1707,7 +1676,7 @@
                                  # This argument can be set to an integer between 1 and 1000.
                                  #
                                  # When proxying, Kong sends all the request post
-                                 # arguments and this setting does not have any effect.
+                                 # arguments, and this setting does not have any effect.
                                  # It is used to limit Kong and its plugins from reading
                                  # too many post arguments.
 
@@ -1728,29 +1697,29 @@
                                         # The special value `system` attempts to search for the
                                         # "usual default" provided by each distro, according
                                         # to an arbitrary heuristic. In the current implementation,
-                                        # The following pathnames will be tested in order,
+                                        # the following pathnames will be tested in order,
                                         # and the first one found will be used:
                                         #
-                                        # - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)
-                                        # - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)
-                                        # - /etc/ssl/ca-bundle.pem (OpenSUSE)
-                                        # - /etc/pki/tls/cacert.pem (OpenELEC)
-                                        # - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)
-                                        # - /etc/ssl/cert.pem (OpenBSD, Alpine)
+                                        # - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo)
+                                        # - `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6)
+                                        # - `/etc/ssl/ca-bundle.pem` (OpenSUSE)
+                                        # - `/etc/pki/tls/cacert.pem` (OpenELEC)
+                                        # - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7)
+                                        # - `/etc/ssl/cert.pem` (OpenBSD, Alpine)
                                         #
                                         # `system` can be used by itself or in conjunction with other
-                                        # CA filepaths.
+                                        # CA file paths.
                                         #
                                         # When `pg_ssl_verify` is enabled, these
                                         # certificate authority files will be
                                         # used for verifying Kong's database connections.
                                         #
                                         # Certificates can be configured on this property
-                                        # with either of the following values:
-                                        # * `system`
-                                        # * absolute path to the certificate
-                                        # * certificate content
-                                        # * base64 encoded certificate content
+                                        # with any of the following values:
+                                        # - `system`
+                                        # - absolute path to the certificate
+                                        # - certificate content
+                                        # - base64 encoded certificate content
                                         #
                                         # See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
 
@@ -1794,7 +1763,6 @@
                                  # server.
                                  #
                                  # See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
-
 #untrusted_lua = sandbox
                                  # Controls loading of Lua functions from admin-supplied
                                  # sources such as the Admin API. LuaJIT bytecode
@@ -1911,9 +1879,9 @@
 #------------------------------------------------------------------------------
 # KONG MANAGER
 #------------------------------------------------------------------------------
-
-# The Admin GUI for Kong Gateway.
-
+#
+# The Admin GUI for Kong Enterprise.
+#
 #admin_gui_listen = 0.0.0.0:8002, 0.0.0.0:8445 ssl
                         # Kong Manager Listeners
                         #
@@ -1925,13 +1893,9 @@
                         # Suffixes can be specified for each pair, similarly to
                         # the `admin_listen` directive.
 
-#admin_gui_url =
-                        # Kong Manager URL
+#admin_gui_url =        # Kong Manager URL
                         #
                         # The lookup, or balancer, address for Kong Manager.
-                        #
-                        # When set, the CORS headers in the Admin API response
-                        # will also change to the corresponding origin
                         #
                         # Accepted format (items in parentheses are optional):
                         #
@@ -1940,16 +1904,19 @@
                         # Examples:
                         #
                         # - `http://127.0.0.1:8003`
-                        # - `https://kong-manager.test`
+                        # - `https://kong-admin.test`
                         # - `http://dev-machine`
+                        #
+                        # By default, Kong Manager will use the window request
+                        # host and append the resolved listener port depending
+                        # on the requested protocol.
 
-#admin_gui_path = /
-                        # Kong Manager base path
+#admin_gui_path = /     # Kong Manager base path
                         #
                         # This configuration parameter allows the user to customize
                         # the path prefix where Kong Manager is served. When updating
-                        # this parameter, it's recommended to update the path in
-                        # `admin_gui_url` as well.
+                        # this parameter, it's recommended to update the path in `admin_gui_url`
+                        # as well.
                         #
                         # Accepted format:
                         #
@@ -1966,37 +1933,34 @@
                         # - `/kong-manager`
                         # - `/kong/manager`
 
-#admin_gui_api_url =
-                        # Hierarchical part of a URL which is composed
+#admin_gui_api_url =    # Hierarchical part of a URI which is composed
                         # optionally of a host, port, and path at which the
                         # Admin API accepts HTTP or HTTPS traffic. When
-                        # this config is not provided, Kong Manager will
+                        # this config is disabled, Kong Manager will
                         # use the window protocol + host and append the
                         # resolved admin_listen HTTP/HTTPS port.
 
-#admin_gui_ssl_cert =
-                        # The SSL certificate for `admin_gui_listen` values
+#admin_gui_ssl_cert =   # The SSL certificate for `admin_gui_listen` values
                         # with SSL enabled.
                         #
                         # values:
-                        # * absolute path to the certificate
-                        # * certificate content
-                        # * base64 encoded certificate content
+                        # - absolute path to the certificate
+                        # - certificate content
+                        # - base64 encoded certificate content
 
-#admin_gui_ssl_cert_key =
-                        # The SSL key for `admin_gui_listen` values with SSL
-                        # enabled.
-                        #
-                        # values:
-                        # * absolute path to the certificate key
-                        # * certificate key content
-                        # * base64 encoded certificate key content
+#admin_gui_ssl_cert_key = # The SSL key for `admin_gui_listen` values with SSL
+                          # enabled.
+                          #
+                          # values:
+                          # - absolute path to the certificate key
+                          # - certificate key content
+                          # - base64 encoded certificate key content
 
 #admin_gui_access_log = logs/admin_gui_access.log
                         # Kong Manager Access Logs
                         #
-                        # Here you can set an absolute or relative path for
-                        # Kong Manager access logs. When the path is relative,
+                        # Here you can set an absolute or relative path for Kong
+                        # Manager access logs. When the path is relative,
                         # logs are placed in the `prefix` location.
                         #
                         # Setting this value to `off` disables access logs
@@ -2006,8 +1970,8 @@
 #admin_gui_error_log = logs/admin_gui_error.log
                         # Kong Manager Error Logs
                         #
-                        # Here you can set an absolute or relative path for
-                        # Kong Manager access logs. When the path is relative,
+                        # Here you can set an absolute or relative path for Kong
+                        # Manager access logs. When the path is relative,
                         # logs are placed in the `prefix` location.
                         #
                         # Setting this value to `off` disables error logs for
@@ -2018,7 +1982,7 @@
 
 
 #------------------------------------------------------------------------------
-# WASM
+# WEBASSEMBLY (WASM)
 #------------------------------------------------------------------------------
 
 #wasm = off             # Enable/disable wasm support. This must be enabled in
@@ -2044,14 +2008,14 @@
                         # The resulting filter modules available for use in Kong
                         # will be:
                         #
-                        # * `my_module`
-                        # * `my_other_module`
+                        # - `my_module`
+                        # - `my_other_module`
                         #
                         # Notes:
                         #
-                        # * No recursion is performed. Only .wasm files at the
-                        #   top level are registered
-                        # * This path _may_ be a symlink to a directory.
+                        # - No recursion is performed. Only .wasm files at the
+                        #   top level are registered.
+                        # - This path _may_ be a symlink to a directory.
 
 #wasm_filters = bundled,user        # Comma-separated list of Wasm filters to be made
                                     # available for use in filter chains.
@@ -2073,7 +2037,7 @@
                                     #   filters
                                     # - `wasm_filters = filter-a,filter-b` enables _only_
                                     #   filters named `filter-a` or `filter-b` (whether
-                                    #   bundled _or_ user-suppplied)
+                                    #   bundled _or_ user-supplied)
                                     #
                                     # If a conflict occurs where a bundled filter and a
                                     # user-supplied filter share the same name, a warning
@@ -2084,7 +2048,7 @@
 # WASM injected directives
 #------------------------------------------------------------------------------
 
-# The Nginx Wasm module (i.e. ngx_wasm_module) has its own settings, which can
+# The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can
 # be tuned via `wasm_*` directives in the Nginx configuration file. Kong
 # supports configuration of these directives via its Nginx directive injection
 # mechanism.
@@ -2102,7 +2066,7 @@
 #   separate namespaces in the `"<name>/<key>"` format.
 #   For using these functions with non-namespaced keys, the Nginx template needs
 #   a `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.
-# - `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`
+# - `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}` 
 #   block, allowing various Wasmtime-specific flags to be set.
 # - `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the
 #   `http {}` or `server {}` blocks, as specified in the Nginx injected directives
@@ -2138,16 +2102,16 @@
 #   `nginx_wasm_tls_trusted_certificate` directive.
 # - `lua_ssl_verify_depth`: when set (to a value greater than zero), several
 #   TLS-related `nginx_wasm_*` settings are enabled:
-#   * `nginx_wasm_tls_verify_cert`
-#   * `nginx_wasm_tls_verify_host`
-#   * `nginx_wasm_tls_no_verify_warn`
+#   - `nginx_wasm_tls_verify_cert`
+#   - `nginx_wasm_tls_verify_host`
+#   - `nginx_wasm_tls_no_verify_warn`
 #
 # Like other `kong.conf` fields, all injected Nginx directives documented here
 # can be set via environment variable. For instance, setting:
 #
 #   `KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`
 #
-#   Will inject the following in to the `wasm {}` block:
+#   Will inject the following into the `wasm {}` block:
 #
 #   `tls_verify_cert <value>;`
 #
@@ -2166,13 +2130,13 @@
 #-------------------------------------------------------------------------------
 # REQUEST DEBUGGING
 #-------------------------------------------------------------------------------
-# Request debugging is a mechanism that allows admin to collect the timing of
-# proxy path request in the response header (X-Kong-Request-Debug-Output)
+# Request debugging is a mechanism that allows admins to collect the timing of
+# proxy path requests in the response header (X-Kong-Request-Debug-Output)
 # and optionally, the error log.
 #
 # This feature provides insights into the time spent within various components of Kong,
 # such as plugins, DNS resolution, load balancing, and more. It also provides contextual
-# information such as domain name tried during these processes.
+# information such as domain names tried during these processes.
 #
 #request_debug = on              # When enabled, Kong will provide detailed timing information
                                  # for its components to the client and the error log
@@ -2180,8 +2144,19 @@
                                  # - `X-Kong-Request-Debug`:
                                  #   If the value is set to `*`,
                                  #   timing information will be collected and exported for the current request.
-                                 #   If this header is not present or contains unknown value,
+                                 #   If this header is not present or contains an unknown value,
                                  #   timing information will not be collected for the current request.
+                                 #   You can also specify a list of filters, separated by commas,
+                                 #   to filter the scope of the time information that is collected.
+                                 # The following filters are supported for `X-Kong-Request-Debug`:
+                                 # - `rewrite`: Collect timing information from the `rewrite` phase.
+                                 # - `access`: Collect timing information from the `access` phase.
+                                 # - `balancer`: Collect timing information from the `balancer` phase.
+                                 # - `response`: Collect timing information from the `response` phase.
+                                 # - `header_filter`: Collect timing information from the `header_filter` phase.
+                                 # - `body_filter`: Collect timing information from the `body_filter` phase.
+                                 # - `log`: Collect timing information from the `log` phase.
+                                 # - `upstream`: Collect timing information from the `upstream` phase.
                                  #
                                  # - `X-Kong-Request-Debug-Log`:
                                  #   If set to `true`, timing information will also be logged


### PR DESCRIPTION
### Summary
The kong.conf.default doc requires a lot of formatting changes to fix on the docs website. This PR contains those changes .

Corresponding EE PR https://github.com/Kong/kong-ee/pull/9473 

This CE one needs to be merged first and then I will update on EE. 

### Checklist

- [x ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/7490

### Issue reference

https://konghq.atlassian.net/jira/software/c/projects/DOCU/boards/58?selectedIssue=DOCU-829
https://konghq.atlassian.net/browse/DOCU-3896