### PR TITLE
fix(db): pass "read" on read-only database operations

### DIFF
--- a/changelog/unreleased/kong/fix-db-read-only.yml
+++ b/changelog/unreleased/kong/fix-db-read-only.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where 'read' was not always passed to Postgres read-only database operations."
+type: bugfix
+scope: Core

--- a/kong/db/strategies/postgres/plugins.lua
+++ b/kong/db/strategies/postgres/plugins.lua
@@ -33,7 +33,7 @@ function Plugins:select_by_ca_certificate(ca_id, limit, plugin_names)
     name_condition,
     limit_condition)
 
-  return connector:query(qs)
+  return connector:query(qs, "read")
 end
 
 return Plugins

--- a/kong/db/strategies/postgres/services.lua
+++ b/kong/db/strategies/postgres/services.lua
@@ -14,7 +14,7 @@ function Services:select_by_ca_certificate(ca_id, limit)
     kong.db.connector:escape_literal(ca_id),
     limit_condition)
 
-  return kong.db.connector:query(qs)
+  return kong.db.connector:query(qs, "read")
 end
 
 return Services

--- a/kong/db/strategies/postgres/tags.lua
+++ b/kong/db/strategies/postgres/tags.lua
@@ -94,7 +94,7 @@ local function page(self, size, token, options, tag)
 
   sql = fmt(sql, unpack(args))
 
-  local res, err = self.connector:query(sql)
+  local res, err = self.connector:query(sql, "read")
 
   if not res then
     return nil, self.errors:database_error(err)

--- a/kong/plugins/response-ratelimiting/policies/cluster.lua
+++ b/kong/plugins/response-ratelimiting/policies/cluster.lua
@@ -68,7 +68,7 @@ return {
         connector:escape_literal(service_id),
         connector:escape_literal(route_id))
 
-      local res, err = connector:query(q)
+      local res, err = connector:query(q, "read")
       if not res then
         return nil, err
       end


### PR DESCRIPTION
### Summary

@jeremyjpj0916 mentions in discussion thread:
https://github.com/Kong/kong/discussions/13513

That Kong may work unexpectedly or require write node for general operation.

I did quick search and found couple of  missing places where we don't give "read" as a parameter for readonly operations. This may not fix all the issues that we have for how resilient Kong nodes are for write node being offline, but at least it is obvious to fix these at first.

[KAG-5196](https://konghq.atlassian.net/browse/KAG-5196)

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

[KAG-5196]: https://konghq.atlassian.net/browse/KAG-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ