### PR TITLE
feat(tools): add readonly `tools.table.EMPTY` for common usage

### DIFF
--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -29,7 +29,7 @@ local COMPATIBILITY_CHECKERS = require("kong.clustering.compat.checkers")
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local KONG_VERSION = meta.version
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local _M = {}

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -102,7 +102,7 @@ local UPSTREAM_HEADER_KEY_TO_NAME = {
 }
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 -- NOTE! Prefixes should always follow `nginx_[a-z]+_`.

--- a/kong/hooks.lua
+++ b/kong/hooks.lua
@@ -10,7 +10,7 @@ local unpack = table.unpack
 local insert = table.insert
 local type = type
 local select = select
-local EMPTY = require("pl.tablex").readonly({})
+local EMPTY = require("kong.tools.table").EMPTY
 
 --[[
   The preferred maximum number of return values from a hook,

--- a/kong/llm/init.lua
+++ b/kong/llm/init.lua
@@ -2,7 +2,7 @@ local ai_shared = require("kong.llm.drivers.shared")
 local re_match = ngx.re.match
 local cjson = require("cjson.safe")
 local fmt = string.format
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 -- The module table

--- a/kong/llm/proxy/handler.lua
+++ b/kong/llm/proxy/handler.lua
@@ -27,7 +27,7 @@ end
 --
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 local _M = {}
 

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -1,7 +1,4 @@
-local tablex = require "pl.tablex"
-
-
-local EMPTY = tablex.readonly {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local kong = kong

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -1,5 +1,4 @@
 local constants = require "kong.constants"
-local tablex = require "pl.tablex"
 local groups = require "kong.plugins.acl.groups"
 local kong_meta = require "kong.meta"
 
@@ -10,7 +9,7 @@ local error = error
 local kong = kong
 
 
-local EMPTY = tablex.readonly {}
+local EMPTY = require("kong.tools.table").EMPTY
 local DENY = "DENY"
 local ALLOW = "ALLOW"
 

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -32,7 +32,7 @@ local ngx_encode_base64 = ngx.encode_base64
 local _M = {}
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 local SLASH = string_byte("/")
 local RESPONSE_TYPE = "response_type"
 local STATE = "state"

--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -11,7 +11,7 @@ local sha256_hex = require("kong.tools.sha256").sha256_hex
 local _M = {}
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local function keys(t)

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -25,7 +25,7 @@ local calculate_resource_ttl = require("kong.tools.http").calculate_resource_ttl
 
 local STRATEGY_PATH = "kong.plugins.proxy-cache.strategies"
 local CACHE_VERSION = 1
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 -- http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -21,7 +21,7 @@ local pdk_rl_store_response_header = pdk_private_rl.store_response_header
 local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 local EXPIRATION = require "kong.plugins.rate-limiting.expiration"
 
 

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -15,7 +15,7 @@ local SYNC_RATE_REALTIME = -1
 
 local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 
 local cur_usage = {
   --[[

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -1,7 +1,6 @@
 local multipart = require "multipart"
 local cjson = require("cjson.safe").new()
 local pl_template = require "pl.template"
-local pl_tablex = require "pl.tablex"
 local sandbox = require "kong.tools.sandbox"
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 
@@ -35,7 +34,7 @@ local CONTENT_LENGTH = "content-length"
 local CONTENT_TYPE = "content-type"
 local HOST = "host"
 local JSON, MULTI, ENCODED = "json", "multi_part", "form_encoded"
-local EMPTY = pl_tablex.readonly({})
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local compile_opts = {

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -14,7 +14,7 @@ local pdk_rl_store_response_header = pdk_private_rl.store_response_header
 local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
 
-local EMPTY = {}
+local EMPTY = require("kong.tools.table").EMPTY
 local HTTP_TOO_MANY_REQUESTS = 429
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -65,8 +65,7 @@ local COLON = string_byte(":")
 local DEFAULT_TIMEOUT = 2000 -- 2000 is openresty default
 
 
-local EMPTY = setmetatable({},
-  {__newindex = function() error("The 'EMPTY' table is read-only") end})
+local EMPTY = require("kong.tools.table").EMPTY
 
 -- resolver options
 local config

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -213,7 +213,7 @@ local MATCH_SUBRULES = {
 }
 
 
-local EMPTY_T = {}
+local EMPTY_T = require("kong.tools.table").EMPTY
 
 
 local match_route

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -1,4 +1,3 @@
-local pl_tablex = require "pl.tablex"
 local hostname_type = require("kong.tools.ip").hostname_type
 local hooks = require "kong.hooks"
 local recreate_request = require("ngx.balancer").recreate_request
@@ -34,7 +33,7 @@ local is_http_module   = ngx.config.subsystem == "http"
 local CRIT = ngx.CRIT
 local ERR = ngx.ERR
 local WARN = ngx.WARN
-local EMPTY_T = pl_tablex.readonly {}
+local EMPTY_T = require("kong.tools.table").EMPTY
 
 
 local set_authority

--- a/kong/runloop/balancer/least_connections.lua
+++ b/kong/runloop/balancer/least_connections.lua
@@ -14,8 +14,7 @@ local binaryHeap = require "binaryheap"
 local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 
-local EMPTY = setmetatable({},
-        {__newindex = function() error("The 'EMPTY' table is read-only") end})
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local lc = {}

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -30,8 +30,7 @@ local ERR = ngx.ERR
 local WARN = ngx.WARN
 
 local SRV_0_WEIGHT = 1      -- SRV record with weight 0 should be hit minimally, hence we replace by 1
-local EMPTY = setmetatable({},
-  {__newindex = function() error("The 'EMPTY' table is read-only") end})
+local EMPTY = require("kong.tools.table").EMPTY
 local GLOBAL_QUERY_OPTS = { workspace = null, show_ws_id = true }
 
 -- global binary heap for all balancers to share as a single update timer for

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -1,6 +1,5 @@
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
-local pl_tblx = require "pl.tablex"
 
 
 local type          = type

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -24,7 +24,7 @@ local lower         = string.lower
 local max           = math.max
 local tab_new       = require("table.new")
 
-local EMPTY = pl_tblx.readonly({})
+local EMPTY = require("kong.tools.table").EMPTY
 
 local _M = {}
 

--- a/kong/tools/table.lua
+++ b/kong/tools/table.lua
@@ -11,6 +11,9 @@ local getmetatable  = getmetatable
 local _M = {}
 
 
+_M.EMPTY = require("pl.tablex").readonly({})
+
+
 --- packs a set of arguments in a table.
 -- Explicitly sets field `n` to the number of arguments, so it is `nil` safe
 _M.pack = function(...) return {n = select("#", ...), ...} end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Inspired by #13491.
This PR did not replace all so called `EMPTY` tables, only which are obviously readonly.

KAG-5140

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
