### PR TITLE
fix(dns): added /status/dns API to status_listen port

### DIFF
--- a/changelog/unreleased/kong/refactor_dns_client.yml
+++ b/changelog/unreleased/kong/refactor_dns_client.yml
@@ -1,7 +1,7 @@
 message: >
   Starting from this version, a new DNS client library has been implemented and added into Kong. The new DNS client library has the following changes
   - Introduced global caching for DNS records across workers, significantly reducing the query load on DNS servers.
-  - Introduced observable statistics for the new DNS client, and a new Admin API `/status/dns` to retrieve them.
+  - Introduced observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
   - Simplified the logic and make it more standardized
 type: feature
 scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -169,6 +169,7 @@ build = {
     ["kong.api.routes.tags"] = "kong/api/routes/tags.lua",
     ["kong.api.routes.targets"] = "kong/api/routes/targets.lua",
     ["kong.api.routes.upstreams"] = "kong/api/routes/upstreams.lua",
+    ["kong.api.routes.dns"] = "kong/api/routes/dns.lua",
 
     ["kong.admin_gui"] = "kong/admin_gui/init.lua",
     ["kong.admin_gui.utils"] = "kong/admin_gui/utils.lua",

--- a/kong/api/routes/dns.lua
+++ b/kong/api/routes/dns.lua
@@ -1,0 +1,23 @@
+local kong = kong
+
+
+return {
+  ["/status/dns"] = {
+    GET = function (self, db, helpers)
+
+      if kong.configuration.legacy_dns_client then
+        return kong.response.exit(501, {
+          message = "not implemented with the legacy DNS client"
+        })
+      end
+
+      return kong.response.exit(200, {
+        worker = {
+          id = ngx.worker.id() or -1,
+          count = ngx.worker.count(),
+        },
+        stats = kong.dns.stats(),
+      })
+    end
+  },
+}

--- a/kong/status/init.lua
+++ b/kong/status/init.lua
@@ -27,6 +27,7 @@ ngx.log(ngx.DEBUG, "Loading Status API endpoints")
 -- Load core health route
 api_helpers.attach_routes(app, require "kong.api.routes.health")
 api_helpers.attach_routes(app, require "kong.status.ready")
+api_helpers.attach_routes(app, require "kong.api.routes.dns")
 
 
 if kong.configuration.database == "off" then

--- a/spec/02-integration/08-status_api/05-dns_client_spec.lua
+++ b/spec/02-integration/08-status_api/05-dns_client_spec.lua
@@ -1,9 +1,10 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
+local tcp_status_port = helpers.get_available_port()
 
 for _, strategy in helpers.each_strategy() do
-  describe("Admin API - DNS client route with [#" .. strategy .. "]" , function()
+  describe("[#traditional] Status API - DNS client route with [#" .. strategy .. "]" , function()
     local client
 
     lazy_setup(function()
@@ -20,11 +21,11 @@ for _, strategy in helpers.each_strategy() do
 
       assert(helpers.start_kong({
         database = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
+        status_listen = "127.0.0.1:" .. tcp_status_port,
         legacy_dns_client = "off",
       }))
 
-      client = helpers.admin_client()
+      client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
     end)
 
     teardown(function()
@@ -65,7 +66,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("Admin API - DNS client route with [#" .. strategy .. "]" , function()
+  describe("[#traditional] Status API - DNS client route with [#" .. strategy .. "]" , function()
     local client
 
     lazy_setup(function()
@@ -73,11 +74,11 @@ for _, strategy in helpers.each_strategy() do
 
       assert(helpers.start_kong({
         database = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-        legacy_dns_client = true,
+        status_listen = "127.0.0.1:" .. tcp_status_port,
+        legacy_dns_client = "on",
       }))
 
-      client = helpers.admin_client()
+      client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
     end)
 
     teardown(function()
@@ -98,5 +99,65 @@ for _, strategy in helpers.each_strategy() do
       local json = cjson.decode(body)
       assert.same("not implemented with the legacy DNS client", json.message)
     end)
+  end)
+end
+
+
+-- hybrid mode
+
+for _, strategy in helpers.each_strategy() do
+
+  describe("[#hybrid] Status API - DNS client route with [#" .. strategy .. "]" , function()
+    local client
+
+    lazy_setup(function()
+      helpers.get_db_utils(strategy) -- runs migrations
+
+      assert(helpers.start_kong({
+        role = "control_plane",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        database = strategy,
+        cluster_listen = "127.0.0.1:9005",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        legacy_dns_client = "off",
+      }))
+
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "servroot2",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        proxy_listen = "0.0.0.0:9002",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        status_listen = "127.0.0.1:" .. tcp_status_port,
+        legacy_dns_client = "off",
+      }))
+
+      client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
+    end)
+
+    teardown(function()
+      if client then
+        client:close()
+      end
+      helpers.stop_kong("servroot2")
+      helpers.stop_kong()
+    end)
+
+    it("/status/dns - status code 200", function ()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/dns",
+        headers = { ["Content-Type"] = "application/json" }
+      })
+
+      local body = assert.res_status(200 , res)
+      local json = assert(cjson.decode(body))
+      assert(type(json.stats) == "table")
+    end)
+
   end)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The dns statistics API should be added into status_listen port, otherwise we'll not get the DNS statistics from admin_listen port in DP.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5115 
