### PR TITLE
tests(ai-plugins): fix flaky latency assertion

### DIFF
--- a/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
@@ -436,7 +436,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
         log_message.ai["ai-response-transformer"].usage.time_per_token = 1
 
         assert.same(_EXPECTED_CHAT_STATS, log_message.ai)
-        assert.is_true(actual_llm_latency > 0)
+        assert.is_true(actual_llm_latency >= 0)
         assert.same(actual_time_per_token, time_per_token)
       end)
 


### PR DESCRIPTION
The way this latency is measured in the code is not granular enough to guarantee that it will always produce a non-zero result, so the assertion is changed from `>` to `>=`.

KAG-5251