### PR TITLE
refactor(dns): remove unnecessary DNS client initialization

### DIFF
--- a/changelog/unreleased/kong/fix-dns-initialization.yml
+++ b/changelog/unreleased/kong/fix-dns-initialization.yml
@@ -1,3 +1,3 @@
-message: Removed unnecessary dns initialization
+message: Removed unnecessary DNS client initialization
 type: performance
 scope: Core

--- a/changelog/unreleased/kong/fix-dns-initialization.yml
+++ b/changelog/unreleased/kong/fix-dns-initialization.yml
@@ -1,0 +1,3 @@
+message: Removed unnecessary dns initialization
+type: performance
+scope: Core

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -521,7 +521,7 @@ return function(options)
 
     local client = package.loaded["kong.resty.dns.client"]
     if not client then
-      -- dns initialized here, can't be eliminated due to test dependencies
+      -- dns initialization here is essential for busted tests.
       client = require("kong.tools.dns")()
     end
 

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -521,8 +521,7 @@ return function(options)
 
     local client = package.loaded["kong.resty.dns.client"]
     if not client then
-      -- just require without dns client init, because we only want `toip` function
-      client = require("kong.resty.dns.client")
+      client = require("kong.tools.dns")()
     end
 
     --- Patch the TCP connect and UDP setpeername methods such that all

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -521,7 +521,8 @@ return function(options)
 
     local client = package.loaded["kong.resty.dns.client"]
     if not client then
-      client = require("kong.tools.dns")()
+      -- just require without dns client init, because we only want `toip` function
+      client = require("kong.resty.dns.client")
     end
 
     --- Patch the TCP connect and UDP setpeername methods such that all

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -521,6 +521,7 @@ return function(options)
 
     local client = package.loaded["kong.resty.dns.client"]
     if not client then
+      -- dns initialized here, can't be eliminated due to test dependencies
       client = require("kong.tools.dns")()
     end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -643,6 +643,9 @@ function Kong.init()
   -- retrieve kong_config
   local conf_path = pl_path.join(ngx.config.prefix(), ".kong_env")
   local config = assert(conf_loader(conf_path, nil, { from_kong_env = true }))
+
+  -- The dns client has been initialized in conf_loader, so we set it directly.
+  -- Other modules should use 'kong.dns' to avoid reinitialization.
   kong.dns = assert(package.loaded["kong.resty.dns.client"])
 
   reset_kong_shm(config)

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -69,7 +69,6 @@ _G.kong = kong_global.new() -- no versioned PDK for plugins for now
 
 
 local DB = require "kong.db"
-local dns = require "kong.tools.dns"
 local meta = require "kong.meta"
 local lapis = require "lapis"
 local runloop = require "kong.runloop.handler"

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -644,6 +644,7 @@ function Kong.init()
   -- retrieve kong_config
   local conf_path = pl_path.join(ngx.config.prefix(), ".kong_env")
   local config = assert(conf_loader(conf_path, nil, { from_kong_env = true }))
+  kong.dns = assert(package.loaded["kong.resty.dns.client"])
 
   reset_kong_shm(config)
 
@@ -683,7 +684,6 @@ function Kong.init()
   assert(db:connect())
 
   kong.db = db
-  kong.dns = dns(config)
 
   if config.proxy_ssl_enabled or config.stream_ssl_enabled then
     certificate.init()

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -48,7 +48,7 @@ local resolve_timer_running
 local queryDns
 
 function targets_M.init()
-  dns_client = assert(package.loaded["kong.resty.dns.client"])
+  dns_client = assert(kong.dns)
   if renewal_heap:size() > 0 then
     renewal_heap = require("binaryheap").minUnique()
     renewal_weak_cache = setmetatable({}, { __mode = "v" })    

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -48,7 +48,7 @@ local resolve_timer_running
 local queryDns
 
 function targets_M.init()
-  dns_client = assert(kong.dns)
+  dns_client = assert(package.loaded["kong.resty.dns.client"])
   if renewal_heap:size() > 0 then
     renewal_heap = require("binaryheap").minUnique()
     renewal_weak_cache = setmetatable({}, { __mode = "v" })    

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -48,7 +48,7 @@ local resolve_timer_running
 local queryDns
 
 function targets_M.init()
-  dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
+  dns_client = assert(package.loaded["kong.resty.dns.client"])
   if renewal_heap:size() > 0 then
     renewal_heap = require("binaryheap").minUnique()
     renewal_weak_cache = setmetatable({}, { __mode = "v" })    

--- a/kong/timing/hooks/dns.lua
+++ b/kong/timing/hooks/dns.lua
@@ -1,5 +1,4 @@
 local _M = {}
-
 local timing
 
 local function before_toip(qname, _port, _dnsCacheOnly, _try_list)
@@ -24,7 +23,7 @@ function _M.register_hooks(timing_module)
     Here is the signature of the `toip()` function:
     function toip(self, qname, port, dnsCacheOnly, try_list)
   --]]
-  local client = assert(kong.dns)
+  local client = assert(package.loaded["kong.resty.dns.client"])
   req_dyn_hook.hook_function("timing", client, "toip", 4, {
     befores = { before_toip },
     afters = { after_toip },

--- a/kong/timing/hooks/dns.lua
+++ b/kong/timing/hooks/dns.lua
@@ -2,8 +2,6 @@ local _M = {}
 
 local timing
 
-local client = assert(package.loaded["kong.resty.dns.client"])
-
 local function before_toip(qname, _port, _dnsCacheOnly, _try_list)
   timing.enter_context("dns")
   timing.enter_context(qname)
@@ -26,6 +24,7 @@ function _M.register_hooks(timing_module)
     Here is the signature of the `toip()` function:
     function toip(self, qname, port, dnsCacheOnly, try_list)
   --]]
+  local client = assert(kong.dns)
   req_dyn_hook.hook_function("timing", client, "toip", 4, {
     befores = { before_toip },
     afters = { after_toip },

--- a/kong/timing/hooks/dns.lua
+++ b/kong/timing/hooks/dns.lua
@@ -2,11 +2,7 @@ local _M = {}
 
 local timing
 
-local client = package.loaded["kong.resty.dns.client"]
-if not client then
-  client = require("kong.tools.dns")()
-end
-
+local client = assert(package.loaded["kong.resty.dns.client"])
 
 local function before_toip(qname, _port, _dnsCacheOnly, _try_list)
   timing.enter_context("dns")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

There are muliple duplcated dns initialization which is unnecessary, This PR aims to improve the logic of dns initialization which as less as possible.  

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5059
