### PR TITLE
chore(deps): bump lua-resty-openssl to 1.5.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-openssl.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-openssl.yml
@@ -1,0 +1,2 @@
+message: "Bumped lua-resty-openssl from 1.4.0 to 1.5.0"
+type: dependency

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.1.0",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.5.0",
-  "lua-resty-openssl == 1.4.0",
+  "lua-resty-openssl == 1.5.0",
   "lua-resty-gcp == 0.0.13",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
Fix several issue under high memory pressure.
Full changelog: https://github.com/fffonion/lua-resty-openssl/compare/1.4.0...1.5.0

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
