### PR TITLE
feat(jwt) : add feature to jwt plugin:allow set headers from claim

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -12,6 +12,9 @@ local pairs = pairs
 local tostring = tostring
 local re_gmatch = ngx.re.gmatch
 
+local consts = {
+  JWT_CLAIM_HEADER_PREFIX = "X-Jwt-Claim"
+}
 
 local JwtHandler = {
   VERSION = kong_meta.version,
@@ -150,6 +153,15 @@ local function unauthorized(message, www_auth_content, errors)
   return { status = 401, message = message, headers = { ["WWW-Authenticate"] = www_auth_content }, errors = errors }
 end
 
+-- set header keys from claims
+local function set_headers(conf, claims)
+  local set_header = kong.service.request.set_header
+  for _, v in ipairs(conf.headers_to_set) do
+    if claims[v] then
+      set_header(consts.JWT_CLAIM_HEADER_PREFIX.."-"..v, claims[v])
+    end
+  end
+end
 
 local function do_authentication(conf)
   local token, err = retrieve_tokens(conf)
@@ -253,6 +265,8 @@ local function do_authentication(conf)
   end
 
   set_consumer(consumer, jwt_secret, token)
+
+  set_headers(conf, claims)
 
   return true
 end

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -30,6 +30,11 @@ return {
                 type = "string",
                 one_of = { "exp", "nbf" },
           }, }, },
+          { headers_to_set = {
+            type = "set",
+            elements = {
+              type = "string"
+          }, }, },
           { anonymous = { description = "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.", type = "string" }, },
           { run_on_preflight = { description = "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed.", type = "boolean", required = true, default = true }, },
           { maximum_expiration = {


### PR DESCRIPTION
Summary
Add feature to jwt plugin: allow set header from claims.

Reopenning of https://github.com/Kong/kong/pull/4761 https://github.com/Kong/kong/pull/5713

Full changelog
[Implement] jwt plugin: allow set header from claims
if you configure headers_to_set(set) , headers with prefix "X-Jwt-Claim-" will be set to the response. For example, if 'sub' and 'app' are configured, and both of them are found in jwt's claims, two headers will be set to the response: X-Jwt-Claim-Sub and X-Jwt-Claim-App.