### PR TITLE
chore(*): remove luarocks loader

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -72,8 +72,6 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
   os.exit(rc)
 end
 
-pcall(require, "luarocks.loader")
-
 if os.getenv("BUSTED_EMMY_DEBUGGER") then
   emmy_debugger.init({
     debugger = os.getenv("BUSTED_EMMY_DEBUGGER"),

--- a/bin/kong
+++ b/bin/kong
@@ -1,7 +1,6 @@
 #!/usr/bin/env resty
 
 setmetatable(_G, nil)
-pcall(require, "luarocks.loader")
 package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path
 require("kong.globalpatches")({ cli = true })
 math.randomseed() -- Generate PRNG seed
@@ -133,8 +132,6 @@ local args_str = table.concat(args_table, " ")
 
 local inline_code = string.format([[
 setmetatable(_G, nil)
-
-pcall(require, "luarocks.loader")
 
 package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -27,9 +27,6 @@
 local pcall = pcall
 
 
-pcall(require, "luarocks.loader")
-
-
 assert(package.loaded["resty.core"], "lua-resty-core must be loaded; make " ..
                                      "sure 'lua_load_resty_core' is not "..
                                      "disabled.")


### PR DESCRIPTION
### Summary

This reduces memory usage a bit. I don't think we have any use for this anymore.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE