### PR TITLE
chore(explain_manifest): bump lief and return matched groups

### DIFF
--- a/.github/matrix-commitly.yml
+++ b/.github/matrix-commitly.yml
@@ -10,7 +10,6 @@ build-images:
   base-image: ubuntu:24.04
   package: deb
   artifact-from: ubuntu-24.04
-  check-manifest-suite: docker-image-ubuntu-24.04
 
 smoke-tests:
 - label: ubuntu

--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -92,7 +92,6 @@ build-images:
   artifact-from: ubuntu-24.04
   artifact-from-alt: ubuntu-24.04-arm64
   docker-platforms: linux/amd64, linux/arm64
-  check-manifest-suite: docker-image-ubuntu-24.04
 
 # Debian
 - label: debian

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,19 +423,17 @@ jobs:
         cache: 'pip' # caching pip dependencies
 
     - name: Verify
-      env:
-        SUITE: ${{ matrix.check-manifest-suite || 'docker-image' }}
       run: |
         cd scripts/explain_manifest
         # docker image verify requires sudo to set correct permissions, so we
         # also install deps for root
-        sudo -H -E pip install -r requirements.txt
+        sudo -E pip install -r requirements.txt
         IMAGE=${{ env.PRERELEASE_DOCKER_REPOSITORY }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
 
-        sudo -H -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
+        sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
 
         if [[ ! -z "${{ matrix.docker-platforms }}" ]]; then
-          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s "$SUITE"
+          DOCKER_DEFAULT_PLATFORM=linux/arm64 sudo -E python ./main.py --image $IMAGE -f docker_image_filelist.txt -s docker-image
         fi
 
   scan-images:

--- a/scripts/explain_manifest/explain.py
+++ b/scripts/explain_manifest/explain.py
@@ -132,15 +132,16 @@ class ElfFileInfo(FileInfo):
         if not binary:  # not an ELF file, malformed, etc
             return
 
-        self.arch = binary.header.machine_type.name
+        # lief._lief.ELF.ARCH.X86_64
+        self.arch = str(binary.header.machine_type).split(".")[-1]
 
         for d in binary.dynamic_entries:
-            if d.tag == lief.ELF.DYNAMIC_TAGS.NEEDED:
+            if d.tag == lief._lief.ELF.DynamicEntry.TAG.NEEDED:
                 self.needed_libraries.append(d.name)
-            elif d.tag == lief.ELF.DYNAMIC_TAGS.RPATH:
-                self.rpath = d.name
-            elif d.tag == lief.ELF.DYNAMIC_TAGS.RUNPATH:
-                self.runpath = d.name
+            elif d.tag == lief._lief.ELF.DynamicEntry.TAG.RPATH:
+                self.rpath = d.runpath
+            elif d.tag == lief._lief.ELF.DynamicEntry.TAG.RUNPATH:
+                self.runpath = d.runpath
 
         # create closures and lazily evaluated
         self.get_exported_symbols = lambda: sorted(
@@ -203,7 +204,7 @@ class NginxInfo(ElfFileInfo):
         binary = lief.parse(path)
 
         for s in binary.strings:
-            if re.match("\s*--prefix=/", s):
+            if re.match(r"\s*--prefix=/", s):
                 self.nginx_compile_flags = s
                 for m in re.findall("add(?:-dynamic)?-module=(.*?) ", s):
                     if m.startswith("../"):  # skip bundled modules
@@ -215,7 +216,7 @@ class NginxInfo(ElfFileInfo):
                     else:
                         self.nginx_modules.append(os.path.join(pdir, mname))
                 self.nginx_modules = sorted(self.nginx_modules)
-            elif m := re.match("^built with (.+) \(running with", s):
+            elif m := re.match(r"^built with (.+) \(running with", s):
                 self.nginx_compiled_openssl = m.group(1).strip()
 
         # Fetch DWARF infos

--- a/scripts/explain_manifest/requirements.txt
+++ b/scripts/explain_manifest/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.12.*
+lief==0.15.*
 globmatch==2.0.*
 pyelftools==0.29
 looseversion==1.1.2

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -49,11 +49,11 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False, skip_libsimdj
         .exported_symbols.contain("pcre2_general_context_free_8") \
         .exported_symbols.do_not().contain("pcre_free") \
         .needed_libraries.do_not().contain_match("libpcre.so.+") \
-        .needed_libraries.do_not().contain_match("libpcre.+.so.+") \
-        .needed_libraries.do_not().contain_match("libpcre2\-(8|16|32).so.+") \
+        .needed_libraries.do_not().contain_match(r"libpcre.+.so.+") \
+        .needed_libraries.do_not().contain_match(r"libpcre2\-(8|16|32).so.+") \
 
     expect("/usr/local/openresty/nginx/sbin/nginx", "nginx should not be compiled with debug flag") \
-        .nginx_compile_flags.do_not().match("with\-debug")
+        .nginx_compile_flags.do_not().match(r"with\-debug")
 
     expect("/usr/local/openresty/nginx/sbin/nginx", "nginx should include Kong's patches") \
         .functions \
@@ -96,7 +96,7 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False, skip_libsimdj
             .needed_libraries.contain("libcrypt.so.1")
 
     expect("/usr/local/openresty/nginx/sbin/nginx", "nginx compiled with OpenSSL 3.2.x") \
-        .nginx_compiled_openssl.matches("OpenSSL 3.2.\d") \
+        .nginx_compiled_openssl.matches(r"OpenSSL 3.2.\d") \
         .version_requirement.key("libssl.so.3").less_than("OPENSSL_3.3.0") \
         .version_requirement.key("libcrypto.so.3").less_than("OPENSSL_3.3.0") \
 
@@ -137,12 +137,20 @@ def arm64_suites(expect):
     expect("/usr/local/openresty/nginx/sbin/nginx", "Nginx is arm64 arch") \
         .arch.equals("AARCH64")
 
-def docker_suites(expect, kong_uid: int = 1000, kong_gid: int = 1000):
-    expect("/etc/passwd", "kong user exists") \
-        .text_content.matches("kong:x:%d" % kong_uid)
+def docker_suites(expect):
 
-    expect("/etc/group", "kong group exists") \
-        .text_content.matches("kong:x:%d" % kong_gid)
+    m = expect("/etc/passwd", "kong user exists") \
+        .text_content.matches(r"kong:x:(\d+)").get_last_macthes()
+
+    if m:
+        kong_uid = int(m[0].groups()[0])
+
+
+    m = expect("/etc/group", "kong group exists") \
+        .text_content.matches(r"kong:x:(\d+)").get_last_macthes()
+
+    if m:
+        kong_gid = int(m[0].groups()[0])
 
     for path in ("/usr/local/kong/**", "/usr/local/bin/kong"):
         expect(path, "%s owned by kong:root" % path) \


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Bump lief (0.12.x no longer builds on ubuntu 24.04 host) and return matched groups

### Issue reference
From https://github.com/Kong/kong/pull/13626

KAG-4672
