### PR TITLE
refactor(shorthand_fields): remove translate_backwards in favor of replaced_with

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1805,8 +1805,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.translate_backwards and not(opts and opts.hide_shorthands) then
-        data[sname] = table_path(data, sdata.translate_backwards)
+      if is_select and sdata.deprecation and sdata.deprecation.replaced_with and #sdata.deprecation.replaced_with > 0 and not(opts and opts.hide_shorthands) then
+        if sdata.deprecation.replaced_with[1].reverse_mapping_function then
+          data[sname] = sdata.deprecation.replaced_with[1].reverse_mapping_function(data)
+        else
+          data[sname] = table_path(data, sdata.deprecation.replaced_with[1].path)
+        end
       end
     end
     if has_errs then
@@ -1959,7 +1963,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
       if self.shorthand_fields then
         for _, shorthand_field in ipairs(self.shorthand_fields) do
-          if shorthand_field[key] and shorthand_field[key].translate_backwards then
+          if shorthand_field[key] and shorthand_field[key].deprecation and shorthand_field[key].deprecation.replaced_with and #shorthand_field[key].deprecation.replaced_with > 0 then
             should_be_in_ouput = is_select
           end
         end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1805,11 +1805,15 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         end
       end
 
-      if is_select and sdata.deprecation and sdata.deprecation.replaced_with and #sdata.deprecation.replaced_with > 0 and not(opts and opts.hide_shorthands) then
-        if sdata.deprecation.replaced_with[1].reverse_mapping_function then
-          data[sname] = sdata.deprecation.replaced_with[1].reverse_mapping_function(data)
-        else
-          data[sname] = table_path(data, sdata.deprecation.replaced_with[1].path)
+      if is_select and not(opts and opts.hide_shorthands) then
+        local replaced_with = sdata.deprecation and sdata.deprecation.replaced_with and
+                                                    sdata.deprecation.replaced_with[1]
+        if replaced_with then
+          if replaced_with.reverse_mapping_function then
+          data[sname] = replaced_with.reverse_mapping_function(data)
+          else
+            data[sname] = table_path(data, replaced_with.path)
+          end
         end
       end
     end
@@ -1963,8 +1967,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
       if self.shorthand_fields then
         for _, shorthand_field in ipairs(self.shorthand_fields) do
-          if shorthand_field[key] and shorthand_field[key].deprecation and shorthand_field[key].deprecation.replaced_with and #shorthand_field[key].deprecation.replaced_with > 0 then
-            should_be_in_ouput = is_select
+          if shorthand_field[key] then
+            local replaced_with = shorthand_field[key].deprecation and shorthand_field[key].deprecation.replaced_with and
+                                                                        #shorthand_field[key].deprecation.replaced_with[1]
+            if replaced_with then
+              should_be_in_ouput = is_select
+            end
           end
         end
       end

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -716,7 +716,6 @@ local function make_shorthand_field_schema()
   shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
 
   insert(shorthand_field_schema, { func = { type = "function", required = true } })
-  insert(shorthand_field_schema, { translate_backwards = { type = "array", elements = { type = "string" }, required = false } })
   return shorthand_field_schema
 end
 

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -41,7 +41,6 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { auth = {
     type = "string",
     len_min = 0,
-    translate_backwards = {'password'},
     deprecation = {
       replaced_with = { { path = { 'password' } } },
       message = "acme: config.storage_config.redis.auth is deprecated, please use config.storage_config.redis.password instead",
@@ -52,7 +51,6 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { ssl_server_name = {
     type = "string",
-    translate_backwards = {'server_name'},
     deprecation = {
       replaced_with = { { path = { 'server_name' } } },
       message = "acme: config.storage_config.redis.ssl_server_name is deprecated, please use config.storage_config.redis.server_name instead",
@@ -64,7 +62,6 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   { namespace = {
     type = "string",
     len_min = 0,
-    translate_backwards = {'extra_options', 'namespace'},
     deprecation = {
       replaced_with = { { path = { 'extra_options', 'namespace' } } },
       message = "acme: config.storage_config.redis.namespace is deprecated, please use config.storage_config.redis.extra_options.namespace instead",
@@ -75,7 +72,6 @@ local LEGACY_SCHEMA_TRANSLATIONS = {
   }},
   { scan_count = {
     type = "integer",
-    translate_backwards = {'extra_options', 'scan_count'},
     deprecation = {
       replaced_with = { { path = { 'extra_options', 'scan_count' } } },
       message = "acme: config.storage_config.redis.scan_count is deprecated, please use config.storage_config.redis.extra_options.scan_count instead",

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -102,7 +102,6 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
-            translate_backwards = {'redis', 'host'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'host' } } },
               message = "rate-limiting: config.redis_host is deprecated, please use config.redis.host instead",
@@ -113,7 +112,6 @@ return {
           } },
           { redis_port = {
             type = "integer",
-            translate_backwards = {'redis', 'port'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'port' } } },
               message = "rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
@@ -125,7 +123,6 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
-            translate_backwards = {'redis', 'password'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'password' } } },
               message = "rate-limiting: config.redis_password is deprecated, please use config.redis.password instead",
@@ -136,7 +133,6 @@ return {
           } },
           { redis_username = {
             type = "string",
-            translate_backwards = {'redis', 'username'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'username' } } },
               message = "rate-limiting: config.redis_username is deprecated, please use config.redis.username instead",
@@ -147,7 +143,6 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
-            translate_backwards = {'redis', 'ssl'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'ssl' } } },
               message = "rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
@@ -158,7 +153,6 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
-            translate_backwards = {'redis', 'ssl_verify'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'ssl_verify' } } },
               message = "rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
@@ -169,7 +163,6 @@ return {
           } },
           { redis_server_name = {
             type = "string",
-            translate_backwards = {'redis', 'server_name'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'server_name' } } },
               message = "rate-limiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
@@ -180,7 +173,6 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
-            translate_backwards = {'redis', 'timeout'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'timeout' } } },
               message = "rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
@@ -191,7 +183,6 @@ return {
           } },
           { redis_database = {
             type = "integer",
-            translate_backwards = {'redis', 'database'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'database' } } },
               message = "rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -141,7 +141,6 @@ return {
           -- TODO: deprecated forms, to be removed in Kong 4.0
           { redis_host = {
             type = "string",
-            translate_backwards = {'redis', 'host'},
             deprecation = {
               replaced_with = { { path = { 'redis', 'host' } } },
               message = "response-ratelimiting: config.redis_host is deprecated, please use config.redis.host instead",
@@ -152,7 +151,6 @@ return {
           } },
           { redis_port = {
             type = "integer",
-            translate_backwards = {'redis', 'port'},
             deprecation = {
               replaced_with = { { path = {'redis', 'port'} } },
               message = "response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
@@ -164,7 +162,6 @@ return {
           { redis_password = {
             type = "string",
             len_min = 0,
-            translate_backwards = {'redis', 'password'},
             deprecation = {
               replaced_with = { { path = {'redis', 'password'} } },
               message = "response-ratelimiting: config.redis_password is deprecated, please use config.redis.password instead",
@@ -175,7 +172,6 @@ return {
           } },
           { redis_username = {
             type = "string",
-            translate_backwards = {'redis', 'username'},
             deprecation = {
               replaced_with = { { path = {'redis', 'username'} } },
               message = "response-ratelimiting: config.redis_username is deprecated, please use config.redis.username instead",
@@ -186,7 +182,6 @@ return {
           } },
           { redis_ssl = {
             type = "boolean",
-            translate_backwards = {'redis', 'ssl'},
             deprecation = {
               replaced_with = { { path = {'redis', 'ssl'} } },
               message = "response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
@@ -197,7 +192,6 @@ return {
           } },
           { redis_ssl_verify = {
             type = "boolean",
-            translate_backwards = {'redis', 'ssl_verify'},
             deprecation = {
               replaced_with = { { path = {'redis', 'ssl_verify'} } },
               message = "response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
@@ -208,7 +202,6 @@ return {
           } },
           { redis_server_name = {
             type = "string",
-            translate_backwards = {'redis', 'server_name'},
             deprecation = {
               replaced_with = { { path = {'redis', 'server_name'} } },
               message = "response-ratelimiting: config.redis_server_name is deprecated, please use config.redis.server_name instead",
@@ -219,7 +212,6 @@ return {
           } },
           { redis_timeout = {
             type = "integer",
-            translate_backwards = {'redis', 'timeout'},
             deprecation = {
               replaced_with = { { path = {'redis', 'timeout'} } },
               message = "response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
@@ -230,7 +222,6 @@ return {
           } },
           { redis_database = {
             type = "integer",
-            translate_backwards = {'redis', 'database'},
             deprecation = {
               replaced_with = { { path = {'redis', 'database'} } },
               message = "response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",


### PR DESCRIPTION
### Summary

We've introduced `replaced_with` when working on `shorthand_fields` when used as deprecation and making sure that incoming request do not contain mismatched data: https://github.com/Kong/kong/pull/13565

This made `translate_backwards` field obsolete as `replaced_with` is just more robust and intuitive. This PR removes that code.

### Checklist

- [x] N/A The Pull Request has tests
- [x] N/A A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] N/A There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5298
