### PR TITLE
fix(aws-lambda): fix an incompatibility with multi value header in proxy integration and legacy empty arrays mode

### DIFF
--- a/changelog/unreleased/kong/fix-aws-lambda-empty-array-mutli-value.yml
+++ b/changelog/unreleased/kong/fix-aws-lambda-empty-array-mutli-value.yml
@@ -1,0 +1,3 @@
+message: "**AWS-Lambda**: Fixed an issue that the plugin does not work with multiValueHeaders defined in proxy integration and legacy empty_arrays_mode."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -250,7 +250,13 @@ function AWSLambdaHandler:access(conf)
   -- instead of JSON arrays for empty arrays.
   if conf.empty_arrays_mode == "legacy" then
     local ct = headers["Content-Type"]
-    if ct and ct:lower():match("application/.*json") then
+    -- If Content-Type is specified by multiValueHeader then
+    -- it will be an array, so we need to get the first element
+    if type(ct) == "table" and #ct > 0 then
+      ct = ct[1]
+    end
+
+    if ct and type(ct) == "string" and ct:lower():match("application/.*json") then
       content = remove_array_mt_for_empty_table(content)
     end
   end

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -4,6 +4,7 @@ local ngx_var = ngx.var
 local ngx_now = ngx.now
 local ngx_update_time = ngx.update_time
 local md5_bin = ngx.md5_bin
+local re_match = ngx.re.match
 local fmt = string.format
 local buffer = require "string.buffer"
 local lrucache = require "resty.lrucache"
@@ -256,7 +257,7 @@ function AWSLambdaHandler:access(conf)
       ct = ct[1]
     end
 
-    if ct and type(ct) == "string" and ct:lower():match("application/.*json") then
+    if ct and type(ct) == "string" and re_match(ct:lower(), "application/.*json", "jo") then
       content = remove_array_mt_for_empty_table(content)
     end
   end

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -1005,7 +1005,7 @@ for _, strategy in helpers.each_strategy() do
         assert.matches("\"testbody\":%[%]", body)
       end)
 
-      it("#testme invokes a Lambda function with legacy empty array mode and mutlivalueheaders", function()
+      it("invokes a Lambda function with legacy empty array mode and mutlivalueheaders", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/get",

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -188,6 +188,12 @@ for _, strategy in helpers.each_strategy() do
         service     = null,
       }
 
+      local route28 = bp.routes:insert {
+        hosts       = { "lambda28.test" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
       bp.plugins:insert {
         name     = "aws-lambda",
         route    = { id = route1.id },
@@ -557,6 +563,20 @@ for _, strategy in helpers.each_strategy() do
           aws_region           = "us-east-1",
           function_name        = "functionWithEmptyArray",
           empty_arrays_mode    = "correct",
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route28.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithArrayCTypeInMVHAndEmptyArray",
+          empty_arrays_mode    = "legacy",
+          is_proxy_integration = true,
         }
       }
 
@@ -983,6 +1003,19 @@ for _, strategy in helpers.each_strategy() do
 
         local body = assert.res_status(200, res)
         assert.matches("\"testbody\":%[%]", body)
+      end)
+
+      it("#testme invokes a Lambda function with legacy empty array mode and mutlivalueheaders", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get",
+          headers = {
+            ["Host"] = "lambda28.test"
+          }
+        })
+
+        local _ = assert.res_status(200, res)
+        assert.equal("application/json+test", res.headers["Content-Type"])
       end)
 
       describe("config.is_proxy_integration = true", function()

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -70,6 +70,10 @@ local fixtures = {
                       local str = "{\"statusCode\": 200, \"testbody\": [], \"isBase64Encoded\": false}"
                       ngx.say(str)
 
+                    elseif string.match(ngx.var.uri, "functionWithArrayCTypeInMVHAndEmptyArray") then
+                      ngx.header["Content-Type"] = "application/json"
+                      ngx.say("{\"statusCode\": 200, \"isBase64Encoded\": true, \"body\": \"eyJrZXkiOiAidmFsdWUiLCAia2V5MiI6IFtdfQ==\", \"headers\": {}, \"multiValueHeaders\": {\"Content-Type\": [\"application/json+test\"]}}")
+
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR fixes a bug that introduced by #13084, that when `is_proxy_integration` mode is set to true with `empty_arrays_mode` set to `legacy`, and lambda function returns `multiValueHeader` that contains a `Content-Type` with single value array, the plugin cannot work correctly.

The `multiValueHeaders` field in the proxy integration response can be an array even if the header has only one value. I've tested AWS API gateway and the Kong gateway before #13084 and confirmed that both would work fine with `Content-Type` single value array inside the mutliValueHeader response field.

The reason of #13084 brings in this issue is that before #13084 we did not have any logic about reading `Content-Type` so no problem existed. The single value array will goes into `kong.response.exit` and normalized automatically.

This PR fixes the problem that when `Content-Type` returned by the lambda function is `["application-json"]`, the plugin cannot execute the if-block correctly due to not being able to call the `lower` function on the array(table) object.

Although there is a tiny possibility that the user will encounter this issue(because I think mostly people will define `Content-Type` inside the `headers` field instead of the `mutliValueHeaders` since it should be only one value), it is still good to fix this issue and let it behave like before.


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-6100
