### PR TITLE
Revert "chore(deps): bump lua-protobuf to 0.5.2"

### DIFF
--- a/changelog/unreleased/kong/bump-lua-protobuf.yml
+++ b/changelog/unreleased/kong/bump-lua-protobuf.yml
@@ -1,2 +1,0 @@
-message: "Bumped lua-protobuf 0.5.2"
-type: dependency

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.5.2",
+  "lua-protobuf == 0.5.1",
   "lua-resty-healthcheck == 3.1.0",
   "lua-messagepack == 0.5.4",
   "lua-resty-aws == 1.5.3",


### PR DESCRIPTION
Reverts Kong/kong#13454

This is because we could not get it in EE in green for unknown reasons:
https://github.com/Kong/kong-ee/pull/9965