### PR TITLE
fix(kong.tools.http): ensure the EMPTY table returned by `parse_directive_header` is readonly

### DIFF
--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -1,5 +1,6 @@
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
+local pl_tblx = require "pl.tablex"
 
 
 local type          = type
@@ -23,7 +24,7 @@ local lower         = string.lower
 local max           = math.max
 local tab_new       = require("table.new")
 
-local EMPTY = {}
+local EMPTY = pl_tblx.readonly({})
 
 local _M = {}
 


### PR DESCRIPTION
### Summary

Panic on writing the EMPTY table

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix https://github.com/Kong/kong/pull/13458
