### PR TITLE
fix(cors): ACAO header was not sent when `conf.origins` has multiple

### DIFF
--- a/changelog/unreleased/kong/fix-cors-wildcard.yml
+++ b/changelog/unreleased/kong/fix-cors-wildcard.yml
@@ -1,0 +1,4 @@
+message: "**CORS**: Fixed an issue where the ACAO header was not sent when `conf.origins` has multiple entries and has `*` included."
+type: bugfix
+scope: Plugin
+

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -96,6 +96,11 @@ local function configure_origin(conf, header_filter)
       cached_domains = {}
 
       for _, entry in ipairs(conf.origins) do
+        if entry == "*" then
+          set_header("Access-Control-Allow-Origin", "*")
+          return true
+        end
+
         local domain
         local maybe_regex, _, err = re_find(entry, "[^A-Za-z0-9.:/-]", "jo")
         if err then


### PR DESCRIPTION
### Summary

The CORS plugin allows the use of the wildcard `*` to match all origins. However, when multiple entries are configured in `conf.origins` and one of them is `*`, the CORS plugin fails to send the ACAO response header. Additionally, the logs report an error entry like `pcre2_compile() failed: quantifier does not follow a repeatable item in "*$" at "*$"`.

This fix addresses the issue, and ensures consistent behavior with when setting `*` as a single value in `conf.origins`.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6062
