### PR TITLE
chore(deps): bump lua-resty-acme to 0.15.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-acme.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-acme.yml
@@ -1,0 +1,3 @@
+message: "Bumped lua-resty-acme to 0.15.0 to support username/password auth with redis."
+type: dependency
+scope: Core

--- a/kong-3.8.0-0.rockspec
+++ b/kong-3.8.0-0.rockspec
@@ -38,7 +38,7 @@ dependencies = {
   "lua-resty-gcp == 0.0.13",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.14.0",
+  "lua-resty-acme == 0.15.0",
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.7",
   "lpeg == 1.1.0",


### PR DESCRIPTION
### Summary

### [0.15.0] - 2024-08-14
#### bug fixes
- **tests:** use tlsv1.2 in dual cert test [415be3f](https://github.com/fffonion/lua-resty-acme/commit/415be3fe2a5bfcc3cd6aac5ab8a736f0a672475c)
- **tests:** uses v3 protocol for etcd [c3928b5](https://github.com/fffonion/lua-resty-acme/commit/c3928b5e92dd66e9a22d497935a878b59cb26b36)

#### features
- **etcd:** etcd storage to use v3 protocol [a3353b3](https://github.com/fffonion/lua-resty-acme/commit/a3353b3b26b4cb0c17e98dd36f829a0db18e4ef7)
- **redis:** add support for username/password auth ([#121](https://github.com/fffonion/lua-resty-acme/issues/121)) [186ab23](https://github.com/fffonion/lua-resty-acme/commit/186ab2367c66725b6a38a8f81743328e9a4455e3)

KAG-5189

### Checklist

- [ ] ~The Pull Request has tests~
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~