### PR TITLE
fix(ci): deck integration tests dismiss review

### DIFF
--- a/.github/workflows/deck-integration.yml
+++ b/.github/workflows/deck-integration.yml
@@ -112,3 +112,16 @@ jobs:
               event: 'REQUEST_CHANGES',
               body: `## decK integration tests\n\n:warning: failure detected. Please check [the workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`
             })
+
+      - name: Dismiss requested changes if tests passed
+        if: ${{ fromJson(steps.find-review.outputs.result).review_id != '' && steps.deck_tests.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.pulls.dismissReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              review_id: ${{ fromJson(steps.find-review.outputs.result).review_id }},
+              message: "decK integration tests passed"
+            })


### PR DESCRIPTION
### Summary

when deck integration tests fail, a request for changes is created in the PR. This commit adds a step that automatically dismisses the review when tests pass.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5058
