### PR TITLE
tests(tools): add tests against `kong.tools.http.parse_directive_header()`

### DIFF
--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -179,6 +179,29 @@ describe("Utils", function()
         assert.is_true(tools_http.check_https(true, false))
         assert.is_true(tools_http.check_https(true, true))
       end)
+
+      it("test parsing directive header", function()
+        -- test null
+        assert.same(tools_http.parse_directive_header(nil), {})
+
+        -- test empty string
+        assert.same(tools_http.parse_directive_header(""), {})
+
+        -- test string
+        assert.same(tools_http.parse_directive_header("cache-key=kong-cache,cache-age=300"), {
+          ["cache-age"] = 300,
+          ["cache-key"] = "kong-cache",
+        })
+
+        -- test table
+        assert.same(tools_http.parse_directive_header({
+          "cache-age=300",
+          "cache-key=kong-cache",
+        }), {
+          ["cache-age"] = 300,
+          ["cache-key"] = "kong-cache",
+        })
+      end)
     end)
   end)
 

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -181,6 +181,11 @@ describe("Utils", function()
       end)
 
       it("test parsing directive header", function()
+        -- EMPTY table return by the function with `nil` should be read-only
+        assert.is_false(pcall(function()
+          tools_http.parse_directive_header(nil)["foo"] = "bar"
+        end))
+
         -- test null
         assert.same(tools_http.parse_directive_header(nil), {})
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

From https://github.com/Kong/kong-ee/pull/9910
