### PR TITLE
fix: update otel version to match Kong Gateway version

### DIFF
--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -168,11 +168,20 @@ function _M.check_configuration_compatibility(cp, dp)
         -- CP plugin needs to match DP plugins with major version
         -- CP must have plugin with equal or newer version than that on DP
 
-        if cp_plugin.major ~= dp_plugin.major or
-          cp_plugin.minor < dp_plugin.minor then
-          local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
-                      " is different to control plane plugin version " .. cp_plugin.version
-          return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+        -- luacheck:ignore 542
+        if name == "opentelemetry" and dp_plugin.major == 0 and dp_plugin.minor == 1 then
+          -- The first version of the opentelemetry plugin was introduced into the Kong code base with a version
+          -- number 0.1.0 and released that way.  In subsequent releases, the version number was then not updated
+          -- to avoid the compatibility check from failing.  To work around this issue and allow us to fix the
+          -- version number of the opentelemetry plugin, we're accepting the plugin with version 0.1.0 to be
+          -- compatible
+        else
+          if cp_plugin.major ~= dp_plugin.major or
+            cp_plugin.minor < dp_plugin.minor then
+            local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
+              " is different to control plane plugin version " .. cp_plugin.version
+            return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+          end
         end
       end
     end

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -4,6 +4,7 @@ local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
 local tracing_context = require "kong.tracing.tracing_context"
+local kong_meta = require "kong.meta"
 
 
 local ngx = ngx
@@ -24,7 +25,7 @@ local _log_prefix = "[otel] "
 
 
 local OpenTelemetryHandler = {
-  VERSION = "0.1.0",
+  VERSION = kong_meta.version,
   PRIORITY = 14,
 }
 


### PR DESCRIPTION
### Summary

To make this fix work, we're adding a hack that prevents the normal plugin compatibility checks to be done for the opentelemetry plugin if the version of the plugin reported by the DP is 0.1.0.

Tested using https://github.com/Kong/otel-hybrid-mode-hack-test

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-1410