### PR TITLE
tests(helpers): split constants into a standalone file

### DIFF
--- a/spec/details/constants.lua
+++ b/spec/details/constants.lua
@@ -1,0 +1,43 @@
+
+-- contants used by helpers.lua
+local CONSTANTS = {
+  BIN_PATH = "bin/kong",
+  TEST_CONF_PATH = os.getenv("KONG_SPEC_TEST_CONF_PATH") or "spec/kong_tests.conf",
+  CUSTOM_PLUGIN_PATH = "./spec/fixtures/custom_plugins/?.lua",
+  CUSTOM_VAULT_PATH = "./spec/fixtures/custom_vaults/?.lua;./spec/fixtures/custom_vaults/?/init.lua",
+  DNS_MOCK_LUA_PATH = "./spec/fixtures/mocks/lua-resty-dns/?.lua",
+  GO_PLUGIN_PATH = "./spec/fixtures/go",
+  GRPC_TARGET_SRC_PATH = "./spec/fixtures/grpc/target/",
+  MOCK_UPSTREAM_PROTOCOL = "http",
+  MOCK_UPSTREAM_SSL_PROTOCOL = "https",
+  MOCK_UPSTREAM_HOST = "127.0.0.1",
+  MOCK_UPSTREAM_HOSTNAME = "localhost",
+  MOCK_UPSTREAM_PORT = 15555,
+  MOCK_UPSTREAM_SSL_PORT = 15556,
+  MOCK_UPSTREAM_STREAM_PORT = 15557,
+  MOCK_UPSTREAM_STREAM_SSL_PORT = 15558,
+  GRPCBIN_HOST = os.getenv("KONG_SPEC_TEST_GRPCBIN_HOST") or "localhost",
+  GRPCBIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_PORT")) or 9000,
+  GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) or 9001,
+  MOCK_GRPC_UPSTREAM_PROTO_PATH = "./spec/fixtures/grpc/hello.proto",
+  ZIPKIN_HOST = os.getenv("KONG_SPEC_TEST_ZIPKIN_HOST") or "localhost",
+  ZIPKIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_ZIPKIN_PORT")) or 9411,
+  OTELCOL_HOST = os.getenv("KONG_SPEC_TEST_OTELCOL_HOST") or "localhost",
+  OTELCOL_HTTP_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_HTTP_PORT")) or 4318,
+  OTELCOL_ZPAGES_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_ZPAGES_PORT")) or 55679,
+  OTELCOL_FILE_EXPORTER_PATH = os.getenv("KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH") or "./tmp/otel/file_exporter.json",
+  REDIS_HOST = os.getenv("KONG_SPEC_TEST_REDIS_HOST") or "localhost",
+  REDIS_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_PORT") or 6379),
+  REDIS_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_SSL_PORT") or 6380),
+  REDIS_AUTH_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_AUTH_PORT") or 6381),
+  REDIS_SSL_SNI = os.getenv("KONG_SPEC_TEST_REDIS_SSL_SNI") or "test-redis.example.com",
+  TEST_COVERAGE_MODE = os.getenv("KONG_COVERAGE"),
+  TEST_COVERAGE_TIMEOUT = 30,
+  -- consistent with path set in .github/workflows/build_and_test.yml and build/dockerfiles/deb.pongo.Dockerfile
+  OLD_VERSION_KONG_PATH = os.getenv("KONG_SPEC_TEST_OLD_VERSION_KONG_PATH") or "/usr/local/share/lua/5.1/kong/kong-old",
+  BLACKHOLE_HOST = "10.255.255.255",
+  KONG_VERSION = require("kong.meta")._VERSION,
+}
+
+
+return CONSTANTS

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -5,44 +5,7 @@
 -- @license [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 -- @module spec.helpers
 
-local CONSTANTS = {
-  BIN_PATH = "bin/kong",
-  TEST_CONF_PATH = os.getenv("KONG_SPEC_TEST_CONF_PATH") or "spec/kong_tests.conf",
-  CUSTOM_PLUGIN_PATH = "./spec/fixtures/custom_plugins/?.lua",
-  CUSTOM_VAULT_PATH = "./spec/fixtures/custom_vaults/?.lua;./spec/fixtures/custom_vaults/?/init.lua",
-  DNS_MOCK_LUA_PATH = "./spec/fixtures/mocks/lua-resty-dns/?.lua",
-  GO_PLUGIN_PATH = "./spec/fixtures/go",
-  GRPC_TARGET_SRC_PATH = "./spec/fixtures/grpc/target/",
-  MOCK_UPSTREAM_PROTOCOL = "http",
-  MOCK_UPSTREAM_SSL_PROTOCOL = "https",
-  MOCK_UPSTREAM_HOST = "127.0.0.1",
-  MOCK_UPSTREAM_HOSTNAME = "localhost",
-  MOCK_UPSTREAM_PORT = 15555,
-  MOCK_UPSTREAM_SSL_PORT = 15556,
-  MOCK_UPSTREAM_STREAM_PORT = 15557,
-  MOCK_UPSTREAM_STREAM_SSL_PORT = 15558,
-  GRPCBIN_HOST = os.getenv("KONG_SPEC_TEST_GRPCBIN_HOST") or "localhost",
-  GRPCBIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_PORT")) or 9000,
-  GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) or 9001,
-  MOCK_GRPC_UPSTREAM_PROTO_PATH = "./spec/fixtures/grpc/hello.proto",
-  ZIPKIN_HOST = os.getenv("KONG_SPEC_TEST_ZIPKIN_HOST") or "localhost",
-  ZIPKIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_ZIPKIN_PORT")) or 9411,
-  OTELCOL_HOST = os.getenv("KONG_SPEC_TEST_OTELCOL_HOST") or "localhost",
-  OTELCOL_HTTP_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_HTTP_PORT")) or 4318,
-  OTELCOL_ZPAGES_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_ZPAGES_PORT")) or 55679,
-  OTELCOL_FILE_EXPORTER_PATH = os.getenv("KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH") or "./tmp/otel/file_exporter.json",
-  REDIS_HOST = os.getenv("KONG_SPEC_TEST_REDIS_HOST") or "localhost",
-  REDIS_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_PORT") or 6379),
-  REDIS_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_SSL_PORT") or 6380),
-  REDIS_AUTH_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_AUTH_PORT") or 6381),
-  REDIS_SSL_SNI = os.getenv("KONG_SPEC_TEST_REDIS_SSL_SNI") or "test-redis.example.com",
-  TEST_COVERAGE_MODE = os.getenv("KONG_COVERAGE"),
-  TEST_COVERAGE_TIMEOUT = 30,
-  -- consistent with path set in .github/workflows/build_and_test.yml and build/dockerfiles/deb.pongo.Dockerfile
-  OLD_VERSION_KONG_PATH = os.getenv("KONG_SPEC_TEST_OLD_VERSION_KONG_PATH") or "/usr/local/share/lua/5.1/kong/kong-old",
-  BLACKHOLE_HOST = "10.255.255.255",
-  KONG_VERSION = require("kong.meta")._VERSION,
-}
+local CONSTANTS = require("spec.details.constants")
 
 local PLUGINS_LIST
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5233

It is one of serial refactors of helpers.lua

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
