### PR TITLE
feat(llm): add auth.allow_override option for llm auth functionality

### DIFF
--- a/changelog/unreleased/kong/ai-proxy-add-allow-override-opt.yml
+++ b/changelog/unreleased/kong/ai-proxy-add-allow-override-opt.yml
@@ -1,0 +1,4 @@
+message: |
+  **AI-proxy-plugin**: Add `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
+scope: Plugin
+type: feature

--- a/changelog/unreleased/kong/ai-proxy-add-allow-override-opt.yml
+++ b/changelog/unreleased/kong/ai-proxy-add-allow-override-opt.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI-proxy-plugin**: Add `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
+  **AI-proxy-plugin**: Add `allow_auth_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
 scope: Plugin
 type: feature

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -175,6 +175,7 @@ return {
       "model.options.bedrock",
       "auth.aws_access_key_id",
       "auth.aws_secret_access_key",
+      "auth.allow_auth_override",
       "model_name_header",
     },
     ai_prompt_decorator = {

--- a/kong/llm/drivers/anthropic.lua
+++ b/kong/llm/drivers/anthropic.lua
@@ -472,13 +472,18 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.can_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    query_table[auth_param_name] = auth_param_value
-    kong.service.request.set_query(query_table)
+    if query_table[auth_param_name] == nil or not conf.auth.can_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
   end
 
   -- if auth_param_location is "form", it will have already been set in a pre-request hook

--- a/kong/llm/drivers/anthropic.lua
+++ b/kong/llm/drivers/anthropic.lua
@@ -473,14 +473,14 @@ function _M.configure_request(conf)
 
   if auth_header_name and auth_header_value then
     local exist_value = kong.request.get_header(auth_header_name)
-    if exist_value == nil or not conf.auth.can_override then
+    if exist_value == nil or not conf.auth.allow_auth_override then
       kong.service.request.set_header(auth_header_name, auth_header_value)
     end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    if query_table[auth_param_name] == nil or not conf.auth.can_override then
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
       query_table[auth_param_name] = auth_param_value
       kong.service.request.set_query(query_table)
     end

--- a/kong/llm/drivers/azure.lua
+++ b/kong/llm/drivers/azure.lua
@@ -131,8 +131,12 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_auth_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
+
 
   local query_table = kong.request.get_query()
 
@@ -141,7 +145,9 @@ function _M.configure_request(conf)
                             or (conf.model.options and conf.model.options.azure_api_version)
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
-    query_table[auth_param_name] = auth_param_value
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      query_table[auth_param_name] = auth_param_value
+    end
   end
 
   kong.service.request.set_query(query_table)

--- a/kong/llm/drivers/cohere.lua
+++ b/kong/llm/drivers/cohere.lua
@@ -480,13 +480,18 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_auth_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    query_table[auth_param_name] = auth_param_value
-    kong.service.request.set_query(query_table)
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
   end
 
   -- if auth_param_location is "form", it will have already been set in a pre-request hook

--- a/kong/llm/drivers/llama2.lua
+++ b/kong/llm/drivers/llama2.lua
@@ -277,13 +277,18 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_auth_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    query_table[auth_param_name] = auth_param_value
-    kong.service.request.set_query(query_table)
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
   end
 
   -- if auth_param_location is "form", it will have already been set in a pre-request hook

--- a/kong/llm/drivers/mistral.lua
+++ b/kong/llm/drivers/mistral.lua
@@ -172,13 +172,18 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_auth_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    query_table[auth_param_name] = auth_param_value
-    kong.service.request.set_query(query_table)
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
   end
 
   -- if auth_param_location is "form", it will have already been set in a pre-request hook

--- a/kong/llm/drivers/openai.lua
+++ b/kong/llm/drivers/openai.lua
@@ -213,13 +213,18 @@ function _M.configure_request(conf)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_header_name and auth_header_value then
-    kong.service.request.set_header(auth_header_name, auth_header_value)
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_auth_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
   end
 
   if auth_param_name and auth_param_value and auth_param_location == "query" then
     local query_table = kong.request.get_query()
-    query_table[auth_param_name] = auth_param_value
-    kong.service.request.set_query(query_table)
+    if query_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
   end
 
   -- if auth_param_location is "form", it will have already been set in a global pre-request hook

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -528,7 +528,9 @@ function _M.pre_request(conf, request_table)
   local auth_param_location = conf.auth and conf.auth.param_location
 
   if auth_param_name and auth_param_value and auth_param_location == "body" and request_table then
-    request_table[auth_param_name] = auth_param_value
+    if request_table[auth_param_name] == nil or not conf.auth.allow_auth_override then
+      request_table[auth_param_name] = auth_param_value
+    end
   end
 
   -- retrieve the plugin name

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -97,6 +97,11 @@ local auth_schema = {
         required = false,
         encrypted = true,
         referenceable = true }},
+    { can_override = {
+        type = "boolean",
+        description = "If enabled, the auth header or param can be overridden by the request.",
+        required = false,
+        default = true }},
   }
 }
 

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -97,9 +97,9 @@ local auth_schema = {
         required = false,
         encrypted = true,
         referenceable = true }},
-    { can_override = {
+    { allow_auth_override = {
         type = "boolean",
-        description = "If enabled, the auth header or param can be overridden by the request.",
+        description = "If enabled, the authorization header or parameter can be overridden in the request by the value configured in the plugin.",
         required = false,
         default = true }},
   }

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -242,6 +242,11 @@ return {
     { logging = logging_schema },
   },
   entity_checks = {
+    { conditional =  { if_field = "model.provider",
+                          if_match = { one_of = { "bedrock", "gemini" } },
+                          then_field = "auth.allow_auth_override",
+                          then_match = { eq = false },
+                          then_err = "bedrock and gemini only support auth.allow_auth_override = false" }},
     { mutually_required = { "auth.header_name", "auth.header_value" }, },
     { mutually_required = { "auth.param_name", "auth.param_value", "auth.param_location" }, },
 

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -495,6 +495,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
               header_value = "value",
               gcp_service_account_json = '{"service": "account"}',
               gcp_use_service_account = true,
+              allow_auth_override = false,
             },
             model = {
               name = "any-model-name",
@@ -526,6 +527,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         -- gemini fields
         expected.config.auth.gcp_service_account_json = nil
         expected.config.auth.gcp_use_service_account = nil
+        expected.config.auth.allow_auth_override = nil
         expected.config.model.options.gemini = nil
 
         -- bedrock fields
@@ -562,6 +564,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
                 header_value = "value",
                 gcp_service_account_json = '{"service": "account"}',
                 gcp_use_service_account = true,
+                allow_auth_override = false,
               },
               model = {
                 name = "any-model-name",
@@ -625,6 +628,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
                 header_value = "value",
                 gcp_service_account_json = '{"service": "account"}',
                 gcp_use_service_account = true,
+                allow_auth_override = false,
               },
               model = {
                 name = "any-model-name",
@@ -720,6 +724,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         -- bedrock fields
         expected.config.auth.aws_access_key_id = nil
         expected.config.auth.aws_secret_access_key = nil
+        expected.config.auth.allow_auth_override = nil
         expected.config.model.options.bedrock = nil
 
         do_assert(uuid(), "3.7.0", expected)

--- a/spec/03-plugins/38-ai-proxy/00-config_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/00-config_spec.lua
@@ -289,4 +289,59 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     assert.is_truthy(ok)
   end)
 
+  it("bedrock model can not support ath.allowed_auth_override", function()
+    local config = {
+      route_type = "llm/v1/chat",
+      auth = {
+        param_name = "apikey",
+        param_value = "key",
+        param_location = "query",
+        header_name = "Authorization",
+        header_value = "Bearer token",
+        allow_auth_override = true,
+      },
+      model = {
+        name = "bedrock",
+        provider = "bedrock",
+        options = {
+          max_tokens = 256,
+          temperature = 1.0,
+          upstream_url = "http://nowhere",
+        },
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.is_truthy(err)
+  end)
+
+  it("gemini model can not support ath.allowed_auth_override", function()
+    local config = {
+      route_type = "llm/v1/chat",
+      auth = {
+        param_name = "apikey",
+        param_value = "key",
+        param_location = "query",
+        header_name = "Authorization",
+        header_value = "Bearer token",
+        allow_auth_override = true,
+      },
+      model = {
+        name = "gemini",
+        provider = "gemini",
+        options = {
+          max_tokens = 256,
+          temperature = 1.0,
+          upstream_url = "http://nowhere",
+        },
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_falsy(ok)
+    assert.is_truthy(err)
+  end)
 end)

--- a/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
@@ -166,6 +166,33 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
           },
         },
       }
+      local chat_good_no_allow_override = assert(bp.routes:insert {
+        service = empty_service,
+        protocols = { "http" },
+        strip_path = true,
+        paths = { "/cohere/llm/v1/chat/good-no-allow-override" }
+      })
+      bp.plugins:insert {
+        name = PLUGIN_NAME,
+        route = { id = chat_good_no_allow_override.id },
+        config = {
+          route_type = "llm/v1/chat",
+          auth = {
+            header_name = "Authorization",
+            header_value = "Bearer cohere-key",
+            allow_auth_override = false,
+          },
+          model = {
+            name = "command",
+            provider = "cohere",
+            options = {
+              max_tokens = 256,
+              temperature = 1.0,
+              upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/llm/v1/chat/good",
+            },
+          },
+        },
+      }
       --
 
       -- 200 chat bad upstream response with one option
@@ -406,6 +433,102 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
           headers = {
             ["content-type"] = "application/json",
             ["accept"] = "application/json",
+          },
+          body = pl_file.read("spec/fixtures/ai-proxy/cohere/llm-v1-chat/requests/good.json"),
+        })
+
+        local body = assert.res_status(200 , r)
+        local json = cjson.decode(body)
+
+        -- check this is in the 'kong' response format
+        assert.equals(json.model, "command")
+        assert.equals(json.object, "chat.completion")
+        assert.equals(r.headers["X-Kong-LLM-Model"], "cohere/command")
+
+        assert.is_table(json.choices)
+        assert.is_table(json.choices[1].message)
+        assert.same({
+          content = "The sum of 1 + 1 is 2.",
+          role = "assistant",
+        }, json.choices[1].message)
+      end)
+
+      it("good request with right client auth", function()
+        local r = client:get("/cohere/llm/v1/chat/good", {
+          headers = {
+            ["content-type"] = "application/json",
+            ["accept"] = "application/json",
+            ["Authorization"] = "Bearer cohere-key",
+          },
+          body = pl_file.read("spec/fixtures/ai-proxy/cohere/llm-v1-chat/requests/good.json"),
+        })
+
+        local body = assert.res_status(200 , r)
+        local json = cjson.decode(body)
+
+        -- check this is in the 'kong' response format
+        assert.equals(json.model, "command")
+        assert.equals(json.object, "chat.completion")
+        assert.equals(r.headers["X-Kong-LLM-Model"], "cohere/command")
+
+        assert.is_table(json.choices)
+        assert.is_table(json.choices[1].message)
+        assert.same({
+          content = "The sum of 1 + 1 is 2.",
+          role = "assistant",
+        }, json.choices[1].message)
+      end)
+
+      it("good request with wrong client auth", function()
+        local r = client:get("/cohere/llm/v1/chat/good", {
+          headers = {
+            ["content-type"] = "application/json",
+            ["accept"] = "application/json",
+            ["Authorization"] = "Bearer wrong",
+          },
+          body = pl_file.read("spec/fixtures/ai-proxy/cohere/llm-v1-chat/requests/good.json"),
+        })
+
+        local body = assert.res_status(401 , r)
+        local json = cjson.decode(body)
+
+        -- check this is in the 'kong' response format
+        assert.is_truthy(json.message)
+        assert.equals(json.message, "invalid api token")
+      end)
+
+      it("good request with right client auth and no allow_auth_override", function()
+        local r = client:get("/cohere/llm/v1/chat/good-no-allow-override", {
+          headers = {
+            ["content-type"] = "application/json",
+            ["accept"] = "application/json",
+            ["Authorization"] = "Bearer cohere-key",
+          },
+          body = pl_file.read("spec/fixtures/ai-proxy/cohere/llm-v1-chat/requests/good.json"),
+        })
+
+        local body = assert.res_status(200 , r)
+        local json = cjson.decode(body)
+
+        -- check this is in the 'kong' response format
+        assert.equals(json.model, "command")
+        assert.equals(json.object, "chat.completion")
+        assert.equals(r.headers["X-Kong-LLM-Model"], "cohere/command")
+
+        assert.is_table(json.choices)
+        assert.is_table(json.choices[1].message)
+        assert.same({
+          content = "The sum of 1 + 1 is 2.",
+          role = "assistant",
+        }, json.choices[1].message)
+      end)
+
+      it("good request with wrong client auth and no allow_auth_override", function()
+        local r = client:get("/cohere/llm/v1/chat/good-no-allow-override", {
+          headers = {
+            ["content-type"] = "application/json",
+            ["accept"] = "application/json",
+            ["Authorization"] = "Bearer wrong",
           },
           body = pl_file.read("spec/fixtures/ai-proxy/cohere/llm-v1-chat/requests/good.json"),
         })


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Add `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
/AG-92