### PR TITLE
fix(core): make deprecated shorthand fields take precedence when new value is null

### DIFF
--- a/changelog/unreleased/kong/fix-for-null-aware-shorthand.yml
+++ b/changelog/unreleased/kong/fix-for-null-aware-shorthand.yml
@@ -1,0 +1,5 @@
+message: |
+  Changed the way deprecated shorthand fields are used with new fields.
+  If the new field contains null it allows for deprecated field to overwrite it if both are present in the request.
+type: bugfix
+scope: Core

--- a/kong/tools/table.lua
+++ b/kong/tools/table.lua
@@ -45,6 +45,29 @@ function _M.table_merge(t1, t2)
 end
 
 
+--- Merges two table together but does not replace values from `t1` if `t2` for a given key has `ngx.null` value
+-- A new table is created with a non-recursive copy of the provided tables
+-- @param t1 The first table
+-- @param t2 The second table
+-- @return The (new) merged table
+function _M.null_aware_table_merge(t1, t2)
+  local res = {}
+  if t1 then
+    for k,v in pairs(t1) do
+      res[k] = v
+    end
+  end
+  if t2 then
+    for k,v in pairs(t2) do
+      if res[k] == nil or v ~= ngx.null then
+        res[k] = v
+      end
+    end
+  end
+  return res
+end
+
+
 --- Checks if a value exists in a table.
 -- @param arr The table to use
 -- @param val The value to check

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -4151,6 +4151,11 @@ describe("schema", function()
       local input = { username = "test1", name = "ignored", record = { x = "ignored" }, y = "test1" }
       local output, _ = TestSchema:process_auto_fields(input)
       assert.same({ name = "test1", record = { x = "test1" } }, output)
+
+      -- deprecated fields does take precedence if the new fields are null
+      local input = { username = "overwritten-1", name = ngx.null, record = { x = ngx.null }, y = "overwritten-2"  }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "overwritten-1", record = { x = "overwritten-2" }  }, output)
     end)
 
     it("does not take precedence if deprecated", function()
@@ -4202,6 +4207,11 @@ describe("schema", function()
       local input = { username = "ignored", name = "test1", record = { x = "test1" }, y = "ignored"  }
       local output, _ = TestSchema:process_auto_fields(input)
       assert.same({ name = "test1", record = { x = "test1" }  }, output)
+
+      -- deprecated fields does take precedence if the new fields are null
+      local input = { username = "overwritten-1", name = ngx.null, record = { x = ngx.null }, y = "overwritten-2"  }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "overwritten-1", record = { x = "overwritten-2" }  }, output)
     end)
 
     it("can produce multiple fields", function()


### PR DESCRIPTION
### Summary

When both new field and shorthand fields are used but the new field contains null value and the old field contains some other specific value this change allows for that specific value to overwrite the new null value. If a user wants to set explicit null they have to send request without the old value.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5287
