### PR TITLE
chore(ci): graceful scan-images job execution during grype cdn failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,8 +436,12 @@ jobs:
     name: Scan Images - ${{ matrix.label }}
     needs: [metadata, build-images]
     runs-on: ubuntu-22.04
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    # Use DISABLE_SCA_SCAN to completely disable the scan in case of emergency purposes and revert it back when notified.
+     vars.DISABLE_SCA_SCAN == 'false'
     if: |-
       always()
+      && vars.DISABLE_SCA_SCAN == 'false'
       && fromJSON(needs.metadata.outputs.matrix)['scan-vulnerabilities'] != ''
       && needs.build-images.result == 'success'
       && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
@@ -487,6 +491,16 @@ jobs:
       with:
         asset_prefix: kong-${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}-linux-amd64
         image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
+
+    - name: Cache Grype DB
+      id: cache-grype
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-grype-db
+      with:
+        # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
+        path: ~/.cache/grype/db
+        key: ${{ env.cache-name }}
 
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,8 +437,6 @@ jobs:
     needs: [metadata, build-images]
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
-    # Use DISABLE_SCA_SCAN to completely disable the scan in case of emergency purposes and revert it back when notified.
-     vars.DISABLE_SCA_SCAN == 'false'
     if: |-
       always()
       && vars.DISABLE_SCA_SCAN == 'false'
@@ -487,25 +485,15 @@ jobs:
     - name: Scan AMD64 Image digest
       id: sbom_action_amd64
       if: steps.image_manifest_metadata.outputs.amd64_sha != ''
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v2
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a2132654dffda2a5dd121bbd077a205b4cae8ec0
       with:
         asset_prefix: kong-${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}-linux-amd64
         image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
 
-    - name: Cache Grype DB
-      id: cache-grype
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-grype-db
-      with:
-        # Grype cache files are stored in `~/.cache/grype/db` on Linux/macOS
-        path: ~/.cache/grype/db
-        key: ${{ env.cache-name }}
-
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
       id: sbom_action_arm64
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@v2
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a2132654dffda2a5dd121bbd077a205b4cae8ec0
       with:
         asset_prefix: kong-${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}-linux-arm64
         image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}


### PR DESCRIPTION
# Issue
The SCA tool (grype) invoked as part scan-images job downloads the vulnerability DB on each run. This is leading to issues dues to Grype CDN failures sporadically:
Long running jobs failing due to timeout (job resource wastage) when the job is stuck / hung up
Interim solutions to address from multiple fronts:

# Summary
- Fixes [#140](https://github.com/Kong/public-shared-actions/issues/140)
- Add job timeout for scan job to achieve early graceful job failure
- Ability to bypass  scan-images using the `vars.DISABLE_SCA_SCAN` in the repository variable of emergency when enforcement / fail_build is `true`. Only Github Admin / Repo Admin access can perform this.
- Bump the `scan-actions` version to use GH cache as part of `[2.4.0](https://github.com/Kong/public-shared-actions/releases/tag/v2.4.0)`

Long term solutions:
- The above interim problems Don't work when there first / initial scan job doesn't run until a cache is populated where is long CDN outage. Hence effort to maintain a Kong owned / controlled Grype DB mirror is required.

# Effect:
- Default pipeline will be run as-is without any changes when cache / CDN network to populate grype DB succeeds
- when enforcement / input build_fail is false, CVE analysis is skipped
- when enforcement / input build_fail is true, CVE analysis will failed / error the he downstream caller




<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
