### PR TITLE
chore(ci): fix image release issue by hard-coding branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,7 +586,7 @@ jobs:
 
     - name: Get latest commit SHA on master
       run: |
-        echo "latest_sha=$(git ls-remote origin -h refs/heads/${{ github.event.inputs.default_branch }} | cut -f1)" >> $GITHUB_ENV
+        echo "latest_sha=$(git ls-remote origin -h refs/heads/master | cut -f1)" >> $GITHUB_ENV
 
     - name: Docker meta
       id: meta
@@ -595,7 +595,7 @@ jobs:
         images: ${{ needs.metadata.outputs.docker-repository }}
         sep-tags: " "
         tags: |
-          type=raw,value=latest,enable=${{ matrix.label == 'ubuntu' && github.ref_name == github.event.inputs.default_branch && env.latest_sha == needs.metadata.outputs.commit-sha }}
+          type=raw,value=latest,enable=${{ matrix.label == 'ubuntu' && github.ref_name == 'master' && env.latest_sha == needs.metadata.outputs.commit-sha }}
           type=match,enable=${{ github.event_name == 'workflow_dispatch' }},pattern=\d.\d,value=${{ github.event.inputs.version }}
           type=match,enable=${{ github.event_name == 'workflow_dispatch' && matrix.label == 'ubuntu' }},pattern=\d.\d,value=${{ github.event.inputs.version }},suffix=
           type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},${{ github.event.inputs.version }}


### PR DESCRIPTION
### Summary

Due to ${{ github.event.inputs.default_branch }} being empty, causing an exception when fetching the SHA, so hardcode the branch name.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-4992
