### PR TITLE
chore(plugin): bump prometheus KONG_LATENCY_BUCKETS bucket to 6000

### DIFF
--- a/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
+++ b/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
@@ -1,3 +1,3 @@
-message: "**Prometheus**: bump KONG_LATENCY_BUCKETS bucket maximal capacity to 6000"
+message: "**Prometheus**: Bumped KONG_LATENCY_BUCKETS bucket's maximal capacity to 6000"
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
+++ b/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
@@ -1,3 +1,3 @@
 message: "**Prometheus**: Bumped KONG_LATENCY_BUCKETS bucket's maximal capacity to 6000"
-type: bugfix
+type: feature
 scope: Plugin

--- a/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
+++ b/changelog/unreleased/kong/bump-prometheus-latency-bucket.yml
@@ -1,0 +1,3 @@
+message: "**Prometheus**: bump KONG_LATENCY_BUCKETS bucket maximal capacity to 6000"
+type: bugfix
+scope: Plugin

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -17,7 +17,7 @@ local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
 
 local role = kong.configuration.role
 
-local KONG_LATENCY_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 30, 50, 75, 100, 200, 500, 750, 1000 }
+local KONG_LATENCY_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 30, 50, 75, 100, 200, 500, 750, 1000, 3000, 6000 }
 local UPSTREAM_LATENCY_BUCKETS = { 25, 50, 80, 100, 250, 400, 700, 1000, 2000, 5000, 10000, 30000, 60000 }
 local AI_LLM_PROVIDER_LATENCY_BUCKETS = { 250, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 10000, 30000, 60000 }
 local IS_PROMETHEUS_ENABLED


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5990
