### PR TITLE
fix(clustering): fix compat for prometheus ai metrics config fields

### DIFF
--- a/changelog/unreleased/kong/fix-ai-metrics-prometheus-compat.yml
+++ b/changelog/unreleased/kong/fix-ai-metrics-prometheus-compat.yml
@@ -1,0 +1,4 @@
+message: >
+  "**Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
+type: bugfix
+scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -195,5 +195,8 @@ return {
       "llm.auth.gcp_use_service_account",
       "llm.auth.gcp_service_account_json",
     },
+    prometheus = {
+      "ai_metrics",
+    },
   },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -805,6 +805,28 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       end)
     end)
 
+    describe("prometheus plugins", function()
+      it("[prometheus] remove ai_metrics property for versions below 3.8", function()
+        -- [[ 3.8.x ]] --
+        local prometheus = admin.plugins:insert {
+          name = "prometheus",
+          enabled = true,
+          config = {
+            ai_metrics = true, -- becomes nil
+          },
+        }
+        -- ]]
+
+        local expected_prometheus_prior_38 = cycle_aware_deep_copy(prometheus)
+        expected_prometheus_prior_38.config.ai_metrics = nil
+
+        do_assert(uuid(), "3.7.0", expected_prometheus_prior_38)
+
+        -- cleanup
+        admin.plugins:remove({ id = prometheus.id })
+      end)
+    end)
+
     describe("www-authenticate header in plugins (realm config)", function()
       it("[basic-auth] removes realm for versions below 3.6", function()
         local basic_auth = admin.plugins:insert {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix compat prometheus ai metrics
https://konghq.atlassian.net/browse/KAG-4934

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
