### PR TITLE
fix(aws-lambda): add null handling for multiValueHeaders

### DIFF
--- a/changelog/unreleased/kong/fix-aws-lambda-multi-value-header-null.yml
+++ b/changelog/unreleased/kong/fix-aws-lambda-multi-value-header-null.yml
@@ -1,0 +1,3 @@
+message: "**AWS-Lambda**: Fixed an issue in proxy integration mode that caused internal server error when the `multiValueHeaders` is null."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -1,6 +1,7 @@
 local kong = kong
 local ngx_encode_base64 = ngx.encode_base64
 local ngx_decode_base64 = ngx.decode_base64
+local null = ngx.null
 local cjson = require "cjson.safe"
 
 local date = require("date")
@@ -89,6 +90,10 @@ local function validate_custom_response(response)
     return nil, "body must be a string"
   end
 
+  if response.isBase64Encoded ~= nil and type(response.isBase64Encoded) ~= "boolean" then
+    return nil, "isBase64Encoded must be a boolean"
+  end
+
   return true
 end
 
@@ -118,13 +123,10 @@ local function extract_proxy_response(content)
   local isBase64Encoded = serialized_content.isBase64Encoded
   if isBase64Encoded == true then
     body = ngx_decode_base64(body)
-
-  elseif isBase64Encoded ~= false and isBase64Encoded ~= nil then
-    return nil, "isBase64Encoded must be a boolean"
   end
 
   local multiValueHeaders = serialized_content.multiValueHeaders
-  if multiValueHeaders then
+  if multiValueHeaders and multiValueHeaders ~= null then
     for header, values in pairs(multiValueHeaders) do
       headers[header] = values
     end

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -74,6 +74,10 @@ local fixtures = {
                       ngx.header["Content-Type"] = "application/json"
                       ngx.say("{\"statusCode\": 200, \"isBase64Encoded\": true, \"body\": \"eyJrZXkiOiAidmFsdWUiLCAia2V5MiI6IFtdfQ==\", \"headers\": {}, \"multiValueHeaders\": {\"Content-Type\": [\"application/json+test\"]}}")
 
+                    -- elseif string.match(ngx.var.uri, "functionWithNullMultiValueHeaders") then
+                    --   ngx.header["Content-Type"] = "application/json"
+                    --   ngx.say("{\"statusCode\": 200, \"headers\": { \"Age\": \"3600\"}, \"multiValueHeaders\": null}")
+
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -74,10 +74,6 @@ local fixtures = {
                       ngx.header["Content-Type"] = "application/json"
                       ngx.say("{\"statusCode\": 200, \"isBase64Encoded\": true, \"body\": \"eyJrZXkiOiAidmFsdWUiLCAia2V5MiI6IFtdfQ==\", \"headers\": {}, \"multiValueHeaders\": {\"Content-Type\": [\"application/json+test\"]}}")
 
-                    -- elseif string.match(ngx.var.uri, "functionWithNullMultiValueHeaders") then
-                    --   ngx.header["Content-Type"] = "application/json"
-                    --   ngx.say("{\"statusCode\": 200, \"headers\": { \"Age\": \"3600\"}, \"multiValueHeaders\": null}")
-
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

A small PR for adding a null handling code for the `multiValueHeaders` field. Also contains a small refactor to put `isBase64Encode` check into the validate function to keep consistency with other fields

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6168
