### PR TITLE
fix(correlation-id): auto-complete config.generator when constructing if it is `null` in database

### DIFF
--- a/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
+++ b/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
@@ -1,3 +1,3 @@
-message: fix a bug where correlation-id plugin would cause 500 error if `config.generator=null` in database
+message: **correlation-id**: Fixed an issue where the plugin would not work if we explicitly set the `generator` to `null`.
 scope: Plugin
 type: bugfix

--- a/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
+++ b/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
@@ -1,3 +1,4 @@
-message: **correlation-id**: Fixed an issue where the plugin would not work if we explicitly set the `generator` to `null`.
+message: |
+  **correlation-id**: Fixed an issue where the plugin would not work if we explicitly set the `generator` to `null`.
 scope: Plugin
 type: bugfix

--- a/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
+++ b/changelog/unreleased/kong/fix-correlation-id-config-generator.yml
@@ -1,0 +1,3 @@
+message: fix a bug where correlation-id plugin would cause 500 error if `config.generator=null` in database
+scope: Plugin
+type: bugfix

--- a/kong/plugins/correlation-id/schema.lua
+++ b/kong/plugins/correlation-id/schema.lua
@@ -9,8 +9,8 @@ return {
         type = "record",
         fields = {
           { header_name = { description = "The HTTP header name to use for the correlation ID.", type = "string", default = "Kong-Request-ID" }, },
-          { generator = { description = "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators).", type = "string", default = "uuid#counter",
-                          one_of = { "uuid", "uuid#counter", "tracker" }, }, },
+          { generator = { description = "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators).",
+                          type = "string", default = "uuid#counter", required = true, one_of = { "uuid", "uuid#counter", "tracker" }, }, },
           { echo_downstream = { description = "Whether to echo the header back to downstream (the client).", type = "boolean", required = true, default = false, }, },
         },
       },

--- a/spec/03-plugins/11-correlation-id/02-schema_spec.lua
+++ b/spec/03-plugins/11-correlation-id/02-schema_spec.lua
@@ -88,7 +88,7 @@ describe("Plugin: correlation-id (schema) #a [#" .. strategy .."]", function()
 
   describe("in hybrid mode", function()
     local route
-    setup(function()
+    lazy_setup(function()
       route = bp.routes:insert({
         hosts = {"example.com"},
       })

--- a/spec/03-plugins/11-correlation-id/02-schema_spec.lua
+++ b/spec/03-plugins/11-correlation-id/02-schema_spec.lua
@@ -1,0 +1,82 @@
+local schema_def = require "kong.plugins.correlation-id.schema"
+local v = require("spec.helpers").validate_plugin_config_schema
+local helpers = require "spec.helpers"
+local uuid = require "resty.jit-uuid"
+local pgmoon_json = require("pgmoon.json")
+local cjson = require "cjson"
+
+describe("Schema: correlation-id", function ()
+  it("requried field must be included", function()
+    local ok, err = v({
+      generator = ngx.null,
+     }, schema_def)
+
+    assert.falsy(ok)
+    assert.is_not_nil(err)
+    assert.equals("required field missing", err.config.generator)
+  end)
+end)
+
+local strategy = "postgres"
+describe("Plugin: correlation-id (schema) [#" .. strategy .."]", function()
+  local admin_client, db, plugin_id
+  local plugin_config = {
+    generator = ngx.null,
+    header_name = "Kong-Request-ID",
+    echo_downstream = false,
+  }
+
+  local function render(template, keys)
+    return (template:gsub("$%(([A-Z_]+)%)", keys))
+  end
+
+  setup(function()
+    local plugin_name = "correlation-id"
+    _, db = helpers.get_db_utils(strategy, { "plugins", "workspaces", })
+    local ws = db.workspaces:select_by_name("default")
+    assert.is_truthy(ws)
+    plugin_id = uuid.generate_v4()
+    local sql = render([[
+      INSERT INTO plugins (id, name, config, enabled, ws_id) VALUES
+        ('$(ID)', '$(PLUGIN_NAME)', $(CONFIG)::jsonb, TRUE, '$(WS_ID)');
+      COMMIT;
+    ]], {
+      ID = plugin_id,
+      PLUGIN_NAME = plugin_name,
+      CONFIG = pgmoon_json.encode_json(plugin_config),
+      WS_ID = ws.id,
+    })
+
+    local res, err = db.connector:query(sql)
+    assert.is_nil(err)
+    assert.is_not_nil(res)
+
+    assert(helpers.start_kong({
+      database = strategy,
+      log_level = "info",
+    }))
+    admin_client = helpers.admin_client()
+  end)
+
+  lazy_teardown(function()
+    if admin_client then
+      admin_client:close()
+    end
+    helpers.stop_kong()
+  end)
+
+  after_each(function()
+    db:truncate()
+  end)
+
+  it("auto-complete generator if it is `null` in database", function()
+    local sql = 'SELECT config FROM plugins WHERE id=\''.. plugin_id ..'\';'
+    local res, err = db.connector:query(sql)
+    assert.is_nil(err)
+    assert.is_nil(res[1].generator)
+
+    res = admin_client:get("/plugins")
+    res = cjson.decode(assert.res_status(200, res))
+    assert.equals(res.data[1].config.generator, "uuid#counter")
+  end)
+end)


### PR DESCRIPTION
### Summary

Some fields in the request body to admin api occasionally are specified as `json.null`.
In this PR, we add `required=true` to the schema of the field so that it can be auto-completed with the default when construction if it is `null` in database. It will become a mandatory field in KM.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6134
