### PR TITLE
fix(clustering): still encoding with cjson

### DIFF
--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -3,6 +3,7 @@ local ws_client = require("resty.websocket.client")
 local ws_server = require("resty.websocket.server")
 local parse_url = require("socket.url").parse
 local process_type = require("ngx.process").type
+local cjson = require("cjson.safe")
 
 local type = type
 local table_insert = table.insert
@@ -169,12 +170,12 @@ end
 -- encode/decode json with cjson or simdjson
 local ok, simdjson_dec = pcall(require, "resty.simdjson.decoder")
 if not ok or kong.configuration.cluster_cjson then
-  local cjson = require("cjson.safe")
-
   _M.json_decode = cjson.decode
   _M.json_encode = cjson.encode
 
 else
+  _M.json_decode = cjson.decode
+  --[[ TODO: fix the behavior of simdjson encoding
   _M.json_decode = function(str)
     -- enable yield and not reentrant for decode
     local dec = simdjson_dec.new(true)
@@ -184,6 +185,7 @@ else
 
     return res, err
   end
+  --]]
 
   -- enable yield and reentrant for encode
   local enc = require("resty.simdjson.encoder").new(true)

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -168,14 +168,12 @@ end
 
 
 -- encode/decode json with cjson or simdjson
-local ok, simdjson_dec = pcall(require, "resty.simdjson.decoder") -- luacheck:ignore
+local ok, simdjson_dec = pcall(require, "resty.simdjson.decoder")
 if not ok or kong.configuration.cluster_cjson then
   _M.json_decode = cjson.decode
   _M.json_encode = cjson.encode
 
 else
-  _M.json_decode = cjson.decode
-  --[[ TODO: make simdjson decoding more compatible with cjson
   _M.json_decode = function(str)
     -- enable yield and not reentrant for decode
     local dec = simdjson_dec.new(true)
@@ -185,14 +183,16 @@ else
 
     return res, err
   end
-  --]]
 
+  _M.json_encode = cjson.encode
+  --[[ TODO: make simdjson encoding more compatible with cjson
   -- enable yield and reentrant for encode
   local enc = require("resty.simdjson.encoder").new(true)
 
   _M.json_encode = function(obj)
     return enc:process(obj)
   end
+  --]]
 end
 
 

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -168,14 +168,14 @@ end
 
 
 -- encode/decode json with cjson or simdjson
-local ok, simdjson_dec = pcall(require, "resty.simdjson.decoder")
+local ok, simdjson_dec = pcall(require, "resty.simdjson.decoder") -- luacheck:ignore
 if not ok or kong.configuration.cluster_cjson then
   _M.json_decode = cjson.decode
   _M.json_encode = cjson.encode
 
 else
   _M.json_decode = cjson.decode
-  --[[ TODO: fix the behavior of simdjson encoding
+  --[[ TODO: make simdjson decoding more compatible with cjson
   _M.json_decode = function(str)
     -- enable yield and not reentrant for decode
     local dec = simdjson_dec.new(true)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

In #13421 we introduced lua-resty-simdjson, but the behavior of encoding has some differences with cjson, this PR disabled simdjson encoding temporarily. 

KAG-5061

Related PR: https://github.com/Kong/lua-resty-simdjson/pull/38

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
