### PR TITLE
fix(patches): add patches from upstream openresty

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.26_07-tcpsock-setkeepalive-tls13.patch
+++ b/build/openresty/patches/ngx_lua-0.10.26_07-tcpsock-setkeepalive-tls13.patch
@@ -1,0 +1,26 @@
+diff --git a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
+index 037faef..0e6dcd0 100644
+--- a/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
++++ b/bundle/ngx_lua-0.10.26/src/ngx_http_lua_socket_tcp.c
+@@ -5731,7 +5731,7 @@ ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev)
+     ngx_http_lua_socket_pool_t          *spool;
+
+     int                n;
+-    char               buf[1];
++    unsigned char      buf[1];
+     ngx_connection_t  *c;
+
+     c = ev->data;
+@@ -5752,9 +5752,10 @@ ngx_http_lua_socket_keepalive_close_handler(ngx_event_t *ev)
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
+                    "lua tcp socket keepalive close handler check stale events");
+
+-    n = recv(c->fd, buf, 1, MSG_PEEK);
++    /* consume the possible ssl-layer data implicitly */
++    n = c->recv(c, buf, 1);
+
+-    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
++    if (n == NGX_AGAIN) {
+         /* stale event */
+
+         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {

--- a/build/openresty/patches/ngx_stream_lua-0.0.14_06-tcpsock-setkeepalive-tls13.patch
+++ b/build/openresty/patches/ngx_stream_lua-0.0.14_06-tcpsock-setkeepalive-tls13.patch
@@ -1,0 +1,26 @@
+diff --git a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
+index 9d5472a..c5b33df 100644
+--- a/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
++++ b/bundle/ngx_stream_lua-0.0.14/src/ngx_stream_lua_socket_tcp.c
+@@ -5595,7 +5595,7 @@ ngx_stream_lua_socket_keepalive_close_handler(ngx_event_t *ev)
+     ngx_stream_lua_socket_pool_t                *spool;
+
+     int                n;
+-    char               buf[1];
++    unsigned char      buf[1];
+     ngx_connection_t  *c;
+
+     c = ev->data;
+@@ -5617,9 +5617,10 @@ ngx_stream_lua_socket_keepalive_close_handler(ngx_event_t *ev)
+                    "stream lua tcp socket keepalive close handler "
+                    "check stale events");
+
+-    n = recv(c->fd, buf, 1, MSG_PEEK);
++    /* consume the possible ssl-layer data implicitly */
++    n = c->recv(c, buf, 1);
+
+-    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
++    if (n == NGX_AGAIN) {
+         /* stale event */
+
+         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {

--- a/spec/internal/ssl.lua
+++ b/spec/internal/ssl.lua
@@ -152,12 +152,12 @@ function SSL.wrap(sock, cfg)
    if s then
     local fd = sock:getfd()
     C.SSL_set_fd(s, fd)
-    sock:setfd(SOCKET_INVALID)
 
     local self = setmetatable({
       ssl_ctx = ctx,
       ctx = s,
       fd = fd,
+      sock = sock,
     }, ssl_mt)
 
     return self, nil
@@ -259,9 +259,7 @@ function SSL:send(s)
 end
 
 function SSL:close()
-  if C.SSL_shutdown(self.ctx) ~= 1 then
-    return nil, format_error("SSL_shutdown")
-  end
+  self.sock:close()
   return true
 end
 


### PR DESCRIPTION
### Summary

Fixing the issue where a connection can't be setkeepalive successfully when using TLSv1.3. The issue was originally found in the tcp-log plugin.

#### ngx_lua patches
- https://github.com/openresty/lua-nginx-module/commit/bf4bdcd5b299fc5680eb7d6fd594d4a49983de21
- https://github.com/openresty/lua-nginx-module/commit/ea09d92adf835e30cab8d79343c7b8266e888128
- https://github.com/openresty/lua-nginx-module/commit/816483d6e66efa1b5a93571932d4e33f336b2d36

#### ngx_stream_lua patches
- https://github.com/openresty/stream-lua-nginx-module/commit/5954e22fa1e03125df7c0c55aa003c1076e02f7c
- https://github.com/openresty/stream-lua-nginx-module/commit/69f0cd762112a6e0cddb07f2b5192e9a65034a93
- https://github.com/openresty/stream-lua-nginx-module/commit/1e1d93eac29a3d8ffe2183c0470c090ef4da700f


### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-6190
