### PR TITLE
feat(aws-lambda): add configurable sts endpoint url for aws-lambda plugin

### DIFF
--- a/changelog/unreleased/kong/feat-aws-lambda-configurable-sts-endpoint.yml
+++ b/changelog/unreleased/kong/feat-aws-lambda-configurable-sts-endpoint.yml
@@ -1,0 +1,4 @@
+message: >
+  "**AWS-Lambda**: Added support for a configurable STS endpoint with the new configuration field `aws_sts_endpoint_url`.
+type: feature
+scope: Plugin

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -38,6 +38,19 @@ local compatible_checkers = {
         end
       end
 
+      for _, plugin in ipairs(config_table.plugins or {}) do
+        if plugin.name == 'aws-lambda' then
+          local config = plugin.config
+          if config.aws_sts_endpoint_url ~= nil then
+            config.aws_sts_endpoint_url = nil
+            has_update = true
+            log_warn_message('configures ' .. plugin.name .. ' plugin with aws_sts_endpoint_url',
+              'will be removed.',
+              dp_version, log_suffix)
+          end
+        end
+      end
+
       return has_update
     end
   },

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -48,6 +48,7 @@ local build_cache_key do
   -- vault refresh can take effect when key/secret is rotated
   local SERVICE_RELATED_FIELD = { "timeout", "keepalive", "aws_key", "aws_secret",
                                   "aws_assume_role_arn", "aws_role_session_name",
+                                  "aws_sts_endpoint_url",
                                   "aws_region", "host", "port", "disable_https",
                                   "proxy_url", "aws_imds_protocol_version" }
 
@@ -132,6 +133,7 @@ function AWSLambdaHandler:access(conf)
         credentials = credentials,
         region = region,
         stsRegionalEndpoints = AWS_GLOBAL_CONFIG.sts_regional_endpoints,
+        endpoint = conf.aws_sts_endpoint_url,
         ssl_verify = false,
         http_proxy = conf.proxy_url,
         https_proxy = conf.proxy_url,

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -38,6 +38,7 @@ return {
         { aws_role_session_name = { description = "The identifier of the assumed role session.", type = "string",
           default = "kong"
         } },
+        { aws_sts_endpoint_url = typedefs.url },
         { aws_region = typedefs.host },
         { function_name = {
           type = "string",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This is a cherry-pick of part of the https://github.com/Kong/kong-ee/pull/9654. Please REBASE MERGE to keep consistency between commits.
<!--- Why is this change required? What problem does it solve? -->
EE part PR already has ut/integration test for the STS service, and it seems meaningless to add another integration test for the lambda plugin, so skipped the test on this PR.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4599
