### PR TITLE
Revert "fix(core): Regex header values in traditional router are now validated"

### DIFF
--- a/changelog/unreleased/kong/traditional_router_header_validation.yml
+++ b/changelog/unreleased/kong/traditional_router_header_validation.yml
@@ -1,3 +1,0 @@
-message: Fixed an issue where the `route` entity would accept an invalid regex pattern if the `router_flavor` is `traditional` or `traditional_compatible`. Now, the invalid regex pattern for matching the value of request headers will not be accepted when creating the `route` entity.
-type: bugfix
-scope: Core

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -196,10 +196,6 @@ local routes = {
             },
           },
         },
-        values = {
-          type = "array",
-          elements = typedefs.regex_or_plain_pattern,
-        }
       } },
 
       { regex_priority = { description = "A number used to choose which route resolves a given request when several routes match it using regexes simultaneously.", type = "integer", default = 0 }, },

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -497,54 +497,36 @@ local function validate_host_with_wildcards(host)
   return typedefs.host_with_optional_port.custom_validator(no_wildcards)
 end
 
-
-local function is_regex_pattern(pattern)
-  return pattern:sub(1, 1) == "~"
-end
-
-
-local function is_valid_regex_pattern(pattern)
-  local regex = pattern:sub(2) -- remove the leading "~"
-  -- the value will be interpreted as a regex by the router; but is it a
-  -- valid one? Let's dry-run it with the same options as our router.
-  local _, _, err = ngx.re.find("", regex, "aj")
-  if err then
-    return nil,
-           string.format("invalid regex: '%s' (PCRE returned: %s)",
-                         regex, err)
-  end
-
-  return true
-end
-
-
 local function validate_path_with_regexes(path)
+
   local ok, err, err_code = typedefs.path.custom_validator(path)
 
   if err_code == "percent" then
     return ok, err, err_code
   end
 
-  if is_regex_pattern(path) then
-    return is_valid_regex_pattern(path)
-  end
+  if path:sub(1, 1) ~= "~" then
+    -- prefix matching. let's check if it's normalized form
+    local normalized = normalize(path, true)
+    if path ~= normalized then
+      return nil, "non-normalized path, consider use '" .. normalized .. "' instead"
+    end
 
-  -- prefix matching. let's check if it's normalized form
-  local normalized = normalize(path, true)
-  if path ~= normalized then
-    return nil, "non-normalized path, consider use '" .. normalized .. "' instead"
-  end
-
-  return true
-end
-
-
-local function validate_regex_or_plain_pattern(pattern)
-  if not is_regex_pattern(pattern) then
     return true
   end
 
-  return is_valid_regex_pattern(pattern)
+  path = path:sub(2)
+
+  -- the value will be interpreted as a regex by the router; but is it a
+  -- valid one? Let's dry-run it with the same options as our router.
+  local _, _, err = ngx.re.find("", path, "aj")
+  if err then
+    return nil,
+           string.format("invalid regex: '%s' (PCRE returned: %s)",
+                         path, err)
+  end
+
+  return true
 end
 
 
@@ -644,12 +626,6 @@ typedefs.headers = Schema.define {
     },
   },
   description = "A map of header names to arrays of header values."
-}
-
-typedefs.regex_or_plain_pattern = Schema.define {
-  type = "string",
-  custom_validator = validate_regex_or_plain_pattern,
-  description = "A string representing a regex or plain pattern."
 }
 
 typedefs.no_headers = Schema.define(typedefs.headers { eq = null, description = "A null value representing no headers." })

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -621,17 +621,6 @@ describe("routes schema (flavor = " .. flavor .. ")", function()
       assert.falsy(ok)
       assert.equal("length must be at least 1", err.headers[1])
     end)
-
-    it("value must be a plain pattern or a valid regex pattern", function()
-      local route = {
-        headers = { location = { "~[" } },
-        protocols = { "http" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.match("invalid regex", err.headers[1])
-    end)
   end)
 
   describe("methods attribute", function()


### PR DESCRIPTION
Reverts Kong/kong#12365

It fails KIC nightly

Fix https://konghq.atlassian.net/browse/KAG-4788