### PR TITLE
fix(vault): let vault entity cache key not containing workspace id

### DIFF
--- a/changelog/unreleased/kong/fix-vault-cache-workspace-id.yml
+++ b/changelog/unreleased/kong/fix-vault-cache-workspace-id.yml
@@ -1,0 +1,4 @@
+message: |
+   **Vault**: Fixed an issue where updating a vault entity in a non-default workspace will not take effect.
+type: bugfix
+scope: Core

--- a/kong/db/dao/vaults.lua
+++ b/kong/db/dao/vaults.lua
@@ -84,4 +84,14 @@ function Vaults:load_vault_schemas(vault_set)
 end
 
 
+function Vaults:cache_key(prefix)
+  if type(prefix) == "table" then
+    prefix = prefix.prefix
+  end
+
+  -- Always return the cache_key without a workspace because prefix is unique across workspaces
+  return "vaults:" .. prefix .. ":::::"
+end
+
+
 return Vaults

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -175,5 +175,10 @@ for _, strategy in helpers.each_strategy() do
       assert.is_equal("{vault://unknown/missing-key}", certificate.key_alt)
       assert.is_nil(certificate["$refs"])
     end)
+
+    it("generate correct cache key", function ()
+      local cache_key = db.vaults:cache_key("test")
+      assert.equal("vaults:test:::::", cache_key)
+    end)
   end)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR modifies the `cache_key` function of the vault entity to always generate a cache key without workspace id.

Vault entity is workspace-able, but our secret rotation timer always run without workspace settings(thus the default workspace is being used), so during secret rotation, the code https://github.com/Kong/kong/blob/4e38b965b922f57febe8652fb96b7d74aeab591a/kong/pdk/vault.lua#L620-L621 will generate a duplicate vault cache with default workspace id for each non-default workspace vault entity, and those cache will never be refreshed. The result of this issue is that when you update a vault entity's configuration inside a non-default workspace, it will never take effect in the secret rotation.

Since the prefix of vault entity is unique across workspaces, it should be safe to only use one cache key without workspace id, so that the correct cache is used during secret rotation.


### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6152
