### PR TITLE
fix(dns): change dns client switch to `new_dns_client`

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1542,9 +1542,7 @@
 # It provides observable statistics, you can retrieve them through the Admin API
 # `/status/dns`.
 
-#legacy_dns_client = off         # Disable the new DNS resolver, using the
-                                 # original DNS resolver. See above `dns_xxx`
-                                 # options for the original DNS resolver.
+#new_dns_client = on             # Enable the new DNS resolver
 
 #resolver_address = <name servers parsed from resolv.conf>
                                  # Comma-separated list of nameservers, each

--- a/kong/api/routes/dns.lua
+++ b/kong/api/routes/dns.lua
@@ -5,7 +5,7 @@ return {
   ["/status/dns"] = {
     GET = function (self, db, helpers)
 
-      if kong.configuration.legacy_dns_client then
+      if not kong.configuration.new_dns_client then
         return kong.response.exit(501, {
           message = "not implemented with the legacy DNS client"
         })

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -272,7 +272,7 @@ return {
   },
   ["/status/dns"] = {
     GET = function (self, db, helpers)
-      if kong.configuration.legacy_dns_client then
+      if not kong.configuration.new_dns_client then
         return kong.response.exit(501, { message = "not implemented with the legacy DNS client" })
       end
 

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -371,7 +371,7 @@ local CONF_PARSERS = {
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
 
-  legacy_dns_client = { typ = "boolean" },
+  new_dns_client = { typ = "boolean" },
 
   resolver_address = { typ = "array" },
   resolver_hosts_file = { typ = "string" },

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -1,6 +1,6 @@
 -- Use the new dns client library instead. If you want to switch to the original
--- one, you can set `legacy_dns_client = on` in kong.conf.
-if ngx.shared.kong_dns_cache and not _G.busted_legacy_dns_client then
+-- one, you can set `new_dns_client = off` in kong.conf.
+if ngx.shared.kong_dns_cache and _G.busted_new_dns_client then
   package.loaded["kong.dns.client"] = nil
   return require("kong.dns.client")
 end

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -1506,7 +1506,6 @@ end
 -- @param force_no_sync force noSynchronisation = true for a single call
 -- @return `ip address + port + try_list`, or in case of an error `nil + error + try_list`
 local function execute_toip(qname, port, dnsCacheOnly, try_list, force_no_sync)
-  ngx.log(ngx.ERR, "++++++++++++++++ execute_toip: ", qname)
   local rec, err
   rec, err, try_list = resolve(qname, nil, dnsCacheOnly, try_list, force_no_sync)
   if err then

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -1,6 +1,6 @@
 -- Use the new dns client library instead. If you want to switch to the original
 -- one, you can set `new_dns_client = off` in kong.conf.
-if ngx.shared.kong_dns_cache and _G.busted_new_dns_client then
+if ngx.shared.kong_dns_cache and _G.busted_new_dns_client ~= false then
   package.loaded["kong.dns.client"] = nil
   return require("kong.dns.client")
 end
@@ -1506,6 +1506,7 @@ end
 -- @param force_no_sync force noSynchronisation = true for a single call
 -- @return `ip address + port + try_list`, or in case of an error `nil + error + try_list`
 local function execute_toip(qname, port, dnsCacheOnly, try_list, force_no_sync)
+  ngx.log(ngx.ERR, "++++++++++++++++ execute_toip: ", qname)
   local rec, err
   rec, err, try_list = resolve(qname, nil, dnsCacheOnly, try_list, force_no_sync)
   if err then

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -170,7 +170,7 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
-legacy_dns_client = off
+new_dns_client = on
 
 resolver_address = NONE
 resolver_hosts_file = /etc/hosts

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -23,7 +23,7 @@ lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
 lua_shared_dict kong_secrets                5m;
 
-> if not legacy_dns_client then
+> if new_dns_client then
 lua_shared_dict kong_dns_cache              ${{RESOLVER_MEM_CACHE_SIZE}};
 > end
 

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -38,7 +38,7 @@ local setup_client = function(conf)
   }
 
   -- new dns client
-  if ngx.shared.kong_dns_cache and _G.busted_new_dns_client then
+  if ngx.shared.kong_dns_cache and _G.busted_new_dns_client ~= false then
 
     servers = {}
 

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -38,7 +38,7 @@ local setup_client = function(conf)
   }
 
   -- new dns client
-  if ngx.shared.kong_dns_cache and not _G.busted_legacy_dns_client then
+  if ngx.shared.kong_dns_cache and _G.busted_new_dns_client then
 
     servers = {}
 

--- a/spec/01-unit/09-balancer/02-least_connections_spec.lua
+++ b/spec/01-unit/09-balancer/02-least_connections_spec.lua
@@ -153,11 +153,17 @@ local function validate_lcb(b, debug)
 end
 
 
-describe("[least-connections]", function()
+for _, enable_new_dns_client in ipairs{ false, true } do
+
+describe("[least-connections]" .. (enable_new_dns_client and "[new dns]" or ""), function()
+  local srv_name = enable_new_dns_client and "_test._tcp.konghq.com"
+                                         or  "konghq.com"
 
   local snapshot
 
   setup(function()
+    _G.busted_new_dns_client = enable_new_dns_client
+
     _G.package.loaded["kong.resty.dns.client"] = nil -- make sure module is reloaded
     _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
 
@@ -262,10 +268,10 @@ describe("[least-connections]", function()
 
     it("honours weights", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local counts = {}
       local handles = {}
@@ -286,10 +292,10 @@ describe("[least-connections]", function()
 
     it("first returns top weights, on a 0-connection balancer", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local handles = {}
       local ip, _, handle
@@ -316,13 +322,13 @@ describe("[least-connections]", function()
 
     it("doesn't use unavailable addresses", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       -- mark one as unavailable
-      b:setAddressStatus(b:findAddress("50.50.50.50", 80, "konghq.com"), false)
+      b:setAddressStatus(b:findAddress("50.50.50.50", 80, srv_name), false)
       local counts = {}
       local handles = {}
       for i = 1,70 do
@@ -342,13 +348,13 @@ describe("[least-connections]", function()
 
     it("uses reenabled (available) addresses again", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       -- mark one as unavailable
-      b:setAddressStatus(b:findAddress("20.20.20.20", 80, "konghq.com"), false)
+      b:setAddressStatus(b:findAddress("20.20.20.20", 80, srv_name), false)
       local counts = {}
       local handles = {}
       for i = 1,70 do
@@ -365,7 +371,7 @@ describe("[least-connections]", function()
       }, counts)
 
       -- let's do another 70, after resetting
-      b:setAddressStatus(b:findAddress("20.20.20.20", 80, "konghq.com"), true)
+      b:setAddressStatus(b:findAddress("20.20.20.20", 80, srv_name), true)
       for i = 1,70 do
         local ip, _, _, handle = b:getPeer()
         counts[ip] = (counts[ip] or 0) + 1
@@ -388,11 +394,11 @@ describe("[least-connections]", function()
 
     it("does not return already failed addresses", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
-        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "70.70.70.70", port = 80, weight = 70 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local tried = {}
       local ip, _, handle
@@ -424,11 +430,11 @@ describe("[least-connections]", function()
 
     it("retries, after all addresses failed, restarts with previously failed ones", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
-        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "70.70.70.70", port = 80, weight = 70 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local tried = {}
       local ip, _, handle
@@ -449,10 +455,10 @@ describe("[least-connections]", function()
 
     it("releases the previous connection", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "50.50.50.50", port = 80, weight = 50 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local handle -- define outside loop, so it gets reused and released
       for i = 1,70 do
@@ -478,9 +484,9 @@ describe("[least-connections]", function()
 
     it("releases a connection", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local ip, _, _, handle = b:getPeer()
       assert.equal("20.20.20.20", ip)
@@ -493,9 +499,9 @@ describe("[least-connections]", function()
 
     it("releases connection of already disabled/removed address", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },
       })
-      local b = validate_lcb(new_balancer({ "konghq.com" }))
+      local b = validate_lcb(new_balancer({ srv_name }))
 
       local ip, _, _, handle = b:getPeer()
       assert.equal("20.20.20.20", ip)
@@ -513,3 +519,5 @@ describe("[least-connections]", function()
   end)
 
 end)
+
+end

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -200,11 +200,16 @@ end
 -- END TEST HELPERS --
 ----------------------
 
-describe("[consistent_hashing]", function()
+for _, enable_new_dns_client in ipairs{ false, true } do
 
+describe("[consistent_hashing]" .. (enable_new_dns_client and "[new dns]" or ""), function()
+  local srv_name = enable_new_dns_client and "_test._tcp.gelato.io"
+                                         or  "gelato.io"
   local snapshot
 
   setup(function()
+    _G.busted_new_dns_client = enable_new_dns_client
+
     _G.package.loaded["kong.resty.dns.client"] = nil -- make sure module is reloaded
     _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
 
@@ -552,10 +557,10 @@ describe("[consistent_hashing]", function()
         { name = "mashape2.com", address = "12.34.56.2" },
       })
       dnsSRV({
-        { name = "mashape.com", target = "mashape1.com", port = 8001, weight = 5 },
-        { name = "mashape.com", target = "mashape2.com", port = 8002, weight = 5 },
+        { name = srv_name, target = "mashape1.com", port = 8001, weight = 5 },
+        { name = srv_name, target = "mashape2.com", port = 8002, weight = 5 },
       })
-      add_target(b, "mashape.com", 123, 100)
+      add_target(b, srv_name, 123, 100)
       ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
@@ -883,15 +888,15 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com", address = "1.2.3.5" },
       })
       dnsSRV({
-        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5 },
       })
       local b = new_balancer({
         dns = client,
         wheelSize = 1000,
       })
       add_target(b, "mashape.com", 80, 10)
-      add_target(b, "gelato.io", 80, 10)  --> port + weight will be ignored
+      add_target(b, srv_name, 80, 10)  --> port + weight will be ignored
       local count = count_indices(b)
       local state = copyWheel(b)
       -- 33%: 106 points
@@ -903,7 +908,7 @@ describe("[consistent_hashing]", function()
         ["1.2.3.6:8002"] = 53,
       }, count)
 
-      add_target(b, "gelato.io", 80, 20)  --> port + weight will be ignored
+      add_target(b, srv_name, 80, 20)  --> port + weight will be ignored
       count = count_indices(b)
       assert.same({
         ["1.2.3.4:80"]   = 106,
@@ -978,16 +983,16 @@ describe("[consistent_hashing]", function()
     end)
     it("renewed DNS SRV record; no changes", function()
       local record = dnsSRV({
-        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8003, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8003, weight = 5 },
       })
       dnsA({
         { name = "getkong.org", address = "9.9.9.9" },
       })
       local b = new_balancer({
         hosts = {
-          { name = "gelato.io" },
+          { name = srv_name },
           { name = "getkong.org", port = 123, weight = 10 },
         },
         dns = client,
@@ -996,9 +1001,9 @@ describe("[consistent_hashing]", function()
       local state = copyWheel(b)
       record.expire = gettime() -1 -- expire current dns cache record
       dnsSRV({    -- create a new record (identical)
-        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8003, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8003, weight = 5 },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -1006,7 +1011,7 @@ describe("[consistent_hashing]", function()
       -- invoke balancer, to expire record and re-query dns
       --b:_hit_all()
       targets.resolve_targets(b.targets)
-      assert.spy(client.resolve).was_called_with("gelato.io",nil, nil)
+      assert.spy(client.resolve).was_called_with(srv_name,nil, nil)
       assert.same(state, copyWheel(b))
     end)
     it("low weight with zero-indices assigned doesn't fail", function()
@@ -1046,13 +1051,13 @@ describe("[consistent_hashing]", function()
       -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       dnsSRV({
-        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 0 },
-        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 0 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 0 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 0 },
       })
       local b = new_balancer({
         hosts = {
           -- port and weight will be overridden by the above
-          { name = "gelato.io", port = 80, weight = 99999 },
+          { name = srv_name, port = 80, weight = 99999 },
         },
         dns = client,
         wheelSize = 100,
@@ -1120,3 +1125,5 @@ describe("[consistent_hashing]", function()
     end)
   end)
 end)
+
+end

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -236,12 +236,17 @@ end
 -- END TEST HELPERS --
 ----------------------
 
+for _, enable_new_dns_client in ipairs{ false, true } do
 
 describe("[round robin balancer]", function()
+  local srv_name = enable_new_dns_client and "_test._tcp.gelato.test"
+                                         or  "gelato.test"
 
   local snapshot
 
   setup(function()
+    _G.busted_new_dns_client = enable_new_dns_client
+
     _G.package.loaded["kong.resty.dns.client"] = nil -- make sure module is reloaded
     _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
 
@@ -327,12 +332,12 @@ describe("[round robin balancer]", function()
         { name = "getkong.test", address = "::1" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003 },
+        { name = srv_name, target = "1.2.3.6", port = 8001 },
+        { name = srv_name, target = "1.2.3.6", port = 8002 },
+        { name = srv_name, target = "1.2.3.6", port = 8003 },
       })
       local b = new_balancer{
-        hosts = {"mashape.test", "getkong.test", "gelato.test" },
+        hosts = {"mashape.test", "getkong.test", srv_name },
         dns = client,
         wheelSize = 10,
       }
@@ -376,10 +381,10 @@ describe("[round robin balancer]", function()
           { name = "getkong.test", address = "::1" },
         })
         dnsSRV({
-          { name = "gelato.test", target = "1.2.3.4", port = 8001 },
+          { name = srv_name, target = "1.2.3.4", port = 8001 },
         })
         local b = new_balancer{
-          hosts = {"mashape.test", "getkong.test", "gelato.test" },
+          hosts = {"mashape.test", "getkong.test", srv_name },
           dns = client,
           wheelSize = 10,
         }
@@ -503,10 +508,10 @@ describe("[round robin balancer]", function()
           { name = "mashape2.test", address = "12.34.56.2" },
         })
         dnsSRV({
-          { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
-          { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+          { name = srv_name, target = "mashape1.test", port = 8001, weight = 5 },
+          { name = srv_name, target = "mashape2.test", port = 8002, weight = 5 },
         })
-        add_target(b, "mashape.test", 80, 10)
+        add_target(b, srv_name, 80, 10)
 
         local _, _, _, handle = b:getPeer()
         local ok, err = b:setAddressStatus(handle.address, false)
@@ -530,9 +535,9 @@ describe("[round robin balancer]", function()
           { name = "mashape1.test", address = "12.34.56.78" },
         })
         dnsSRV({
-          { name = "mashape.test", target = "mashape1.test", port = 0, weight = 5 },
+          { name = srv_name, target = "mashape1.test", port = 0, weight = 5 },
         })
-        add_target(b, "mashape.test", 80, 10)
+        add_target(b, srv_name, 80, 10)
         local ip, port = b:getPeer()
         assert.equals("12.34.56.78", ip)
         assert.equals(80, port)
@@ -550,18 +555,18 @@ describe("[round robin balancer]", function()
         { name = "mashape.test", address = "1.2.3.4" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "mashape.test", port = 8001 },
+        { name = srv_name, target = "mashape.test", port = 8001 },
       })
       local b = check_balancer(new_balancer {
         hosts = {
-          {name = "gelato.test", port = 123, weight = 100},
+          {name = srv_name, port = 123, weight = 100},
         },
         dns = client,
       })
       local addr, port, host = b:getPeer()
       assert.equal("1.2.3.4", addr)
       assert.equal(8001, port)
-      assert.equal("gelato.test", host)
+      assert.equal(srv_name, host)
     end)
     it("gets an IP address and port number; round-robin", function()
       dnsA({
@@ -758,10 +763,10 @@ describe("[round robin balancer]", function()
         { name = "mashape2.test", address = "12.34.56.2" },
       })
       dnsSRV({
-        { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
-        { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+        { name = srv_name, target = "mashape1.test", port = 8001, weight = 5 },
+        { name = srv_name, target = "mashape2.test", port = 8002, weight = 5 },
       })
-      add_target(b, "mashape.test", 123, 100)
+      add_target(b, srv_name, 123, 100)
       ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
@@ -1078,15 +1083,15 @@ describe("[round robin balancer]", function()
         { name = "mashape.test", address = "1.2.3.5" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5 },
       })
       local b = check_balancer(new_balancer {
         dns = client,
         wheelSize = 120,
       })
       add_target(b, "mashape.test", 80, 10)
-      add_target(b, "gelato.test", 80, 10)  --> port + weight will be ignored
+      add_target(b, srv_name, 80, 10)  --> port + weight will be ignored
       local count = count_indices(b)
       local state = copyWheel(b)
       assert.same({
@@ -1096,7 +1101,7 @@ describe("[round robin balancer]", function()
         ["1.2.3.6:8002"] = 1,
       }, count)
 
-      add_target(b, "gelato.test", 80, 20)  --> port + weight will be ignored
+      add_target(b, srv_name, 80, 20)  --> port + weight will be ignored
       count = count_indices(b)
       assert.same({
         ["1.2.3.4:80"]   = 2,
@@ -1171,16 +1176,16 @@ describe("[round robin balancer]", function()
     end)
     it("renewed DNS SRV record; no changes", function()
       local record = dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5, ttl = 0.1 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5, ttl = 0.1 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5, ttl = 0.1 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5, ttl = 0.1 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5, ttl = 0.1 },
+        { name = srv_name, target = "1.2.3.6", port = 8003, weight = 5, ttl = 0.1 },
       })
       dnsA({
         { name = "getkong.test", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
-          { name = "gelato.test" },
+          { name = srv_name },
           { name = "getkong.test", port = 123, weight = 10 },
         },
         dns = client,
@@ -1190,16 +1195,16 @@ describe("[round robin balancer]", function()
       record.expire = gettime() -1 -- expire current dns cache record
       sleep(0.2)  -- wait for record expiration
       dnsSRV({    -- create a new record (identical)
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = srv_name, target = "1.2.3.6", port = 8003, weight = 5 },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
       for _ = 1, b.wheelSize do -- call all, to make sure we hit the expired one
         b:getPeer()  -- invoke balancer, to expire record and re-query dns
       end
-      assert.spy(client.resolve).was_called_with("gelato.test",nil, nil)
+      assert.spy(client.resolve).was_called_with(srv_name,nil, nil)
       assert.same(state, copyWheel(b))
     end)
     it("renewed DNS A record; address changes", function()
@@ -1294,7 +1299,9 @@ describe("[round robin balancer]", function()
       local test_name = "really.really.really.does.not.exist.hostname.test"
       local ttl = 0.1
       local staleTtl = 0   -- stale ttl = 0, force lookup upon expiring
-      client.getobj().stale_ttl = 0
+      if client.getobj then
+        client.getobj().stale_ttl = 0
+      end
       local record = dnsA({
         { name = test_name, address = "1.2.3.4", ttl = ttl },
       }, staleTtl)
@@ -1317,7 +1324,9 @@ describe("[round robin balancer]", function()
         assert.is_nil(ip)
         assert.equal(port, "Balancer is unhealthy")
       end
-      client.getobj().stale_ttl = 4
+      if client.getobj then
+        client.getobj().stale_ttl = 4
+      end
     end)
     it("renewed DNS A record; unhealthy entries remain unhealthy after renewal", function()
       local record = dnsA({
@@ -1418,13 +1427,13 @@ describe("[round robin balancer]", function()
       -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 0 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 0 },
+        { name = srv_name, target = "1.2.3.6", port = 8001, weight = 0 },
+        { name = srv_name, target = "1.2.3.6", port = 8002, weight = 0 },
       })
       local b = check_balancer(new_balancer {
         hosts = {
           -- port and weight will be overridden by the above
-          { name = "gelato.test", port = 80, weight = 99999 },
+          { name = srv_name, port = 80, weight = 99999 },
         },
         dns = client,
         wheelSize = 100,
@@ -1562,3 +1571,5 @@ describe("[round robin balancer]", function()
     end)
   end)
 end)
+
+end

--- a/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
+++ b/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
@@ -124,16 +124,9 @@ local function setup_kong(fixtures)
   return kong
 end
 
-for _, enable_new_dns_client in ipairs{ false, true } do
+
 for _, consistency in ipairs({"strict", "eventual"}) do
-  describe("Balancer (worker_consistency = " .. consistency .. ")" ..
-           (enable_new_dns_client and "[new dns]" or ""), function()
-
-    ngx.log(ngx.ERR, "setting ", (enable_new_dns_client and "[new dns]" or "[old dns]"))
-
-    package.loaded["kong.resty.dns.client"] = nil
-    _G.busted_new_dns_client = enable_new_dns_client
-
+  describe("Balancer (worker_consistency = " .. consistency .. ")", function()
     local balancer
     local targets, upstreams, balancers, healthcheckers
     local UPSTREAMS_FIXTURES
@@ -565,5 +558,4 @@ for _, consistency in ipairs({"strict", "eventual"}) do
       end)
     end)
   end)
-end
 end

--- a/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
+++ b/spec/01-unit/09-balancer/05-worker_consistency_spec.lua
@@ -124,9 +124,16 @@ local function setup_kong(fixtures)
   return kong
 end
 
-
+for _, enable_new_dns_client in ipairs{ false, true } do
 for _, consistency in ipairs({"strict", "eventual"}) do
-  describe("Balancer (worker_consistency = " .. consistency .. ")", function()
+  describe("Balancer (worker_consistency = " .. consistency .. ")" ..
+           (enable_new_dns_client and "[new dns]" or ""), function()
+
+    ngx.log(ngx.ERR, "setting ", (enable_new_dns_client and "[new dns]" or "[old dns]"))
+
+    package.loaded["kong.resty.dns.client"] = nil
+    _G.busted_new_dns_client = enable_new_dns_client
+
     local balancer
     local targets, upstreams, balancers, healthcheckers
     local UPSTREAMS_FIXTURES
@@ -558,4 +565,5 @@ for _, consistency in ipairs({"strict", "eventual"}) do
       end)
     end)
   end)
+end
 end

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -39,7 +39,6 @@ describe("[DNS client]", function()
   local client, resolver
 
   before_each(function()
-    _G.busted_legacy_dns_client = true
     client = require("kong.resty.dns.client")
     resolver = require("resty.dns.resolver")
 
@@ -72,7 +71,6 @@ describe("[DNS client]", function()
   end)
 
   after_each(function()
-    _G.busted_legacy_dns_client = nil
     package.loaded["kong.resty.dns.client"] = nil
     package.loaded["resty.dns.resolver"] = nil
     client = nil

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -39,6 +39,8 @@ describe("[DNS client]", function()
   local client, resolver
 
   before_each(function()
+    _G.busted_new_dns_client = false
+
     client = require("kong.resty.dns.client")
     resolver = require("resty.dns.resolver")
 

--- a/spec/01-unit/21-dns-client/03-client_cache_spec.lua
+++ b/spec/01-unit/21-dns-client/03-client_cache_spec.lua
@@ -22,6 +22,8 @@ describe("[DNS client cache]", function()
   local client, resolver
 
   before_each(function()
+    _G.busted_new_dns_client = false
+
     client = require("kong.resty.dns.client")
     resolver = require("resty.dns.resolver")
 

--- a/spec/01-unit/21-dns-client/03-client_cache_spec.lua
+++ b/spec/01-unit/21-dns-client/03-client_cache_spec.lua
@@ -22,7 +22,6 @@ describe("[DNS client cache]", function()
   local client, resolver
 
   before_each(function()
-    _G.busted_legacy_dns_client = true
     client = require("kong.resty.dns.client")
     resolver = require("resty.dns.resolver")
 
@@ -56,7 +55,6 @@ describe("[DNS client cache]", function()
   end)
 
   after_each(function()
-    _G.busted_legacy_dns_client = nil
     package.loaded["kong.resty.dns.client"] = nil
     package.loaded["resty.dns.resolver"] = nil
     client = nil

--- a/spec/01-unit/30-new-dns-client/04-client_ipc_spec.lua
+++ b/spec/01-unit/30-new-dns-client/04-client_ipc_spec.lua
@@ -30,7 +30,7 @@ describe("[dns-client] inter-process communication:",function()
       nginx_conf = "spec/fixtures/custom_nginx.template",
       plugins = "bundled,dns-client-test",
       nginx_main_worker_processes = num_workers,
-      legacy_dns_client = "off",
+      new_dns_client = "on",
     }))
   end)
 

--- a/spec/02-integration/08-status_api/05-dns_client_spec.lua
+++ b/spec/02-integration/08-status_api/05-dns_client_spec.lua
@@ -22,7 +22,7 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong({
         database = strategy,
         status_listen = "127.0.0.1:" .. tcp_status_port,
-        legacy_dns_client = "off",
+        new_dns_client = "on",
       }))
 
       client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
@@ -75,7 +75,7 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong({
         database = strategy,
         status_listen = "127.0.0.1:" .. tcp_status_port,
-        legacy_dns_client = "on",
+        new_dns_client = "off",
       }))
 
       client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
@@ -120,7 +120,7 @@ for _, strategy in helpers.each_strategy() do
         database = strategy,
         cluster_listen = "127.0.0.1:9005",
         nginx_conf = "spec/fixtures/custom_nginx.template",
-        legacy_dns_client = "off",
+        new_dns_client = "on",
       }))
 
       assert(helpers.start_kong({
@@ -133,7 +133,7 @@ for _, strategy in helpers.each_strategy() do
         proxy_listen = "0.0.0.0:9002",
         nginx_conf = "spec/fixtures/custom_nginx.template",
         status_listen = "127.0.0.1:" .. tcp_status_port,
-        legacy_dns_client = "off",
+        new_dns_client = "on",
       }))
 
       client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)

--- a/spec/helpers/dns.lua
+++ b/spec/helpers/dns.lua
@@ -82,10 +82,17 @@ function _M.dnsSRV(client, records, staleTtl)
   records.ttl = records[1].ttl
 
   -- create key, and insert it
+
+  -- for orignal dns client
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+
+  -- for new dns client
   local key = records[1].name..":"..records[1].type
   dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
-  key = records[1].name..":-1"  -- A/AAAA
-  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+
   return records
 end
 
@@ -124,10 +131,19 @@ function _M.dnsA(client, records, staleTtl)
   records.ttl = records[1].ttl
 
   -- create key, and insert it
+
+  -- for original dns client
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+
+  -- for new dns client
   local key = records[1].name..":"..records[1].type
   dnscache:set(key, records, records[1].ttl)
   key = records[1].name..":-1"  -- A/AAAA
   dnscache:set(key, records, records[1].ttl)
+
   return records
 end
 
@@ -165,10 +181,19 @@ function _M.dnsAAAA(client, records, staleTtl)
   records.ttl = records[1].ttl
 
   -- create key, and insert it
+
+  -- for orignal dns client
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+
+  -- for new dns client
   local key = records[1].name..":"..records[1].type
   dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
   key = records[1].name..":-1" -- A/AAAA
   dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+
   return records
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. The option `legacy_dns_client` in method is counterintuitive, so we need to change it to `new_dns_client`.
2. Enable both original DNS client and new DNS client in balancer test cases.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests (original test cases will test this new feature)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5176
