### PR TITLE
fix(ai-proxy): gemini: broke cluster compat in last commit

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -37,6 +37,43 @@ local compatible_checkers = {
               dp_version, log_suffix)
           end
         end
+
+        if plugin.name == 'ai-proxy' then
+          local config = plugin.config
+          if config.model.provider == "gemini" then
+            config.model.provider = "openai"
+            config.route_type = "preserve"
+            log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
+                              ' "openai preserve mode", because gemini' ..
+                              ' provider is not supported in this release',
+                              dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'ai-request-transformer' then
+          local config = plugin.config
+          if config.llm.model.provider == "gemini" then
+            config.llm.model.provider = "openai"
+            log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
+                              ' "openai preserve mode", because gemini' ..
+                              ' provider is not supported in this release',
+                              dp_version, log_suffix)
+            has_update = true
+          end
+        end
+
+        if plugin.name == 'ai-response-transformer' then
+          local config = plugin.config
+          if config.llm.model.provider == "gemini" then
+            config.llm.model.provider = "openai"
+            log_warn_message('configures ' .. plugin.name .. ' plugin with' ..
+                              ' "openai preserve mode", because gemini' ..
+                              ' provider is not supported in this release',
+                              dp_version, log_suffix)
+            has_update = true
+          end
+        end
       end
 
       return has_update

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -169,6 +169,9 @@ return {
     },
     ai_proxy = {
       "max_request_body_size",
+      "model.options.gemini",
+      "auth.gcp_use_service_account",
+      "auth.gcp_service_account_json",
     },
     ai_prompt_decorator = {
       "max_request_body_size",
@@ -182,9 +185,15 @@ return {
     },
     ai_request_transformer = {
       "max_request_body_size",
+      "llm.model.options.gemini",
+      "llm.auth.gcp_use_service_account",
+      "llm.auth.gcp_service_account_json",
     },
     ai_response_transformer = {
       "max_request_body_size",
+      "llm.model.options.gemini",
+      "llm.auth.gcp_use_service_account",
+      "llm.auth.gcp_service_account_json",
     },
   },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -481,7 +481,168 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       end)
     end)
 
-    describe("ai plugins", function()
+    describe("ai plugins supported providers", function()
+      it("[ai-proxy] tries to use unsupported gemini on older Kong versions", function()
+        -- [[ 3.8.x ]] --
+        local ai_proxy = admin.plugins:insert {
+          name = "ai-proxy",
+          enabled = true,
+          config = {
+            response_streaming = "allow",
+            route_type = "llm/v1/chat",
+            auth = {
+              header_name = "header",
+              header_value = "value",
+              gcp_service_account_json = '{"service": "account"}',
+              gcp_use_service_account = true,
+            },
+            model = {
+              name = "any-model-name",
+              provider = "gemini",
+              options = {
+                max_tokens = 512,
+                temperature = 0.5,
+                gemini = {
+                  api_endpoint = "https://gemini.local",
+                  project_id = "kong-gemini",
+                  location_id = "us-east5",
+                },
+              },
+            },
+            max_request_body_size = 8192,
+          },
+        }
+        -- ]]
+
+        local expected = cycle_aware_deep_copy(ai_proxy)
+
+        expected.config.max_request_body_size = nil
+        expected.config.auth.gcp_service_account_json = nil
+        expected.config.auth.gcp_use_service_account = nil
+        expected.config.model.options.gemini = nil
+        expected.config.route_type = "preserve"
+        expected.config.model.provider = "openai"
+
+        do_assert(uuid(), "3.7.0", expected)
+
+        expected.config.response_streaming = nil
+        expected.config.model.options.upstream_path = nil
+        expected.config.route_type = "llm/v1/chat"
+
+        do_assert(uuid(), "3.6.0", expected)
+
+        -- cleanup
+        admin.plugins:remove({ id = ai_proxy.id })
+      end)
+
+      it("[ai-request-transformer] tries to use unsupported gemini on older Kong versions", function()
+        -- [[ 3.8.x ]] --
+        local ai_request_transformer = admin.plugins:insert {
+          name = "ai-request-transformer",
+          enabled = true,
+          config = {
+            llm = {
+              route_type = "llm/v1/chat",
+              auth = {
+                header_name = "header",
+                header_value = "value",
+                gcp_service_account_json = '{"service": "account"}',
+                gcp_use_service_account = true,
+              },
+              model = {
+                name = "any-model-name",
+                provider = "gemini",
+                options = {
+                  max_tokens = 512,
+                  temperature = 0.5,
+                  gemini = {
+                    api_endpoint = "https://gemini.local",
+                    project_id = "kong-gemini",
+                    location_id = "us-east5",
+                  },
+                },
+              },
+            },
+            max_request_body_size = 8192,
+            prompt = "anything",
+          },
+        }
+        -- ]]
+
+        local expected = cycle_aware_deep_copy(ai_request_transformer)
+
+        expected.config.max_request_body_size = nil
+        expected.config.llm.auth.gcp_service_account_json = nil
+        expected.config.llm.auth.gcp_use_service_account = nil
+        expected.config.llm.model.options.gemini = nil
+        expected.config.llm.model.provider = "openai"
+
+        do_assert(uuid(), "3.7.0", expected)
+
+        expected.config.llm.model.options.upstream_path = nil
+        expected.config.llm.route_type = "llm/v1/chat"
+
+        do_assert(uuid(), "3.6.0", expected)
+
+        -- cleanup
+        admin.plugins:remove({ id = ai_request_transformer.id })
+      end)
+
+      it("[ai-response-transformer] tries to use unsupported gemini on older Kong versions", function()
+        -- [[ 3.8.x ]] --
+        local ai_response_transformer = admin.plugins:insert {
+          name = "ai-response-transformer",
+          enabled = true,
+          config = {
+            llm = {
+              route_type = "llm/v1/chat",
+              auth = {
+                header_name = "header",
+                header_value = "value",
+                gcp_service_account_json = '{"service": "account"}',
+                gcp_use_service_account = true,
+              },
+              model = {
+                name = "any-model-name",
+                provider = "gemini",
+                options = {
+                  max_tokens = 512,
+                  temperature = 0.5,
+                  gemini = {
+                    api_endpoint = "https://gemini.local",
+                    project_id = "kong-gemini",
+                    location_id = "us-east5",
+                  },
+                },
+              },
+            },
+            max_request_body_size = 8192,
+            prompt = "anything",
+          },
+        }
+        -- ]]
+
+        local expected = cycle_aware_deep_copy(ai_response_transformer)
+
+        expected.config.max_request_body_size = nil
+        expected.config.llm.auth.gcp_service_account_json = nil
+        expected.config.llm.auth.gcp_use_service_account = nil
+        expected.config.llm.model.options.gemini = nil
+        expected.config.llm.model.provider = "openai"
+
+        do_assert(uuid(), "3.7.0", expected)
+
+        expected.config.llm.model.options.upstream_path = nil
+        expected.config.llm.route_type = "llm/v1/chat"
+
+        do_assert(uuid(), "3.6.0", expected)
+
+        -- cleanup
+        admin.plugins:remove({ id = ai_response_transformer.id })
+      end)
+    end)
+
+    describe("ai plugins shared options", function()
       it("[ai-proxy] sets unsupported AI LLM properties to nil or defaults", function()
         -- [[ 3.7.x ]] --
         local ai_proxy = admin.plugins:insert {
@@ -511,6 +672,9 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         local expected = cycle_aware_deep_copy(ai_proxy)
 
         expected.config.max_request_body_size = nil
+        expected.config.auth.gcp_service_account_json = nil
+        expected.config.auth.gcp_use_service_account = nil
+        expected.config.model.options.gemini = nil
 
         do_assert(uuid(), "3.7.0", expected)
 
@@ -557,6 +721,9 @@ describe("CP/DP config compat transformations #" .. strategy, function()
 
         local expected = cycle_aware_deep_copy(ai_request_transformer)
         expected.config.max_request_body_size = nil
+        expected.config.llm.auth.gcp_service_account_json = nil
+        expected.config.llm.auth.gcp_use_service_account = nil
+        expected.config.llm.model.options.gemini = nil
 
         do_assert(uuid(), "3.7.0", expected)
 
@@ -595,10 +762,13 @@ describe("CP/DP config compat transformations #" .. strategy, function()
             max_request_body_size = 8192,
           },
         }
-        -- ]]
+        --]]
 
         local expected = cycle_aware_deep_copy(ai_response_transformer)
         expected.config.max_request_body_size = nil
+        expected.config.llm.auth.gcp_service_account_json = nil
+        expected.config.llm.auth.gcp_use_service_account = nil
+        expected.config.llm.model.options.gemini = nil
 
         do_assert(uuid(), "3.7.0", expected)
 


### PR DESCRIPTION
### Summary

The last Gemini PR (https://github.com/Kong/kong/pull/12948) broke cluster compat of <3.8 with the new 3.8 control plane.

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5020
