### PR TITLE
feat(request-debugging): Finer time resolution and latency in total

### DIFF
--- a/changelog/unreleased/kong/feat-request-debguger-finer-resolution-and-total-latency.yml
+++ b/changelog/unreleased/kong/feat-request-debguger-finer-resolution-and-total-latency.yml
@@ -1,0 +1,7 @@
+message: |
+  Improved the output of the request debugger:
+  - Now the resolution of field `total_time` is microseconds.
+  - A new field `total_time_without_upstream` on the top level shows the latency only introduced by Kong.
+type: feature
+scope: Core
+

--- a/kong/timing/context.lua
+++ b/kong/timing/context.lua
@@ -1,4 +1,4 @@
-local cjson         = require("cjson.safe")
+local cjson         = require("cjson.safe").new()
 
 local ngx_get_phase = ngx.get_phase
 local ngx_re_gmatch = ngx.re.gmatch
@@ -15,6 +15,8 @@ local assert        = assert
 local _M            = {}
 local _MT           = { __index = _M }
 
+-- Set number precision smaller than 16 to avoid floating point errors
+cjson.encode_number_precision(14)
 
 function _M:enter_subcontext(name)
   assert(name ~= nil, "name is required")

--- a/kong/timing/context.lua
+++ b/kong/timing/context.lua
@@ -120,7 +120,9 @@ function _M:to_json()
 
   self:set_root_context_prop("dangling", dangling)
   self:finalize(self.root_context)
-  self.root_context.total_time_without_upstream = self:get_total_time_without_upstream()
+  if self.root_context.child ~= nil then
+    self.root_context.total_time_without_upstream = self:get_total_time_without_upstream()
+  end
   return assert(cjson.encode(self.root_context))
 end
 

--- a/kong/timing/context.lua
+++ b/kong/timing/context.lua
@@ -8,7 +8,7 @@ local setmetatable  = setmetatable
 local table_insert  = table.insert
 local table_remove  = table.remove
 
-local get_cur_msec  = require("kong.tools.time").get_updated_monotonic_ms
+local time_ns       = require("kong.tools.time").time_ns
 
 local assert        = assert
 
@@ -29,14 +29,13 @@ function _M:enter_subcontext(name)
   end
 
   self.current_subcontext = self.current_subcontext.child[name]
-  self.current_subcontext.____start____ = get_cur_msec()
+  self.current_subcontext.____start____ = time_ns()
 end
 
 
 function _M:leave_subcontext(attributes)
   assert(#self.sub_context_stack > 0, "subcontext stack underflow")
-
-  local elapsed = get_cur_msec() - self.current_subcontext.____start____
+  local elapsed = (time_ns() - self.current_subcontext.____start____) / 1e6
   local old_total_time = self.current_subcontext.total_time or 0
   self.current_subcontext.total_time = old_total_time + elapsed
   self.current_subcontext.____start____ = nil
@@ -75,11 +74,37 @@ function _M:set_root_context_prop(k, v)
 end
 
 
+function _M:finalize(subcontext)
+  -- finalize total_time optionally rounding to the nearest integer
+  if subcontext.total_time then
+    -- round to 2 decimal places
+    subcontext.total_time = math_floor(subcontext.total_time * 100) / 100
+  end
+
+  if subcontext.child then
+    for _, child in pairs(subcontext.child) do
+      self:finalize(child)
+    end
+  end
+end
+
+
+function _M:get_total_time_without_upstream()
+  local total_time = 0
+  for k, child in pairs(self.root_context.child) do
+    if k ~= "upstream" and child.total_time then
+      total_time = total_time + child.total_time
+    end
+  end
+  return total_time
+end
+
+
 function _M:to_json()
   local dangling = nil
 
   -- `> 1` means we have at least one subcontext (the root context)
-  -- We always call this function at then end of the header_filter and 
+  -- We always call this function at then end of the header_filter and
   -- log phases, so we should always have at least one subcontext.
   while #self.sub_context_stack > 1 do
     self:set_context_prop("dangling", true)
@@ -92,6 +117,8 @@ function _M:to_json()
   end
 
   self:set_root_context_prop("dangling", dangling)
+  self:finalize(self.root_context)
+  self.root_context.total_time_without_upstream = self:get_total_time_without_upstream()
   return assert(cjson.encode(self.root_context))
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Using `time_ns` to measure the context duration and make `total_time` finer resolution when less than 1ms.

A field called `total_time_without_upsteam` is introduced to represent total latency without upstream.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference
KAG-4733
FTI-5989