### PR TITLE
fix(proxy-cache): correctly add age header on cache hit

### DIFF
--- a/changelog/unreleased/kong/proxy-cache-fix-age-header.yml
+++ b/changelog/unreleased/kong/proxy-cache-fix-age-header.yml
@@ -1,0 +1,4 @@
+message: |
+  **proxy-cache**: Fixed an issue where the Age header was not being updated correctly when serving cached responses.
+scope: Plugin
+type: bugfix

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -401,7 +401,7 @@ function ProxyCacheHandler:access(conf)
 
 
   reset_res_header(res)
-  set_res_header(res, "Age", floor(time() - res.timestamp), conf)
+  set_res_header(res, "age", floor(time() - res.timestamp), conf)
   set_res_header(res, "X-Cache-Status", "Hit", conf)
   set_res_header(res, "X-Cache-Key", cache_key, conf)
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -102,6 +102,12 @@ do
       local route22 = assert(bp.routes:insert({
         hosts = { "route-22.test" },
       }))
+      local route23 = assert(bp.routes:insert({
+        hosts = { "route-23.test" },
+      }))
+      local route24 = assert(bp.routes:insert({
+        hosts = { "route-24.test" },
+      }))
 
       local consumer1 = assert(bp.consumers:insert {
         username = "bob",
@@ -336,6 +342,32 @@ do
         },
       })
 
+      assert(bp.plugins:insert {
+        name = "proxy-cache",
+        route = { id = route23.id },
+        config = {
+          strategy = policy,
+          content_type = { "text/plain", "application/json" },
+          [policy] = policy_config,
+          response_headers = {
+            age = true,
+            ["X-Cache-Status"] = true,
+            ["X-Cache-Key"]  = true
+          },
+        },
+      })
+
+      assert(bp.plugins:insert {
+        name = "proxy-cache",
+        route = { id = route24.id },
+        config = {
+          strategy = policy,
+          content_type = { "text/plain", "application/json" },
+          [policy] = policy_config,
+          -- leave reponse_header to default values
+        },
+      })
+
       assert(helpers.start_kong({
         plugins = "bundled",
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -412,6 +444,56 @@ do
         },
       }))
       assert.same("Hit", res.headers["X-Cache-Status"])
+      assert.is_not_nil(res.headers["Age"])
+      assert.is_not_nil(res.headers["X-Cache-Key"])
+    end)
+
+    it("response_headers headers on the response when configured", function()
+      -- Initial query to set cache
+      local res =  assert(client:get("/get", {
+        headers = {
+          Host = "route-23.test",
+        },
+      }))
+      -- Cache should be Miss
+      assert.res_status(200, res)
+      assert.is_same("Miss", res.headers["X-Cache-Status"])
+      assert.is_not_nil(res.headers["X-Cache-Key"])
+      assert.is_nil(res.headers["Age"])
+      -- Cache should be HIT
+      res =  assert(client:get("/get", {
+        headers = {
+          Host = "route-23.test",
+        },
+      }))
+      assert.res_status(200, res)
+      assert.same("Hit", res.headers["X-Cache-Status"])
+      -- response_headers are configured
+      assert.is_not_nil(res.headers["Age"])
+      assert.is_not_nil(res.headers["X-Cache-Key"])
+    end)
+
+    it("response_headers headers on the response when set to default", function()
+      -- Initial query to set cache
+      local res =  assert(client:get("/get", {
+        headers = {
+          Host = "route-24.test",
+        },
+      }))
+      -- Cache should be Miss
+      assert.res_status(200, res)
+      assert.is_same("Miss", res.headers["X-Cache-Status"])
+      assert.is_not_nil(res.headers["X-Cache-Key"])
+      assert.is_nil(res.headers["Age"])
+      res =  assert(client:get("/get", {
+        headers = {
+          Host = "route-24.test",
+        },
+      }))
+      -- Cache should be Hit
+      assert.res_status(200, res)
+      assert.same("Hit", res.headers["X-Cache-Status"])
+      -- response_headers are on by default
       assert.is_not_nil(res.headers["Age"])
       assert.is_not_nil(res.headers["X-Cache-Key"])
     end)


### PR DESCRIPTION
### Summary

The `age` header should be added by default or when explicitly configured.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #12787 
