### PR TITLE
feat: Add Ubuntu 24.04 to build matrix

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -1,15 +1,16 @@
 # please see matrix-full.yml for meaning of each field
 build-packages:
-- label: ubuntu-22.04
-  image: ubuntu:22.04
+- label: ubuntu-24.04
+  image: ubuntu:24.04
   package: deb
-  check-manifest-suite: ubuntu-22.04-amd64
+  check-manifest-suite: ubuntu-24.04-amd64
 
 build-images:
 - label: ubuntu
-  base-image: ubuntu:22.04
+  base-image: ubuntu:24.04
   package: deb
-  artifact-from: ubuntu-22.04
+  artifact-from: ubuntu-24.04
+  check-manifest-suite: docker-image-ubuntu-24.04
 
 smoke-tests:
 - label: ubuntu

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -20,6 +20,15 @@ build-packages:
   package: deb
   bazel-args: --platforms=//:generic-crossbuild-aarch64
   check-manifest-suite: ubuntu-22.04-arm64
+- label: ubuntu-24.04
+  image: ubuntu:24.04
+  package: deb
+  check-manifest-suite: ubuntu-24.04-amd64
+- label: ubuntu-24.04-arm64
+  image: ubuntu:24.04
+  package: deb
+  bazel-args: --platforms=//:generic-crossbuild-aarch64
+  check-manifest-suite: ubuntu-24.04-arm64
 
 # Debian
 - label: debian-11
@@ -78,11 +87,12 @@ build-images:
 
 # Ubuntu
 - label: ubuntu
-  base-image: ubuntu:22.04
+  base-image: ubuntu:24.04
   package: deb
-  artifact-from: ubuntu-22.04
-  artifact-from-alt: ubuntu-22.04-arm64
+  artifact-from: ubuntu-24.04
+  artifact-from-alt: ubuntu-24.04-arm64
   docker-platforms: linux/amd64, linux/arm64
+  check-manifest-suite: docker-image-ubuntu-24.04
 
 # Debian
 - label: debian
@@ -127,6 +137,18 @@ release-packages:
   package: deb
   artifact-from: ubuntu-22.04-arm64
   artifact-version: 22.04
+  artifact-type: ubuntu
+  artifact: kong.arm64.deb
+- label: ubuntu-24.04
+  package: deb
+  artifact-from: ubuntu-24.04
+  artifact-version: 24.04
+  artifact-type: ubuntu
+  artifact: kong.amd64.deb
+- label: ubuntu-24.04-arm64
+  package: deb
+  artifact-from: ubuntu-24.04-arm64
+  artifact-version: 24.04
   artifact-type: ubuntu
   artifact: kong.arm64.deb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,7 @@ jobs:
                 m4 \
                 perl \
                 pkg-config \
+                python-is-python3 \
                 unzip \
                 zlib1g-dev
 
@@ -419,17 +420,19 @@ jobs:
         cache: 'pip' # caching pip dependencies
 
     - name: Verify
+      env:
+        SUITE: ${{ matrix.check-manifest-suite || 'docker-image' }}
       run: |
         cd scripts/explain_manifest
         # docker image verify requires sudo to set correct permissions, so we
         # also install deps for root
-        sudo -E pip install -r requirements.txt
+        sudo -H -E pip install -r requirements.txt
         IMAGE=${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
 
-        sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
+        sudo -H -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
 
         if [[ ! -z "${{ matrix.docker-platforms }}" ]]; then
-          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
+          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
         fi
 
   scan-images:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,6 @@ jobs:
                 m4 \
                 perl \
                 pkg-config \
-                python-is-python3 \
                 unzip \
                 zlib1g-dev
 

--- a/build/README.md
+++ b/build/README.md
@@ -220,7 +220,7 @@ time to control how the ngx_wasm_module repository is sourced:
 
 ## Cross compiling
 
-Cross compiling is currently only tested on Ubuntu 22.04 x86_64 with following targeting platforms:
+Cross compiling is currently only tested on Ubuntu 22.04/24.04 x86_64 with following targeting platforms:
 
 - **//:generic-crossbuild-aarch64** Use the system installed aarch64 toolchain.
   - Requires user to manually install `crossbuild-essential-arm64` on Debian/Ubuntu.

--- a/build/cross_deps/README.md
+++ b/build/cross_deps/README.md
@@ -17,6 +17,7 @@ We currently do cross compile on following platforms:
 - Amazonlinux 2023
 - Ubuntu 18.04 (Version 3.4.x.x only)
 - Ubuntu 22.04
+- Ubuntu 24.04
 - RHEL 9
 - Debian 12
 

--- a/build/cross_deps/libxcrypt/001-4.4.27-enable-hash-all.patch
+++ b/build/cross_deps/libxcrypt/001-4.4.27-enable-hash-all.patch
@@ -1,0 +1,70 @@
+This is roughly adapted from https://patchwork.yoctoproject.org/project/oe-core/patch/20230726131331.2239727-1-Martin.Jansa@gmail.com
+Which is a patch adopted around 4.4.30 upstream.
+
+diff --color -Naur a/build-aux/scripts/BuildCommon.pm b/build-aux/scripts/BuildCommon.pm
+--- a/build-aux/scripts/BuildCommon.pm	2021-12-17 07:16:06.000000000 -0800
++++ b/build-aux/scripts/BuildCommon.pm	2024-09-05 12:47:53.534533364 -0700
+@@ -519,19 +519,19 @@
+     my $COMPAT_ABI;
+     local $_;
+     for (@args) {
+-        when (/^SYMVER_MIN=(.+)$/) {
++        if (/^SYMVER_MIN=(.+)$/) {
+             $usage_error->() if defined $SYMVER_MIN;
+             $SYMVER_MIN = $1;
+         }
+-        when (/^SYMVER_FLOOR=(.+)$/) {
++        elsif (/^SYMVER_FLOOR=(.+)$/) {
+             $usage_error->() if defined $SYMVER_FLOOR;
+             $SYMVER_FLOOR = $1;
+         }
+-        when (/^COMPAT_ABI=(.+)$/) {
++        elsif (/^COMPAT_ABI=(.+)$/) {
+             $usage_error->() if defined $COMPAT_ABI;
+             $COMPAT_ABI = $1;
+         }
+-        default {
++        else {
+             $usage_error->() if defined $map_in;
+             $map_in = $_;
+         }
+diff --color -Naur a/build-aux/scripts/gen-crypt-h b/build-aux/scripts/gen-crypt-h
+--- a/build-aux/scripts/gen-crypt-h	2021-12-17 07:16:06.000000000 -0800
++++ b/build-aux/scripts/gen-crypt-h	2024-09-05 12:48:58.446980478 -0700
+@@ -37,22 +37,20 @@
+     local $_;
+     while (<$fh>) {
+         chomp;
+-        # Yes, 'given $_' is really required here.
+-        given ($_) {
+-            when ('#define HAVE_SYS_CDEFS_H 1') {
+-                $have_sys_cdefs_h = 1;
+-            }
+-            when ('#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
+-                $have_sys_cdefs_begin_end_decls = 1;
+-            }
+-            when ('#define HAVE_SYS_CDEFS_THROW 1') {
+-                $have_sys_cdefs_throw = 1;
+-            }
+-            when (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
+-                $substs{XCRYPT_VERSION_STR}   = $1;
+-                $substs{XCRYPT_VERSION_MAJOR} = $2;
+-                $substs{XCRYPT_VERSION_MINOR} = $3;
+-            }
++
++        if ($_ eq '#define HAVE_SYS_CDEFS_H 1') {
++            $have_sys_cdefs_h = 1;
++        }
++        elsif ($_ eq '#define HAVE_SYS_CDEFS_BEGIN_END_DECLS 1') {
++            $have_sys_cdefs_begin_end_decls = 1;
++        }
++        elsif ($_ eq '#define HAVE_SYS_CDEFS_THROW 1') {
++            $have_sys_cdefs_throw = 1;
++        }
++        elsif (/^#define PACKAGE_VERSION "((\d+)\.(\d+)\.\d+)"$/) {
++            $substs{XCRYPT_VERSION_STR}   = $1;
++            $substs{XCRYPT_VERSION_MAJOR} = $2;
++            $substs{XCRYPT_VERSION_MINOR} = $3;
+         }
+     }
+

--- a/build/cross_deps/libxcrypt/repositories.bzl
+++ b/build/cross_deps/libxcrypt/repositories.bzl
@@ -9,6 +9,7 @@ def libxcrypt_repositories():
     # thus crypt.h and libcrypt.so.1 are missing from cross tool chain
     # ubuntu2004: 4.4.10
     # ubuntu2204: 4.4.27
+    # ubuntu2204: 4.4.36
     # NOTE: do not bump the following version, see build/cross_deps/README.md for detail.
     http_archive(
         name = "cross_deps_libxcrypt",
@@ -16,4 +17,6 @@ def libxcrypt_repositories():
         sha256 = "500898e80dc0d027ddaadb5637fa2bf1baffb9ccd73cd3ab51d92ef5b8a1f420",
         strip_prefix = "libxcrypt-4.4.27",
         build_file = "//build/cross_deps/libxcrypt:BUILD.libxcrypt.bazel",
+        patches = ["//build/cross_deps/libxcrypt:001-4.4.27-enable-hash-all.patch"],
+        patch_args = ["-p1"],
     )

--- a/build/cross_deps/libxcrypt/repositories.bzl
+++ b/build/cross_deps/libxcrypt/repositories.bzl
@@ -9,7 +9,7 @@ def libxcrypt_repositories():
     # thus crypt.h and libcrypt.so.1 are missing from cross tool chain
     # ubuntu2004: 4.4.10
     # ubuntu2204: 4.4.27
-    # ubuntu2204: 4.4.36
+    # ubuntu2404: 4.4.36
     # NOTE: do not bump the following version, see build/cross_deps/README.md for detail.
     http_archive(
         name = "cross_deps_libxcrypt",

--- a/changelog/unreleased/kong/add-noble-numbat.yml
+++ b/changelog/unreleased/kong/add-noble-numbat.yml
@@ -1,0 +1,2 @@
+message: "Add Ubuntu 24.04 (Noble Numbat) to build"
+type: dependency

--- a/scripts/explain_manifest/config.py
+++ b/scripts/explain_manifest/config.py
@@ -125,6 +125,19 @@ targets = {
             },
         }
     ),
+    "ubuntu-24.04-amd64": ExpectSuite(
+        name="Ubuntu 24.04 (amd64)",
+        manifest="fixtures/ubuntu-24.04-amd64.txt",
+        tests={
+            common_suites: {},
+            libc_libcpp_suites: {
+                "libc_max_version": "2.35",
+                # gcc 11.2.0
+                "libcxx_max_version": "3.4.29",
+                "cxxabi_max_version": "1.3.13",
+            },
+        }
+    ),
     "debian-11-amd64": ExpectSuite(
         name="Debian 11 (amd64)",
         manifest="fixtures/debian-11-amd64.txt",
@@ -156,6 +169,16 @@ targets = {
         manifest=None,
         tests={
             docker_suites: {},
+        }
+    ),
+    "docker-image-ubuntu-24.04": ExpectSuite(
+        name="Ubuntu 24.04 Docker Image",
+        manifest=None,
+        tests={
+            docker_suites: {
+                "kong_uid": 1001,
+                "kong_gid": 1001,
+            },
         }
     ),
 }

--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
@@ -1,0 +1,209 @@
+- Path      : /etc/kong/kong.logrotate
+
+- Path      : /lib/systemd/system/kong.service
+
+- Path      : /usr/local/kong/gui
+  Type      : directory
+
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libada.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/kong/lib/libsnappy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lxp.so
+  Needed    :
+  - libexpat.so.1
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasmx_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libcrypt.so.1
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  - ngx_brotli
+  - ngx_wasmx_module
+  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+
+- Path      : /usr/local/openresty/site/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libm.so.6
+  - libc.so.6
+  - ld-linux-x86-64.so.2
+  - libstdc++.so.6
+
+- Path      : /usr/local/openresty/site/lualib/libsimdjson_ffi.so
+  Needed    :
+  - libstdc++.so.6
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6

--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
@@ -1,0 +1,207 @@
+- Path      : /etc/kong/kong.logrotate
+
+- Path      : /lib/systemd/system/kong.service
+
+- Path      : /usr/local/kong/gui
+  Type      : directory
+
+- Path      : /usr/local/kong/include/google
+  Type      : directory
+
+- Path      : /usr/local/kong/include/kong
+  Type      : directory
+
+- Path      : /usr/local/kong/lib/engines-3/afalg.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/capi.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/loader_attic.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/engines-3/padlock.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libada.so
+  Needed    :
+  - libstdc++.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/kong/lib/libcrypto.so.3
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/libexpat.so.1.9.2
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/kong/lib/libsnappy.so
+  Needed    :
+  - libstdc++.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/kong/lib/libssl.so.3
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/kong/lib/ossl-modules/legacy.so
+  Needed    :
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lfs.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lpeg.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lsyslog.so
+  Needed    :
+  - libc.so.6
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_pack.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lua_system_constants.so
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/lxp.so
+  Needed    :
+  - libexpat.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/mime/core.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/pb.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/core.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/serial.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/socket/unix.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/ssl.so
+  Needed    :
+  - libssl.so.3
+  - libcrypto.so.3
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/kong/lib
+
+- Path      : /usr/local/lib/lua/5.1/yaml.so
+  Needed    :
+  - libyaml-0.so.2
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/cjson.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/librestysignal.so
+
+- Path      : /usr/local/openresty/lualib/rds/parser.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/lualib/redis/parser.so
+  Needed    :
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+
+- Path      : /usr/local/openresty/nginx/modules/ngx_wasmx_module.so
+  Needed    :
+  - libm.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+
+- Path      : /usr/local/openresty/nginx/sbin/nginx
+  Needed    :
+  - libcrypt.so.1
+  - libluajit-5.1.so.2
+  - libm.so.6
+  - libssl.so.3
+  - libcrypto.so.3
+  - libz.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1
+  Runpath   : /usr/local/openresty/luajit/lib:/usr/local/kong/lib:/usr/local/openresty/lualib
+  Modules   :
+  - lua-kong-nginx-module
+  - lua-kong-nginx-module/stream
+  - lua-resty-events
+  - lua-resty-lmdb
+  - ngx_brotli
+  - ngx_wasmx_module
+  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  DWARF     : True
+  DWARF - ngx_http_request_t related DWARF DIEs: True
+
+- Path      : /usr/local/openresty/site/lualib/libatc_router.so
+  Needed    :
+  - libgcc_s.so.1
+  - libc.so.6
+
+- Path      : /usr/local/openresty/site/lualib/libsimdjson_ffi.so
+  Needed    :
+  - libstdc++.so.6
+  - libgcc_s.so.1
+  - libc.so.6
+  - ld-linux-aarch64.so.1

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -137,10 +137,7 @@ def arm64_suites(expect):
     expect("/usr/local/openresty/nginx/sbin/nginx", "Nginx is arm64 arch") \
         .arch.equals("AARCH64")
 
-def docker_suites(expect):
-    kong_uid = 1000
-    kong_gid = 1000
-
+def docker_suites(expect, kong_uid: int = 1000, kong_gid: int = 1000):
     expect("/etc/passwd", "kong user exists") \
         .text_content.matches("kong:x:%d" % kong_uid)
 

--- a/scripts/release-kong.sh
+++ b/scripts/release-kong.sh
@@ -96,6 +96,9 @@ function push_package () {
   if [ "$ARTIFACT_VERSION" == "22.04" ]; then
     dist_version="--dist-version jammy"
   fi
+  if [ "$ARTIFACT_VERSION" == "24.04" ]; then
+    dist_version="--dist-version noble"
+  fi
 
   # test for sanitized github actions input
   if [[ -n "$(echo "$PACKAGE_TAGS" | tr -d 'a-zA-Z0-9._,')" ]]; then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR introduces the next LTS version of Ubuntu, and makes it the default Ubuntu version used for building PRs, the `-ubuntu` tagged docker images, etc. Notably, this PR does NOT change any `runs-on` statements for github actions. A later PR will need to address that.

Had to make some changes to get the build rolling on 24.04:
- a `libxcrypt` patch that fixes some logic in their build scripts that wasn't adapted for modern perl
- parameterize the `GID` and `UID` in the docker parts of the explain_manifest script (`ubuntu` is already UID 1000 in Noble Numbat)
- add [`libsimdjson_ffi.so`](https://github.com/Kong/lua-resty-simdjson/blob/7e6466ce91b2bc763b45701a4f055e94b1e8143b/Makefile#L33-L34) and [`libada.so`](https://github.com/ada-url/ada) to the new explain_manifest fixtures
- add a new `check-manifest-suite` for docker such `kong_uid` and `kong_gid` can be passed

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - [PUT DOCS PR HERE](https://github.com/Kong/docs.konghq.com/pull/7471)

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-4672]_

Replaces: https://github.com/Kong/kong/pull/13121

[KAG-4672]: https://konghq.atlassian.net/browse/KAG-4672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ