### PR TITLE
fix(vault): apply secret rotation error log throttling

### DIFF
--- a/changelog/unreleased/kong/fix-vault-secret-rotate-error-log-throttling.yml
+++ b/changelog/unreleased/kong/fix-vault-secret-rotate-error-log-throttling.yml
@@ -1,0 +1,4 @@
+message: |
+  Applied an error log throttling on the secret rotation for each secret. Errors happened during secret rotation will only be logged once. This will prevent the log from being flooded with the same error message.
+type: bugfix
+scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This is a simpler alternative solution for https://github.com/Kong/kong/pull/13194. Apply error log throttling on the error logs that happened during secret rotation. Each secret will only log its error once during the period that it fails to rotate the value.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5775
