### PR TITLE
style(dns): style and typo fixes

### DIFF
--- a/kong/dns/README.md
+++ b/kong/dns/README.md
@@ -155,7 +155,7 @@ We evaluated the capacity of DNS records using the following resources:
     * Record: ~80 bytes json string, e.g., `{address = "127.0.0.1", name = <domain>, ttl = 3600, class = 1, type = 1}`.
   * Domain: ~36 bytes string, e.g., `example<n>.long.long.long.long.test`. Domain names with lengths between 10 and 36 bytes yield similar results.
 
-The results of ) are as follows:
+The results of evaluation are as follows:
 
 | shared memory size | number of records per response | number of loaded responses |
 |--------------------|-------------------|----------|

--- a/kong/dns/utils.lua
+++ b/kong/dns/utils.lua
@@ -1,8 +1,11 @@
 local utils = require("kong.resty.dns.utils")
 
+
 local log = ngx.log
 
+
 local NOTICE = ngx.NOTICE
+
 
 local type = type
 local ipairs = ipairs
@@ -12,15 +15,19 @@ local table_clear = require("table.clear")
 local table_insert = table.insert
 local table_remove = table.remove
 
+
 local readlines = require("pl.utils").readlines
+
 
 local DEFAULT_HOSTS_FILE = "/etc/hosts"
 local DEFAULT_RESOLV_CONF = "/etc/resolv.conf"
+
 
 local LOCALHOST = {
   ipv4 = "127.0.0.1",
   ipv6 = "[::1]",
 }
+
 
 local DEFAULT_HOSTS = { localhost = LOCALHOST }
 
@@ -29,7 +36,7 @@ local _M = {}
 
 
 -- checks the hostname type
--- @return "ipv4", "ipv6", or "name"
+-- @return "ipv4", "ipv6", or "domain"
 function _M.hostname_type(name)
   local remainder, colons = name:gsub(":", "")
   if colons > 1 then
@@ -86,20 +93,22 @@ function _M.parse_hosts(path, enable_ipv6)
   for _, line in ipairs(lines) do
     -- Remove leading/trailing whitespaces and split by whitespace
     local parts = {}
+    local n = 0
     for part in line:gmatch("%S+") do
       if part:sub(1, 1) == '#' then
         break
       end
 
-      table_insert(parts, part:lower())
+      n = n + 1
+      parts[n] = part:lower()
     end
 
     -- Check if the line contains an IP address followed by hostnames
-    if #parts >= 2 then
+    if n >= 2 then
       local ip, _, family = _M.parse_hostname(parts[1])
 
-      if family ~= "name" then    -- ipv4/ipv6
-        for i = 2, #parts do
+      if family ~= "domain" then    -- ipv4/ipv6
+        for i = 2, n do
           local host = parts[i]
           local v = hosts[host]
 

--- a/kong/dns/utils.lua
+++ b/kong/dns/utils.lua
@@ -29,7 +29,7 @@ local LOCALHOST = {
 }
 
 
-local DEFAULT_HOSTS = { localhost = LOCALHOST }
+local DEFAULT_HOSTS = { localhost = LOCALHOST, }
 
 
 local _M = {}
@@ -54,7 +54,7 @@ end
 -- parses a hostname with an optional port
 -- IPv6 addresses are always returned in square brackets
 -- @param name the string to check (this may contain a port number)
--- @return `name/ip` + `port (or nil)` + `type ("ipv4", "ipv6" or "name")`
+-- @return `name/ip` + `port (or nil)` + `type ("ipv4", "ipv6" or "domain")`
 function _M.parse_hostname(name)
   local t = _M.hostname_type(name)
   if t == "ipv4" or t == "domain" then

--- a/spec/01-unit/30-new-dns-client/01-utils_spec.lua
+++ b/spec/01-unit/30-new-dns-client/01-utils_spec.lua
@@ -112,6 +112,54 @@ describe("[utils]", function ()
     end)
   end)
 
+  describe("parsing hostname", function ()
+    it("hostname_type()", function ()
+      assert.equal(utils.hostname_type("10.0.0.1"), "ipv4")
+      assert.equal(utils.hostname_type("127.0.0.1"), "ipv4")
+
+      assert.equal(utils.hostname_type("::1"), "ipv6")
+      assert.equal(utils.hostname_type("[::1]"), "ipv6")
+      assert.equal(utils.hostname_type("2001:db8::1"), "ipv6")
+      assert.equal(utils.hostname_type("[2001:db8::1]"), "ipv6")
+
+      assert.equal(utils.hostname_type("localhost"), "domain")
+      assert.equal(utils.hostname_type("example.test"), "domain")
+      assert.equal(utils.hostname_type("example.org"), "domain")
+      assert.equal(utils.hostname_type("example.com"), "domain")
+      assert.equal(utils.hostname_type("10.0.0.1.example.test"), "domain")
+    end)
+
+    it("parse_hostname()", function ()
+      local function check(name, expected_name, expected_port, expected_name_type)
+        local name_ip, port, name_type = utils.parse_hostname(name)
+
+        assert.equal(name_ip, expected_name, "checking the returned name/ip of " .. name)
+        assert.equal(port, expected_port, "checking the returned port of " .. name)
+        assert.equal(name_type, expected_name_type, "checking the returned type of " .. name)
+      end
+
+      check("127.0.0.1", "127.0.0.1", nil, "ipv4")
+      check("127.0.0.1:", "127.0.0.1", nil, "ipv4")
+      check("127.0.0.1:0", "127.0.0.1", 0, "ipv4")
+      check("127.0.0.1:80", "127.0.0.1", 80, "ipv4")
+
+      check("::1", "[::1]", nil, "ipv6")
+      check("[::1]:", "[::1]", nil, "ipv6")
+      check("[::1]:0", "[::1]", 0, "ipv6")
+      check("[::1]:80", "[::1]", 80, "ipv6")
+
+      check("www.example.test", "www.example.test", nil, "domain")
+      check("www.example.test:", "www.example.test", nil, "domain")
+      check("www.example.test:0", "www.example.test", 0, "domain")
+      check("www.example.test:80", "www.example.test", 80, "domain")
+
+      check("localhost", "localhost", nil, "domain")
+      check("localhost:", "localhost", nil, "domain")
+      check("localhost:0", "localhost", 0, "domain")
+      check("localhost:80", "localhost", 80, "domain")
+    end)
+  end)
+
   describe("ipv6_bracket()", function ()
     it("IPv6 address", function ()
       assert.equal(utils.ipv6_bracket("::1"), "[::1]")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Merge ready since #12305 was cherry-picked successfully.

KAG-5001

* two blank lines between blocks
* optimize table.insert
* family should compare to `domain`, not `name`.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
