### PR TITLE
style(tools): should not use `tools.utils` module

### DIFF
--- a/kong/llm/proxy/handler.lua
+++ b/kong/llm/proxy/handler.lua
@@ -11,7 +11,7 @@ local llm_state = require("kong.llm.state")
 local cjson = require("cjson.safe")
 local kong_utils = require("kong.tools.gzip")
 local buffer = require "string.buffer"
-local strip = require("kong.tools.utils").strip
+local strip = require("kong.tools.string").strip
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 
 

--- a/kong/observability/logs.lua
+++ b/kong/observability/logs.lua
@@ -12,7 +12,7 @@ end
 local request_id_get = require "kong.observability.tracing.request_id".get
 local time_ns = require "kong.tools.time".time_ns
 local table_merge = require "kong.tools.table".table_merge
-local deep_copy = require "kong.tools.utils".deep_copy
+local deep_copy = require "kong.tools.table".deep_copy
 
 local get_log_level = require "resty.kong.log".get_log_level
 local constants_log_levels = require "kong.constants".LOG_LEVELS


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The module `tools.utils` is deprecated, we should not use it anymore.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
