### PR TITLE
fix(core): relocate unix sockets to a subdirectory

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -46,11 +46,12 @@ if [[ "$1" == "kong" ]]; then
 
     # remove all dangling sockets in $PREFIX dir before starting Kong
     LOGGED_SOCKET_WARNING=0
-    for localfile in "$PREFIX"/*; do
+    runtime_prefix=$PREFIX/runtime
+    for localfile in "$runtime_prefix"/*; do
       if [ -S "$localfile" ]; then
         if (( LOGGED_SOCKET_WARNING == 0 )); then
-          printf >&2 'WARN: found dangling unix sockets in the prefix directory '
-          printf >&2 '(%q) ' "$PREFIX"
+          printf >&2 'WARN: found dangling unix sockets in the runtime prefix '
+          printf >&2 '(%q) ' "$runtime_prefix"
           printf >&2 'while preparing to start Kong. This may be a sign that Kong '
           printf >&2 'was previously shut down uncleanly or is in an unknown state '
           printf >&2 'and could require further investigation.\n'

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -46,12 +46,12 @@ if [[ "$1" == "kong" ]]; then
 
     # remove all dangling sockets in $PREFIX dir before starting Kong
     LOGGED_SOCKET_WARNING=0
-    runtime_prefix=$PREFIX/runtime
-    for localfile in "$runtime_prefix"/*; do
+    socket_path=$PREFIX/sockets
+    for localfile in "$socket_path"/*; do
       if [ -S "$localfile" ]; then
         if (( LOGGED_SOCKET_WARNING == 0 )); then
-          printf >&2 'WARN: found dangling unix sockets in the runtime prefix '
-          printf >&2 '(%q) ' "$runtime_prefix"
+          printf >&2 'WARN: found dangling unix sockets in the prefix directory '
+          printf >&2 '(%q) ' "$socket_path"
           printf >&2 'while preparing to start Kong. This may be a sign that Kong '
           printf >&2 'was previously shut down uncleanly or is in an unknown state '
           printf >&2 'and could require further investigation.\n'

--- a/changelog/unreleased/kong/move-sockets-to-subdir.yml
+++ b/changelog/unreleased/kong/move-sockets-to-subdir.yml
@@ -1,0 +1,3 @@
+message: Moved internal unix sockets to a subdirectory of the Kong prefix.
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/move-sockets-to-subdir.yml
+++ b/changelog/unreleased/kong/move-sockets-to-subdir.yml
@@ -1,3 +1,3 @@
-message: Moved internal unix sockets to a subdirectory of the Kong prefix.
+message: Moved internal Unix sockets to a subdirectory (`sockets`) of the Kong prefix.
 type: bugfix
 scope: Core

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -25,7 +25,7 @@ local _log_prefix = "[clustering] "
 local KONG_VERSION = kong.version
 
 local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/cluster_proxy_ssl_terminator.sock",
-                                              kong.configuration.runtime_prefix)
+                                              kong.configuration.socket_path)
 
 local _M = {}
 

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -24,8 +24,8 @@ local _log_prefix = "[clustering] "
 
 local KONG_VERSION = kong.version
 
-local prefix = kong.configuration.prefix or require("pl.path").abspath(ngx.config.prefix())
-local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/cluster_proxy_ssl_terminator.sock", prefix)
+local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/cluster_proxy_ssl_terminator.sock",
+                                              kong.configuration.runtime_prefix)
 
 local _M = {}
 

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -13,11 +13,11 @@ local function is_socket(path)
   return lfs.attributes(path, "mode") == "socket"
 end
 
-local function cleanup_dangling_unix_sockets(runtime_prefix)
+local function cleanup_dangling_unix_sockets(socket_path)
   local found = {}
 
-  for child in lfs.dir(runtime_prefix) do
-    local path = runtime_prefix .. "/" .. child
+  for child in lfs.dir(socket_path) do
+    local path = socket_path .. "/" .. child
     if is_socket(path) then
       table.insert(found, path)
     end
@@ -27,11 +27,11 @@ local function cleanup_dangling_unix_sockets(runtime_prefix)
     return
   end
 
-  log.warn("Found dangling unix sockets in the runtime prefix (%q) while " ..
+  log.warn("Found dangling unix sockets in the prefix directory (%q) while " ..
            "preparing to start Kong. This may be a sign that Kong was " ..
            "previously shut down uncleanly or is in an unknown state and " ..
            "could require further investigation.",
-           runtime_prefix)
+           socket_path)
 
   log.warn("Attempting to remove dangling sockets before starting Kong...")
 
@@ -59,7 +59,7 @@ local function execute(args)
   assert(prefix_handler.prepare_prefix(conf, args.nginx_conf, nil, nil,
          args.nginx_conf_flags))
 
-  cleanup_dangling_unix_sockets(conf.runtime_prefix)
+  cleanup_dangling_unix_sockets(conf.socket_path)
 
   _G.kong = kong_global.new()
   kong_global.init_pdk(_G.kong, conf)

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -13,11 +13,11 @@ local function is_socket(path)
   return lfs.attributes(path, "mode") == "socket"
 end
 
-local function cleanup_dangling_unix_sockets(prefix)
+local function cleanup_dangling_unix_sockets(runtime_prefix)
   local found = {}
 
-  for child in lfs.dir(prefix) do
-    local path = prefix .. "/" .. child
+  for child in lfs.dir(runtime_prefix) do
+    local path = runtime_prefix .. "/" .. child
     if is_socket(path) then
       table.insert(found, path)
     end
@@ -27,11 +27,11 @@ local function cleanup_dangling_unix_sockets(prefix)
     return
   end
 
-  log.warn("Found dangling unix sockets in the prefix directory (%q) while " ..
+  log.warn("Found dangling unix sockets in the runtime prefix (%q) while " ..
            "preparing to start Kong. This may be a sign that Kong was " ..
            "previously shut down uncleanly or is in an unknown state and " ..
            "could require further investigation.",
-           prefix)
+           runtime_prefix)
 
   log.warn("Attempting to remove dangling sockets before starting Kong...")
 
@@ -59,7 +59,7 @@ local function execute(args)
   assert(prefix_handler.prepare_prefix(conf, args.nginx_conf, nil, nil,
          args.nginx_conf_flags))
 
-  cleanup_dangling_unix_sockets(conf.prefix)
+  cleanup_dangling_unix_sockets(conf.runtime_prefix)
 
   _G.kong = kong_global.new()
   kong_global.init_pdk(_G.kong, conf)

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -481,6 +481,13 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     return nil, kong_config.prefix .. " is not a directory"
   end
 
+  if not exists(kong_config.runtime_prefix) then
+    local ok, err = makepath(kong_config.runtime_prefix)
+    if not ok then
+      return nil, err
+    end
+  end
+
   -- create directories in prefix
   for _, dir in ipairs {"logs", "pids"} do
     local ok, err = makepath(join(kong_config.prefix, dir))

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -481,8 +481,8 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     return nil, kong_config.prefix .. " is not a directory"
   end
 
-  if not exists(kong_config.runtime_prefix) then
-    local ok, err = makepath(kong_config.runtime_prefix)
+  if not exists(kong_config.socket_path) then
+    local ok, err = makepath(kong_config.socket_path)
     if not ok then
       return nil, err
     end

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -482,6 +482,10 @@ local function load(path, custom_conf, opts)
   -- load absolute paths
   conf.prefix = abspath(conf.prefix)
 
+  -- the runtime prefix is where we keep listening unix sockets for IPC and
+  -- private APIs
+  conf.runtime_prefix = pl_path.join(conf.prefix, "runtime")
+
   if conf.lua_ssl_trusted_certificate
      and #conf.lua_ssl_trusted_certificate > 0 then
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -483,8 +483,8 @@ local function load(path, custom_conf, opts)
   -- load absolute paths
   conf.prefix = abspath(conf.prefix)
 
-  -- the socket path is where we store listening unix sockets for IPC and
-  -- private APIs
+  -- The socket path is where we store listening unix sockets for IPC and private APIs.
+  -- It is derived from the prefix and is NOT intended to be user-configurable
   conf.socket_path = pl_path.join(conf.prefix, constants.SOCKET_DIRECTORY)
 
   if conf.lua_ssl_trusted_certificate

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -482,9 +482,9 @@ local function load(path, custom_conf, opts)
   -- load absolute paths
   conf.prefix = abspath(conf.prefix)
 
-  -- the runtime prefix is where we keep listening unix sockets for IPC and
+  -- the socket path is where we store listening unix sockets for IPC and
   -- private APIs
-  conf.runtime_prefix = pl_path.join(conf.prefix, "runtime")
+  conf.socket_path = pl_path.join(conf.prefix, "sockets")
 
   if conf.lua_ssl_trusted_certificate
      and #conf.lua_ssl_trusted_certificate > 0 then

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -17,6 +17,7 @@ local pl_path = require "pl.path"
 local tablex = require "pl.tablex"
 local log = require "kong.cmd.utils.log"
 local env = require "kong.cmd.utils.env"
+local constants = require "kong.constants"
 
 
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
@@ -484,7 +485,7 @@ local function load(path, custom_conf, opts)
 
   -- the socket path is where we store listening unix sockets for IPC and
   -- private APIs
-  conf.socket_path = pl_path.join(conf.prefix, "sockets")
+  conf.socket_path = pl_path.join(conf.prefix, constants.SOCKET_DIRECTORY)
 
   if conf.lua_ssl_trusted_certificate
      and #conf.lua_ssl_trusted_certificate > 0 then

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -280,6 +280,8 @@ local constants = {
       service = "upstream",
     }
   },
+
+  SOCKET_DIRECTORY = "sockets",
 }
 
 for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -174,12 +174,12 @@ function _GLOBAL.init_worker_events(kong_config)
   local worker_events
   local opts
 
-  local runtime_prefix = kong_config.runtime_prefix
+  local socket_path = kong_config.socket_path
   local sock = ngx.config.subsystem == "stream" and
                "stream_worker_events.sock" or
                "worker_events.sock"
 
-  local listening = "unix:" .. runtime_prefix .. "/" .. sock
+  local listening = "unix:" .. socket_path .. "/" .. sock
 
   local max_payload_len = kong_config.worker_events_max_payload
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -168,28 +168,20 @@ function _GLOBAL.init_pdk(self, kong_config)
 end
 
 
-function _GLOBAL.init_worker_events()
+function _GLOBAL.init_worker_events(kong_config)
   -- Note: worker_events will not work correctly if required at the top of the file.
   --       It must be required right here, inside the init function
   local worker_events
   local opts
 
-  local configuration = kong.configuration
-
-  -- `kong.configuration.prefix` is already normalized to an absolute path,
-  -- but `ngx.config.prefix()` is not
-  local prefix = configuration and
-                 configuration.prefix or
-                 require("pl.path").abspath(ngx.config.prefix())
-
+  local runtime_prefix = kong_config.runtime_prefix
   local sock = ngx.config.subsystem == "stream" and
                "stream_worker_events.sock" or
                "worker_events.sock"
 
-  local listening = "unix:" .. prefix .. "/" .. sock
+  local listening = "unix:" .. runtime_prefix .. "/" .. sock
 
-  local max_payload_len = configuration and
-                          configuration.worker_events_max_payload
+  local max_payload_len = kong_config.worker_events_max_payload
 
   if max_payload_len and max_payload_len > 65535 then   -- default is 64KB
     ngx.log(ngx.WARN,
@@ -203,9 +195,9 @@ function _GLOBAL.init_worker_events()
     listening = listening,  -- unix socket for broker listening
     max_queue_len = 1024 * 50,  -- max queue len for events buffering
     max_payload_len = max_payload_len,  -- max payload size in bytes
-    enable_privileged_agent = configuration and configuration.dedicated_config_processing
-                                            and configuration.role == "data_plane"
-                                             or false
+    enable_privileged_agent = kong_config.dedicated_config_processing
+                          and kong_config.role == "data_plane"
+                           or false,
   }
 
   worker_events = require "resty.events.compat"

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -837,7 +837,7 @@ function Kong.init_worker()
 
   schema_state = nil
 
-  local worker_events, err = kong_global.init_worker_events()
+  local worker_events, err = kong_global.init_worker_events(kong.configuration)
   if not worker_events then
     stash_init_worker_error("failed to instantiate 'kong.worker_events' " ..
                             "module: " .. err)

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -508,16 +508,16 @@ do
   local buffer = require "string.buffer"
 
   -- this module may be loaded before `kong.configuration` is initialized
-  local runtime_prefix = kong and kong.configuration
-                         and kong.configuration.runtime_prefix
+  local socket_path = kong and kong.configuration
+                      and kong.configuration.socket_path
 
-  if not runtime_prefix then
-    -- `kong.configuration.runtime_prefix` is already normalized to an absolute
+  if not socket_path then
+    -- `kong.configuration.socket_path` is already normalized to an absolute
     -- path, but `ngx.config.prefix()` is not
-    runtime_prefix = require("pl.path").abspath(ngx.config.prefix() .. "/runtime")
+    socket_path = require("pl.path").abspath(ngx.config.prefix() .. "/sockets")
   end
 
-  local STREAM_CONFIG_SOCK = "unix:" .. runtime_prefix .. "/stream_config.sock"
+  local STREAM_CONFIG_SOCK = "unix:" .. socket_path .. "/stream_config.sock"
   local IS_HTTP_SUBSYSTEM  = ngx.config.subsystem == "http"
 
   local function broadcast_reconfigure_event(data)

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -514,7 +514,8 @@ do
   if not socket_path then
     -- `kong.configuration.socket_path` is already normalized to an absolute
     -- path, but `ngx.config.prefix()` is not
-    socket_path = require("pl.path").abspath(ngx.config.prefix() .. "/sockets")
+    socket_path = require("pl.path").abspath(ngx.config.prefix() .. "/"
+                                             .. constants.SOCKET_DIRECTORY)
   end
 
   local STREAM_CONFIG_SOCK = "unix:" .. socket_path .. "/stream_config.sock"

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -896,11 +896,9 @@ return {
 
   init_worker = {
     before = function()
-      -- TODO: PR #9337 may affect the following line
-      local prefix = kong.configuration.prefix or ngx.config.prefix()
-
-      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", prefix)
-      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", prefix)
+      local runtime_prefix = kong.configuration.runtime_prefix
+      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", runtime_prefix)
+      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", runtime_prefix)
 
       log_level.init_worker()
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -896,9 +896,9 @@ return {
 
   init_worker = {
     before = function()
-      local runtime_prefix = kong.configuration.runtime_prefix
-      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", runtime_prefix)
-      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", runtime_prefix)
+      local socket_path = kong.configuration.socket_path
+      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", socket_path)
+      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", socket_path)
 
       log_level.init_worker()
 

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -83,7 +83,7 @@ stream {
 
 > if cluster_ssl_tunnel then
     server {
-        listen unix:${{RUNTIME_PREFIX}}/cluster_proxy_ssl_terminator.sock;
+        listen unix:${{SOCKET_PATH}}/cluster_proxy_ssl_terminator.sock;
 
         proxy_pass ${{cluster_ssl_tunnel}};
         proxy_ssl on;

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -83,7 +83,7 @@ stream {
 
 > if cluster_ssl_tunnel then
     server {
-        listen unix:${{PREFIX}}/cluster_proxy_ssl_terminator.sock;
+        listen unix:${{RUNTIME_PREFIX}}/cluster_proxy_ssl_terminator.sock;
 
         proxy_pass ${{cluster_ssl_tunnel}};
         proxy_ssl on;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -592,7 +592,7 @@ server {
 server {
     charset UTF-8;
     server_name kong_worker_events;
-    listen unix:${{PREFIX}}/worker_events.sock;
+    listen unix:${{RUNTIME_PREFIX}}/worker_events.sock;
     access_log off;
     location / {
         content_by_lua_block {

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -592,7 +592,7 @@ server {
 server {
     charset UTF-8;
     server_name kong_worker_events;
-    listen unix:${{RUNTIME_PREFIX}}/worker_events.sock;
+    listen unix:${{SOCKET_PATH}}/worker_events.sock;
     access_log off;
     location / {
         content_by_lua_block {

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -94,7 +94,7 @@ server {
 > end
 
 > if stream_proxy_ssl_enabled then
-    listen unix:${{RUNTIME_PREFIX}}/stream_tls_terminate.sock ssl proxy_protocol;
+    listen unix:${{SOCKET_PATH}}/stream_tls_terminate.sock ssl proxy_protocol;
 > end
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
@@ -175,7 +175,7 @@ server {
 }
 
 server {
-    listen unix:${{RUNTIME_PREFIX}}/stream_tls_passthrough.sock proxy_protocol;
+    listen unix:${{SOCKET_PATH}}/stream_tls_passthrough.sock proxy_protocol;
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
     error_log ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
@@ -205,7 +205,7 @@ server {
 
 > if database == "off" then
 server {
-    listen unix:${{RUNTIME_PREFIX}}/stream_config.sock;
+    listen unix:${{SOCKET_PATH}}/stream_config.sock;
 
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
@@ -216,7 +216,7 @@ server {
 > end -- database == "off"
 
 server {        # ignore (and close }, to ignore content)
-    listen unix:${{RUNTIME_PREFIX}}/stream_rpc.sock;
+    listen unix:${{SOCKET_PATH}}/stream_rpc.sock;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     content_by_lua_block {
         Kong.stream_api()
@@ -225,7 +225,7 @@ server {        # ignore (and close }, to ignore content)
 > end -- #stream_listeners > 0
 
 server {
-    listen unix:${{RUNTIME_PREFIX}}/stream_worker_events.sock;
+    listen unix:${{SOCKET_PATH}}/stream_worker_events.sock;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     access_log off;
     content_by_lua_block {

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -94,7 +94,7 @@ server {
 > end
 
 > if stream_proxy_ssl_enabled then
-    listen unix:${{PREFIX}}/stream_tls_terminate.sock ssl proxy_protocol;
+    listen unix:${{RUNTIME_PREFIX}}/stream_tls_terminate.sock ssl proxy_protocol;
 > end
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
@@ -175,7 +175,7 @@ server {
 }
 
 server {
-    listen unix:${{PREFIX}}/stream_tls_passthrough.sock proxy_protocol;
+    listen unix:${{RUNTIME_PREFIX}}/stream_tls_passthrough.sock proxy_protocol;
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
     error_log ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
@@ -205,7 +205,7 @@ server {
 
 > if database == "off" then
 server {
-    listen unix:${{PREFIX}}/stream_config.sock;
+    listen unix:${{RUNTIME_PREFIX}}/stream_config.sock;
 
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
@@ -216,7 +216,7 @@ server {
 > end -- database == "off"
 
 server {        # ignore (and close }, to ignore content)
-    listen unix:${{PREFIX}}/stream_rpc.sock;
+    listen unix:${{RUNTIME_PREFIX}}/stream_rpc.sock;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     content_by_lua_block {
         Kong.stream_api()
@@ -225,7 +225,7 @@ server {        # ignore (and close }, to ignore content)
 > end -- #stream_listeners > 0
 
 server {
-    listen unix:${{PREFIX}}/stream_worker_events.sock;
+    listen unix:${{RUNTIME_PREFIX}}/stream_worker_events.sock;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     access_log off;
     content_by_lua_block {

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -38,7 +38,7 @@ local MAX_DATA_LEN = 2^22 - 1
 local HEADER_LEN = #st_pack(PACK_F, MAX_KEY_LEN, MAX_DATA_LEN)
 
 -- this module may be loaded before `kong.configuration` is initialized
-local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/runtime/stream_rpc.sock"
+local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/sockets/stream_rpc.sock"
 
 local stream_api = {}
 

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -3,6 +3,7 @@
 -- may changed or be removed in the future Kong releases once a better mechanism
 -- for inter subsystem communication in OpenResty became available.
 
+local constants = require "kong.constants"
 local lpack = require "lua_pack"
 
 local kong = kong
@@ -38,7 +39,8 @@ local MAX_DATA_LEN = 2^22 - 1
 local HEADER_LEN = #st_pack(PACK_F, MAX_KEY_LEN, MAX_DATA_LEN)
 
 -- this module may be loaded before `kong.configuration` is initialized
-local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/sockets/stream_rpc.sock"
+local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/"
+                    .. constants.SOCKET_DIRECTORY .. "/stream_rpc.sock"
 
 local stream_api = {}
 

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -37,7 +37,8 @@ local MAX_DATA_LEN = 2^22 - 1
 
 local HEADER_LEN = #st_pack(PACK_F, MAX_KEY_LEN, MAX_DATA_LEN)
 
-local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/stream_rpc.sock"
+-- this module may be loaded before `kong.configuration` is initialized
+local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/runtime/stream_rpc.sock"
 
 local stream_api = {}
 

--- a/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
+++ b/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
@@ -187,7 +187,7 @@ describe("#off preserve nulls", function()
     kong.configuration = kong_config
     kong.worker_events = kong.worker_events or
                          kong.cache and kong.cache.worker_events or
-                         assert(kong_global.init_worker_events())
+                         assert(kong_global.init_worker_events(kong.configuration))
     kong.cluster_events = kong.cluster_events or
                           kong.cache and kong.cache.cluster_events or
                           assert(kong_global.init_cluster_events(kong.configuration, kong.db))

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -2395,7 +2395,7 @@ describe("Configuration loader", function()
       local FIELDS = {
         -- CONF_BASIC
         prefix = true,
-        runtime_prefix = true,
+        socket_path = true,
         vaults = true,
         database = true,
         lmdb_environment_path = true,

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -2395,6 +2395,7 @@ describe("Configuration loader", function()
       local FIELDS = {
         -- CONF_BASIC
         prefix = true,
+        runtime_prefix = true,
         vaults = true,
         database = true,
         lmdb_environment_path = true,

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -10,12 +10,14 @@ local read_file = helpers.file.read
 
 
 local PREFIX = helpers.test_conf.prefix
+local RUNTIME_PREFIX = helpers.test_conf.runtime_prefix
 local TEST_CONF = helpers.test_conf
 local TEST_CONF_PATH = helpers.test_conf_path
 
 
 local function wait_until_healthy(prefix)
   prefix = prefix or PREFIX
+  local runtime_prefix = prefix .. "/runtime"
 
   local cmd
 
@@ -41,11 +43,11 @@ local function wait_until_healthy(prefix)
   local conf = assert(helpers.get_running_conf(prefix))
 
   if conf.proxy_listen and conf.proxy_listen ~= "off" then
-    helpers.wait_for_file("socket", prefix .. "/worker_events.sock")
+    helpers.wait_for_file("socket", runtime_prefix .. "/worker_events.sock")
   end
 
   if conf.stream_listen and conf.stream_listen ~= "off" then
-    helpers.wait_for_file("socket", prefix .. "/stream_worker_events.sock")
+    helpers.wait_for_file("socket", runtime_prefix .. "/stream_worker_events.sock")
   end
 
   if conf.admin_listen and conf.admin_listen ~= "off" then
@@ -1034,11 +1036,51 @@ describe("kong start/stop #" .. strategy, function()
     end)
   end)
 
+  describe("runtime_prefix", function()
+    it("is created on demand by `kong prepare`", function()
+      local dir, cleanup = helpers.make_temp_dir()
+      finally(cleanup)
+
+      local cmd = fmt("prepare -p %q", dir)
+      assert.truthy(kong_exec(cmd), "expected '" .. cmd .. "' to succeed")
+      assert.truthy(helpers.path.isdir(dir .. "/runtime"),
+                    "expected '" .. dir .. "/runtime' directory to be created")
+    end)
+
+    it("can be a user-created symlink", function()
+      local prefix, cleanup = helpers.make_temp_dir()
+      finally(cleanup)
+
+      local runtime_prefix
+      runtime_prefix, cleanup = helpers.make_temp_dir()
+      finally(cleanup)
+
+      assert.truthy(helpers.execute(fmt("ln -sf %q %q/runtime", runtime_prefix, prefix)),
+                    "failed to symlink runtime prefix")
+
+      local preserve_prefix = true
+      assert(helpers.start_kong({
+        prefix = prefix,
+        database = "off",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }, nil, preserve_prefix))
+
+      finally(function()
+        helpers.stop_kong(prefix)
+      end)
+
+      wait_until_healthy(prefix)
+
+      assert.truthy(helpers.path.exists(runtime_prefix .. "/worker_events.sock"),
+                    "worker events socket was not created in the runtime_prefix dir")
+    end)
+  end)
+
   describe("dangling socket cleanup", function()
     local pidfile = TEST_CONF.nginx_pid
 
     -- the worker events socket is just one of many unix sockets we use
-    local event_sock = PREFIX .. "/worker_events.sock"
+    local event_sock = RUNTIME_PREFIX .. "/worker_events.sock"
 
     local env = {
       prefix                      = PREFIX,
@@ -1133,8 +1175,8 @@ describe("kong start/stop #" .. strategy, function()
     it("removes unix socket files in the prefix directory", function()
       local _, stderr = assert_start()
 
-      assert.matches("[warn] Found dangling unix sockets in the prefix directory", stderr, nil, true)
-      assert.matches(PREFIX, stderr, nil, true)
+      assert.matches("[warn] Found dangling unix sockets in the runtime prefix", stderr, nil, true)
+      assert.matches(RUNTIME_PREFIX, stderr, nil, true)
 
       assert.matches("removing unix socket", stderr)
       assert.matches(event_sock, stderr, nil, true)
@@ -1175,6 +1217,7 @@ describe("kong start/stop #" .. strategy, function()
 
     it("works with resty.events when KONG_PREFIX is a relative path", function()
       local prefix = "relpath"
+      local runtime_prefix = "relpath/runtime"
 
       finally(function()
         -- this test uses a non-default prefix, so it must manage
@@ -1201,8 +1244,8 @@ describe("kong start/stop #" .. strategy, function()
       -- wait until everything is running
       wait_until_healthy(prefix)
 
-      assert.truthy(helpers.path.exists(prefix .. "/worker_events.sock"))
-      assert.truthy(helpers.path.exists(prefix .. "/stream_worker_events.sock"))
+      assert.truthy(helpers.path.exists(runtime_prefix .. "/worker_events.sock"))
+      assert.truthy(helpers.path.exists(runtime_prefix .. "/stream_worker_events.sock"))
 
       local log = prefix .. "/logs/error.log"
       assert.logfile(log).has.no.line("[error]", true, 0)

--- a/spec/02-integration/03-db/14-dao_spec.lua
+++ b/spec/02-integration/03-db/14-dao_spec.lua
@@ -85,7 +85,7 @@ for _, strategy in helpers.all_strategies() do
         local kong_global = require("kong.global")
         local kong = _G.kong
 
-        kong.worker_events = assert(kong_global.init_worker_events())
+        kong.worker_events = assert(kong_global.init_worker_events(kong.configuration))
         kong.cluster_events = assert(kong_global.init_cluster_events(kong.configuration, kong.db))
         kong.cache = assert(kong_global.init_cache(kong.configuration, kong.cluster_events, kong.worker_events))
         kong.core_cache = assert(kong_global.init_core_cache(kong.configuration, kong.cluster_events, kong.worker_events))

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -102,10 +102,10 @@ describe("#stream proxy interface listeners", function()
       stream_listen = "127.0.0.1:9011, 127.0.0.1:9012",
     }))
 
-    local stream_events_sock_path = "unix:" .. helpers.test_conf.prefix .. "/stream_worker_events.sock"
+    local stream_events_sock_path = "unix:" .. helpers.test_conf.runtime_prefix .. "/stream_worker_events.sock"
 
     if helpers.test_conf.database == "off" then
-      local stream_config_sock_path = "unix:" .. helpers.test_conf.prefix .. "/stream_config.sock"
+      local stream_config_sock_path = "unix:" .. helpers.test_conf.runtime_prefix .. "/stream_config.sock"
 
       assert.equals(3, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
       assert.same({

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -102,10 +102,10 @@ describe("#stream proxy interface listeners", function()
       stream_listen = "127.0.0.1:9011, 127.0.0.1:9012",
     }))
 
-    local stream_events_sock_path = "unix:" .. helpers.test_conf.runtime_prefix .. "/stream_worker_events.sock"
+    local stream_events_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/stream_worker_events.sock"
 
     if helpers.test_conf.database == "off" then
-      local stream_config_sock_path = "unix:" .. helpers.test_conf.runtime_prefix .. "/stream_config.sock"
+      local stream_config_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/stream_config.sock"
 
       assert.equals(3, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
       assert.same({

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -13,7 +13,7 @@ describe("Stream module API endpoint", function()
       plugins = "stream-api-echo",
     })
 
-    socket_path = "unix:" .. helpers.get_running_conf().prefix .. "/stream_rpc.sock"
+    socket_path = "unix:" .. helpers.get_running_conf().runtime_prefix .. "/stream_rpc.sock"
   end)
 
   lazy_teardown(function()

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -13,7 +13,7 @@ describe("Stream module API endpoint", function()
       plugins = "stream-api-echo",
     })
 
-    socket_path = "unix:" .. helpers.get_running_conf().runtime_prefix .. "/stream_rpc.sock"
+    socket_path = "unix:" .. helpers.get_running_conf().socket_path .. "/stream_rpc.sock"
   end)
 
   lazy_teardown(function()

--- a/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
+++ b/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
@@ -33,7 +33,7 @@ include '*.stream_mock';
 
 > if cluster_ssl_tunnel then
 server {
-    listen unix:${{RUNTIME_PREFIX}}/cluster_proxy_ssl_terminator.sock;
+    listen unix:${{SOCKET_PATH}}/cluster_proxy_ssl_terminator.sock;
 
     proxy_pass ${{cluster_ssl_tunnel}};
     proxy_ssl on;

--- a/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
+++ b/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
@@ -33,7 +33,7 @@ include '*.stream_mock';
 
 > if cluster_ssl_tunnel then
 server {
-    listen unix:${{PREFIX}}/cluster_proxy_ssl_terminator.sock;
+    listen unix:${{RUNTIME_PREFIX}}/cluster_proxy_ssl_terminator.sock;
 
     proxy_pass ${{cluster_ssl_tunnel}};
     proxy_ssl on;

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3844,7 +3844,7 @@ end
 local function cleanup_kong(prefix, preserve_prefix, preserve_dc)
   -- remove socket files to ensure `pl.dir.rmtree()` ok
   prefix = prefix or conf.prefix
-  local socket_path = pl_path.join(prefix, "sockets")
+  local socket_path = pl_path.join(prefix, constants.SOCKET_DIRECTORY)
   for child in lfs.dir(socket_path) do
     if child:sub(-5) == ".sock" then
       local path = pl_path.join(socket_path, child)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3844,10 +3844,10 @@ end
 local function cleanup_kong(prefix, preserve_prefix, preserve_dc)
   -- remove socket files to ensure `pl.dir.rmtree()` ok
   prefix = prefix or conf.prefix
-  local runtime_prefix = pl_path.join(prefix, "runtime")
-  for child in lfs.dir(runtime_prefix) do
+  local socket_path = pl_path.join(prefix, "sockets")
+  for child in lfs.dir(socket_path) do
     if child:sub(-5) == ".sock" then
-      local path = pl_path.join(runtime_prefix, child)
+      local path = pl_path.join(socket_path, child)
       os.remove(path)
     end
   end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -545,7 +545,7 @@ end
 -- @param db the database object
 -- @return ml_cache instance
 local function get_cache(db)
-  local worker_events = assert(kong_global.init_worker_events())
+  local worker_events = assert(kong_global.init_worker_events(conf))
   local cluster_events = assert(kong_global.init_cluster_events(conf, db))
   local cache = assert(kong_global.init_cache(conf,
                                               cluster_events,
@@ -3843,10 +3843,13 @@ end
 -- @param preserve_dc ???
 local function cleanup_kong(prefix, preserve_prefix, preserve_dc)
   -- remove socket files to ensure `pl.dir.rmtree()` ok
-  local socks = { "/worker_events.sock", "/stream_worker_events.sock", }
-  for _, name in ipairs(socks) do
-    local sock_file = (prefix or conf.prefix) .. name
-    os.remove(sock_file)
+  prefix = prefix or conf.prefix
+  local runtime_prefix = pl_path.join(prefix, "runtime")
+  for child in lfs.dir(runtime_prefix) do
+    if child:sub(-5) == ".sock" then
+      local path = pl_path.join(runtime_prefix, child)
+      os.remove(path)
+    end
   end
 
   -- note: set env var "KONG_TEST_DONT_CLEAN" !! the "_TEST" will be dropped


### PR DESCRIPTION
This moves all internal unix sockets managed by Kong from `{{prefix}}` into a subdirectory at `{{prefix}}/sockets`. The conf loader makes this available via the new `socket_path` field, which is intended as a step towards relocating this path _outside_ of the prefix tree in a later release.

KAG-4947