### PR TITLE
chore(changelog): add missing changelogs

### DIFF
--- a/changelog/unreleased/kong/make_rpm_relocatable.yml
+++ b/changelog/unreleased/kong/make_rpm_relocatable.yml
@@ -1,0 +1,2 @@
+message: Made the RPM package relocatable.
+type: dependency

--- a/changelog/unreleased/kong/remove_eol_debian_rhel.yml
+++ b/changelog/unreleased/kong/remove_eol_debian_rhel.yml
@@ -1,0 +1,2 @@
+message: Debian 10, CentOS 7, and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
+type: deprecation


### PR DESCRIPTION
Add changelogs for
- [KAG-4847](https://konghq.atlassian.net/browse/KAG-4847) (https://github.com/Kong/kong/pull/13340)
- [FTI-6054](https://konghq.atlassian.net/browse/FTI-6054) (https://github.com/Kong/kong/pull/13351)
- [KAG-4549](https://konghq.atlassian.net/browse/KAG-4549) (https://github.com/Kong/kong/pull/13052)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5122


[KAG-4847]: https://konghq.atlassian.net/browse/KAG-4847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-6054]: https://konghq.atlassian.net/browse/FTI-6054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAG-4549]: https://konghq.atlassian.net/browse/KAG-4549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ