### PR TITLE
fix(opentelemetry): tostring `header_type` avoid concatenation nil error in log

### DIFF
--- a/changelog/unreleased/kong-ee/fix-opentelemetry-header-type-is-null.yml
+++ b/changelog/unreleased/kong-ee/fix-opentelemetry-header-type-is-null.yml
@@ -1,0 +1,3 @@
+message: "**OpenTelemetry**: Fixed an issue where header_type being nil caused a concatenation error."
+type: bugfix
+scope: Plugin

--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -583,7 +583,7 @@ local function set(conf_header_type, found_header_type, proxy_span, conf_default
      found_header_type ~= nil and
      conf_header_type ~= found_header_type
   then
-    kong.log.warn("Mismatched header types. conf: " .. conf_header_type .. ". found: " .. found_header_type)
+    kong.log.warn("Mismatched header types. conf: " .. tostring(conf_header_type) .. ". found: " .. found_header_type)
   end
 
   found_header_type = found_header_type or conf_default_header_type or "b3"


### PR DESCRIPTION

This is a backport of the https://github.com/Kong/kong-ee/pull/10137

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The require of header_type is false, so the consumer can choose `header_type` to be nil in Kong Manager; if this is, Kong Manager would pass `json.null` to Kong, `header_type` could be nil in this case.

This PR respects this behavior and handles concatenation nil error when `header_type` is nil.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix: [FTI-6119](https://konghq.atlassian.net/browse/FTI-6119)


[FTI-6119]: https://konghq.atlassian.net/browse/FTI-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ