### PR TITLE
chore(ci): fallback to use the starting point of the previous branch for old plugin compatibility test if the first release tag doesn't exist yet

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,11 +51,18 @@ jobs:
         KONG_VERSION=$(bash scripts/grep-kong-version.sh)
         major=$(echo "$KONG_VERSION" | cut -d. -f1)
         minor=$(echo "$KONG_VERSION" | cut -d. -f2)
-        # if the minor version isn't 0, use the first release of the previous minor version;
+        # if the minor version isn't 0, use the first release or starting point of the previous minor branch;
         # otherwise just leave it empty, so later the default branch or commit will be used.
         if [ "$minor" -ne 0 ]; then
           minor=$((minor - 1))
-          echo "ref=$major.$minor.0" >> $GITHUB_OUTPUT
+          git fetch origin master -t
+          if [ $(git tag -l "$major.$minor.0") ]; then
+              echo "ref=$major.$minor.0" >> $GITHUB_OUTPUT
+          else
+              git fetch origin release/$major.$minor.x
+              COMMIT_HASH=$(git merge-base origin/master origin/release/$major.$minor.x)
+              echo "ref=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          fi
         else
           echo "ref=" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
### Summary

When a new minor version is just bumped, the tag x.x.0 doesn't exist yet. So we fallback to use the starting point of the previous branch instead of the tag x.x.0 of the previous branch.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-5923
