### PR TITLE
fix(checkers): remove log warning of acme redis password

### DIFF
--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -50,12 +50,6 @@ local compatible_checkers = {
               'not work in this release',
               dp_version, log_suffix)
           end
-
-          if config.storage_config.redis.password ~= nil then
-            log_warn_message('configures ' .. plugin.name .. ' plugin with redis password',
-              'not work in this release. Please use redis.auth config instead',
-              dp_version, log_suffix)
-          end
         end
 
         if plugin.name == 'aws-lambda' then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

redis.password should work and redis.auth is just a shorthand left for backwards compatiblity reasons.
