### PR TITLE
fix(bazel): cp luarocks-admin to bin

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -218,6 +218,7 @@ kong_genrule(
     ],
     outs = [
         "bin/luarocks",
+        "bin/luarocks-admin",
         "etc/kong/kong.conf.default",
         "etc/luarocks",
         "lib",
@@ -231,6 +232,7 @@ kong_genrule(
         LUAROCKS=${WORKSPACE_PATH}/$(dirname '$(location @luarocks//:luarocks_make)')/luarocks_tree
         cp -r ${LUAROCKS}/share ${LUAROCKS}/lib ${LUAROCKS}/etc ${BUILD_DESTDIR}/.
         cp ${LUAROCKS}/bin/luarocks ${BUILD_DESTDIR}/bin/.
+        cp ${LUAROCKS}/bin/luarocks-admin ${BUILD_DESTDIR}/bin/.
         chmod -R "u+rw" ${BUILD_DESTDIR}/share/lua
 
         mkdir -p ${BUILD_DESTDIR}/etc/kong/

--- a/changelog/unreleased/kong/cp-luarocks-admin-to-bin.yml
+++ b/changelog/unreleased/kong/cp-luarocks-admin-to-bin.yml
@@ -1,3 +1,3 @@
-message: "Ensure luarocks-admin is available in /usr/local/bin"
+message: "Fixed an issue where luarocks-admin was not available in /usr/local/bin."
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/cp-luarocks-admin-to-bin.yml
+++ b/changelog/unreleased/kong/cp-luarocks-admin-to-bin.yml
@@ -1,0 +1,3 @@
+message: "Ensure luarocks-admin is available in /usr/local/bin"
+type: bugfix
+scope: Core

--- a/scripts/explain_manifest/docker_image_filelist.txt
+++ b/scripts/explain_manifest/docker_image_filelist.txt
@@ -3,6 +3,7 @@
 /usr/local/kong/**
 /usr/local/bin/kong
 /usr/local/bin/luarocks
+/usr/local/bin/luarocks-admin
 /usr/local/etc/luarocks/**
 /usr/local/lib/lua/**
 /usr/local/lib/luarocks/**

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -143,6 +143,7 @@ def docker_suites(expect):
             .gid.equals(0)
 
     for path in ("/usr/local/bin/luarocks",
+                 "/usr/local/bin/luarocks-admin",
                  "/usr/local/etc/luarocks/**",
                  "/usr/local/lib/lua/**",
                  "/usr/local/lib/luarocks/**",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Port of https://github.com/Kong/kong-ee/pull/9671 to ensure that `luarocks-admin` is present in CE packages/docker images:
```bash
$ podman run --user=root --privileged --rm -it kong/kong:master bash -c 'find /usr/local -name luarocks-admin'
/usr/local/lib/luarocks/rocks-5.1/luarocks/3.11.1-1/bin/luarocks-admin
```

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-911]_


[KAG-911]: https://konghq.atlassian.net/browse/KAG-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ