### PR TITLE
chore(release): bump version to 3.9 as part of the feature freeze

### DIFF
--- a/kong-3.9.0-0.rockspec
+++ b/kong-3.9.0-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong"
-version = "3.8.0-0"
+version = "3.9.0-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git+https://github.com/Kong/kong.git",
-  tag = "3.8.0"
+  tag = "3.9.0"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,6 +1,6 @@
 local version = setmetatable({
   major = 3,
-  minor = 8,
+  minor = 9,
   patch = 0,
   --suffix = "-alpha.13"
 }, {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Bump the kong master version to 3.9 as part of the 3.8 feature freeze work.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference
KAG-5216
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
