### PR TITLE
fix(rate-limiting-plugin): fix a bug where the return values from `get_redis_connection()` are mistaken

### DIFF
--- a/changelog/unreleased/kong/fix-return-values-mistaken-in-rate-limiting-plugin.yml
+++ b/changelog/unreleased/kong/fix-return-values-mistaken-in-rate-limiting-plugin.yml
@@ -1,0 +1,3 @@
+message: **Rate-limiting-Plugin**: Fix a bug where the return values from `get_redis_connection()` are mistaken.
+scope: Plugin
+type: bugfix

--- a/changelog/unreleased/kong/fix-return-values-mistaken-in-rate-limiting-plugin.yml
+++ b/changelog/unreleased/kong/fix-return-values-mistaken-in-rate-limiting-plugin.yml
@@ -1,3 +1,3 @@
-message: **Rate-limiting-Plugin**: Fix a bug where the return values from `get_redis_connection()` are mistaken.
+message: "**Rate-limiting-Plugin**: Fix a bug where the return values from `get_redis_connection()` are mistaken."
 scope: Plugin
 type: bugfix

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -396,7 +396,7 @@ return {
         return 0
       end
 
-      local red, err = get_redis_connection(conf)
+      local red, db_key, err = get_redis_connection(conf)
       if not red then
         return nil, err
       end


### PR DESCRIPTION
### Summary

As described in the title.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
