### PR TITLE
fix(schema): deprecated shorthand fields precedence 

### DIFF
--- a/changelog/unreleased/fix-deprecate-shorthands-precedence.yml
+++ b/changelog/unreleased/fix-deprecate-shorthands-precedence.yml
@@ -1,0 +1,3 @@
+message: Deprecated shorthand fields don't take precedence over replacement fields when both are specified.
+type: bugfix
+scope: Core

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -76,27 +76,22 @@ end
 
 local function patch_plugin(self, db, _, parent)
   local post = self.args and self.args.post
+  if post then
+    -- Read-before-write only if necessary
+    if post.name == nil then
+      -- We need the name, otherwise we don't know what type of
+      -- plugin this is and we can't perform *any* validations.
+      local plugin, _, err_t = endpoints.select_entity(self, db, db.plugins.schema)
+      if err_t then
+        return endpoints.handle_error(err_t)
+      end
 
-  -- Read-before-write only if necessary
-  if post and (post.name     == nil or
-               post.route    == nil or
-               post.service  == nil or
-               post.consumer == nil) then
+      if not plugin then
+        return kong.response.exit(404, { message = "Not found" })
+      end
 
-    -- We need the name, otherwise we don't know what type of
-    -- plugin this is and we can't perform *any* validations.
-    local plugin, _, err_t = endpoints.select_entity(self, db, db.plugins.schema)
-    if err_t then
-      return endpoints.handle_error(err_t)
+      post.name = plugin.name
     end
-
-    if not plugin then
-      return kong.response.exit(404, { message = "Not found" })
-    end
-
-    plugin = plugin or {}
-
-    post.name = post.name or plugin.name
 
     -- Only now we can decode the 'config' table for form-encoded values
     local content_type = ngx.var.content_type
@@ -106,23 +101,6 @@ local function patch_plugin(self, db, _, parent)
          find(content_type, "multipart/form-data",               1, true) == 1 then
         post = arguments.decode(post, kong.db.plugins.schema)
       end
-    end
-
-    -- While we're at it, get values for composite uniqueness check
-    post.route = post.route or plugin.route
-    post.service = post.service or plugin.service
-    post.consumer = post.consumer or plugin.consumer
-
-    if not post.route and self.params.routes then
-      post.route = { id = self.params.routes }
-    end
-
-    if not post.service and self.params.services then
-      post.service = { id = self.params.services }
-    end
-
-    if not post.consumer and self.params.consumers then
-      post.consumer = { id = self.params.consumers }
     end
 
     self.args.post = post

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -11,6 +11,7 @@ local Plugins = {}
 
 
 local fmt = string.format
+local type = type
 local null = ngx.null
 local pairs = pairs
 local tostring = tostring
@@ -64,9 +65,8 @@ local function check_protocols_match(self, plugin)
       })
       return nil, tostring(err_t), err_t
     end
-  end
 
-  if type(plugin.service) == "table" then
+  elseif type(plugin.service) == "table" then
     if not has_common_protocol_with_service(self, plugin, plugin.service) then
       local err_t = self.errors:schema_violation({
         protocols = "must match the protocols of at least one route " ..
@@ -89,18 +89,23 @@ end
 
 
 function Plugins:update(primary_key, entity, options)
-  options = options or {}
-  options.hide_shorthands = true
-  local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
-  if rbw_entity then
-    entity = self.schema:merge_values(entity, rbw_entity)
+  if entity.protocols or entity.service or entity.route then
+    if (entity.protocols and not entity.route)
+    or (entity.service and not entity.protocols)
+    or (entity.route and not entity.protocols)
+    then
+      local rbw_entity = self.super.select(self, primary_key, options)
+      if rbw_entity then
+        entity.protocols = entity.protocols or rbw_entity.protocols
+        entity.service = entity.service or rbw_entity.service
+        entity.route = entity.route or rbw_entity.route
+      end
+    end
+    local ok, err, err_t = check_protocols_match(self, entity)
+    if not ok then
+      return nil, err, err_t
+    end
   end
-  local ok, err, err_t = check_protocols_match(self, entity)
-  if not ok then
-    return nil, err, err_t
-  end
-
-  options.hide_shorthands = false
   return self.super.update(self, primary_key, entity, options)
 end
 

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -4110,6 +4110,60 @@ describe("schema", function()
       assert.same({ name = "test1" }, output)
     end)
 
+    it("takes precedence", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            username = {
+              type = "string",
+              func = function(value)
+                return {
+                  name = value
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { username = "test1", name = "ignored" }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "test1" }, output)
+    end)
+
+    it("does not take precedence if deprecated", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            username = {
+              type = "string",
+              func = function(value)
+                return {
+                  name = value
+                }
+              end,
+              deprecation = {
+                message = "username is deprecated, please use name instead",
+                removal_in_version = "4.0",
+              },
+            },
+          },
+        },
+      })
+
+      local input = { username = "ignored", name = "test1" }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "test1" }, output)
+    end)
+
     it("can produce multiple fields", function()
       local TestSchema = Schema.new({
         name = "test",


### PR DESCRIPTION
### Summary

The shorthand fields e.g. as used in (the url is a shorthand) take precedence:
```
http PUT :8001/services/test url=http://test.org/ port=2345
```

That means that `port=2345` will be overwritten by http default port of `80` that is implicit in shorthand field `url`.

This is how it has been for a long long time.

In PR https://github.com/Kong/kong/pull/12686 we added `deprecation` field to shorthand fields definition.

Some of our automatic migrations without database migrations magic use this functionality, but the precedence there does not good:

```
http -f PUT :8001/plugins/x name=x config.new=test config.old=should_be_ignored
```

In above the `config.old` is a shorthand field with a deprecation property. Thus it should not overwrite the `config.new`, but in current code base it does. This PR changes it so that it doesn't do it anymore.

[KAG-5134](https://konghq.atlassian.net/browse/KAG-5134) and https://kongstrong.slack.com/archives/C07AQH7SAF8/p1722589141558609

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

[KAG-5134]: https://konghq.atlassian.net/browse/KAG-5134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ