### PR TITLE
fix(plugins): ai proxy cloud identity transformers

### DIFF
--- a/changelog/unreleased/kong/ai-proxy-cloud-identity-transformer-plugins.yml
+++ b/changelog/unreleased/kong/ai-proxy-cloud-identity-transformer-plugins.yml
@@ -1,0 +1,5 @@
+message: |
+  **AI-Transformer-Plugins**: Fixed a bug where cloud identity authentication 
+  was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
+scope: Plugin
+type: bugfix

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -59,6 +59,22 @@ local log_entry_keys = {
 
 local openai_override = os.getenv("OPENAI_TEST_PORT")
 
+---- IDENTITY SETTINGS
+local GCP_SERVICE_ACCOUNT do
+  GCP_SERVICE_ACCOUNT = os.getenv("GCP_SERVICE_ACCOUNT")
+end
+
+local GCP = require("resty.gcp.request.credentials.accesstoken")
+local aws_config = require "resty.aws.config"  -- reads environment variables whilst available
+local AWS = require("resty.aws")
+local AWS_REGION do
+  AWS_REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+end
+
+local AZURE_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default"
+local AZURE_TOKEN_VERSION = "v2.0"
+----
+
 _M._CONST = {
   ["SSE_TERMINATOR"] = "[DONE]",
 }
@@ -226,6 +242,75 @@ local function handle_stream_event(event_table, model_info, route_type)
       }
 
     end
+  end
+end
+
+---
+-- Manages cloud SDKs, for using "workload identity" authentications,
+-- that are tied to this specific plugin in-memory.
+--
+-- This allows users to run different authentication configurations
+-- between different AI Plugins.
+--
+-- @param {table} this_cache self - stores all the SDK instances
+-- @param {table} plugin_config the configuration to cache against and also provide SDK settings with
+-- @return {table} self
+_M.cloud_identity_function = function(this_cache, plugin_config)
+  if plugin_config.model.provider == "gemini" and
+      plugin_config.auth and
+      plugin_config.auth.gcp_use_service_account then
+
+    ngx.log(ngx.NOTICE, "loading gcp sdk for plugin ", kong.plugin.get_id())
+
+    local service_account_json = (plugin_config.auth and plugin_config.auth.gcp_service_account_json) or GCP_SERVICE_ACCOUNT
+
+    local ok, gcp_auth = pcall(GCP.new, nil, service_account_json)
+    if ok and gcp_auth then
+      -- store our item for the next time we need it
+      gcp_auth.service_account_json = service_account_json
+      this_cache[plugin_config] = { interface = gcp_auth, error = nil }
+      return this_cache[plugin_config]
+    end
+
+    return { interface = nil, error = "cloud-authentication with GCP failed" }
+
+  elseif plugin_config.model.provider == "bedrock" then
+    ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
+    local aws
+
+    local region = plugin_config.model.options
+                and plugin_config.model.options.bedrock
+                and plugin_config.model.options.bedrock.aws_region
+                or AWS_REGION
+
+    if not region then
+      return { interface = nil, error = "AWS region not specified anywhere" }
+    end
+
+    local access_key_set = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
+                        or aws_config.global.AWS_ACCESS_KEY_ID
+    local secret_key_set = plugin_config.auth and plugin_config.auth.aws_secret_access_key
+                        or aws_config.global.AWS_SECRET_ACCESS_KEY
+
+    aws = AWS({
+      -- if any of these are nil, they either use the SDK default or
+      -- are deliberately null so that a different auth chain is used
+      region = region,
+    })
+
+    if access_key_set and secret_key_set then
+      -- Override credential config according to plugin config, if set
+      local creds = aws:Credentials {
+        accessKeyId = access_key_set,
+        secretAccessKey = secret_key_set,
+      }
+
+      aws.config.credentials = creds
+    end
+
+    this_cache[plugin_config] = { interface = aws, error = nil }
+
+    return this_cache[plugin_config]
   end
 end
 

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -70,9 +70,6 @@ local AWS = require("resty.aws")
 local AWS_REGION do
   AWS_REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
 end
-
-local AZURE_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default"
-local AZURE_TOKEN_VERSION = "v2.0"
 ----
 
 _M._CONST = {
@@ -260,7 +257,7 @@ _M.cloud_identity_function = function(this_cache, plugin_config)
       plugin_config.auth and
       plugin_config.auth.gcp_use_service_account then
 
-    ngx.log(ngx.NOTICE, "loading gcp sdk for plugin ", kong.plugin.get_id())
+    ngx.log(ngx.DEBUG, "loading gcp sdk for plugin ", kong.plugin.get_id())
 
     local service_account_json = (plugin_config.auth and plugin_config.auth.gcp_service_account_json) or GCP_SERVICE_ACCOUNT
 
@@ -275,7 +272,7 @@ _M.cloud_identity_function = function(this_cache, plugin_config)
     return { interface = nil, error = "cloud-authentication with GCP failed" }
 
   elseif plugin_config.model.provider == "bedrock" then
-    ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
+    ngx.log(ngx.DEBUG, "loading aws sdk for plugin ", kong.plugin.get_id())
     local aws
 
     local region = plugin_config.model.options

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -95,9 +95,9 @@ do
     local ai_request
 
     -- mistral, cohere, titan (via Bedrock) don't support system commands
-    if self.driver == "bedrock" then
+    if self.conf.model.provider == "bedrock" then
       for _, p in ipairs(self.driver.bedrock_unsupported_system_role_patterns) do
-        if request.model:find(p) then
+        if self.conf.model.name:find(p) then
           ai_request = {
             messages = {
               [1] = {
@@ -147,7 +147,7 @@ do
     ai_shared.pre_request(self.conf, ai_request)
 
     -- send it to the ai service
-    local ai_response, _, err = self.driver.subrequest(ai_request, self.conf, http_opts, false)
+    local ai_response, _, err = self.driver.subrequest(ai_request, self.conf, http_opts, false, self.identity_interface)
     if err then
       return nil, "failed to introspect request with AI service: " .. err
     end
@@ -225,13 +225,15 @@ do
   --- Instantiate a new LLM driver instance.
   -- @tparam table conf Configuration table
   -- @tparam table http_opts HTTP options table
+  -- @tparam table [optional] cloud-authentication identity interface
   -- @treturn[1] table A new LLM driver instance
   -- @treturn[2] nil
   -- @treturn[2] string An error message if instantiation failed
-  function _M.new_driver(conf, http_opts)
+  function _M.new_driver(conf, http_opts, identity_interface)
     local self = {
       conf = conf or {},
       http_opts = http_opts or {},
+      identity_interface = identity_interface,  -- 'or nil'
     }
     setmetatable(self, LLM)
 

--- a/kong/llm/proxy/handler.lua
+++ b/kong/llm/proxy/handler.lua
@@ -13,19 +13,6 @@ local kong_utils = require("kong.tools.gzip")
 local buffer = require "string.buffer"
 local strip = require("kong.tools.utils").strip
 
--- cloud auth/sdk providers
-local GCP_SERVICE_ACCOUNT do
-  GCP_SERVICE_ACCOUNT = os.getenv("GCP_SERVICE_ACCOUNT")
-end
-
-local GCP = require("resty.gcp.request.credentials.accesstoken")
-local aws_config = require "resty.aws.config"  -- reads environment variables whilst available
-local AWS = require("resty.aws")
-local AWS_REGION do
-  AWS_REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
-end
---
-
 
 local EMPTY = require("kong.tools.table").EMPTY
 

--- a/kong/llm/proxy/handler.lua
+++ b/kong/llm/proxy/handler.lua
@@ -48,64 +48,7 @@ local ERROR__NOT_SET = 'data: {"error": true, "message": "empty or unsupported t
 
 local _KEYBASTION = setmetatable({}, {
   __mode = "k",
-  __index = function(this_cache, plugin_config)
-    if plugin_config.model.provider == "gemini" and
-       plugin_config.auth and
-       plugin_config.auth.gcp_use_service_account then
-
-      ngx.log(ngx.NOTICE, "loading gcp sdk for plugin ", kong.plugin.get_id())
-
-      local service_account_json = (plugin_config.auth and plugin_config.auth.gcp_service_account_json) or GCP_SERVICE_ACCOUNT
-
-      local ok, gcp_auth = pcall(GCP.new, nil, service_account_json)
-      if ok and gcp_auth then
-        -- store our item for the next time we need it
-        gcp_auth.service_account_json = service_account_json
-        this_cache[plugin_config] = { interface = gcp_auth, error = nil }
-        return this_cache[plugin_config]
-      end
-
-      return { interface = nil, error = "cloud-authentication with GCP failed" }
-
-    elseif plugin_config.model.provider == "bedrock" then
-      ngx.log(ngx.NOTICE, "loading aws sdk for plugin ", kong.plugin.get_id())
-      local aws
-
-      local region = plugin_config.model.options
-                 and plugin_config.model.options.bedrock
-                 and plugin_config.model.options.bedrock.aws_region
-                  or AWS_REGION
-
-      if not region then
-        return { interface = nil, error = "AWS region not specified anywhere" }
-      end
-
-      local access_key_set = (plugin_config.auth and plugin_config.auth.aws_access_key_id)
-                          or aws_config.global.AWS_ACCESS_KEY_ID
-      local secret_key_set = plugin_config.auth and plugin_config.auth.aws_secret_access_key
-                          or aws_config.global.AWS_SECRET_ACCESS_KEY
-
-      aws = AWS({
-        -- if any of these are nil, they either use the SDK default or
-        -- are deliberately null so that a different auth chain is used
-        region = region,
-      })
-
-      if access_key_set and secret_key_set then
-        -- Override credential config according to plugin config, if set
-        local creds = aws:Credentials {
-          accessKeyId = access_key_set,
-          secretAccessKey = secret_key_set,
-        }
-
-        aws.config.credentials = creds
-      end
-
-      this_cache[plugin_config] = { interface = aws, error = nil }
-
-      return this_cache[plugin_config]
-    end
-  end,
+  __index = ai_shared.cloud_identity_function,
 })
 
 
@@ -521,6 +464,7 @@ function _M:access(conf)
 
   -- get the provider's cached identity interface - nil may come back, which is fine
   local identity_interface = _KEYBASTION[conf]
+
   if identity_interface and identity_interface.error then
     llm_state.set_response_transformer_skipped()
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)

--- a/kong/plugins/ai-response-transformer/handler.lua
+++ b/kong/plugins/ai-response-transformer/handler.lua
@@ -7,10 +7,16 @@ local fmt           = string.format
 local kong_utils    = require("kong.tools.gzip")
 local llm           = require("kong.llm")
 local llm_state     = require("kong.llm.state")
+local ai_shared     = require("kong.llm.drivers.shared")
 --
 
 _M.PRIORITY = 769
 _M.VERSION = kong_meta.version
+
+local _KEYBASTION = setmetatable({}, {
+  __mode = "k",
+  __index = ai_shared.cloud_identity_function,
+})
 
 local function bad_request(msg)
   kong.log.info(msg)
@@ -99,14 +105,25 @@ end
 
 
 function _M:access(conf)
+  local kong_ctx_shared = kong.ctx.shared
+
   kong.service.request.enable_buffering()
   llm_state.disable_ai_proxy_response_transform()
+
+  -- get cloud identity SDK, if required
+  local identity_interface = _KEYBASTION[conf.llm]
+
+  if identity_interface and identity_interface.error then
+    kong_ctx_shared.skip_response_transformer = true
+    kong.log.err("error authenticating with ", conf.model.provider, " using native provider auth, ", identity_interface.error)
+    return kong.response.exit(500, "LLM request failed before proxying")
+  end
 
   -- first find the configured LLM interface and driver
   local http_opts = create_http_opts(conf)
   conf.llm.__plugin_id = conf.__plugin_id
   conf.llm.__key__ = conf.__key__
-  local ai_driver, err = llm.new_driver(conf.llm, http_opts)
+  local ai_driver, err = llm.new_driver(conf.llm, http_opts, identity_interface)
 
   if not ai_driver then
     return internal_server_error(err)


### PR DESCRIPTION
### Summary

- Fixed a bug where cloud identity authentication was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
- Re-factor "cloud SDK auth" function to be shared across many AI plugins.

### Checklist

- [x] The Pull Request has tests - already has them
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - already are docs

### Issue reference

AG-94