### PR TITLE
fix(wasm): re-enable Lua DNS resolver for proxy-wasm

### DIFF
--- a/changelog/unreleased/kong/fix-wasm-enable-pwm-lua-resolver.yml
+++ b/changelog/unreleased/kong/fix-wasm-enable-pwm-lua-resolver.yml
@@ -1,0 +1,4 @@
+message: |
+  Re-enabled the Lua DNS resolver from proxy-wasm by default.
+type: bugfix
+scope: Configuration

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -640,8 +640,7 @@ local function load(path, custom_conf, opts)
     -- set it as such in kong_defaults, because it can only be used if wasm is
     -- _also_ enabled. We inject it here if the user has not opted to set it
     -- themselves.
-    -- TODO: as a temporary compatibility fix, we are forcing it to 'off'.
-    add_wasm_directive("nginx_http_proxy_wasm_lua_resolver", "off")
+    add_wasm_directive("nginx_http_proxy_wasm_lua_resolver", "on")
 
     -- configure wasmtime module cache
     if conf.role == "traditional" or conf.role == "data_plane" then

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -968,7 +968,7 @@ describe("NGINX conf compiler", function()
       end)
       it("injects default configurations if wasm=on", function()
         assert.matches(
-          ".+proxy_wasm_lua_resolver off;.+",
+          ".+proxy_wasm_lua_resolver on;.+",
           kong_ngx_cfg({ wasm = true, }, debug)
         )
       end)
@@ -983,14 +983,6 @@ describe("NGINX conf compiler", function()
           ".+proxy_wasm_lua_resolver off;.+",
           kong_ngx_cfg({ wasm = true,
                          nginx_http_proxy_wasm_lua_resolver = "off",
-                       }, debug)
-        )
-      end)
-      it("permits overriding proxy_wasm_lua_resolver to on", function()
-        assert.matches(
-          ".+proxy_wasm_lua_resolver on;.+",
-          kong_ngx_cfg({ wasm = true,
-                         nginx_http_proxy_wasm_lua_resolver = "on",
                        }, debug)
         )
       end)

--- a/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
+++ b/spec/02-integration/20-wasm/04-proxy-wasm_spec.lua
@@ -787,7 +787,7 @@ describe("proxy-wasm filters (#wasm) (#" .. strategy .. ")", function()
       assert.logfile().has.no.line("[crit]",  true, 0)
     end)
 
-    pending("resolves DNS hostnames to send an http dispatch, return its response body", function()
+    it("resolves DNS hostnames to send an http dispatch, return its response body", function()
       local client = helpers.proxy_client()
       finally(function() client:close() end)
 


### PR DESCRIPTION
### Summary

This was previously disabled in 9a5d48bfca (#12825) due to shortcomings of the underlying ngx_wasm_module Lua execution model, which has since been fixed and merged into master (19ee6a9dd66ad2275209b29406303a88f59eb3b6).

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com~

### Issue reference

[KAG-4671](https://konghq.atlassian.net/browse/KAG-4671)

Replace #13363 (can't re-open this PR after force-pushing the branch)

[KAG-4671]: https://konghq.atlassian.net/browse/KAG-4671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ