### PR TITLE
chore(ci): fix the verify manifest error on AWS Linux 2

### DIFF
--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -43,7 +43,9 @@ targets = {
         manifest="fixtures/amazonlinux-2-amd64.txt",
         use_rpath=True,
         tests={
-            common_suites: {},
+            common_suites: {
+                "skip_libsimdjson_ffi": True,
+            },
             libc_libcpp_suites: {
                 "libc_max_version": "2.26",
                 # gcc 7.3.1

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -20,7 +20,7 @@ def read_requirements(path=None):
         lines = [re.findall("(.+)=([^# ]+)", d) for d in f.readlines()]
         return {l[0][0]: l[0][1].strip() for l in lines if l}
 
-def common_suites(expect, libxcrypt_no_obsolete_api: bool = False):
+def common_suites(expect, libxcrypt_no_obsolete_api: bool = False, skip_libsimdjson_ffi: bool = False):
     # file existence
     expect("/usr/local/kong/include/google/protobuf/**.proto",
            "includes Google protobuf headers").exists()
@@ -82,9 +82,10 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False):
         .functions \
         .contain("router_execute")
 
-    expect("/usr/local/openresty/site/lualib/libsimdjson_ffi.so", "simdjson should have ffi module compiled") \
-        .functions \
-        .contain("simdjson_ffi_state_new")
+    if not skip_libsimdjson_ffi:
+        expect("/usr/local/openresty/site/lualib/libsimdjson_ffi.so", "simdjson should have ffi module compiled") \
+            .functions \
+            .contain("simdjson_ffi_state_new")
 
     if libxcrypt_no_obsolete_api:
         expect("/usr/local/openresty/nginx/sbin/nginx", "nginx linked with libxcrypt.so.2") \


### PR DESCRIPTION
Just simply skip the `libsimdjson.so` check.

KAG-5070

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
