### PR TITLE
chore(build): do not download ngx_brotli with '--//:brotli=false'

### DIFF
--- a/build/openresty/BUILD.openresty.bazel
+++ b/build/openresty/BUILD.openresty.bazel
@@ -268,8 +268,12 @@ configure_make(
         "@lua-kong-nginx-module//:all_srcs",
         "@lua-resty-events//:all_srcs",
         "@lua-resty-lmdb//:all_srcs",
-        "@ngx_brotli//:all_srcs",
     ] + select({
+        "@kong//:brotli_flag": [
+            "@ngx_brotli//:all_srcs",
+        ],
+        "//conditions:default": [],
+    }) + select({
         "@kong//:wasmx_flag": [
             "@ngx_wasmx_module//:all_srcs",
             # wasm_runtime has to be a "data" (target) instead of "build_data" (exec)


### PR DESCRIPTION
### Summary

Had issues with `bazel build //build:kong` due to ngx_brotli. Re-run with `--//:brotli=false` and ngx_brotli is still being downloaded, which caused another issue with recursive cloning. This now truly disable ngx_brotli when asked, assuming user has a good reason to.

### Checklist

~- [ ] The Pull Request has tests~
~- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)~
~- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
~Fix #_[issue number]_~
