### PR TITLE
fix(opentelemetry): migration exception when upgrading from below version 3.3 to 3.7

### DIFF
--- a/changelog/unreleased/kong/fix-otel-migrations-exception.yml
+++ b/changelog/unreleased/kong/fix-otel-migrations-exception.yml
@@ -1,0 +1,3 @@
+message: "**OpenTelemetry:** Fixed an issue where migration fails when upgrading from below version 3.3 to 3.7."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/opentelemetry/migrations/001_331_to_332.lua
+++ b/kong/plugins/opentelemetry/migrations/001_331_to_332.lua
@@ -4,6 +4,10 @@ local operations = require "kong.db.migrations.operations.331_to_332"
 local function ws_migration_teardown(ops)
   return function(connector)
     return ops:fixup_plugin_config(connector, "opentelemetry", function(config)
+      if not config.queue then
+        return false
+      end
+
       if config.queue.max_batch_size == 1 then
         config.queue.max_batch_size = 200
         return true

--- a/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
+++ b/spec/05-migration/plugins/opentelemetry/migrations/001_331_to_332_spec.lua
@@ -4,7 +4,56 @@ local uh = require "spec.upgrade_helpers"
 
 
 if uh.database_type() == 'postgres' then
-    local handler = uh.get_busted_handler("3.3.0", "3.6.0")
+    local handler = uh.get_busted_handler("3.0.0", "3.2.0")
+    handler("opentelemetry plugin migration", function()
+        lazy_setup(function()
+            assert(uh.start_kong())
+        end)
+
+        lazy_teardown(function ()
+            assert(uh.stop_kong())
+        end)
+
+        uh.setup(function ()
+            local admin_client = assert(uh.admin_client())
+
+            local res = assert(admin_client:send {
+                method = "POST",
+                path = "/plugins/",
+                body = {
+                    name = "opentelemetry",
+                    config = {
+                        endpoint = "http://localhost:8080/v1/traces",
+                    }
+                },
+                headers = {
+                    ["Content-Type"] = "application/json"
+                }
+            })
+            assert.res_status(201, res)
+            admin_client:close()
+        end)
+
+        uh.new_after_finish("has opentelemetry queue configuration", function ()
+            local admin_client = assert(uh.admin_client())
+            local res = assert(admin_client:send {
+                method = "GET",
+                path = "/plugins/"
+            })
+            local body = cjson.decode(assert.res_status(200, res))
+            assert.equal(1, #body.data)
+            assert.equal("opentelemetry", body.data[1].name)
+            local expected_config = {
+                queue = {
+                    max_batch_size = 200
+                },
+            }
+            assert.partial_match(expected_config, body.data[1].config)
+            admin_client:close()
+        end)
+    end)
+
+    handler = uh.get_busted_handler("3.3.0", "3.6.0")
     handler("opentelemetry plugin migration", function()
         lazy_setup(function()
             assert(uh.start_kong())


### PR DESCRIPTION
### Summary

The migration job try to reset `config.queue.max_batch_size` of opentelemetry plugin. However the `config.queue` field has only been introduced since 3.3. 

This means that if users are upgrading from a version below 3.3 to 3.7, they will encounter `kong migrations finish` terminates unsuccessfully with the error:

```
kong@943321e5c877:/$ kong migrations finish
migrating opentelemetry on database 'kong'...
Error: [PostgreSQL error] cluster_mutex callback threw an error: /usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:174: [PostgreSQL error] failed to run migration '001_331_to_332' teardown: ./opentelemetry/migrations/001_331_to_332.lua:14: attempt to index field 'queue' (a nil value)
stack traceback:
	./opentelemetry/migrations/001_331_to_332.lua:14: in function 'fixup_fn'
	...are/lua/5.1/kong/db/migrations/operations/331_to_332.lua:48: in function <...are/lua/5.1/kong/db/migrations/operations/331_to_332.lua:35>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/kong/db/init.lua:595: in function 'run_migrations'
	/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:174: in function </usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:158>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/kong/db/init.lua:408: in function </usr/local/share/lua/5.1/kong/db/init.lua:358>
	[C]: in function 'pcall'
	/usr/local/share/lua/5.1/kong/concurrency.lua:66: in function 'cluster_mutex'
	/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:158: in function 'finish'
	/usr/local/share/lua/5.1/kong/cmd/migrations.lua:332: in function 'cmd_exec'
	/usr/local/share/lua/5.1/kong/cmd/init.lua:38: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:38>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/kong/cmd/init.lua:38: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:22>
	(command line -e):7: in function 'inline_gen'
	init_worker_by_lua(nginx.conf:157):44: in function <init_worker_by_lua(nginx.conf:157):43>
	[C]: in function 'xpcall'
	init_worker_by_lua(nginx.conf:157):52: in function <init_worker_by_lua(nginx.conf:157):50>
stack traceback:
	[C]: in function 'assert'
	/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:174: in function </usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:158>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/kong/db/init.lua:408: in function </usr/local/share/lua/5.1/kong/db/init.lua:358>
	[C]: in function 'pcall'
	/usr/local/share/lua/5.1/kong/concurrency.lua:66: in function 'cluster_mutex'
	/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:158: in function 'finish'
	/usr/local/share/lua/5.1/kong/cmd/migrations.lua:332: in function 'cmd_exec'
	/usr/local/share/lua/5.1/kong/cmd/init.lua:38: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:38>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/kong/cmd/init.lua:38: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:22>
	(command line -e):7: in function 'inline_gen'
	init_worker_by_lua(nginx.conf:157):44: in function <init_worker_by_lua(nginx.conf:157):43>
	[C]: in function 'xpcall'
	init_worker_by_lua(nginx.conf:157):52: in function <init_worker_by_lua(nginx.conf:157):50>

  Run with --v (verbose) or --vv (debug) for more details
```


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6109
