### PR TITLE
fix(certificates): can't load certificate related's snis in dbless mode.

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -350,7 +350,8 @@ local function populate_references(input, known_entities, by_id, by_key, expecte
     local child_key
     if parent_entity then
       local parent_schema = all_schemas[parent_entity]
-      if parent_schema.fields[entity] then
+      local field = parent_schema.fields[entity]
+      if field and not field.transient then
         goto continue
       end
       parent_fk = parent_schema:extract_pk_values(input)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -5,6 +5,7 @@ local pl_utils = require "pl.utils"
 local helpers  = require "spec.helpers"
 local Errors   = require "kong.db.errors"
 local mocker   = require("spec.fixtures.mocker")
+local ssl_fixtures = require "spec.fixtures.ssl"
 local deepcompare  = require("pl.tablex").deepcompare
 local inspect = require "inspect"
 local nkeys = require "table.nkeys"
@@ -453,8 +454,86 @@ describe("Admin API #off", function()
         assert.is_nil(entities.keyauth_credentials["487ab43c-b2c9-51ec-8da5-367586ea2b61"].ws_id)
         assert.is_nil(entities.plugins["0611a5a9-de73-5a2d-a4e6-6a38ad4c3cb2"].ws_id)
         assert.is_nil(entities.plugins["661199ff-aa1c-5498-982c-d57a4bd6e48b"].ws_id)
-        assert.is_nil(entities.routes["481a9539-f49c-51b6-b2e2-fe99ee68866c"].ws_id)
-        assert.is_nil(entities.services["0855b320-0dd2-547d-891d-601e9b38647f"].ws_id)
+
+        local services = entities.services["0855b320-0dd2-547d-891d-601e9b38647f"]
+        local routes = entities.routes["481a9539-f49c-51b6-b2e2-fe99ee68866c"]
+
+        assert.is_not_nil(services)
+        assert.is_not_nil(routes)
+        assert.is_nil(services.ws_id)
+        assert.is_nil(routes.ws_id)
+        assert.equals(routes.service.id, services.id)
+      end)
+
+      it("certificates should be auto-related with attach snis from /config response", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {    
+            _format_version = "1.1",
+            certificates = {
+              {
+                cert = ssl_fixtures.cert,
+                id = "d83994d2-c24c-4315-b431-ee76b6611dcb",
+                key = ssl_fixtures.key,
+                snis = {
+                  {
+                    name = "foo.example",
+                    id = "1c6e83b7-c9ad-40ac-94e8-52f5ee7bde44",
+                  },
+                }
+              }
+            },
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+
+        local body = assert.response(res).has.status(201)
+        local entities = cjson.decode(body)
+        local certificates = entities.certificates["d83994d2-c24c-4315-b431-ee76b6611dcb"]
+        local snis = entities.snis["1c6e83b7-c9ad-40ac-94e8-52f5ee7bde44"]
+        assert.is_not_nil(certificates)
+        assert.is_not_nil(snis)
+        assert.equals(snis.certificate.id, certificates.id)
+      end)
+
+      it("certificates should be auto-related with separate snis from /config response", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            _format_version = "1.1",
+            certificates = {
+              {
+                cert = ssl_fixtures.cert,
+                id = "d83994d2-c24c-4315-b431-ee76b6611dcb",
+                key = ssl_fixtures.key,
+              },
+            },
+            snis = {
+              {
+                name = "foo.example",
+                id = "1c6e83b7-c9ad-40ac-94e8-52f5ee7bde44",
+                certificate = {
+                  id = "d83994d2-c24c-4315-b431-ee76b6611dcb"
+                }
+              },
+            },
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+
+        local body = assert.response(res).has.status(201)
+        local entities = cjson.decode(body)
+        local certificates = entities.certificates["d83994d2-c24c-4315-b431-ee76b6611dcb"]
+        local snis = entities.snis["1c6e83b7-c9ad-40ac-94e8-52f5ee7bde44"]
+        assert.is_not_nil(certificates)
+        assert.is_not_nil(snis)
+        assert.equals(snis.certificate.id, certificates.id)
       end)
 
       it("can reload upstreams (regression test)", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
