### PR TITLE
chore(docker): use ubi8 -> ubi9

### DIFF
--- a/build/dockerfiles/rpm.Dockerfile
+++ b/build/dockerfiles/rpm.Dockerfile
@@ -1,4 +1,4 @@
-ARG KONG_BASE_IMAGE=redhat/ubi8
+ARG KONG_BASE_IMAGE=redhat/ubi9
 FROM --platform=$TARGETPLATFORM $KONG_BASE_IMAGE
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
@@ -18,7 +18,7 @@ LABEL name="Kong" \
 # RedHat required LICENSE file approved path
 COPY LICENSE /licenses/
 
-ARG RPM_PLATFORM=el8
+ARG RPM_PLATFORM=el9
 
 ARG KONG_PREFIX=/usr/local/kong
 ENV KONG_PREFIX $KONG_PREFIX

--- a/changelog/unreleased/kong/bump-dockerfile-ubi9.yml
+++ b/changelog/unreleased/kong/bump-dockerfile-ubi9.yml
@@ -1,2 +1,2 @@
-message: "Bumped rpm dockerfile to UBI 9"
+message: "Bumped rpm dockerfile default base UBI 8 -> 9"
 type: dependency

--- a/changelog/unreleased/kong/bump-dockerfile-ubi9.yml
+++ b/changelog/unreleased/kong/bump-dockerfile-ubi9.yml
@@ -1,0 +1,2 @@
+message: "Bumped rpm dockerfile to UBI 9"
+type: dependency


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR updates the Dockerfile used when building RHEL-family docker images so that it uses redhat/ubi9 as its base.

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
