### PR TITLE
chore(deps): bump lua-resty-openssl to 1.5.1

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-openssl.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-openssl.yml
@@ -1,2 +1,3 @@
-message: "Bumped lua-resty-openssl from 1.4.0 to 1.5.0"
+message: "Bumped lua-resty-openssl to 1.5.1."
 type: dependency
+scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-healthcheck == 3.1.0",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.5.3",
-  "lua-resty-openssl == 1.5.0",
+  "lua-resty-openssl == 1.5.1",
   "lua-resty-gcp == 0.0.13",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",


### PR DESCRIPTION
### Summary

- chore(kdf): fix the outlen type to be size_t

KAG-5095