### PR TITLE
tests(helpers): separate grpc test functions

### DIFF
--- a/spec/details/grpc.lua
+++ b/spec/details/grpc.lua
@@ -1,0 +1,90 @@
+local pl_path = require("pl.path")
+local shell = require("resty.shell")
+local resty_signal = require("resty.signal")
+
+
+local CONSTANTS = require("spec.details.constants")
+
+
+local function isnewer(path_a, path_b)
+  if not pl_path.exists(path_a) then
+    return true
+  end
+  if not pl_path.exists(path_b) then
+    return false
+  end
+  return assert(pl_path.getmtime(path_b)) > assert(pl_path.getmtime(path_a))
+end
+
+
+local function make(workdir, specs)
+  workdir = pl_path.normpath(workdir or pl_path.currentdir())
+
+  for _, spec in ipairs(specs) do
+    local targetpath = pl_path.join(workdir, spec.target)
+    for _, src in ipairs(spec.src) do
+      local srcpath = pl_path.join(workdir, src)
+      if isnewer(targetpath, srcpath) then
+        local ok, _, stderr = shell.run(string.format("cd %s; %s", workdir, spec.cmd), nil, 0)
+        assert(ok, stderr)
+        if isnewer(targetpath, srcpath) then
+          error(string.format("couldn't make %q newer than %q", targetpath, srcpath))
+        end
+        break
+      end
+    end
+  end
+
+  return true
+end
+
+
+local grpc_target_proc
+
+
+local function start_grpc_target()
+  local ngx_pipe = require("ngx.pipe")
+  assert(make(CONSTANTS.GRPC_TARGET_SRC_PATH, {
+    {
+      target = "targetservice/targetservice.pb.go",
+      src    = { "../targetservice.proto" },
+      cmd    = "protoc --go_out=. --go-grpc_out=. -I ../ ../targetservice.proto",
+    },
+    {
+      target = "targetservice/targetservice_grpc.pb.go",
+      src    = { "../targetservice.proto" },
+      cmd    = "protoc --go_out=. --go-grpc_out=. -I ../ ../targetservice.proto",
+    },
+    {
+      target = "target",
+      src    = { "grpc-target.go", "targetservice/targetservice.pb.go", "targetservice/targetservice_grpc.pb.go" },
+      cmd    = "go mod tidy && go mod download all && go build",
+    },
+  }))
+  grpc_target_proc = assert(ngx_pipe.spawn({ CONSTANTS.GRPC_TARGET_SRC_PATH .. "/target" }, {
+      merge_stderr = true,
+  }))
+
+  return true
+end
+
+
+local function stop_grpc_target()
+  if grpc_target_proc then
+    grpc_target_proc:kill(resty_signal.signum("QUIT"))
+    grpc_target_proc = nil
+  end
+end
+
+
+local function get_grpc_target_port()
+  return 15010
+end
+
+
+return {
+  start_grpc_target = start_grpc_target,
+  stop_grpc_target = stop_grpc_target,
+  get_grpc_target_port = get_grpc_target_port,
+}
+

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -5,6 +5,7 @@
 -- @license [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 -- @module spec.helpers
 
+
 local PLUGINS_LIST
 
 
@@ -37,7 +38,6 @@ local ws_client = require "resty.websocket.client"
 local table_clone = require "table.clone"
 local https_server = require "spec.fixtures.https_server"
 local stress_generator = require "spec.fixtures.stress_generator"
-local resty_signal = require "resty.signal"
 local lfs = require "lfs"
 local luassert = require "luassert.assert"
 local uuid = require("kong.tools.uuid").uuid
@@ -56,6 +56,7 @@ end
 local CONSTANTS = reload_module("spec.details.constants")
 local shell = reload_module("spec.details.shell")
 local misc = reload_module("spec.details.misc")
+local grpc = reload_module("spec.details.grpc")
 
 
 local conf = shell.conf
@@ -3392,76 +3393,6 @@ local function build_go_plugins(path)
   end
 end
 
-local function isnewer(path_a, path_b)
-  if not pl_path.exists(path_a) then
-    return true
-  end
-  if not pl_path.exists(path_b) then
-    return false
-  end
-  return assert(pl_path.getmtime(path_b)) > assert(pl_path.getmtime(path_a))
-end
-
-local function make(workdir, specs)
-  workdir = pl_path.normpath(workdir or pl_path.currentdir())
-
-  for _, spec in ipairs(specs) do
-    local targetpath = pl_path.join(workdir, spec.target)
-    for _, src in ipairs(spec.src) do
-      local srcpath = pl_path.join(workdir, src)
-      if isnewer(targetpath, srcpath) then
-        local ok, _, stderr = shell.run(string.format("cd %s; %s", workdir, spec.cmd), nil, 0)
-        assert(ok, stderr)
-        if isnewer(targetpath, srcpath) then
-          error(string.format("couldn't make %q newer than %q", targetpath, srcpath))
-        end
-        break
-      end
-    end
-  end
-
-  return true
-end
-
-local grpc_target_proc
-local function start_grpc_target()
-  local ngx_pipe = require "ngx.pipe"
-  assert(make(CONSTANTS.GRPC_TARGET_SRC_PATH, {
-    {
-      target = "targetservice/targetservice.pb.go",
-      src    = { "../targetservice.proto" },
-      cmd    = "protoc --go_out=. --go-grpc_out=. -I ../ ../targetservice.proto",
-    },
-    {
-      target = "targetservice/targetservice_grpc.pb.go",
-      src    = { "../targetservice.proto" },
-      cmd    = "protoc --go_out=. --go-grpc_out=. -I ../ ../targetservice.proto",
-    },
-    {
-      target = "target",
-      src    = { "grpc-target.go", "targetservice/targetservice.pb.go", "targetservice/targetservice_grpc.pb.go" },
-      cmd    = "go mod tidy && go mod download all && go build",
-    },
-  }))
-  grpc_target_proc = assert(ngx_pipe.spawn({ CONSTANTS.GRPC_TARGET_SRC_PATH .. "/target" }, {
-      merge_stderr = true,
-  }))
-
-  return true
-end
-
-local function stop_grpc_target()
-  if grpc_target_proc then
-    grpc_target_proc:kill(resty_signal.signum("QUIT"))
-    grpc_target_proc = nil
-  end
-end
-
-local function get_grpc_target_port()
-  return 15010
-end
-
-
 --- Start the Kong instance to test against.
 -- The fixtures passed to this function can be 3 types:
 --
@@ -4140,9 +4071,9 @@ end
   get_kong_workers = get_kong_workers,
   wait_until_no_common_workers = wait_until_no_common_workers,
 
-  start_grpc_target = start_grpc_target,
-  stop_grpc_target = stop_grpc_target,
-  get_grpc_target_port = get_grpc_target_port,
+  start_grpc_target = grpc.start_grpc_target,
+  stop_grpc_target = grpc.stop_grpc_target,
+  get_grpc_target_port = grpc.get_grpc_target_port,
 
   -- plugin compatibility test
   use_old_plugin = use_old_plugin,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It is one of the serial refactors of helpers.lua

KAG-5242

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
