### PR TITLE
chore(changelog): update the changelog regarding the RPM prefix

### DIFF
--- a/changelog/unreleased/kong/make_rpm_relocatable.yml
+++ b/changelog/unreleased/kong/make_rpm_relocatable.yml
@@ -1,2 +1,2 @@
-message: Made the RPM package relocatable.
+message: Made the RPM package relocatable with the default prefix set to `/`.
 type: dependency


### PR DESCRIPTION
FTI-6054

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
