### PR TITLE
fix(build): set type of kong.logrotate as config|noreplace avoid overwriting during the upgrade

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -32,8 +32,7 @@ contents:
 - src: nfpm-prefix/share
   dst: /usr/local/share
   type: tree
-- src: nfpm-prefix/etc/kong
-  dst: /etc/kong
+- dst: /etc/kong
   type: dir
 - src: bin/kong
   dst: /usr/local/bin/kong

--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -34,6 +34,7 @@ contents:
   type: tree
 - src: nfpm-prefix/etc/kong
   dst: /etc/kong
+  type: dir
 - src: bin/kong
   dst: /usr/local/bin/kong
 - src: bin/kong-health
@@ -45,6 +46,9 @@ contents:
   type: config|noreplace
   file_info:
     mode: 0644
+- src: nfpm-prefix/etc/kong/kong.conf.default
+  dst: /etc/kong/kong.conf.default
+  type: config
 - src: /usr/local/openresty/bin/resty
   dst: /usr/local/bin/resty
   type: symlink

--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -42,6 +42,7 @@ contents:
   dst: /lib/systemd/system/kong.service
 - src: build/package/kong.logrotate
   dst: /etc/kong/kong.logrotate
+  type: config|noreplace
   file_info:
     mode: 0644
 - src: /usr/local/openresty/bin/resty

--- a/changelog/unreleased/kong/fix-type-of-logrotate.yml
+++ b/changelog/unreleased/kong/fix-type-of-logrotate.yml
@@ -1,3 +1,3 @@
-message: "set type of kong.logrotate as config|noreplace avoid overwriting during the upgrade"
+message: "Set type of kong.logrotate as `config|noreplace` to avoid overwriting during the upgrade."
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-type-of-logrotate.yml
+++ b/changelog/unreleased/kong/fix-type-of-logrotate.yml
@@ -1,3 +1,3 @@
-message: "Set type of kong.logrotate as `config|noreplace` to avoid overwriting during the upgrade."
+message: "The kong.logrotate configuration file will no longer be overwritten during upgrade."
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-type-of-logrotate.yml
+++ b/changelog/unreleased/kong/fix-type-of-logrotate.yml
@@ -1,3 +1,5 @@
-message: "The kong.logrotate configuration file will no longer be overwritten during upgrade."
+message: |
+    The kong.logrotate configuration file will no longer be overwritten during upgrade.
+    When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-type-of-logrotate.yml
+++ b/changelog/unreleased/kong/fix-type-of-logrotate.yml
@@ -1,0 +1,3 @@
+message: "set type of kong.logrotate as config|noreplace avoid overwriting during the upgrade"
+type: bugfix
+scope: Core


### PR DESCRIPTION
…

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-6079](https://konghq.atlassian.net/browse/FTI-6079)


[FTI-6079]: https://konghq.atlassian.net/browse/FTI-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ