### PR TITLE
fix(*): lower the secret rotation error log level

### DIFF
--- a/changelog/unreleased/kong/fix-vault-secret-rotation-log-level.yml
+++ b/changelog/unreleased/kong/fix-vault-secret-rotation-log-level.yml
@@ -1,0 +1,3 @@
+message: Erorr logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix-vault-secret-rotation-log-level.yml
+++ b/changelog/unreleased/kong/fix-vault-secret-rotation-log-level.yml
@@ -1,3 +1,3 @@
-message: Erorr logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
+message: Error logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
 type: bugfix
 scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -1300,7 +1300,7 @@ local function new(self)
 
       local ok, err = rotate_secret(cache_key, caching_strategy)
       if not ok then
-        self.log.warn(err)
+        self.log.notice(err)
       end
     end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR lowers the log level for secret rotation errors to `notice`.
Feels more like a "chore" to me but it changed the Lua code, thus the "fix"

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5775
