### PR TITLE
fix(core): rename unix sockets to shorter names to avoid exceeding socket name limit

### DIFF
--- a/changelog/unreleased/kong/shorten-socket-names.yml
+++ b/changelog/unreleased/kong/shorten-socket-names.yml
@@ -1,0 +1,3 @@
+message: Shorten names of internal Unix sockets to avoid exceeding the socket name limit.
+type: bugfix
+scope: Core

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -26,8 +26,9 @@ local _log_prefix = "[clustering] "
 
 local KONG_VERSION = kong.version
 
-local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/cluster_proxy_ssl_terminator.sock",
-                                              kong.configuration.socket_path)
+local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/%s",
+                                              kong.configuration.socket_path,
+                                              constants.SOCKETS.CLUSTER_PROXY_SSL_TERMINATOR)
 
 local _M = {}
 

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -9,6 +9,7 @@ local lower = string.lower
 local HEADERS = constants.HEADERS
 local BUNDLED_VAULTS = constants.BUNDLED_VAULTS
 local BUNDLED_PLUGINS = constants.BUNDLED_PLUGINS
+local SOCKETS = constants.SOCKETS
 
 
 -- Version 5.7: https://wiki.mozilla.org/Security/Server_Side_TLS
@@ -637,6 +638,7 @@ return {
   HEADERS = HEADERS,
   BUNDLED_VAULTS = BUNDLED_VAULTS,
   BUNDLED_PLUGINS = BUNDLED_PLUGINS,
+  SOCKETS = SOCKETS,
 
   CIPHER_SUITES = CIPHER_SUITES,
   DEFAULT_PATHS = DEFAULT_PATHS,

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -486,6 +486,14 @@ local function load(path, custom_conf, opts)
   -- The socket path is where we store listening unix sockets for IPC and private APIs.
   -- It is derived from the prefix and is NOT intended to be user-configurable
   conf.socket_path = pl_path.join(conf.prefix, constants.SOCKET_DIRECTORY)
+  conf.worker_events_sock = constants.SOCKETS.WORKER_EVENTS
+  conf.stream_worker_events_sock = constants.SOCKETS.STREAM_WORKER_EVENTS
+  conf.stream_rpc_sock = constants.SOCKETS.STREAM_RPC
+  conf.stream_config_sock = constants.SOCKETS.STREAM_CONFIG
+  conf.stream_tls_passthrough_sock = constants.SOCKETS.STREAM_TLS_PASSTHROUGH
+  conf.stream_tls_terminate_sock = constants.SOCKETS.STREAM_TLS_TERMINATE
+  conf.cluster_proxy_ssl_terminator_sock = constants.SOCKETS.CLUSTER_PROXY_SSL_TERMINATOR
+
 
   if conf.lua_ssl_trusted_certificate
      and #conf.lua_ssl_trusted_certificate > 0 then

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -282,6 +282,15 @@ local constants = {
   },
 
   SOCKET_DIRECTORY = "sockets",
+  SOCKETS = {
+    WORKER_EVENTS = "we",
+    STREAM_WORKER_EVENTS = "sw",
+    CLUSTER_PROXY_SSL_TERMINATOR = "cp",
+    STREAM_CONFIG = "sc",
+    STREAM_TLS_TERMINATE = "st",
+    STREAM_TLS_PASSTHROUGH = "sp",
+    STREAM_RPC = "rp",
+  },
 }
 
 for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -14,8 +14,6 @@ local error = error
 local setmetatable = setmetatable
 
 
-
-
 local KONG_VERSION = tostring(meta._VERSION)
 local KONG_VERSION_NUM = tonumber(string.format("%d%.2d%.2d",
                                   meta._VERSION_TABLE.major * 100,

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -6,11 +6,14 @@ local phase_checker = require "kong.pdk.private.phases"
 local kong_cache = require "kong.cache"
 local kong_cluster_events = require "kong.cluster_events"
 local private_node = require "kong.pdk.private.node"
+local constants = require "kong.constants"
 
 local ngx = ngx
 local type = type
 local error = error
 local setmetatable = setmetatable
+
+
 
 
 local KONG_VERSION = tostring(meta._VERSION)
@@ -176,8 +179,8 @@ function _GLOBAL.init_worker_events(kong_config)
 
   local socket_path = kong_config.socket_path
   local sock = ngx.config.subsystem == "stream" and
-               "stream_worker_events.sock" or
-               "worker_events.sock"
+               constants.SOCKETS.STREAM_WORKER_EVENTS or
+               constants.SOCKETS.WORKER_EVENTS
 
   local listening = "unix:" .. socket_path .. "/" .. sock
 

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -518,7 +518,7 @@ do
                                              .. constants.SOCKET_DIRECTORY)
   end
 
-  local STREAM_CONFIG_SOCK = "unix:" .. socket_path .. "/stream_config.sock"
+  local STREAM_CONFIG_SOCK = "unix:" .. socket_path .. "/" .. constants.SOCKETS.STREAM_CONFIG
   local IS_HTTP_SUBSYSTEM  = ngx.config.subsystem == "http"
 
   local function broadcast_reconfigure_event(data)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -897,8 +897,8 @@ return {
   init_worker = {
     before = function()
       local socket_path = kong.configuration.socket_path
-      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", socket_path)
-      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", socket_path)
+      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/%s", socket_path, constants.SOCKETS.STREAM_TLS_TERMINATE)
+      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/%s", socket_path, constants.SOCKETS.STREAM_TLS_PASSTHROUGH)
 
       log_level.init_worker()
 

--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -83,7 +83,7 @@ stream {
 
 > if cluster_ssl_tunnel then
     server {
-        listen unix:${{SOCKET_PATH}}/cluster_proxy_ssl_terminator.sock;
+        listen unix:${{SOCKET_PATH}}/${{CLUSTER_PROXY_SSL_TERMINATOR_SOCK}};
 
         proxy_pass ${{cluster_ssl_tunnel}};
         proxy_ssl on;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -592,7 +592,7 @@ server {
 server {
     charset UTF-8;
     server_name kong_worker_events;
-    listen unix:${{SOCKET_PATH}}/worker_events.sock;
+    listen unix:${{SOCKET_PATH}}/${{WORKER_EVENTS_SOCK}};
     access_log off;
     location / {
         content_by_lua_block {

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -94,7 +94,7 @@ server {
 > end
 
 > if stream_proxy_ssl_enabled then
-    listen unix:${{SOCKET_PATH}}/stream_tls_terminate.sock ssl proxy_protocol;
+    listen unix:${{SOCKET_PATH}}/${{STREAM_TLS_TERMINATE_SOCK}} ssl proxy_protocol;
 > end
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
@@ -175,7 +175,7 @@ server {
 }
 
 server {
-    listen unix:${{SOCKET_PATH}}/stream_tls_passthrough.sock proxy_protocol;
+    listen unix:${{SOCKET_PATH}}/${{STREAM_TLS_PASSTHROUGH_SOCK}} proxy_protocol;
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
     error_log ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
@@ -205,7 +205,7 @@ server {
 
 > if database == "off" then
 server {
-    listen unix:${{SOCKET_PATH}}/stream_config.sock;
+    listen unix:${{SOCKET_PATH}}/${{STREAM_CONFIG_SOCK}};
 
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
@@ -216,7 +216,7 @@ server {
 > end -- database == "off"
 
 server {        # ignore (and close }, to ignore content)
-    listen unix:${{SOCKET_PATH}}/stream_rpc.sock;
+    listen unix:${{SOCKET_PATH}}/${{STREAM_RPC_SOCK}};
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     content_by_lua_block {
         Kong.stream_api()
@@ -225,7 +225,7 @@ server {        # ignore (and close }, to ignore content)
 > end -- #stream_listeners > 0
 
 server {
-    listen unix:${{SOCKET_PATH}}/stream_worker_events.sock;
+    listen unix:${{SOCKET_PATH}}/${{STREAM_WORKER_EVENTS_SOCK}};
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     access_log off;
     content_by_lua_block {

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -40,7 +40,7 @@ local HEADER_LEN = #st_pack(PACK_F, MAX_KEY_LEN, MAX_DATA_LEN)
 
 -- this module may be loaded before `kong.configuration` is initialized
 local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/"
-                    .. constants.SOCKET_DIRECTORY .. "/stream_rpc.sock"
+                    .. constants.SOCKET_DIRECTORY .. "/" .. constants.SOCKETS.STREAM_RPC
 
 local stream_api = {}
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -2472,6 +2472,13 @@ describe("Configuration loader", function()
         -- CONF_BASIC
         prefix = true,
         socket_path = true,
+        worker_events_sock = true,
+        stream_worker_events_sock = true,
+        stream_rpc_sock = true,
+        stream_config_sock = true,
+        stream_tls_passthrough_sock = true,
+        stream_tls_terminate_sock = true,
+        cluster_proxy_ssl_terminator_sock = true,
         vaults = true,
         database = true,
         lmdb_environment_path = true,
@@ -2522,7 +2529,7 @@ describe("Configuration loader", function()
       }
       local conf = assert(conf_loader(nil, nil, { pre_cmd = true }))
       for k, _ in pairs(conf) do
-        assert.equal(true, FIELDS[k])
+        assert.equal(true, FIELDS[k], "key " .. k .. " is not in FIELDS")
       end
     end)
   end)

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -43,11 +43,11 @@ local function wait_until_healthy(prefix)
   local conf = assert(helpers.get_running_conf(prefix))
 
   if conf.proxy_listen and conf.proxy_listen ~= "off" then
-    helpers.wait_for_file("socket", socket_path .. "/worker_events.sock")
+    helpers.wait_for_file("socket", socket_path .. "/" .. constants.SOCKETS.WORKER_EVENTS)
   end
 
   if conf.stream_listen and conf.stream_listen ~= "off" then
-    helpers.wait_for_file("socket", socket_path .. "/stream_worker_events.sock")
+    helpers.wait_for_file("socket", socket_path .. "/" .. constants.SOCKETS.STREAM_WORKER_EVENTS)
   end
 
   if conf.admin_listen and conf.admin_listen ~= "off" then
@@ -1071,7 +1071,7 @@ describe("kong start/stop #" .. strategy, function()
 
       wait_until_healthy(prefix)
 
-      assert.truthy(helpers.path.exists(socket_path .. "/worker_events.sock"),
+      assert.truthy(helpers.path.exists(socket_path .. "/" .. constants.SOCKETS.WORKER_EVENTS),
                     "worker events socket was not created in the socket_path dir")
     end)
   end)
@@ -1080,7 +1080,7 @@ describe("kong start/stop #" .. strategy, function()
     local pidfile = TEST_CONF.nginx_pid
 
     -- the worker events socket is just one of many unix sockets we use
-    local event_sock = SOCKET_PATH .. "/worker_events.sock"
+    local event_sock = SOCKET_PATH .. "/" .. constants.SOCKETS.WORKER_EVENTS
 
     local env = {
       prefix                      = PREFIX,
@@ -1244,8 +1244,8 @@ describe("kong start/stop #" .. strategy, function()
       -- wait until everything is running
       wait_until_healthy(prefix)
 
-      assert.truthy(helpers.path.exists(socket_path .. "/worker_events.sock"))
-      assert.truthy(helpers.path.exists(socket_path .. "/stream_worker_events.sock"))
+      assert.truthy(helpers.path.exists(socket_path .. "/" .. constants.SOCKETS.WORKER_EVENTS))
+      assert.truthy(helpers.path.exists(socket_path .. "/" .. constants.SOCKETS.STREAM_WORKER_EVENTS))
 
       local log = prefix .. "/logs/error.log"
       assert.logfile(log).has.no.line("[error]", true, 0)

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require "spec.helpers"
 local utils = require "pl.utils"
 local http = require "resty.http"
+local constants = require "kong.constants"
 
 
 local strip = require("kong.tools.string").strip
@@ -102,10 +103,10 @@ describe("#stream proxy interface listeners", function()
       stream_listen = "127.0.0.1:9011, 127.0.0.1:9012",
     }))
 
-    local stream_events_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/stream_worker_events.sock"
+    local stream_events_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/" .. constants.SOCKETS.STREAM_WORKER_EVENTS
 
     if helpers.test_conf.database == "off" then
-      local stream_config_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/stream_config.sock"
+      local stream_config_sock_path = "unix:" .. helpers.test_conf.socket_path .. "/" .. constants.SOCKETS.STREAM_CONFIG
 
       assert.equals(3, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
       assert.same({

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require "spec.helpers"
 local stream_api = require "kong.tools.stream_api"
 local encode = require("cjson").encode
+local constants = require "kong.constants"
+
 
 describe("Stream module API endpoint", function()
 
@@ -13,7 +15,7 @@ describe("Stream module API endpoint", function()
       plugins = "stream-api-echo",
     })
 
-    socket_path = "unix:" .. helpers.get_running_conf().socket_path .. "/stream_rpc.sock"
+    socket_path = "unix:" .. helpers.get_running_conf().socket_path .. "/" .. constants.SOCKETS.STREAM_RPC
   end)
 
   lazy_teardown(function()

--- a/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
+++ b/spec/fixtures/template_inject/nginx_kong_test_custom_inject_stream.lua
@@ -33,7 +33,7 @@ include '*.stream_mock';
 
 > if cluster_ssl_tunnel then
 server {
-    listen unix:${{SOCKET_PATH}}/cluster_proxy_ssl_terminator.sock;
+    listen unix:${{SOCKET_PATH}}/${{CLUSTER_PROXY_SSL_TERMINATOR_SOCK}};
 
     proxy_pass ${{cluster_ssl_tunnel}};
     proxy_ssl on;

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3831,8 +3831,8 @@ local function cleanup_kong(prefix, preserve_prefix, preserve_dc)
   prefix = prefix or conf.prefix
   local socket_path = pl_path.join(prefix, constants.SOCKET_DIRECTORY)
   for child in lfs.dir(socket_path) do
-    if child:sub(-5) == ".sock" then
-      local path = pl_path.join(socket_path, child)
+    local path = pl_path.join(socket_path, child)
+    if lfs.attributes(path, "mode") == "socket" then
       os.remove(path)
     end
   end


### PR DESCRIPTION

### Summary
Unix domain sockets have a hard length limit of around 108 characters. When Kong is configured in a deeply nested directory structure, this can cause Kong to fail to start. Reducing the file name length will help alleviate this issue.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix: KAG-5136
