### PR TITLE
Revert "fix: update otel version to match Kong Gateway version"

### DIFF
--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -4,7 +4,6 @@ local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
 local tracing_context = require "kong.tracing.tracing_context"
-local kong_meta = require "kong.meta"
 
 
 local ngx = ngx
@@ -25,7 +24,7 @@ local _log_prefix = "[otel] "
 
 
 local OpenTelemetryHandler = {
-  VERSION = kong_meta.version,
+  VERSION = "0.1.0",
   PRIORITY = 14,
 }
 


### PR DESCRIPTION
### Summary

This reverts commit 1afd6c637a98bf9567dd7e829a6c8d8c6d5c734a.

The reason is that this still causes https://konghq.atlassian.net/browse/KAG-1410 we'll probably want to wait for the next major before syncing this with EE's version again.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-4850](https://konghq.atlassian.net/browse/KAG-4850)
