### PR TITLE
fix(certificates): validate the certificates schema failed if `snis` was in the request body

### DIFF
--- a/changelog/unreleased/kong/certificates_schema_validate.yml
+++ b/changelog/unreleased/kong/certificates_schema_validate.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where validation of the certificate schema failed if the `snis` field was present in the request body."
+scope: Admin API
+type: bugfix

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -60,7 +60,6 @@ function _Certificates:insert(cert, options)
     end
   end
 
-  cert.snis = nil
   cert, err, err_t = self.super.insert(self, cert, options)
   if not cert then
     return nil, err, err_t
@@ -99,7 +98,6 @@ function _Certificates:update(cert_pk, cert, options)
     end
   end
 
-    cert.snis = nil
     cert, err, err_t = self.super.update(self, cert_pk, cert, options)
     if err then
       return nil, err, err_t
@@ -137,7 +135,6 @@ function _Certificates:upsert(cert_pk, cert, options)
     end
   end
 
-  cert.snis = nil
   cert, err, err_t = self.super.upsert(self, cert_pk, cert, options)
   if err then
     return nil, err, err_t

--- a/kong/db/schema/entities/certificates.lua
+++ b/kong/db/schema/entities/certificates.lua
@@ -21,6 +21,7 @@ return {
     { cert_alt   = typedefs.certificate { required = false, referenceable = true }, },
     { key_alt    = typedefs.key         { required = false, referenceable = true, encrypted = true }, },
     { tags       = typedefs.tags },
+    { snis       = { type = "array", elements = typedefs.wildcard_host, required = false, transient = true }, },
   },
 
   entity_checks = {

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -192,6 +192,8 @@ local field_schema = {
   { encrypted = { type = "boolean" }, },
   { referenceable = { type = "boolean" }, },
   { json_schema = json_metaschema },
+  -- Transient attribute: used to mark a field as a non-db column
+  { transient = { type = "boolean" }, },
   -- Deprecation attribute: used to mark a field as deprecated
   -- Results in `message` and `removal_in_version` to be printed in a warning
   -- (via kong.deprecation) when the field is used.
@@ -489,6 +491,14 @@ local attribute_types = {
   },
   json_schema = {
     ["json"] = true,
+  },
+  transient = {
+    ["string"] = true,
+    ["number"] = true,
+    ["integer"] = true,
+    ["array"] = true,
+    ["set"] = true,
+    ["boolean"] = true,
   },
 }
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -844,6 +844,10 @@ function _M.new(connector, schema, errors)
 
 
   for field_name, field in schema:each_field() do
+    if field.transient then
+      goto continue
+    end
+
     if field.type == "foreign" then
       local foreign_schema           = field.schema
       local foreign_key_names        = {}
@@ -925,6 +929,7 @@ function _M.new(connector, schema, errors)
 
       insert(fields, prepared_field)
     end
+    ::continue::
   end
 
   local primary_key_names        = {}

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require "spec.helpers"
+local ssl_fixtures = require "spec.fixtures.ssl"
 local cjson = require "cjson"
 local constants = require "kong.constants"
+local Errors  = require "kong.db.errors"
 
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
@@ -554,6 +556,45 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local json = cjson.decode(body)
       assert.equal("schema validation successful", json.message)
     end)
+ 
+    it("returns 200 on certificates schema with snis", function()
+
+      local res = assert(client:post("/schemas/certificates/validate", {
+        body = {
+          cert = ssl_fixtures.cert,
+          key  = ssl_fixtures.key,
+          snis = {"a", "b", "c" },
+        },
+        headers = { ["Content-Type"] = "application/json" }
+      }))
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("schema validation successful", json.message)
+    end)
+    
+    it("returns 400 on certificates schema with invalid snis", function()
+
+      local res = assert(client:post("/schemas/certificates/validate", {
+        body = {
+          cert = ssl_fixtures.cert,
+          key  = ssl_fixtures.key,
+          snis = {"120.0.9.32:90" },
+        },
+        headers = { ["Content-Type"] = "application/json" }
+      }))
+      local body = assert.res_status(400, res)
+      local json = cjson.decode(body)
+      local expected_body = {
+        fields= {
+          snis= { "must not be an IP" }
+        },
+        name= "schema violation",
+        message= "schema violation (snis.1: must not be an IP)",
+        code= Errors.codes.SCHEMA_VIOLATION,
+      }
+      assert.same(expected_body, json)
+    end)
+
     it("returns 200 on a valid plugin schema", function()
       local res = assert(client:post("/schemas/plugins/validate", {
         body = {

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -36,12 +36,23 @@ describe("Admin API: #" .. strategy, function()
     local n2 = get_name()
     local names = { n1, n2 }
 
+     local certificate = {
+      cert  = ssl_fixtures.cert,
+      key   = ssl_fixtures.key,
+      snis  = names,
+    }
+
+    local validate_res = client:post("/schemas/certificates/validate", {
+      body    = certificate,
+      headers = { ["Content-Type"] = "application/json" },
+    })
+
+    local validate_body = assert.res_status(200, validate_res)
+    local json = cjson.decode(validate_body)
+    assert.equal("schema validation successful", json.message)
+
     local res = client:post("/certificates", {
-      body    = {
-        cert  = ssl_fixtures.cert,
-        key   = ssl_fixtures.key,
-        snis  = names,
-      },
+      body    = certificate,
       headers = { ["Content-Type"] = "application/json" },
     })
 
@@ -370,9 +381,8 @@ describe("Admin API: #" .. strategy, function()
         assert.equal(cjson.null, json.key_alt)
 
         assert.same({ n1 }, json.snis)
-        json.snis = nil
 
-        local in_db = assert(db.certificates:select({ id = id }, { nulls = true }))
+        local in_db = assert(db.certificates:select_with_name_list({ id = id }, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -395,9 +405,8 @@ describe("Admin API: #" .. strategy, function()
         assert.equal(cjson.null, json.key_alt)
 
         assert.same({ n1, n2 }, json.snis)
-        json.snis = nil
 
-        local in_db = assert(db.certificates:select(json, { nulls = true }))
+        local in_db = assert(db.certificates:select_with_name_list(json, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -420,9 +429,8 @@ describe("Admin API: #" .. strategy, function()
         assert.equal(cjson.null, json.key_alt)
 
         assert.same({ n1, n2 }, json.snis)
-        json.snis = nil
 
-        local in_db = assert(db.certificates:select(json, { nulls = true }))
+        local in_db = assert(db.certificates:select_with_name_list(json, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -444,9 +452,7 @@ describe("Admin API: #" .. strategy, function()
         assert.same({}, json.snis)
         assert.truthy(certificate.updated_at < json.updated_at)
 
-        json.snis = nil
-
-        local in_db = assert(db.certificates:select(certificate, { nulls = true }))
+        local in_db = assert(db.certificates:select_with_name_list(certificate, { nulls = true }))
         assert.same(json, in_db)
       end)
 
@@ -470,9 +476,7 @@ describe("Admin API: #" .. strategy, function()
         assert.same(ssl_fixtures.key_alt_ecdsa, json.key_alt)
         assert.same({}, json.snis)
 
-        json.snis = nil
-
-        local in_db = assert(db.certificates:select(certificate, { nulls = true }))
+        local in_db = assert(db.certificates:select_with_name_list(certificate, { nulls = true }))
         assert.same(json, in_db)
       end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
the endpoint  POST `/schemas/certificates/validate` with entity data:
>{
	"cert":"<input valid cert>",
	"key":"<input valid key>",
	"snis":["a","b","c"]
}

It throws an error.

>{
	"code": 2,
	"name": "schema violation",
	"fields": {
		"snis": "unknown field"
	},
	"message": "schema violation (snis: unknown field)"
}

Currently, the endpoint POST `/certificates` can batch-create sni entities with `snis`. But the `snis` is not part of the certificate schema. so we need to remove it from the request body.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KM-223
