### PR TITLE
chore(cd): update rpm prefix and add resty symlink

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -49,6 +49,9 @@ contents:
   dst: /etc/kong/kong.conf.default
   type: config
 - src: /usr/local/openresty/bin/resty
+  dst: /usr/bin/resty
+  type: symlink
+- src: /usr/local/openresty/bin/resty
   dst: /usr/local/bin/resty
   type: symlink
 - src: /usr/local/openresty/nginx/modules
@@ -85,7 +88,7 @@ overrides:
 
 rpm:
   prefixes:
-  - /usr/local
+  - /
   signature:
     # PGP secret key (can also be ASCII-armored), the passphrase is taken
     # from the environment variable $NFPM_RPM_PASSPHRASE with a fallback


### PR DESCRIPTION
FTI-6054

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
