### PR TITLE
chore(ci): migrate bazelbuild/setup-bazelisk to bazel-contrib/setup-bazel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,15 @@ jobs:
         grep -v '^#' .requirements >> $GITHUB_ENV
 
     - name: Setup Bazel
-      uses: bazelbuild/setup-bazelisk@95c9bf48d0c570bb3e28e57108f3450cd67c1a44 # v2.0.0
+      uses: bazel-contrib/setup-bazel@0.8.5
+      with:
+        bazelisk-version: "1.20.0"
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}
+        # Share repository cache between workflows.
+        repository-cache: true
 
     - name: Install Deb Dependencies
       if: matrix.package == 'deb' && steps.cache-deps.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Summary

According to the [bazelbuild/setup-bazelisk](https://github.com/bazelbuild/setup-bazelisk) README, the action is superseded by the [bazel-contrib/setup-bazel](https://github.com/bazel-contrib/setup-bazel). Please check if we need to migrate to the new action. One of the possible motivation of this migration is that node.js 16 is deprecated soon from github runners.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5221
