### PR TITLE
fix(*): reject config if both deprecated and new field defined and their values mismatch

### DIFF
--- a/changelog/unreleased/kong/reject-config-on-deprecated-fields-mismatch.yml
+++ b/changelog/unreleased/kong/reject-config-on-deprecated-fields-mismatch.yml
@@ -1,0 +1,5 @@
+message: |
+  Changed the behaviour of shorthand fields that are used to describe deprecated fields. If
+  both fields are sent in the request and their values mismatch - the request will be rejected.
+type: bugfix
+scope: Core

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -6,7 +6,6 @@ local is_reference = require "kong.pdk.vault".is_reference
 local json         = require "kong.db.schema.json"
 local cjson_safe   = require "cjson.safe"
 local deprecation  = require "kong.deprecation"
-local inspect      = require "inspect"
 
 
 local compare_no_order = require "pl.tablex".compare_no_order
@@ -1707,22 +1706,27 @@ end
 
 
 local function validate_deprecation_exclusiveness(data, shorthand_value, shorthand_name, shorthand_definition)
-  if shorthand_value and shorthand_value ~= ngx.null and shorthand_definition.deprecation and shorthand_definition.deprecation.replaced_with then
-    for _, replaced_with_element in ipairs(shorthand_definition.deprecation.replaced_with) do
-      local new_field_value = replaced_with_element.translation and replaced_with_element.translation(data)
-                                                                or table_path(data, replaced_with_element.path)
+  if shorthand_value == nil or
+      shorthand_value == ngx.null or
+      shorthand_definition.deprecation == nil or
+      shorthand_definition.deprecation.replaced_with == nil then
+    return true
+  end
 
-      if new_field_value and
-        new_field_value ~= ngx.null and
-        not deepcompare(new_field_value, shorthand_value) then
-        local new_field_name = join_string(".", replaced_with_element.path)
+  for _, replaced_with_element in ipairs(shorthand_definition.deprecation.replaced_with) do
+    local new_field_value = replaced_with_element.reverse_mapping_function and replaced_with_element.reverse_mapping_function(data)
+                                                                            or table_path(data, replaced_with_element.path)
 
-        return nil, string.format(
-          "both deprecated and new field are used but their values mismatch: %s = %s vs %s = %s",
-          shorthand_name, inspect(shorthand_value),
-          new_field_name, inspect(new_field_value)
-        )
-      end
+    if new_field_value and
+      new_field_value ~= ngx.null and
+      not deepcompare(new_field_value, shorthand_value) then
+      local new_field_name = join_string(".", replaced_with_element.path)
+
+      return nil, string.format(
+        "both deprecated and new field are used but their values mismatch: %s = %s vs %s = %s",
+        shorthand_name, tostring(shorthand_value),
+        new_field_name, tostring(new_field_value)
+      )
     end
   end
 
@@ -1781,9 +1785,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
             -- field value takes the precedence, otherwise the shorthand's
             -- return value takes the precedence.
             local deprecation = sdata.deprecation
-
             for k, v in pairs(new_values) do
-
               if type(v) == "table" then
                 local source = {}
                 if data[k] and data[k] ~= null then

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -211,7 +211,7 @@ local field_schema = {
             required = false,
             fields = {
               { path = { type = "array", len_min = 1, required = true, elements = { type = "string"}} },
-              { translation = { type = "function", required = false }}
+              { reverse_mapping_function = { type = "function", required = false }}
             },
           }
       } },

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -206,6 +206,15 @@ local field_schema = {
       { message = { type = "string", required = true } },
       { removal_in_version = { type = "string", required = true } },
       { old_default = { type = "any", required = false } },
+      { replaced_with = { type = "array", required = false,
+          elements = { type = "record",
+            required = false,
+            fields = {
+              { path = { type = "array", len_min = 1, required = true, elements = { type = "string"}} },
+              { translation = { type = "function", required = false }}
+            },
+          }
+      } },
     },
   } },
 }

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -43,6 +43,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     len_min = 0,
     translate_backwards = {'password'},
     deprecation = {
+      replaced_with = { { path = { 'password' } } },
       message = "acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
       removal_in_version = "4.0", },
     func = function(value)
@@ -53,6 +54,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     type = "string",
     translate_backwards = {'server_name'},
     deprecation = {
+      replaced_with = { { path = { 'server_name' } } },
       message = "acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
       removal_in_version = "4.0", },
     func = function(value)
@@ -64,6 +66,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     len_min = 0,
     translate_backwards = {'extra_options', 'namespace'},
     deprecation = {
+      replaced_with = { { path = { 'extra_options', 'namespace' } } },
       message = "acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
       removal_in_version = "4.0", },
     func = function(value)
@@ -74,6 +77,7 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
     type = "integer",
     translate_backwards = {'extra_options', 'scan_count'},
     deprecation = {
+      replaced_with = { { path = { 'extra_options', 'scan_count' } } },
       message = "acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",
       removal_in_version = "4.0", },
     func = function(value)

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -104,6 +104,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'host'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'host' } } },
               message = "rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -114,6 +115,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'port'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'port' } } },
               message = "rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -125,6 +127,7 @@ return {
             len_min = 0,
             translate_backwards = {'redis', 'password'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'password' } } },
               message = "rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -135,6 +138,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'username'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'username' } } },
               message = "rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -145,6 +149,7 @@ return {
             type = "boolean",
             translate_backwards = {'redis', 'ssl'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'ssl' } } },
               message = "rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -155,6 +160,7 @@ return {
             type = "boolean",
             translate_backwards = {'redis', 'ssl_verify'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'ssl_verify' } } },
               message = "rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -165,6 +171,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'server_name'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'server_name' } } },
               message = "rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -175,6 +182,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'timeout'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'timeout' } } },
               message = "rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -185,6 +193,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'database'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'database' } } },
               message = "rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
               removal_in_version = "4.0", },
             func = function(value)

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -143,6 +143,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'host'},
             deprecation = {
+              replaced_with = { { path = { 'redis', 'host' } } },
               message = "response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -153,6 +154,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'port'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'port'} } },
               message = "response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -164,6 +166,7 @@ return {
             len_min = 0,
             translate_backwards = {'redis', 'password'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'password'} } },
               message = "response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -174,6 +177,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'username'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'username'} } },
               message = "response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -184,6 +188,7 @@ return {
             type = "boolean",
             translate_backwards = {'redis', 'ssl'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'ssl'} } },
               message = "response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -194,6 +199,7 @@ return {
             type = "boolean",
             translate_backwards = {'redis', 'ssl_verify'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'ssl_verify'} } },
               message = "response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -204,6 +210,7 @@ return {
             type = "string",
             translate_backwards = {'redis', 'server_name'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'server_name'} } },
               message = "response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -214,6 +221,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'timeout'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'timeout'} } },
               message = "response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
               removal_in_version = "4.0", },
             func = function(value)
@@ -224,6 +232,7 @@ return {
             type = "integer",
             translate_backwards = {'redis', 'database'},
             deprecation = {
+              replaced_with = { { path = {'redis', 'database'} } },
               message = "response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
               removal_in_version = "4.0", },
             func = function(value)

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1,6 +1,7 @@
 local Schema = require "kong.db.schema"
 local cjson  = require "cjson"
 local helpers = require "spec.helpers"
+local table_copy = require "kong.tools.table".deep_copy
 
 
 local SchemaKind = {
@@ -4114,8 +4115,8 @@ describe("schema", function()
       local TestSchema = Schema.new({
         name = "test",
         fields = {
-          { name = { type = "string" } },
-          { record = {
+          { field_A = { type = "string" } },
+          { field_B = {
             type = "record",
               fields = {
                 { x = { type = "string" } }
@@ -4124,21 +4125,21 @@ describe("schema", function()
         },
         shorthand_fields = {
           {
-            username = {
+            shorthand_A = {
               type = "string",
               func = function(value)
                 return {
-                  name = value
+                  field_A = value
                 }
               end,
             },
           },
           {
-            y = {
+            shorthand_B = {
               type = "string",
               func = function(value)
                 return {
-                  record = {
+                  field_B = {
                     x = value,
                   },
                 }
@@ -4148,70 +4149,338 @@ describe("schema", function()
         },
       })
 
-      local input = { username = "test1", name = "ignored", record = { x = "ignored" }, y = "test1" }
+      local input = { shorthand_A = "test1", field_A = "ignored",
+                      shorthand_B = "test2", field_B = { x = "ignored" } }
       local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "test1", record = { x = "test1" } }, output)
+      assert.same({ field_A = "test1", field_B = { x = "test2" } }, output)
 
-      -- deprecated fields does take precedence if the new fields are null
-      local input = { username = "overwritten-1", name = ngx.null, record = { x = ngx.null }, y = "overwritten-2"  }
+      -- shorthand value takes precedence if the destination field is null
+      local input = { shorthand_A = "overwritten-1", field_A = ngx.null,
+                      shorthand_B = "overwritten-2", field_B = { x = ngx.null }}
       local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "overwritten-1", record = { x = "overwritten-2" }  }, output)
+      assert.same({ field_A = "overwritten-1", field_B = { x = "overwritten-2" }  }, output)
     end)
 
-    it("does not take precedence if deprecated", function()
+    describe("with simple 'table_path' translation", function()
       local TestSchema = Schema.new({
         name = "test",
         fields = {
-          { name = { type = "string" } },
-          { record = {
+          { new_A = { type = "string" } },
+          { new_B = {
             type = "record",
             fields = {
               { x = { type = "string" } }
             },
           }},
+          { new_C = { type = "string", default = "abc", required = true }},
+          { new_D_1 = { type = "string" }},
+          { new_D_2 = { type = "string" }},
         },
         shorthand_fields = {
           {
-            username = {
+            old_A = {
               type = "string",
               func = function(value)
                 return {
-                  name = value
+                  new_A = value
                 }
               end,
               deprecation = {
-                message = "username is deprecated, please use name instead",
+                replaced_with = { { path = { "new_A" } } },
+                message = "old_A is deprecated, please use new_A instead",
                 removal_in_version = "4.0",
               },
             },
           },
           {
-            y = {
+            old_B = {
               type = "string",
               func = function(value)
                 return {
-                  record = {
+                  new_B = {
                     x = value,
                   },
                 }
               end,
               deprecation = {
-                message = "y is deprecated, please use record.x instead",
+                replaced_with = { { path = { "new_B", "x" } } },
+                message = "old_B is deprecated, please use new_B.x instead",
                 removal_in_version = "4.0",
               },
             },
           },
+          {
+            old_C = {
+              type = "string",
+              func = function(value)
+                return {
+                  new_C = value
+                }
+              end,
+              deprecation = {
+                replaced_with = { { path = { "new_C" } } },
+                message = "old_C is deprecated, please use new_C instead",
+                removal_in_version = "4.0",
+              }
+            }
+          },
+          {
+            old_D = {
+              type = "string",
+              func = function(value)
+                return { new_D_1 = value, new_D_2 = value }
+              end,
+              deprecation = {
+                replaced_with = { { path = { "new_D_1" } }, { path = { "new_D_2" } } },
+                message = "old_D is deprecated, please use new_D_1 and new_D_2 instead",
+                removal_in_version = "4.0",
+              }
+            }
+          }
         },
       })
 
-      local input = { username = "ignored", name = "test1", record = { x = "test1" }, y = "ignored"  }
-      local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "test1", record = { x = "test1" }  }, output)
+      it("notifes of error if values mismatch with replaced field", function()
+        local input = { old_A = "not-test-1", new_A = "test-1",
+                        old_B = "not-test-2", new_B = { x = "test-2" },
+                        old_C = "abc", new_C = "not-abc",  -- "abc" is the default value
+                        old_D = "test-4", new_D_1 = "test-4", new_D_2 = "not-test-4", }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.same({
+            old_A = 'both deprecated and new field are used but their values mismatch: old_A = "not-test-1" vs new_A = "test-1"',
+            old_B = 'both deprecated and new field are used but their values mismatch: old_B = "not-test-2" vs new_B.x = "test-2"' ,
+            old_C = 'both deprecated and new field are used but their values mismatch: old_C = "abc" vs new_C = "not-abc"',
+            old_D = 'both deprecated and new field are used but their values mismatch: old_D = "test-4" vs new_D_2 = "not-test-4"' },
+          err
+        )
+        assert.falsy(output)
+      end)
 
-      -- deprecated fields does take precedence if the new fields are null
-      local input = { username = "overwritten-1", name = ngx.null, record = { x = ngx.null }, y = "overwritten-2"  }
-      local output, _ = TestSchema:process_auto_fields(input)
-      assert.same({ name = "overwritten-1", record = { x = "overwritten-2" }  }, output)
+      it("accepts config if both new field and deprecated field defined and their values match", function()
+        local input = { old_A = "test-1", new_A = "test-1",
+                        old_B = "test-2", new_B = { x = "test-2" },
+                        -- "C" field is using default
+                        old_D = "test-4", new_D_1 = "test-4", new_D_2 = "test-4", }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "test-1", new_B = { x = "test-2" }, new_C = "abc", new_D_1 = "test-4", new_D_2 = "test-4" }, output)
+
+
+        local input = { old_A = "test-1", new_A = "test-1",
+                        old_B = "test-2", new_B = { x = "test-2" },
+                        old_C = "test-3", -- no new field C specified but it has a default which should be ignored
+                                          new_D_1 = "test-4-1", new_D_2 = "test-4-2", }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "test-1", new_B = { x = "test-2" }, new_C = "test-3", new_D_1 = "test-4-1", new_D_2 = "test-4-2" }, output)
+
+        -- when new values are null it's still accepted
+        local input = { old_A = "test-1", new_A = ngx.null,
+                        old_B = "test-2", new_B = { x = ngx.null },
+                        old_C = "test-3", new_C = ngx.null,
+                        old_D = "test-4", new_D_1 = ngx.null, new_D_2 = ngx.null, }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({new_A = "test-1", new_B = { x = "test-2" }, new_C = "test-3", new_D_1 = "test-4", new_D_2 = "test-4" }, output)
+
+        -- when old values are null it's still accepted
+        local input = { old_A = ngx.null, new_A = "test-1",
+                        old_B = ngx.null, new_B = { x = "test-2" },
+                        old_C = ngx.null, new_C = "test-3",
+                        old_D = ngx.null, new_D_1 = "test-4-1", new_D_2 = "test-4-2", }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "test-1", new_B = { x = "test-2" }, new_C = "test-3", new_D_1 = "test-4-1", new_D_2 = "test-4-2" }, output)
+      end)
+
+      it("allows to set explicit nulls when only one set of fields was passed", function()
+        -- when new values are null it's still accepted
+        local input = { new_A = ngx.null,
+                        new_B = { x = ngx.null },
+                        new_C = ngx.null,
+                        new_D_1 = ngx.null, new_D_2 = ngx.null }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({new_A = ngx.null, new_B = { x = ngx.null }, new_C = ngx.null, new_D_1 = ngx.null, new_D_2 = ngx.null}, output)
+
+        -- when old values are null it's still accepted
+        local input = { old_A = ngx.null,
+                        old_B = ngx.null,
+                        old_C = ngx.null,
+                        old_D = ngx.null }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({new_A = ngx.null, new_B = { x = ngx.null }, new_C = ngx.null, new_D_1 = ngx.null, new_D_2 = ngx.null}, output)
+      end)
+    end)
+
+    describe("with complex field translation", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { new_A = { type = "string" } },
+          { new_B = {
+            type = "record",
+            fields = {
+              { x = { type = "string" } }
+            },
+          }},
+          { new_C = {
+            type = "array",
+            elements = {
+              type = "number"
+            }
+          }}
+        },
+        shorthand_fields = {
+          {
+            old_A = {
+              type = "string",
+              func = function(value)
+                if value == ngx.null then
+                  return { new_A = ngx.null }
+                end
+                return { new_A = value:upper() }
+              end,
+              deprecation = {
+                replaced_with = {
+                  { path = { "new_A" },
+                    translation = function(data)
+                      if data.new_A and data.new_A ~= ngx.null then
+                        return data.new_A:lower()
+                      end
+
+                      return data.new_A
+                    end }
+                },
+                message = "old_A is deprecated, please use new_A instead",
+                removal_in_version = "4.0",
+              },
+            },
+          },
+          {
+            old_B = {
+              type = "string",
+              func = function(value)
+                if value == ngx.null then
+                  return {
+                    new_B = {
+                      x = ngx.null,
+                    },
+                  }
+                end
+
+                return {
+                  new_B = {
+                    x = value:upper(),
+                  },
+                }
+              end,
+              deprecation = {
+                replaced_with = {
+                  { path = { "new_B", "x" },
+                    translation = function (data)
+                      if data.new_B and data.new_B.x ~= ngx.null then
+                        return data.new_B.x:lower()
+                      end
+                      return ngx.null
+                    end
+                } },
+                message = "old_B is deprecated, please use new_B.x instead",
+                removal_in_version = "4.0",
+              },
+            },
+          },
+          {
+            old_C = {
+              type = "array",
+              elements = {
+                type = "number"
+              },
+              func = function(value)
+                if value == ngx.null then
+                  return { new_C = ngx.null }
+                end
+                local copy = table_copy(value)
+                table.sort(copy, function(a,b) return a > b end )
+                return { new_C = copy } -- new field is reversed
+              end,
+              deprecation = {
+                replaced_with = {
+                  { path = { "new_C" },
+                    translation = function (data)
+                      if data.new_C == ngx.null then
+                        return ngx.null
+                      end
+
+                      local copy = table_copy(data.new_C)
+                      table.sort(copy, function(a,b) return a < b end)
+                      return copy
+                    end
+                  },
+                }
+              }
+            }
+          }
+        },
+      })
+
+      it("notifes of error if values mismatch with replaced field", function()
+        local input = { old_A = "not-test-1", new_A = "TEST1",
+                        old_B = "not-test-2", new_B = { x = "TEST2" },
+                        old_C = { 1, 2, 4 },  new_C = { 3, 2, 1 } }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.same({
+            old_A = 'both deprecated and new field are used but their values mismatch: old_A = "not-test-1" vs new_A = "test1"',
+            old_B = 'both deprecated and new field are used but their values mismatch: old_B = "not-test-2" vs new_B.x = "test2"' ,
+            old_C = 'both deprecated and new field are used but their values mismatch: old_C = { 1, 2, 4 } vs new_C = { 1, 2, 3 }' },
+          err
+        )
+        assert.falsy(output)
+      end)
+
+      it("accepts config if both new field and deprecated field defined and their values match", function()
+        local input = { old_A = "test-1", new_A = "TEST-1",
+                        old_B = "test-2", new_B = { x = "TEST-2" },
+                        old_C = { 1, 2, 3 }, new_C = { 3, 2, 1 } }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "TEST-1", new_B = { x = "TEST-2" }, new_C = { 3, 2, 1 }}, output)
+
+        -- when new values are null it's still accepted
+        local input = { old_A = "test-1", new_A = ngx.null,
+                        old_B = "test-2", new_B = { x = ngx.null },
+                        old_C = { 1, 2, 3 }, new_C = ngx.null }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "TEST-1", new_B = { x = "TEST-2" }, new_C = { 3, 2, 1 }}, output)
+
+        -- when old values are null it's still accepted
+        local input = { old_A = ngx.null, new_A = "TEST-1",
+                        old_B = ngx.null, new_B = { x = "TEST-2" },
+                        old_C = ngx.null, new_C = { 3, 2, 1 } }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({ new_A = "TEST-1", new_B = { x = "TEST-2" }, new_C = { 3, 2, 1 }}, output)
+      end)
+
+      it("allows to set explicit nulls when only one set of fields was passed", function()
+        -- when new values are null it's still accepted
+        local input = { new_A = ngx.null,
+                        new_B = { x = ngx.null },
+                        new_C = ngx.null }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({new_A = ngx.null, new_B = { x = ngx.null }, new_C = ngx.null}, output)
+
+        -- when old values are null it's still accepted
+        local input = { old_A = ngx.null,
+                        old_B = ngx.null,
+                        old_C = ngx.null }
+        local output, err = TestSchema:process_auto_fields(input)
+        assert.is_nil(err)
+        assert.same({new_A = ngx.null, new_B = { x = ngx.null }, new_C = ngx.null}, output)
+      end)
     end)
 
     it("can produce multiple fields", function()

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -4161,7 +4161,7 @@ describe("schema", function()
       assert.same({ field_A = "overwritten-1", field_B = { x = "overwritten-2" }  }, output)
     end)
 
-    describe("with simple 'table_path' translation", function()
+    describe("with simple 'table_path' reverse mapping", function()
       local TestSchema = Schema.new({
         name = "test",
         fields = {
@@ -4247,10 +4247,10 @@ describe("schema", function()
                         old_D = "test-4", new_D_1 = "test-4", new_D_2 = "not-test-4", }
         local output, err = TestSchema:process_auto_fields(input)
         assert.same({
-            old_A = 'both deprecated and new field are used but their values mismatch: old_A = "not-test-1" vs new_A = "test-1"',
-            old_B = 'both deprecated and new field are used but their values mismatch: old_B = "not-test-2" vs new_B.x = "test-2"' ,
-            old_C = 'both deprecated and new field are used but their values mismatch: old_C = "abc" vs new_C = "not-abc"',
-            old_D = 'both deprecated and new field are used but their values mismatch: old_D = "test-4" vs new_D_2 = "not-test-4"' },
+            old_A = 'both deprecated and new field are used but their values mismatch: old_A = not-test-1 vs new_A = test-1',
+            old_B = 'both deprecated and new field are used but their values mismatch: old_B = not-test-2 vs new_B.x = test-2' ,
+            old_C = 'both deprecated and new field are used but their values mismatch: old_C = abc vs new_C = not-abc',
+            old_D = 'both deprecated and new field are used but their values mismatch: old_D = test-4 vs new_D_2 = not-test-4' },
           err
         )
         assert.falsy(output)
@@ -4314,7 +4314,7 @@ describe("schema", function()
       end)
     end)
 
-    describe("with complex field translation", function()
+    describe("with complex field reverse_mapping_function", function()
       local TestSchema = Schema.new({
         name = "test",
         fields = {
@@ -4345,7 +4345,7 @@ describe("schema", function()
               deprecation = {
                 replaced_with = {
                   { path = { "new_A" },
-                    translation = function(data)
+                    reverse_mapping_function = function(data)
                       if data.new_A and data.new_A ~= ngx.null then
                         return data.new_A:lower()
                       end
@@ -4379,7 +4379,7 @@ describe("schema", function()
               deprecation = {
                 replaced_with = {
                   { path = { "new_B", "x" },
-                    translation = function (data)
+                    reverse_mapping_function = function (data)
                       if data.new_B and data.new_B.x ~= ngx.null then
                         return data.new_B.x:lower()
                       end
@@ -4408,7 +4408,7 @@ describe("schema", function()
               deprecation = {
                 replaced_with = {
                   { path = { "new_C" },
-                    translation = function (data)
+                    reverse_mapping_function = function (data)
                       if data.new_C == ngx.null then
                         return ngx.null
                       end
@@ -4430,12 +4430,9 @@ describe("schema", function()
                         old_B = "not-test-2", new_B = { x = "TEST2" },
                         old_C = { 1, 2, 4 },  new_C = { 3, 2, 1 } }
         local output, err = TestSchema:process_auto_fields(input)
-        assert.same({
-            old_A = 'both deprecated and new field are used but their values mismatch: old_A = "not-test-1" vs new_A = "test1"',
-            old_B = 'both deprecated and new field are used but their values mismatch: old_B = "not-test-2" vs new_B.x = "test2"' ,
-            old_C = 'both deprecated and new field are used but their values mismatch: old_C = { 1, 2, 4 } vs new_C = { 1, 2, 3 }' },
-          err
-        )
+        assert.same('both deprecated and new field are used but their values mismatch: old_A = not-test-1 vs new_A = test1', err.old_A)
+        assert.same('both deprecated and new field are used but their values mismatch: old_B = not-test-2 vs new_B.x = test2', err.old_B)
+        assert.matches('both deprecated and new field are used but their values mismatch: old_C = .+ vs new_C = .+', err.old_C)
         assert.falsy(output)
       end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adds a validation to deprecated fields that checks the case in which both new field and old field were defined; when that happens their values must match.

It introduces a new structure to deprecation definition by adding `replaced_with` information. This way field validation can verify if the `replaced_with` field has the same value as the old deprecated field. By default the comparison is done via translation through simple path but there might be instances where translation from old to new is more complicated and then the translation function should be provided in `translation` field.

The plan is to remove `translate_backwards` field in the future in favor of `replaced_with`.


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5262