### PR TITLE
feat(tools): add a function to parse Nginx size strings

### DIFF
--- a/changelog/unreleased/kong/feat-parse-ngx-size.yml
+++ b/changelog/unreleased/kong/feat-parse-ngx-size.yml
@@ -1,2 +1,3 @@
 message: Added a function to parse Nginx size strings.
 type: feature
+scope: Core

--- a/changelog/unreleased/kong/feat-parse-ngx-size.yml
+++ b/changelog/unreleased/kong/feat-parse-ngx-size.yml
@@ -1,3 +1,0 @@
-message: Added a function to parse Nginx size strings.
-type: feature
-scope: Core

--- a/changelog/unreleased/kong/feat-parse-ngx-size.yml
+++ b/changelog/unreleased/kong/feat-parse-ngx-size.yml
@@ -1,0 +1,2 @@
+message: Added a function to parse Nginx size strings.
+type: feature

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -151,6 +151,33 @@ function _M.bytes_to_str(bytes, unit, scale)
 end
 
 
+local SCALES = {
+  k = 1024,
+  K = 1024,
+  m = 1024 * 1024,
+  M = 1024 * 1024,
+  g = 1024 * 1024 * 1024,
+  G = 1024 * 1024 * 1024,
+}
+
+function _M.parse_ngx_size(str)
+  local len = #str
+  local unit = sub(str, len)
+  local scale = SCALES[unit]
+
+  if scale then
+    len = len - 1
+
+  else
+    scale = 1
+  end
+
+  local size = tonumber(sub(str, 1, len)) or 0
+
+  return size * scale
+end
+
+
 local try_decode_base64
 do
   local decode_base64    = ngx.decode_base64

--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -161,6 +161,8 @@ local SCALES = {
 }
 
 function _M.parse_ngx_size(str)
+  assert(type(str) == "string", "Parameter #1 must be a string")
+
   local len = #str
   local unit = sub(str, len)
   local scale = SCALES[unit]

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -207,6 +207,7 @@ describe("Utils", function()
       assert.equal(1024 * 1024, parse_ngx_size("1m"))
       assert.equal(1024, parse_ngx_size("1k"))
       assert.equal(1024, parse_ngx_size("1K"))
+      assert.equal(10, parse_ngx_size("10"))
     end)
 
     describe("random_string()", function()

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -202,7 +202,9 @@ describe("Utils", function()
       local parse_ngx_size = require("kong.tools.string").parse_ngx_size
 
       assert.equal(1024 * 1024 * 1024, parse_ngx_size("1G"))
+      assert.equal(1024 * 1024 * 1024, parse_ngx_size("1g"))
       assert.equal(1024 * 1024, parse_ngx_size("1M"))
+      assert.equal(1024 * 1024, parse_ngx_size("1m"))
       assert.equal(1024, parse_ngx_size("1k"))
       assert.equal(1024, parse_ngx_size("1K"))
     end)

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -197,6 +197,16 @@ describe("Utils", function()
       assert.False(validate_utf8(string.char(255))) -- impossible byte
       assert.False(validate_utf8(string.char(237, 160, 128))) -- Single UTF-16 surrogate
     end)
+
+    it("checks valid nginx size values", function()
+      local parse_ngx_size = require("kong.tools.string").parse_ngx_size
+
+      assert.equal(1024 * 1024 * 1024, parse_ngx_size("1G"))
+      assert.equal(1024 * 1024, parse_ngx_size("1M"))
+      assert.equal(1024, parse_ngx_size("1k"))
+      assert.equal(1024, parse_ngx_size("1K"))
+    end)
+
     describe("random_string()", function()
       local utils = require "kong.tools.rand"
       it("should return a random string", function()


### PR DESCRIPTION
It is the cherry-pick of kong/kong-ee#9472.

KAG-4698

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
