### PR TITLE
Docs(proxy-cache): Improve description of vary_query_params

### DIFF
--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -68,7 +68,7 @@ return {
               }},
             },
           }},
-          { vary_query_params = { description = "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.", type = "array",
+          { vary_query_params = { description = "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration. By default, the max number of params accepted is 100. You can change this value via the `lua_max_post_args` in `kong.conf`.", type = "array",
             elements = { type = "string" },
           }},
           { vary_headers = { description = "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.", type = "array",


### PR DESCRIPTION

### Summary

A customer encountered an issue with the Proxy Cache and Proxy Cache Advanced plugins when sending requests with more than 100 query parameters. They weren't aware that the params were limited by the [lua_max_uri_args parameter](https://docs.konghq.com/gateway/latest/reference/configuration/#lua_max_uri_args).

Updating the description of vary_query_params to mention the dependency on lua_max_uri_args so that users can more easily troubleshoot issues with this plugin.

Parallel PR in kong repo: https://github.com/Kong/kong-ee/pull/10131

https://konghq.atlassian.net/browse/DOCU-4043

### Checklist

- [ n/a ] The Pull Request has tests
- [ n/a ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ tbd, this PR needs to be merged first ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

