### PR TITLE
tests(db): add shorthands precedence test when using complex records

### DIFF
--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -4115,6 +4115,12 @@ describe("schema", function()
         name = "test",
         fields = {
           { name = { type = "string" } },
+          { record = {
+            type = "record",
+              fields = {
+                { x = { type = "string" } }
+              },
+          }},
         },
         shorthand_fields = {
           {
@@ -4127,12 +4133,24 @@ describe("schema", function()
               end,
             },
           },
+          {
+            y = {
+              type = "string",
+              func = function(value)
+                return {
+                  record = {
+                    x = value,
+                  },
+                }
+              end,
+            },
+          },
         },
       })
 
-      local input = { username = "test1", name = "ignored" }
+      local input = { username = "test1", name = "ignored", record = { x = "ignored" }, y = "test1" }
       local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "test1" }, output)
+      assert.same({ name = "test1", record = { x = "test1" } }, output)
     end)
 
     it("does not take precedence if deprecated", function()
@@ -4140,6 +4158,12 @@ describe("schema", function()
         name = "test",
         fields = {
           { name = { type = "string" } },
+          { record = {
+            type = "record",
+            fields = {
+              { x = { type = "string" } }
+            },
+          }},
         },
         shorthand_fields = {
           {
@@ -4156,12 +4180,28 @@ describe("schema", function()
               },
             },
           },
+          {
+            y = {
+              type = "string",
+              func = function(value)
+                return {
+                  record = {
+                    x = value,
+                  },
+                }
+              end,
+              deprecation = {
+                message = "y is deprecated, please use record.x instead",
+                removal_in_version = "4.0",
+              },
+            },
+          },
         },
       })
 
-      local input = { username = "ignored", name = "test1" }
+      local input = { username = "ignored", name = "test1", record = { x = "test1" }, y = "ignored"  }
       local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "test1" }, output)
+      assert.same({ name = "test1", record = { x = "test1" }  }, output)
     end)
 
     it("can produce multiple fields", function()


### PR DESCRIPTION
### Summary

Gladly we found an issue where merge conflict in EE was wrongly resolved (by me, @bungle, most likely) before we released.

Thanks to @nowNick for finding it out.

Here is the missing tests that hopefully helps us in a future to spot it better.