### PR TITLE
fix(dns): disable new dns client by default

### DIFF
--- a/changelog/unreleased/kong/refactor_dns_client.yml
+++ b/changelog/unreleased/kong/refactor_dns_client.yml
@@ -1,5 +1,5 @@
 message: >
-  Starting from this version, a new DNS client library has been implemented and added into Kong. The new DNS client library has the following changes
+  Starting from this version, a new DNS client library has been implemented and added into Kong, which is disabled by default. The new DNS client library has the following changes
   - Introduced global caching for DNS records across workers, significantly reducing the query load on DNS servers.
   - Introduced observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
   - Simplified the logic and make it more standardized

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1542,7 +1542,7 @@
 # It provides observable statistics, you can retrieve them through the Admin API
 # `/status/dns`.
 
-#new_dns_client = on             # Enable the new DNS resolver
+#new_dns_client = off            # Enable or disable the new DNS resolver
 
 #resolver_address = <name servers parsed from resolv.conf>
                                  # Comma-separated list of nameservers, each

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -170,7 +170,7 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
-new_dns_client = on
+new_dns_client = off
 
 resolver_address = NONE
 resolver_hosts_file = /etc/hosts


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

For the ongoing 3.8 release, we need to disable the new DNS client by default to avoid breaking the original DNS client's behavior.

Dont merge it until 3.8 RC2, 3.8 RC1 still enables the new DNS client for testing.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests (using original test cases)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5174
