### PR TITLE
chore(ci): mount package directory at image build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
         platforms: ${{ steps.docker_platforms_arg.outputs.platforms }}
         build-args: |
           KONG_BASE_IMAGE=${{ matrix.base-image }}
-          KONG_ARTIFACT_PATH=bazel-bin/pkg/
+          KONG_ARTIFACT_PATH=bazel-bin/pkg
           KONG_VERSION=${{ needs.metadata.outputs.kong-version }}
           RPM_PLATFORM=${{ steps.docker_rpm_platform_arg.outputs.rpm_platform }}
           EE_PORTS=8002 8445 8003 8446 8004 8447

--- a/build/dockerfiles/deb.Dockerfile
+++ b/build/dockerfiles/deb.Dockerfile
@@ -14,16 +14,15 @@ ARG EE_PORTS
 ARG TARGETARCH
 
 ARG KONG_ARTIFACT=kong.${TARGETARCH}.deb
-ARG KONG_ARTIFACT_PATH=
-COPY ${KONG_ARTIFACT_PATH}${KONG_ARTIFACT} /tmp/kong.deb
+ARG KONG_ARTIFACT_PATH
 
-RUN apt-get update \
+RUN --mount=type=bind,source=${KONG_ARTIFACT_PATH},target=/tmp/pkg \
+    apt-get update \
     && apt-get -y upgrade \
     && apt-get -y autoremove \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata \
-    && apt-get install -y --no-install-recommends /tmp/kong.deb \
+    && apt-get install -y --no-install-recommends /tmp/pkg/${KONG_ARTIFACT} \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 ${KONG_PREFIX} \
     && ln -sf /usr/local/openresty/bin/resty /usr/local/bin/resty \

--- a/build/dockerfiles/rpm.Dockerfile
+++ b/build/dockerfiles/rpm.Dockerfile
@@ -28,13 +28,12 @@ ARG EE_PORTS
 ARG TARGETARCH
 
 ARG KONG_ARTIFACT=kong.${RPM_PLATFORM}.${TARGETARCH}.rpm
-ARG KONG_ARTIFACT_PATH=
-COPY ${KONG_ARTIFACT_PATH}${KONG_ARTIFACT} /tmp/kong.rpm
+ARG KONG_ARTIFACT_PATH
 
 # hadolint ignore=DL3015
-RUN yum update -y \
-    && yum install -y /tmp/kong.rpm \
-    && rm /tmp/kong.rpm \
+RUN --mount=type=bind,source=${KONG_ARTIFACT_PATH},target=/tmp/pkg \
+    yum update -y \
+    && yum install -y /tmp/pkg/${KONG_ARTIFACT} \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 /usr/local/kong \
     && ln -sf /usr/local/openresty/bin/resty /usr/local/bin/resty \


### PR DESCRIPTION
This updates our release workflow to use docker's build-time [bind mount](https://docs.docker.com/reference/dockerfile/#run---mounttypebind) support to supply the package file(s) instead of copying into the image.

The idea behind this is that mounting the package removes a large `COPY` layer and reduces the image size.

The directory that is mounted is checksum-ed by docker as part of the build context, so build cache is automatically invalidated when the package file changes.

### before

```
$ docker image ls kong/kong-gateway-dev:master \
> --format 'table {{.Repository}}\t{{.Tag}}\t{{.Size}}'
REPOSITORY              TAG       SIZE
kong/kong-gateway-dev   master    538MB
```

```
$ docker image history kong/kong-gateway-dev:master \
> --format 'table {{.CreatedAt}}\t{{.CreatedBy}}\t{{.Size}}'
CREATED AT                  CREATED BY                                      SIZE
2024-07-08T01:52:13-07:00   CMD ["kong" "docker-start"]                     0B
2024-07-08T01:52:13-07:00   HEALTHCHECK &{["CMD-SHELL" "kong-health"] "1…   0B
2024-07-08T01:52:13-07:00   STOPSIGNAL SIGQUIT                              0B
2024-07-08T01:52:13-07:00   EXPOSE map[8000/tcp:{} 8001/tcp:{} 8002/tcp:…   0B
2024-07-08T01:52:13-07:00   ENTRYPOINT ["/entrypoint.sh"]                   0B
2024-07-08T01:52:13-07:00   USER kong                                       0B
2024-07-08T01:52:13-07:00   COPY build/dockerfiles/entrypoint.sh /entryp…   2.22kB
2024-07-08T01:52:13-07:00   RUN |6 KONG_VERSION=3.8.0.0 KONG_PREFIX=/usr…   379MB
2024-07-08T01:51:55-07:00   COPY bazel-bin/pkg/kong.amd64.deb /tmp/kong.…   81.3MB
2024-07-08T01:51:55-07:00   ARG KONG_ARTIFACT_PATH=bazel-bin/pkg/           0B
2024-07-08T01:51:55-07:00   ARG KONG_ARTIFACT=kong.amd64.deb                0B
2024-07-08T01:51:55-07:00   ARG TARGETARCH=amd64                            0B
2024-07-08T01:51:55-07:00   ARG EE_PORTS=8002 8445 8003 8446 8004 8447      0B
2024-07-08T01:51:55-07:00   ENV KONG_PREFIX=/usr/local/kong                 0B
2024-07-08T01:51:55-07:00   ARG KONG_PREFIX=/usr/local/kong                 0B
2024-07-08T01:51:55-07:00   ENV KONG_VERSION=3.8.0.0                        0B
2024-07-08T01:51:55-07:00   ARG KONG_VERSION=3.8.0.0                        0B
2024-07-08T01:51:55-07:00   LABEL maintainer=Kong Docker Maintainers <do…   0B
2024-06-27T13:10:12-07:00   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
2024-06-27T13:10:12-07:00   /bin/sh -c #(nop) ADD file:d5da92199726e42da…   77.9MB
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  ARG RELEASE                  0B
```

### after

```
$ docker image ls kong/kong-gateway-dev:b5195bbdb9a613a81359b4c1498220738af99a37 \
> --format 'table {{.Repository}}\t{{.Tag}}\t{{.Size}}'
REPOSITORY              TAG                                        SIZE
kong/kong-gateway-dev   b5195bbdb9a613a81359b4c1498220738af99a37   457MB
```

```
$ docker image history kong/kong-gateway-dev:b5195bbdb9a613a81359b4c1498220738af99a37 \
> --format 'table {{.CreatedAt}}\t{{.CreatedBy}}\t{{.Size}}'
CREATED AT                  CREATED BY                                      SIZE
2024-07-08T11:17:32-07:00   CMD ["kong" "docker-start"]                     0B
2024-07-08T11:17:32-07:00   HEALTHCHECK &{["CMD-SHELL" "kong-health"] "1…   0B
2024-07-08T11:17:32-07:00   STOPSIGNAL SIGQUIT                              0B
2024-07-08T11:17:32-07:00   EXPOSE map[8000/tcp:{} 8001/tcp:{} 8002/tcp:…   0B
2024-07-08T11:17:32-07:00   ENTRYPOINT ["/entrypoint.sh"]                   0B
2024-07-08T11:17:32-07:00   USER kong                                       0B
2024-07-08T11:17:32-07:00   COPY build/dockerfiles/entrypoint.sh /entryp…   2.22kB
2024-07-08T11:17:32-07:00   RUN |6 KONG_VERSION=3.8.0.0 KONG_PREFIX=/usr…   379MB
2024-07-08T11:17:32-07:00   ARG KONG_ARTIFACT_PATH=bazel-bin/pkg            0B
2024-07-08T11:17:32-07:00   ARG KONG_ARTIFACT=kong.amd64.deb                0B
2024-07-08T11:17:32-07:00   ARG TARGETARCH=amd64                            0B
2024-07-08T11:17:32-07:00   ARG EE_PORTS=8002 8445 8003 8446 8004 8447      0B
2024-07-08T11:17:32-07:00   ENV KONG_PREFIX=/usr/local/kong                 0B
2024-07-08T11:17:32-07:00   ARG KONG_PREFIX=/usr/local/kong                 0B
2024-07-08T11:17:32-07:00   ENV KONG_VERSION=3.8.0.0                        0B
2024-07-08T11:17:32-07:00   ARG KONG_VERSION=3.8.0.0                        0B
2024-07-08T11:17:32-07:00   LABEL maintainer=Kong Docker Maintainers <do…   0B
2024-06-27T13:10:12-07:00   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
2024-06-27T13:10:12-07:00   /bin/sh -c #(nop) ADD file:d5da92199726e42da…   77.9MB
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
2024-06-27T13:10:10-07:00   /bin/sh -c #(nop)  ARG RELEASE                  0B
```