### PR TITLE
chore(build): remove the download link from openssl.org and add a fal…

### DIFF
--- a/build/openresty/openssl/openssl_repositories.bzl
+++ b/build/openresty/openssl/openssl_repositories.bzl
@@ -7,6 +7,11 @@ load("@kong_bindings//:variables.bzl", "KONG_VAR")
 def openssl_repositories():
     version = KONG_VAR["OPENSSL"]
 
+    openssl_verion_uri = version
+    if version.startswith("3"):
+        # for 3.x only use the first two digits
+        openssl_verion_uri = ".".join(version.split(".")[:2])
+
     maybe(
         http_archive,
         name = "openssl",
@@ -14,7 +19,7 @@ def openssl_repositories():
         sha256 = KONG_VAR["OPENSSL_SHA256"],
         strip_prefix = "openssl-" + version,
         urls = [
-            "https://www.openssl.org/source/openssl-" + version + ".tar.gz",
             "https://github.com/openssl/openssl/releases/download/openssl-" + version + "/openssl-" + version + ".tar.gz",
+            "https://openssl.org/source/old/3.1/openssl-" + version + ".tar.gz",
         ],
     )


### PR DESCRIPTION
…lback url for old sources

The openssl.org/source link is dead for new releases.