### PR TITLE
docs(DEVELOPER.md): explain how to get the Rust build system authenticated by GitHub

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -144,7 +144,7 @@ using either one of the following ways:
 * By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
 * Use [git credential helper](https://git-scm.com/docs/gitcredentials).
 
-Then you have to make the rust build system also authenticate with GitHub,
+Then you have to make the Rust build system also authenticate with GitHub,
 there is nothing you need to do if you were authenticated using `gh` or `git credential helper`,
 otherwise, you can set the[`CARGO_NET_GIT_FETCH_WITH_CLI`](https://doc.rust-lang.org/cargo/reference/config.html)
 environment variable to `true`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -412,24 +412,24 @@ To avoid long compilation times, give the VM plenty of RAM (8GB recommended) and
 You will need to setup port forwarding on VirtualBox to be able to ssh into the box which can be done as follows:
 
 1. Select the virtual machine you want to use and click "Settings"
-2. Click the "Network" tab
-3. Click the "Advanced" dropdown
-4. Click "Port Forwarding"
-5. Add a new rule in the popup. The only thing you will need is "Host Port" to be 22222 and "Guest Port" to be 22. Everything else can be left default (see screenshot below)
-6. Click "Ok"
+1. Click the "Network" tab
+1. Click the "Advanced" dropdown
+1. Click "Port Forwarding"
+1. Add a new rule in the popup. The only thing you will need is "Host Port" to be 22222 and "Guest Port" to be 22. Everything else can be left default (see screenshot below)
+1. Click "Ok"
 
 Now you should be able to `ssh <your_name>@127.1 -p 22222` to get SSH prompt. However, this requires us to type a long command and password every time we sign in. It is recommended you set up a public key and SSH alias to make this process simpler:
 
 1. On your host machine, generate a keypair for SSH into the guest: `ssh-keygen -t ed25519`.
 Just keep hitting Enter until the key is generated. You do not need a password for this key file since it is only used for SSH into your guest
-2. Type `cat .ssh/id_ed25519.pub` and copy the public key
-3. SSH into the guest using the command above
-4. Create the ssh config directory (if it doesn't exist) `$ mkdir -p .ssh`
-5. Edit the authorized keys list: `vim .ssh/authorized_keys`
-6. Paste in the content of .ssh/id_ed25519.pub
-7. Adjust the required privileges: `chmod 700 .ssh/`  and `chmod 400 .ssh/authorized_keys`
-8. Logout of guest and make sure you are not promoted password when SSH again
-9. Edit the .ssh/config file on your host and put in the following content:
+1. Type `cat .ssh/id_ed25519.pub` and copy the public key
+1. SSH into the guest using the command above
+1. Create the ssh config directory (if it doesn't exist) `$ mkdir -p .ssh`
+1. Edit the authorized keys list: `vim .ssh/authorized_keys`
+1. Paste in the content of .ssh/id_ed25519.pub
+1. Adjust the required privileges: `chmod 700 .ssh/`  and `chmod 400 .ssh/authorized_keys`
+1. Logout of guest and make sure you are not promoted password when SSH again
+1. Edit the .ssh/config file on your host and put in the following content:
 
 ```
     Host dev

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -153,6 +153,13 @@ environment variable to `true`.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 ```
 
+An alternative is to edit the `~/.cargo/config` file and add the following lines:
+
+```toml
+[net]
+git-fetch-with-cli = true
+```
+
 Finally, we start the build process:
 
 ```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -140,7 +140,7 @@ brew install libyaml
 
 Now, you have to authenticate with GitHub to download some essential repos
 using either one of the following ways:
-* By [`gh`](https://cli.github.com/), basically `gh auth login`.
+* Download [`gh cli`](https://cli.github.com/) and run `gh auth login` once.
 * By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
 * Use [git credential helper](https://git-scm.com/docs/gitcredentials).
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -142,7 +142,7 @@ Now, you have to authenticate with GitHub to download some essential repos.
 There are three ways to do it:
 * By [`gh`](https://cli.github.com/), basically `gh auth login`.
 * By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
-* By [git credential helper](https://git-scm.com/docs/gitcredentials).
+* Use [git credential helper](https://git-scm.com/docs/gitcredentials).
 
 Then you have to make the rust build system also authenticate with GitHub,
 there is nothing you need to do if you were authenticated using `gh` or `git credential helper`,

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -138,8 +138,8 @@ macOS
 brew install libyaml
 ```
 
-Now, you have to authenticate with GitHub to download some essential repos.
-There are three ways to do it:
+Now, you have to authenticate with GitHub to download some essential repos
+using either one of the following ways:
 * By [`gh`](https://cli.github.com/), basically `gh auth login`.
 * By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
 * Use [git credential helper](https://git-scm.com/docs/gitcredentials).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -138,11 +138,19 @@ macOS
 brew install libyaml
 ```
 
-Now, we have to set environment variable `GITHUB_TOKEN` to download some essential repos.
-You can follow [Managing your personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to generate an access token. It does not need to have any other permission than `Public Repositories (read-only)`.
+Now, you have to authenticate with GitHub to download some essential repos.
+There are three ways to do it:
+* By [`gh`](https://cli.github.com/), basically `gh auth login`.
+* By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
+* By [git credential helper](https://git-scm.com/docs/gitcredentials).
 
-```bash
-# export GITHUB_TOKEN=ghp_xxxxxx_your_access_token
+Then you have to make the rust build system also authenticate with GitHub,
+there is nothing you need to do if you were authenticated using `gh` or `git credential helper`,
+otherwise, you can set the[`CARGO_NET_GIT_FETCH_WITH_CLI`](https://doc.rust-lang.org/cargo/reference/config.html)
+environment variable to `true`.
+
+```shell
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
 ```
 
 Finally, we start the build process:
@@ -404,24 +412,24 @@ To avoid long compilation times, give the VM plenty of RAM (8GB recommended) and
 You will need to setup port forwarding on VirtualBox to be able to ssh into the box which can be done as follows:
 
 1. Select the virtual machine you want to use and click "Settings"
-1. Click the "Network" tab
-1. Click the "Advanced" dropdown
-1. Click "Port Forwarding"
-1. Add a new rule in the popup. The only thing you will need is "Host Port" to be 22222 and "Guest Port" to be 22. Everything else can be left default (see screenshot below)
-1. Click "Ok"
+2. Click the "Network" tab
+3. Click the "Advanced" dropdown
+4. Click "Port Forwarding"
+5. Add a new rule in the popup. The only thing you will need is "Host Port" to be 22222 and "Guest Port" to be 22. Everything else can be left default (see screenshot below)
+6. Click "Ok"
 
 Now you should be able to `ssh <your_name>@127.1 -p 22222` to get SSH prompt. However, this requires us to type a long command and password every time we sign in. It is recommended you set up a public key and SSH alias to make this process simpler:
 
 1. On your host machine, generate a keypair for SSH into the guest: `ssh-keygen -t ed25519`.
 Just keep hitting Enter until the key is generated. You do not need a password for this key file since it is only used for SSH into your guest
-1. Type `cat .ssh/id_ed25519.pub` and copy the public key
-1. SSH into the guest using the command above
-1. Create the ssh config directory (if it doesn't exist) `$ mkdir -p .ssh`
-1. Edit the authorized keys list: `vim .ssh/authorized_keys`
-1. Paste in the content of .ssh/id_ed25519.pub
-1. Adjust the required privileges: `chmod 700 .ssh/`  and `chmod 400 .ssh/authorized_keys`
-1. Logout of guest and make sure you are not promoted password when SSH again
-1. Edit the .ssh/config file on your host and put in the following content:
+2. Type `cat .ssh/id_ed25519.pub` and copy the public key
+3. SSH into the guest using the command above
+4. Create the ssh config directory (if it doesn't exist) `$ mkdir -p .ssh`
+5. Edit the authorized keys list: `vim .ssh/authorized_keys`
+6. Paste in the content of .ssh/id_ed25519.pub
+7. Adjust the required privileges: `chmod 700 .ssh/`  and `chmod 400 .ssh/authorized_keys`
+8. Logout of guest and make sure you are not promoted password when SSH again
+9. Edit the .ssh/config file on your host and put in the following content:
 
 ```
     Host dev

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -141,7 +141,7 @@ brew install libyaml
 Now, you have to authenticate with GitHub to download some essential repos
 using either one of the following ways:
 * Download [`gh cli`](https://cli.github.com/) and run `gh auth login` once.
-* By [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
+* Use a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This token does not need to have any other permission than `Public Repositories (read-only)`, and set it as `GITHUB_TOKEN` environment variable.
 * Use [git credential helper](https://git-scm.com/docs/gitcredentials).
 
 Then you have to make the Rust build system also authenticate with GitHub,


### PR DESCRIPTION
### Summary

* Added two new ways to do authentication with GitHub.
* Explained how to get the Rust build system authenticated by GitHub.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
