### PR TITLE
[Backport -> release/3.8.x] chore(release): fix issues in 3.8.0 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,53 +28,60 @@ Individual unreleased changelog entries can be located at [changelog/unreleased]
 
 - Fixed an inefficiency issue in the Luajit hashing algorithm
  [#13240](https://github.com/Kong/kong/issues/13240)
+ 
 ##### Core
 
 - Removed unnecessary DNS client initialization
  [#13479](https://github.com/Kong/kong/issues/13479)
+ 
 
 - Improved latency performance when gzipping/gunzipping large data (such as CP/DP config data).
  [#13338](https://github.com/Kong/kong/issues/13338)
+ 
 
 
 #### Deprecations
 ##### Default
 
-- Debian 10 and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
- [#13468](https://github.com/Kong/kong/issues/13468)
+- Debian 10, CentOS 7, and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 #### Dependencies
 ##### Core
 
 - Bumped lua-resty-acme to 0.15.0 to support username/password auth with redis.
  [#12909](https://github.com/Kong/kong/issues/12909)
+ 
 
-- Bumped lua-resty-aws to 1.5.3 to fix a bug related to the STS regional endpoint.
+- Bumped lua-resty-aws to 1.5.3 to fix a bug related to STS regional endpoint.
  [#12846](https://github.com/Kong/kong/issues/12846)
+ 
 
-- Bumped lua-resty-events to 0.3.0
- [#13097](https://github.com/Kong/kong/issues/13097)
+- Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0 to fix an issue that was causing high memory usage
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0 to reduce active healthcheck timer usage.
- [#13038](https://github.com/Kong/kong/issues/13038)
-
-- Bumped lua-resty-lmdb to 1.4.3 (lmdb 0.9.33)
+- Bumped lua-resty-lmdb to 1.4.3 to get fixes from the upstream (lmdb 0.9.33), which resolved numerous race conditions and fixed a cursor issue.
  [#12786](https://github.com/Kong/kong/issues/12786)
 
 
-- Bumped lua-resty-openssl to 1.5.1.
+- Bumped lua-resty-openssl to 1.5.1 to fix some issues including a potential use-after-free issue.
  [#12665](https://github.com/Kong/kong/issues/12665)
 
 
-- Bumped OpenResty to 1.25.3.2
+- Bumped OpenResty to 1.25.3.2 to improve the performance of the LuaJIT hash computation.
  [#12327](https://github.com/Kong/kong/issues/12327)
+ 
 
-- Bumped PCRE2 to 10.44 to fix some bugs and tidy up the release.
- [#12366](https://github.com/Kong/kong/issues/12366)
+- Bumped PCRE2 to 10.44 to fix some bugs and tidy-up the release (nothing important)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - Introduced a yieldable JSON library `lua-resty-simdjson`,
-which significantly improves latency.
+which would improve the latency significantly.
  [#13421](https://github.com/Kong/kong/issues/13421)
+ 
 ##### Default
 
 - Bumped lua-protobuf 0.5.2
@@ -83,6 +90,7 @@ which significantly improves latency.
 
 - Bumped LuaRocks from 3.11.0 to 3.11.1
  [#12662](https://github.com/Kong/kong/issues/12662)
+ 
 
 - Bumped `ngx_wasm_module` to `96b4e27e10c63b07ed40ea88a91c22f23981db35`
  [#12011](https://github.com/Kong/kong/issues/12011)
@@ -94,61 +102,61 @@ which significantly improves latency.
 
 - Made the RPM package relocatable with the default prefix set to `/`.
  [#13468](https://github.com/Kong/kong/issues/13468)
+ 
 
 #### Features
-##### Plugins
-
-- **prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage.
- [#13148](https://github.com/Kong/kong/issues/13148)
-
 ##### Configuration
 
-- You can now configure the Wasmtime module cache when Wasm is enabled.
- [#12930](https://github.com/Kong/kong/issues/12930)
+- Configure Wasmtime module cache when Wasm is enabled
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### Core
 
-- Added the new configuration parameter `concurrency_limit` (integer, defaults to 1), which lets you specify the number of delivery timers in the queue.
+- **prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
+
+- Added a new configuration `concurrency_limit`(integer, default to 1) for Queue to specify the number of delivery timers.
 Note that setting `concurrency_limit` to `-1` means no limit at all, and each HTTP log entry would create an individual timer for sending.
  [#13332](https://github.com/Kong/kong/issues/13332)
+ 
 
-- Kong Gateway now appends gateway info to the upstream `Via` header in the format `1.1 kong/3.8.0`, and optionally to the
-response `Via` header if it is present in the `headers` config of `kong.conf`, in the format `2 kong/3.8.0`.
-This follows standards defined in RFC7230 and RFC9110.
- [#12733](https://github.com/Kong/kong/issues/12733)
+- Append gateway info to upstream `Via` header like `1.1 kong/3.8.0`, and optionally to
+response `Via` header if it is present in the `headers` config of "kong.conf", like `2 kong/3.8.0`,
+according to `RFC7230` and `RFC9110`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Starting from this version, a new DNS client library has been implemented and added into Kong. This library is disabled by default, and can be enabled by setting the `new_dns_client` parameter to `on`.
-The new DNS client library provides the following:
-
- - Global caching for DNS records across workers, significantly reducing the query load on DNS servers.
-
- - Observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
-
- - Simplified and standardized logic.
- [#12305](https://github.com/Kong/kong/issues/12305)
+- Starting from this version, a new DNS client library has been implemented and added into Kong, which is disabled by default. The new DNS client library has the following changes - Introduced global caching for DNS records across workers, significantly reducing the query load on DNS servers. - Introduced observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them. - Simplified the logic and make it more standardized
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### PDK
 
 - Added `0` to support unlimited body size. When parameter `max_allowed_file_size` is `0`, `get_raw_body` will return the entire body, but the size of this body will still be limited by Nginx's `client_max_body_size`.
  [#13431](https://github.com/Kong/kong/issues/13431)
+ 
 
-- Extended `kong.request.get_body` and `kong.request.get_raw_body` to read from buffered files.
- [#13158](https://github.com/Kong/kong/issues/13158)
+- extend kong.request.get_body and kong.request.get_raw_body to read from buffered file
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-
-- Added a new PDK module `kong.telemetry` and the function `kong.telemetry.log`
+- Added a new PDK module `kong.telemetry` and function: `kong.telemetry.log`
 to generate log entries to be reported via the OpenTelemetry plugin.
  [#13329](https://github.com/Kong/kong/issues/13329)
+ 
 ##### Plugin
 
 - **acl:** Added a new config `always_use_authenticated_groups` to support using authenticated groups even when an authenticated consumer already exists.
  [#13184](https://github.com/Kong/kong/issues/13184)
+ 
 
-- AI plugins: Latency data is now pushed to logs and metrics.
- [#13428](https://github.com/Kong/kong/issues/13428)
+- AI plugins: retrieved latency data and pushed it to logs and metrics.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-
-- **AI-proxy-plugin**: Added the `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
- [#13158](https://github.com/Kong/kong/issues/13158)
-
+- allow AI plugin to read request from buffered file
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **AI-proxy-plugin**: Add `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
  [#13493](https://github.com/Kong/kong/issues/13493)
@@ -168,234 +176,299 @@ the Google Gemini "chat" (generateContent) interface.
  [#12948](https://github.com/Kong/kong/issues/12948)
 
 
-- **ai-proxy**: The Mistral provider can now use mistral.ai-managed services by omitting the `upstream_url`.
- [#13481](https://github.com/Kong/kong/issues/13481)
+- **ai-proxy**: Allowed mistral provider to use mistral.ai managed service by omitting upstream_url
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
+- **ai-proxy**: Added a new response header X-Kong-LLM-Model that displays the name of the language model used in the AI-Proxy plugin.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **ai-proxy**: Added the new response header `X-Kong-LLM-Model`, which displays the name of the language model used in the AI Proxy plugin.
- [#13472](https://github.com/Kong/kong/issues/13472)
-
-
-- **AI-Prompt-Guard**: Added the `match_all_roles` option to allow matching all roles in addition to `user`.
- [#13183](https://github.com/Kong/kong/issues/13183)
-
+- **AI-Prompt-Guard**: add `match_all_roles` option to allow match all roles in addition to `user`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - "**AWS-Lambda**: Added support for a configurable STS endpoint with the new configuration field `aws_sts_endpoint_url`.
  [#13388](https://github.com/Kong/kong/issues/13388)
+ 
 
-- **AWS-Lambda**: Added the configuration field `empty_arrays_mode` to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.
- [#13084](https://github.com/Kong/kong/issues/13084)
+- **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **response-transformer**: Added support for `json_body` rename.
- [#13131](https://github.com/Kong/kong/issues/13131)
+- Added support for json_body rename in response-transformer plugin
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **OpenTelemetry:** Added support for OpenTelemetry formatted logs.
  [#13291](https://github.com/Kong/kong/issues/13291)
+ 
 
 - **standard-webhooks**: Added standard webhooks plugin.
- [#12757](https://github.com/Kong/kong/issues/12757)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-
-- **Request-Transformer**: Fixed an issue where renamed query parameters, url-encoded body parameters, and JSON body parameters were not handled properly when the target name was the same as the source name in the request.
- [#13358](https://github.com/Kong/kong/issues/13358)
+- **Request-Transformer**: Fixed an issue where renamed query parameters, url-encoded body parameters, and json body parameters were not handled properly when target name is the same as the source name in the request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### Admin API
 
 - Added support for brackets syntax for map fields configuration via the Admin API
  [#13313](https://github.com/Kong/kong/issues/13313)
+ 
 
 #### Fixes
 ##### CLI Command
 
 - Fixed an issue where some debug level error logs were not being displayed by the CLI.
  [#13143](https://github.com/Kong/kong/issues/13143)
+ 
 ##### Configuration
 
 - Re-enabled the Lua DNS resolver from proxy-wasm by default.
  [#13424](https://github.com/Kong/kong/issues/13424)
+ 
 ##### Core
 
 - Fixed an issue where luarocks-admin was not available in /usr/local/bin.
  [#13372](https://github.com/Kong/kong/issues/13372)
+ 
 
 - Fixed an issue where 'read' was not always passed to Postgres read-only database operations.
  [#13530](https://github.com/Kong/kong/issues/13530)
+ 
 
-- Fixed an issue with deprecated shorthand fields so that they don't take precedence over replacement fields when both are specified.
- [#13486](https://github.com/Kong/kong/issues/13486)
+- Deprecated shorthand fields don't take precedence over replacement fields when both are specified.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()` triggered `filter_finalize`. [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
- [#13316](https://github.com/Kong/kong/issues/13316)
+- Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()` triggered `filter_finalize` [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Changed the way deprecated shorthand fields are used with new fields. If the new field contains null, it allows for deprecated field to overwrite it if both are present in the request.
- [#13592](https://github.com/Kong/kong/issues/13592)
+- Changed the way deprecated shorthand fields are used with new fields.
+If the new field contains null it allows for deprecated field to overwrite it if both are present in the request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where an unnecessary uninitialized variable error log was reported when 400 bad requests were received.
- [#13201](https://github.com/Kong/kong/issues/13201)
+- Fixed an issue where unnecessary uninitialized variable error log is reported when 400 bad requests were received.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where the URI captures were unavailable when the first capture group was absent.
- [#13024](https://github.com/Kong/kong/issues/13024)
+- Fixed an issue where the URI captures are unavailable when the first capture group is absent.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where the priority field could be set in a traditional mode route when `router_flavor` was configured as `expressions`.
- [#13142](https://github.com/Kong/kong/issues/13142)
+- Fixed an issue where the priority field can be set in a traditional mode route
+When 'router_flavor' is configured as 'expressions'.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - Fixed an issue where setting `tls_verify` to `false` didn't override the global level `proxy_ssl_verify`.
  [#13470](https://github.com/Kong/kong/issues/13470)
+ 
 
-- Fixed an issue where the SNI cache wasn't invalidated when an SNI was updated.
- [#13165](https://github.com/Kong/kong/issues/13165)
+- Fixed an issue where the sni cache isn't invalidated when a sni is updated.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- The `kong.logrotate` configuration file will no longer be overwritten during upgrade. When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
- [#13348](https://github.com/Kong/kong/issues/13348)
+- The kong.logrotate configuration file will no longer be overwritten during upgrade.
+When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - Fixed an issue where the Vault secret cache got refreshed during `resurrect_ttl` time and could not be fetched by other workers.
  [#13561](https://github.com/Kong/kong/issues/13561)
+ 
 
-- Error logs produced during Vault secret rotation are now logged at the `notice` level instead of `warn`.
- [#13540](https://github.com/Kong/kong/issues/13540)
+- Error logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where the `host_header` attribute of the upstream entity wouldn't be set correctly as a Host header in requests to the upstream during connection retries.
- [#13135](https://github.com/Kong/kong/issues/13135)
+- fix a bug that the `host_header` attribute of upstream entity can not be set correctly in requests to upstream as Host header when retries to upstream happen.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - Moved internal Unix sockets to a subdirectory (`sockets`) of the Kong prefix.
  [#13409](https://github.com/Kong/kong/issues/13409)
+ 
 
-- Changed the behaviour of shorthand fields that are used to describe deprecated fields. If both fields are sent in the request and their values mismatch, the request will be rejected.
+- Changed the behaviour of shorthand fields that are used to describe deprecated fields. If
+both fields are sent in the request and their values mismatch - the request will be rejected.
  [#13594](https://github.com/Kong/kong/issues/13594)
+ 
 
-- Reverted the DNS client to the original behavior of ignoring ADDITIONAL SECTION in DNS responses.
- [#13278](https://github.com/Kong/kong/issues/13278)
+- Reverted DNS client to original behaviour of ignoring ADDITIONAL SECTION in DNS responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - Shortened names of internal Unix sockets to avoid exceeding the socket name limit.
- [#13571](https://github.com/Kong/kong/issues/13571)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### PDK
 
-- **PDK**: Fixed an issue where the log serializer logged `upstream_status` as nil in the requests that contained subrequests.
- [#12953](https://github.com/Kong/kong/issues/12953)
+- **PDK**: Fixed a bug that log serializer will log `upstream_status` as nil in the requests that contains subrequest
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **Vault**: References ending with a slash, when parsed, will no longer return a key.
- [#13538](https://github.com/Kong/kong/issues/13538)
+- **Vault**: Reference ending with slash when parsed should not return a key.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where `pdk.log.serialize()` threw an error when the JSON entity set by `serialize_value` contained `json.null`.
- [#13376](https://github.com/Kong/kong/issues/13376)
+- Fixed an issue that pdk.log.serialize() will throw an error when JSON entity set by serialize_value contains json.null
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### Plugin
 
-- **AI-proxy**: Fixed an issue where certain Azure models would return partial tokens/words when in response-streaming mode.
- [#13000](https://github.com/Kong/kong/issues/13000)
+- **AI-proxy-plugin**: Fixed a bug where certain Azure models would return partial tokens/words 
+when in response-streaming mode.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI Transformer plugins**: Fixed an issue where Cloud Identity authentication was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
+- **AI-Transformer-Plugins**: Fixed a bug where cloud identity authentication 
+was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
  [#13487](https://github.com/Kong/kong/issues/13487)
 
 
-- **AI-proxy**: Fixed an issue where Cohere and Anthropic providers didn't read the `model` parameter properly
+- **AI-proxy-plugin**: Fixed a bug where Cohere and Anthropic providers don't read the `model` parameter properly 
 from the caller's request body.
- [#13000](https://github.com/Kong/kong/issues/13000)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI-proxy**: Fixed an issue where using OpenAI Function inference requests would log a request error, and then hang until timeout.
- [#13000](https://github.com/Kong/kong/issues/13000)
+- **AI-proxy-plugin**: Fixed a bug where using "OpenAI Function" inference requests would log a 
+request error, and then hang until timeout.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI-proxy**: Fixed an issue where AI Proxy would still allow callers to specify their own model,
+- **AI-proxy-plugin**: Fixed a bug where AI Proxy would still allow callers to specify their own model,  
 ignoring the plugin-configured model name.
- [#13000](https://github.com/Kong/kong/issues/13000)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI-proxy**: Fixed an issue where AI Proxy would not take precedence of the
-plugin's configured model tuning options over those in the user's LLM request.
- [#13000](https://github.com/Kong/kong/issues/13000)
+- **AI-proxy-plugin**: Fixed a bug where AI Proxy would not take precedence of the 
+plugin's configured model tuning options, over those in the user's LLM request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI-proxy**: Fixed an issue where setting OpenAI SDK model parameter "null" caused analytics
+- **AI-proxy-plugin**: Fixed a bug where setting OpenAI SDK model parameter "null" caused analytics 
 to not be written to the logging plugin(s).
- [#13000](https://github.com/Kong/kong/issues/13000)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **ACME**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
+- **ACME**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **ACME**: Fixed an issue where username and password were not accepted as valid authentication methods.
  [#13496](https://github.com/Kong/kong/issues/13496)
+ 
 
-- **AI-Proxy**: Fixed issue when response was gzipped even if the client didn't accept the format.
- [#13155](https://github.com/Kong/kong/issues/13155)
+- **AI-Proxy**: Fixed issue when response is gzipped even if client doesn't accept.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
+- "**Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
- [#13417](https://github.com/Kong/kong/issues/13417)
+- Fixed certain AI plugins cannot be applied per consumer or per service.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- Fixed an issue where certain AI plugins couldn't be applied per consumer or per service.
- [#13209](https://github.com/Kong/kong/issues/13209)
+- **AI-Prompt-Guard**: Fixed an issue when `allow_all_conversation_history` is set to false, the first user request is selected instead of the last one.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
+- **AI-Proxy**: Resolved a bug where the object constructor would set data on the class instead of the instance
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI-Prompt-Guard**: Fixed an issue which occurred when `allow_all_conversation_history` was set to false, and caused the first user request to be selected instead of the last one.
- [#13183](https://github.com/Kong/kong/issues/13183)
+- **AWS-Lambda**: Fixed an issue that the plugin does not work with multiValueHeaders defined in proxy integration and legacy empty_arrays_mode.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-
-- **AI-Proxy**: Resolved an issue where the object constructor would set data on the class instead of the instance.
- [#13028](https://github.com/Kong/kong/issues/13028)
-
-
-- **AWS-Lambda**: Fixed an issue where the plugin didn't work with multiValueHeaders defined in proxy integration and legacy `empty_arrays_mode`.
- [#13381](https://github.com/Kong/kong/issues/13381)
-
-- **AWS-Lambda**: Fixed an issue where the `version` field wasn't set in the request payload when `awsgateway_compatible` was enabled.
- [#13018](https://github.com/Kong/kong/issues/13018)
+- **AWS-Lambda**: Fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **correlation-id**: Fixed an issue where the plugin would not work if we explicitly set the `generator` to `null`.
  [#13439](https://github.com/Kong/kong/issues/13439)
+ 
 
-- **CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` had multiple entries but included `*`.
- [#13334](https://github.com/Kong/kong/issues/13334)
+- **CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` has multiple entries but includes `*`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **grpc-gateway**: When there is a JSON decoding error, respond with status 400 and error information in the body instead of status 500.
  [#12971](https://github.com/Kong/kong/issues/12971)
 
 
-- **HTTP-Log**: Fixed an issue where the plugin didn't include port information in the HTTP host header when sending requests to the log server.
- [#13116](https://github.com/Kong/kong/issues/13116)
+- **HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
+- "**AI Plugins**: Fixed an issue for multi-modal inputs are not properly validated and calculated.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **AI Plugins**: Fixed an issue where multi-modal inputs weren't properly validated and calculated.
- [#13445](https://github.com/Kong/kong/issues/13445)
+- **OpenTelemetry:** Fixed an issue where migration fails when upgrading from below version 3.3 to 3.7.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
+- **OpenTelemetry / Zipkin**: remove redundant deprecation warnings
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **OpenTelemetry:** Fixed an issue where migration failed when upgrading from below version 3.3 to 3.7.
- [#13391](https://github.com/Kong/kong/issues/13391)
+- **Basic-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.6)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **OpenTelemetry and Zipkin**: Removed redundant deprecation warnings.
- [#13220](https://github.com/Kong/kong/issues/13220)
+- **Key-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.7)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **Basic-Auth**: Fixed an issue where the realm field wasn't recognized for older Kong Gateway versions (before 3.6).
- [#13042](https://github.com/Kong/kong/issues/13042)
+- **Request Size Limiting**: Fixed an issue where the body size doesn't get checked when the request body is buffered to a temporary file.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **Key-Auth**: Fixed an issue where the realm field wasn't recognized for older Kong Gateway versions (before 3.7).
- [#13042](https://github.com/Kong/kong/issues/13042)
+- **Response-RateLimiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **Request Size Limiting**: Fixed an issue where the body size didn't get checked when the request body was buffered to a temporary file.
- [#13303](https://github.com/Kong/kong/issues/13303)
-
-- **Response-RateLimiting**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
-
-- **Rate-Limiting**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
+- **Rate-Limiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **OpenTelemetry:** Improved accuracy of sampling decisions.
  [#13275](https://github.com/Kong/kong/issues/13275)
+ 
 
-- **hmac-auth**: Added WWW-Authenticate headers to 401 responses.
- [#11791](https://github.com/Kong/kong/issues/11791)
+- **hmac-auth**: Add WWW-Authenticate headers to 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **Prometheus**: Improved error logging when having inconsistent labels count.
  [#13020](https://github.com/Kong/kong/issues/13020)
 
 
-- **jwt**: Added WWW-Authenticate headers to 401 responses.
- [#11792](https://github.com/Kong/kong/issues/11792)
+- **jwt**: Add WWW-Authenticate headers to 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **ldap-auth**: Added WWW-Authenticate headers to all 401 responses.
- [#11820](https://github.com/Kong/kong/issues/11820)
+- **ldap-auth**: Add WWW-Authenticate headers to all 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
-- **OAuth2**: Added WWW-Authenticate headers to all 401 responses and realm option.
- [#11833](https://github.com/Kong/kong/issues/11833)
+- **OAuth2**: Add WWW-Authenticate headers to all 401 responses and realm option.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 
 - **proxy-cache**: Fixed an issue where the Age header was not being updated correctly when serving cached responses.
  [#13387](https://github.com/Kong/kong/issues/13387)
+
+
+- Fixed an bug that AI semantic cache can't use request provided models
+ [#13633](https://github.com/Kong/kong/issues/13633)
 
 ##### Admin API
 
@@ -404,11 +477,15 @@ to not be written to the logging plugin(s).
 
 ##### Clustering
 
-- Fixed an issue where hybrid mode wasn't working if the forward proxy password contained the special character `#`. Note that the `proxy_server` configuration parameter still needs to be url-encoded.
- [#13457](https://github.com/Kong/kong/issues/13457)
+- Fixed an issue where hybrid mode not working if the forward proxy password contains special character(#). Note that the `proxy_server` configuration parameter still needs to be url-encoded.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ 
 ##### Default
 
-- **AI-proxy**: Added a configuration validation to prevent `log_statistics` from being enabled upon providers not supporting statistics. Accordingly, the default of `log_statistics` is changed from `true` to `false`, and a database migration is added as well for disabling `log_statistics` if it has already been enabled upon unsupported providers.
+- **AI-proxy**: A configuration validation is added to prevent from enabling `log_statistics` upon
+providers not supporting statistics. Accordingly, the default of `log_statistics` is changed from
+`true` to `false`, and a database migration is added as well for disabling `log_statistics` if it
+has already been enabled upon unsupported providers.
  [#12860](https://github.com/Kong/kong/issues/12860)
 
 ### Kong-Manager

--- a/changelog/3.8.0/3.8.0.md
+++ b/changelog/3.8.0/3.8.0.md
@@ -21,9 +21,9 @@
 ### Deprecations
 #### Default
 
-- Debian 10 and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
- [#13468](https://github.com/Kong/kong/issues/13468)
- [KAG-4847](https://konghq.atlassian.net/browse/KAG-4847) [FTI-6054](https://konghq.atlassian.net/browse/FTI-6054) [KAG-4549](https://konghq.atlassian.net/browse/KAG-4549) [KAG-5122](https://konghq.atlassian.net/browse/KAG-5122)
+- Debian 10, CentOS 7, and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 ### Dependencies
 #### Core
@@ -32,36 +32,32 @@
  [#12909](https://github.com/Kong/kong/issues/12909)
  [KAG-4330](https://konghq.atlassian.net/browse/KAG-4330)
 
-- Bumped lua-resty-aws to 1.5.3 to fix a bug related to the STS regional endpoint.
+- Bumped lua-resty-aws to 1.5.3 to fix a bug related to STS regional endpoint.
  [#12846](https://github.com/Kong/kong/issues/12846)
  [KAG-3424](https://konghq.atlassian.net/browse/KAG-3424) [FTI-5732](https://konghq.atlassian.net/browse/FTI-5732)
 
-- Bumped lua-resty-events to 0.3.0
- [#13097](https://github.com/Kong/kong/issues/13097)
- [KAG-4480](https://konghq.atlassian.net/browse/KAG-4480) [KAG-4586](https://konghq.atlassian.net/browse/KAG-4586)
+- Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0 to fix an issue that was causing high memory usage
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0 to reduce active healthcheck timer usage.
- [#13038](https://github.com/Kong/kong/issues/13038)
- [FTI-5847](https://konghq.atlassian.net/browse/FTI-5847)
-
-- Bumped lua-resty-lmdb to 1.4.3 (lmdb 0.9.33)
+- Bumped lua-resty-lmdb to 1.4.3 to get fixes from the upstream (lmdb 0.9.33), which resolved numerous race conditions and fixed a cursor issue.
  [#12786](https://github.com/Kong/kong/issues/12786)
 
 
-- Bumped lua-resty-openssl to 1.5.1.
+- Bumped lua-resty-openssl to 1.5.1 to fix some issues including a potential use-after-free issue.
  [#12665](https://github.com/Kong/kong/issues/12665)
 
 
-- Bumped OpenResty to 1.25.3.2
+- Bumped OpenResty to 1.25.3.2 to improve the performance of the LuaJIT hash computation.
  [#12327](https://github.com/Kong/kong/issues/12327)
  [KAG-3515](https://konghq.atlassian.net/browse/KAG-3515) [KAG-3570](https://konghq.atlassian.net/browse/KAG-3570) [KAG-3571](https://konghq.atlassian.net/browse/KAG-3571) [JIT-2](https://konghq.atlassian.net/browse/JIT-2)
 
-- Bumped PCRE2 to 10.44 to fix some bugs and tidy up the release.
- [#12366](https://github.com/Kong/kong/issues/12366)
- [KAG-3571](https://konghq.atlassian.net/browse/KAG-3571) [KAG-3521](https://konghq.atlassian.net/browse/KAG-3521) [KAG-2025](https://konghq.atlassian.net/browse/KAG-2025)
+- Bumped PCRE2 to 10.44 to fix some bugs and tidy-up the release (nothing important)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - Introduced a yieldable JSON library `lua-resty-simdjson`,
-which significantly improves latency.
+which would improve the latency significantly.
  [#13421](https://github.com/Kong/kong/issues/13421)
  [KAG-3647](https://konghq.atlassian.net/browse/KAG-3647)
 #### Default
@@ -87,50 +83,42 @@ which significantly improves latency.
  [KAG-4847](https://konghq.atlassian.net/browse/KAG-4847) [FTI-6054](https://konghq.atlassian.net/browse/FTI-6054) [KAG-4549](https://konghq.atlassian.net/browse/KAG-4549) [KAG-5122](https://konghq.atlassian.net/browse/KAG-5122)
 
 ### Features
-#### Plugins
-
-- **prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage.
- [#13148](https://github.com/Kong/kong/issues/13148)
-
 #### Configuration
 
-- You can now configure the Wasmtime module cache when Wasm is enabled.
- [#12930](https://github.com/Kong/kong/issues/12930)
- [KAG-4372](https://konghq.atlassian.net/browse/KAG-4372)
+- Configure Wasmtime module cache when Wasm is enabled
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### Core
 
-- Added the new configuration parameter `concurrency_limit` (integer, defaults to 1), which lets you specify the number of delivery timers in the queue.
+- **prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
+
+- Added a new configuration `concurrency_limit`(integer, default to 1) for Queue to specify the number of delivery timers.
 Note that setting `concurrency_limit` to `-1` means no limit at all, and each HTTP log entry would create an individual timer for sending.
  [#13332](https://github.com/Kong/kong/issues/13332)
  [FTI-6022](https://konghq.atlassian.net/browse/FTI-6022)
 
-- Kong Gateway now appends gateway info to the upstream `Via` header in the format `1.1 kong/3.8.0`, and optionally to the
-response `Via` header if it is present in the `headers` config of `kong.conf`, in the format `2 kong/3.8.0`.
-This follows standards defined in RFC7230 and RFC9110.
- [#12733](https://github.com/Kong/kong/issues/12733)
- [FTI-5807](https://konghq.atlassian.net/browse/FTI-5807)
+- Append gateway info to upstream `Via` header like `1.1 kong/3.8.0`, and optionally to
+response `Via` header if it is present in the `headers` config of "kong.conf", like `2 kong/3.8.0`,
+according to `RFC7230` and `RFC9110`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Starting from this version, a new DNS client library has been implemented and added into Kong. This library is disabled by default, and can be enabled by setting the `new_dns_client` parameter to `on`.
-The new DNS client library provides the following:
-
- - Global caching for DNS records across workers, significantly reducing the query load on DNS servers.
-
- - Observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
-
- - Simplified and standardized logic.
- [#12305](https://github.com/Kong/kong/issues/12305)
- [KAG-3220](https://konghq.atlassian.net/browse/KAG-3220)
+- Starting from this version, a new DNS client library has been implemented and added into Kong, which is disabled by default. The new DNS client library has the following changes - Introduced global caching for DNS records across workers, significantly reducing the query load on DNS servers. - Introduced observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them. - Simplified the logic and make it more standardized
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### PDK
 
 - Added `0` to support unlimited body size. When parameter `max_allowed_file_size` is `0`, `get_raw_body` will return the entire body, but the size of this body will still be limited by Nginx's `client_max_body_size`.
  [#13431](https://github.com/Kong/kong/issues/13431)
  [KAG-4698](https://konghq.atlassian.net/browse/KAG-4698)
 
-- Extended `kong.request.get_body` and `kong.request.get_raw_body` to read from buffered files.
- [#13158](https://github.com/Kong/kong/issues/13158)
+- extend kong.request.get_body and kong.request.get_raw_body to read from buffered file
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-
-- Added a new PDK module `kong.telemetry` and the function `kong.telemetry.log`
+- Added a new PDK module `kong.telemetry` and function: `kong.telemetry.log`
 to generate log entries to be reported via the OpenTelemetry plugin.
  [#13329](https://github.com/Kong/kong/issues/13329)
  [KAG-4848](https://konghq.atlassian.net/browse/KAG-4848)
@@ -140,13 +128,13 @@ to generate log entries to be reported via the OpenTelemetry plugin.
  [#13184](https://github.com/Kong/kong/issues/13184)
  [FTI-5945](https://konghq.atlassian.net/browse/FTI-5945)
 
-- AI plugins: Latency data is now pushed to logs and metrics.
- [#13428](https://github.com/Kong/kong/issues/13428)
+- AI plugins: retrieved latency data and pushed it to logs and metrics.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-
-- **AI-proxy-plugin**: Added the `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
- [#13158](https://github.com/Kong/kong/issues/13158)
-
+- allow AI plugin to read request from buffered file
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **AI-proxy-plugin**: Add `allow_override` option to allow overriding the upstream model auth parameter or header from the caller's request.
  [#13493](https://github.com/Kong/kong/issues/13493)
@@ -166,41 +154,41 @@ the Google Gemini "chat" (generateContent) interface.
  [#12948](https://github.com/Kong/kong/issues/12948)
 
 
-- **ai-proxy**: The Mistral provider can now use mistral.ai-managed services by omitting the `upstream_url`.
- [#13481](https://github.com/Kong/kong/issues/13481)
+- **ai-proxy**: Allowed mistral provider to use mistral.ai managed service by omitting upstream_url
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
+- **ai-proxy**: Added a new response header X-Kong-LLM-Model that displays the name of the language model used in the AI-Proxy plugin.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **ai-proxy**: Added the new response header `X-Kong-LLM-Model`, which displays the name of the language model used in the AI Proxy plugin.
- [#13472](https://github.com/Kong/kong/issues/13472)
-
-
-- **AI-Prompt-Guard**: Added the `match_all_roles` option to allow matching all roles in addition to `user`.
- [#13183](https://github.com/Kong/kong/issues/13183)
-
+- **AI-Prompt-Guard**: add `match_all_roles` option to allow match all roles in addition to `user`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - "**AWS-Lambda**: Added support for a configurable STS endpoint with the new configuration field `aws_sts_endpoint_url`.
  [#13388](https://github.com/Kong/kong/issues/13388)
  [KAG-4599](https://konghq.atlassian.net/browse/KAG-4599)
 
-- **AWS-Lambda**: Added the configuration field `empty_arrays_mode` to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.
- [#13084](https://github.com/Kong/kong/issues/13084)
- [FTI-5937](https://konghq.atlassian.net/browse/FTI-5937) [KAG-4622](https://konghq.atlassian.net/browse/KAG-4622) [KAG-4615](https://konghq.atlassian.net/browse/KAG-4615)
+- **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **response-transformer**: Added support for `json_body` rename.
- [#13131](https://github.com/Kong/kong/issues/13131)
- [KAG-4664](https://konghq.atlassian.net/browse/KAG-4664)
+- Added support for json_body rename in response-transformer plugin
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **OpenTelemetry:** Added support for OpenTelemetry formatted logs.
  [#13291](https://github.com/Kong/kong/issues/13291)
  [KAG-4712](https://konghq.atlassian.net/browse/KAG-4712)
 
 - **standard-webhooks**: Added standard webhooks plugin.
- [#12757](https://github.com/Kong/kong/issues/12757)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-
-- **Request-Transformer**: Fixed an issue where renamed query parameters, url-encoded body parameters, and JSON body parameters were not handled properly when the target name was the same as the source name in the request.
- [#13358](https://github.com/Kong/kong/issues/13358)
- [KAG-4915](https://konghq.atlassian.net/browse/KAG-4915)
+- **Request-Transformer**: Fixed an issue where renamed query parameters, url-encoded body parameters, and json body parameters were not handled properly when target name is the same as the source name in the request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### Admin API
 
 - Added support for brackets syntax for map fields configuration via the Admin API
@@ -228,226 +216,237 @@ the Google Gemini "chat" (generateContent) interface.
  [#13530](https://github.com/Kong/kong/issues/13530)
  [KAG-5196](https://konghq.atlassian.net/browse/KAG-5196)
 
-- Fixed an issue with deprecated shorthand fields so that they don't take precedence over replacement fields when both are specified.
- [#13486](https://github.com/Kong/kong/issues/13486)
- [KAG-5134](https://konghq.atlassian.net/browse/KAG-5134)
+- Deprecated shorthand fields don't take precedence over replacement fields when both are specified.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()` triggered `filter_finalize`. [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
- [#13316](https://github.com/Kong/kong/issues/13316)
- [FTI-6005](https://konghq.atlassian.net/browse/FTI-6005)
+- Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()` triggered `filter_finalize` [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Changed the way deprecated shorthand fields are used with new fields. If the new field contains null, it allows for deprecated field to overwrite it if both are present in the request.
- [#13592](https://github.com/Kong/kong/issues/13592)
- [KAG-5287](https://konghq.atlassian.net/browse/KAG-5287)
+- Changed the way deprecated shorthand fields are used with new fields.
+If the new field contains null it allows for deprecated field to overwrite it if both are present in the request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where an unnecessary uninitialized variable error log was reported when 400 bad requests were received.
- [#13201](https://github.com/Kong/kong/issues/13201)
- [FTI-6025](https://konghq.atlassian.net/browse/FTI-6025)
+- Fixed an issue where unnecessary uninitialized variable error log is reported when 400 bad requests were received.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where the URI captures were unavailable when the first capture group was absent.
- [#13024](https://github.com/Kong/kong/issues/13024)
- [KAG-4474](https://konghq.atlassian.net/browse/KAG-4474)
+- Fixed an issue where the URI captures are unavailable when the first capture group is absent.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where the priority field could be set in a traditional mode route when `router_flavor` was configured as `expressions`.
- [#13142](https://github.com/Kong/kong/issues/13142)
- [KAG-4411](https://konghq.atlassian.net/browse/KAG-4411)
+- Fixed an issue where the priority field can be set in a traditional mode route
+When 'router_flavor' is configured as 'expressions'.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - Fixed an issue where setting `tls_verify` to `false` didn't override the global level `proxy_ssl_verify`.
  [#13470](https://github.com/Kong/kong/issues/13470)
  [FTI-6095](https://konghq.atlassian.net/browse/FTI-6095)
 
-- Fixed an issue where the SNI cache wasn't invalidated when an SNI was updated.
- [#13165](https://github.com/Kong/kong/issues/13165)
- [FTI-6009](https://konghq.atlassian.net/browse/FTI-6009)
+- Fixed an issue where the sni cache isn't invalidated when a sni is updated.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- The `kong.logrotate` configuration file will no longer be overwritten during upgrade. When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
- [#13348](https://github.com/Kong/kong/issues/13348)
- [FTI-6079](https://konghq.atlassian.net/browse/FTI-6079)
+- The kong.logrotate configuration file will no longer be overwritten during upgrade.
+When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - Fixed an issue where the Vault secret cache got refreshed during `resurrect_ttl` time and could not be fetched by other workers.
  [#13561](https://github.com/Kong/kong/issues/13561)
  [FTI-6137](https://konghq.atlassian.net/browse/FTI-6137)
 
-- Error logs produced during Vault secret rotation are now logged at the `notice` level instead of `warn`.
- [#13540](https://github.com/Kong/kong/issues/13540)
- [FTI-5775](https://konghq.atlassian.net/browse/FTI-5775)
+- Error logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where the `host_header` attribute of the upstream entity wouldn't be set correctly as a Host header in requests to the upstream during connection retries.
- [#13135](https://github.com/Kong/kong/issues/13135)
- [FTI-5987](https://konghq.atlassian.net/browse/FTI-5987)
+- fix a bug that the `host_header` attribute of upstream entity can not be set correctly in requests to upstream as Host header when retries to upstream happen.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - Moved internal Unix sockets to a subdirectory (`sockets`) of the Kong prefix.
  [#13409](https://github.com/Kong/kong/issues/13409)
  [KAG-4947](https://konghq.atlassian.net/browse/KAG-4947)
 
-- Changed the behaviour of shorthand fields that are used to describe deprecated fields. If both fields are sent in the request and their values mismatch, the request will be rejected.
+- Changed the behaviour of shorthand fields that are used to describe deprecated fields. If
+both fields are sent in the request and their values mismatch - the request will be rejected.
  [#13594](https://github.com/Kong/kong/issues/13594)
  [KAG-5262](https://konghq.atlassian.net/browse/KAG-5262)
 
-- Reverted the DNS client to the original behavior of ignoring ADDITIONAL SECTION in DNS responses.
- [#13278](https://github.com/Kong/kong/issues/13278)
- [FTI-6039](https://konghq.atlassian.net/browse/FTI-6039)
+- Reverted DNS client to original behaviour of ignoring ADDITIONAL SECTION in DNS responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - Shortened names of internal Unix sockets to avoid exceeding the socket name limit.
- [#13571](https://github.com/Kong/kong/issues/13571)
- [KAG-5136](https://konghq.atlassian.net/browse/KAG-5136)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### PDK
 
-- **PDK**: Fixed an issue where the log serializer logged `upstream_status` as nil in the requests that contained subrequests.
- [#12953](https://github.com/Kong/kong/issues/12953)
- [FTI-5844](https://konghq.atlassian.net/browse/FTI-5844)
+- **PDK**: Fixed a bug that log serializer will log `upstream_status` as nil in the requests that contains subrequest
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **Vault**: References ending with a slash, when parsed, will no longer return a key.
- [#13538](https://github.com/Kong/kong/issues/13538)
- [KAG-5181](https://konghq.atlassian.net/browse/KAG-5181)
+- **Vault**: Reference ending with slash when parsed should not return a key.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where `pdk.log.serialize()` threw an error when the JSON entity set by `serialize_value` contained `json.null`.
- [#13376](https://github.com/Kong/kong/issues/13376)
- [FTI-6096](https://konghq.atlassian.net/browse/FTI-6096)
+- Fixed an issue that pdk.log.serialize() will throw an error when JSON entity set by serialize_value contains json.null
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### Plugin
 
-- **AI-proxy**: Fixed an issue where certain Azure models would return partial tokens/words when in response-streaming mode.
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+- **AI-proxy-plugin**: Fixed a bug where certain Azure models would return partial tokens/words 
+when in response-streaming mode.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI Transformer plugins**: Fixed an issue where Cloud Identity authentication was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
+- **AI-Transformer-Plugins**: Fixed a bug where cloud identity authentication 
+was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
  [#13487](https://github.com/Kong/kong/issues/13487)
 
 
-- **AI-proxy**: Fixed an issue where Cohere and Anthropic providers didn't read the `model` parameter properly
+- **AI-proxy-plugin**: Fixed a bug where Cohere and Anthropic providers don't read the `model` parameter properly 
 from the caller's request body.
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI-proxy**: Fixed an issue where using OpenAI Function inference requests would log a request error, and then hang until timeout.
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+- **AI-proxy-plugin**: Fixed a bug where using "OpenAI Function" inference requests would log a 
+request error, and then hang until timeout.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI-proxy**: Fixed an issue where AI Proxy would still allow callers to specify their own model,
+- **AI-proxy-plugin**: Fixed a bug where AI Proxy would still allow callers to specify their own model,  
 ignoring the plugin-configured model name.
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI-proxy**: Fixed an issue where AI Proxy would not take precedence of the
-plugin's configured model tuning options over those in the user's LLM request.
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+- **AI-proxy-plugin**: Fixed a bug where AI Proxy would not take precedence of the 
+plugin's configured model tuning options, over those in the user's LLM request.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI-proxy**: Fixed an issue where setting OpenAI SDK model parameter "null" caused analytics
+- **AI-proxy-plugin**: Fixed a bug where setting OpenAI SDK model parameter "null" caused analytics 
 to not be written to the logging plugin(s).
- [#13000](https://github.com/Kong/kong/issues/13000)
- [KAG-4596](https://konghq.atlassian.net/browse/KAG-4596)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **ACME**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
- [KAG-4515](https://konghq.atlassian.net/browse/KAG-4515)
+- **ACME**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **ACME**: Fixed an issue where username and password were not accepted as valid authentication methods.
  [#13496](https://github.com/Kong/kong/issues/13496)
  [FTI-6143](https://konghq.atlassian.net/browse/FTI-6143)
 
-- **AI-Proxy**: Fixed issue when response was gzipped even if the client didn't accept the format.
- [#13155](https://github.com/Kong/kong/issues/13155)
+- **AI-Proxy**: Fixed issue when response is gzipped even if client doesn't accept.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
+- "**Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
- [#13417](https://github.com/Kong/kong/issues/13417)
- [KAG-4934](https://konghq.atlassian.net/browse/KAG-4934)
+- Fixed certain AI plugins cannot be applied per consumer or per service.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- Fixed an issue where certain AI plugins couldn't be applied per consumer or per service.
- [#13209](https://github.com/Kong/kong/issues/13209)
+- **AI-Prompt-Guard**: Fixed an issue when `allow_all_conversation_history` is set to false, the first user request is selected instead of the last one.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
+- **AI-Proxy**: Resolved a bug where the object constructor would set data on the class instead of the instance
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI-Prompt-Guard**: Fixed an issue which occurred when `allow_all_conversation_history` was set to false, and caused the first user request to be selected instead of the last one.
- [#13183](https://github.com/Kong/kong/issues/13183)
+- **AWS-Lambda**: Fixed an issue that the plugin does not work with multiValueHeaders defined in proxy integration and legacy empty_arrays_mode.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-
-- **AI-Proxy**: Resolved an issue where the object constructor would set data on the class instead of the instance.
- [#13028](https://github.com/Kong/kong/issues/13028)
-
-
-- **AWS-Lambda**: Fixed an issue where the plugin didn't work with multiValueHeaders defined in proxy integration and legacy `empty_arrays_mode`.
- [#13381](https://github.com/Kong/kong/issues/13381)
- [FTI-6100](https://konghq.atlassian.net/browse/FTI-6100)
-
-- **AWS-Lambda**: Fixed an issue where the `version` field wasn't set in the request payload when `awsgateway_compatible` was enabled.
- [#13018](https://github.com/Kong/kong/issues/13018)
- [FTI-5949](https://konghq.atlassian.net/browse/FTI-5949)
+- **AWS-Lambda**: Fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **correlation-id**: Fixed an issue where the plugin would not work if we explicitly set the `generator` to `null`.
  [#13439](https://github.com/Kong/kong/issues/13439)
  [FTI-6134](https://konghq.atlassian.net/browse/FTI-6134)
 
-- **CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` had multiple entries but included `*`.
- [#13334](https://github.com/Kong/kong/issues/13334)
- [FTI-6062](https://konghq.atlassian.net/browse/FTI-6062)
+- **CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` has multiple entries but includes `*`.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **grpc-gateway**: When there is a JSON decoding error, respond with status 400 and error information in the body instead of status 500.
  [#12971](https://github.com/Kong/kong/issues/12971)
 
 
-- **HTTP-Log**: Fixed an issue where the plugin didn't include port information in the HTTP host header when sending requests to the log server.
- [#13116](https://github.com/Kong/kong/issues/13116)
+- **HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
+- "**AI Plugins**: Fixed an issue for multi-modal inputs are not properly validated and calculated.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **AI Plugins**: Fixed an issue where multi-modal inputs weren't properly validated and calculated.
- [#13445](https://github.com/Kong/kong/issues/13445)
+- **OpenTelemetry:** Fixed an issue where migration fails when upgrading from below version 3.3 to 3.7.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
+- **OpenTelemetry / Zipkin**: remove redundant deprecation warnings
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **OpenTelemetry:** Fixed an issue where migration failed when upgrading from below version 3.3 to 3.7.
- [#13391](https://github.com/Kong/kong/issues/13391)
- [FTI-6109](https://konghq.atlassian.net/browse/FTI-6109)
+- **Basic-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.6)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **OpenTelemetry and Zipkin**: Removed redundant deprecation warnings.
- [#13220](https://github.com/Kong/kong/issues/13220)
- [KAG-4744](https://konghq.atlassian.net/browse/KAG-4744)
+- **Key-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.7)
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **Basic-Auth**: Fixed an issue where the realm field wasn't recognized for older Kong Gateway versions (before 3.6).
- [#13042](https://github.com/Kong/kong/issues/13042)
- [KAG-4516](https://konghq.atlassian.net/browse/KAG-4516)
+- **Request Size Limiting**: Fixed an issue where the body size doesn't get checked when the request body is buffered to a temporary file.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **Key-Auth**: Fixed an issue where the realm field wasn't recognized for older Kong Gateway versions (before 3.7).
- [#13042](https://github.com/Kong/kong/issues/13042)
- [KAG-4516](https://konghq.atlassian.net/browse/KAG-4516)
+- **Response-RateLimiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **Request Size Limiting**: Fixed an issue where the body size didn't get checked when the request body was buffered to a temporary file.
- [#13303](https://github.com/Kong/kong/issues/13303)
- [FTI-6034](https://konghq.atlassian.net/browse/FTI-6034)
-
-- **Response-RateLimiting**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
- [KAG-4515](https://konghq.atlassian.net/browse/KAG-4515)
-
-- **Rate-Limiting**: Fixed an issue where the DP would report that deprecated config fields were used when configuration was pushed from the CP.
- [#13069](https://github.com/Kong/kong/issues/13069)
- [KAG-4515](https://konghq.atlassian.net/browse/KAG-4515)
+- **Rate-Limiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **OpenTelemetry:** Improved accuracy of sampling decisions.
  [#13275](https://github.com/Kong/kong/issues/13275)
  [KAG-4785](https://konghq.atlassian.net/browse/KAG-4785)
 
-- **hmac-auth**: Added WWW-Authenticate headers to 401 responses.
- [#11791](https://github.com/Kong/kong/issues/11791)
- [KAG-321](https://konghq.atlassian.net/browse/KAG-321)
+- **hmac-auth**: Add WWW-Authenticate headers to 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **Prometheus**: Improved error logging when having inconsistent labels count.
  [#13020](https://github.com/Kong/kong/issues/13020)
 
 
-- **jwt**: Added WWW-Authenticate headers to 401 responses.
- [#11792](https://github.com/Kong/kong/issues/11792)
- [KAG-321](https://konghq.atlassian.net/browse/KAG-321)
+- **jwt**: Add WWW-Authenticate headers to 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **ldap-auth**: Added WWW-Authenticate headers to all 401 responses.
- [#11820](https://github.com/Kong/kong/issues/11820)
- [KAG-321](https://konghq.atlassian.net/browse/KAG-321)
+- **ldap-auth**: Add WWW-Authenticate headers to all 401 responses.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
-- **OAuth2**: Added WWW-Authenticate headers to all 401 responses and realm option.
- [#11833](https://github.com/Kong/kong/issues/11833)
- [KAG-321](https://konghq.atlassian.net/browse/KAG-321)
+- **OAuth2**: Add WWW-Authenticate headers to all 401 responses and realm option.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 
 - **proxy-cache**: Fixed an issue where the Age header was not being updated correctly when serving cached responses.
  [#13387](https://github.com/Kong/kong/issues/13387)
+
+
+- Fixed an bug that AI semantic cache can't use request provided models
+ [#13633](https://github.com/Kong/kong/issues/13633)
 
 #### Admin API
 
@@ -456,12 +455,15 @@ to not be written to the logging plugin(s).
 
 #### Clustering
 
-- Fixed an issue where hybrid mode wasn't working if the forward proxy password contained the special character `#`. Note that the `proxy_server` configuration parameter still needs to be url-encoded.
- [#13457](https://github.com/Kong/kong/issues/13457)
- [FTI-6145](https://konghq.atlassian.net/browse/FTI-6145)
+- Fixed an issue where hybrid mode not working if the forward proxy password contains special character(#). Note that the `proxy_server` configuration parameter still needs to be url-encoded.
+ [#13532](https://github.com/Kong/kong/issues/13532)
+ [KAG-5216](https://konghq.atlassian.net/browse/KAG-5216)
 #### Default
 
-- **AI-proxy**: Added a configuration validation to prevent `log_statistics` from being enabled upon providers not supporting statistics. Accordingly, the default of `log_statistics` is changed from `true` to `false`, and a database migration is added as well for disabling `log_statistics` if it has already been enabled upon unsupported providers.
+- **AI-proxy**: A configuration validation is added to prevent from enabling `log_statistics` upon
+providers not supporting statistics. Accordingly, the default of `log_statistics` is changed from
+`true` to `false`, and a database migration is added as well for disabling `log_statistics` if it
+has already been enabled upon unsupported providers.
  [#12860](https://github.com/Kong/kong/issues/12860)
 
 ## Kong-Manager

--- a/changelog/3.8.0/kong/add-ai-data-latency.yml
+++ b/changelog/3.8.0/kong/add-ai-data-latency.yml
@@ -1,3 +1,3 @@
-message: "AI plugins: Latency data is now pushed to logs and metrics."
+message: "AI plugins: retrieved latency data and pushed it to logs and metrics."
 type: feature
 scope: "Plugin"

--- a/changelog/3.8.0/kong/add-ai-data-prometheus.yml
+++ b/changelog/3.8.0/kong/add-ai-data-prometheus.yml
@@ -1,3 +1,3 @@
-message: "**prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage."
-type: feature
-scope: Plugins
+"message": "**prometheus**: Added `ai_requests_total`, `ai_cost_total` and `ai_tokens_total` metrics in the Prometheus plugin to start counting AI usage."
+"type": feature
+"scope": Core

--- a/changelog/3.8.0/kong/ai-plugin-read-file.yml
+++ b/changelog/3.8.0/kong/ai-plugin-read-file.yml
@@ -1,5 +1,3 @@
-message: >
-  **AI-proxy-plugin**: Added the `allow_override` option to allow overriding
-  the upstream model auth parameter or header from the caller's request.
+message: "allow AI plugin to read request from buffered file" 
 type: feature
 scope: "Plugin"

--- a/changelog/3.8.0/kong/ai-proxy-azure-streaming.yml
+++ b/changelog/3.8.0/kong/ai-proxy-azure-streaming.yml
@@ -1,5 +1,5 @@
-message: >
-  **AI-proxy**: Fixed an issue where certain Azure models would return partial tokens/words
+message: |
+  **AI-proxy-plugin**: Fixed a bug where certain Azure models would return partial tokens/words 
   when in response-streaming mode.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-cloud-identity-transformer-plugins.yml
+++ b/changelog/3.8.0/kong/ai-proxy-cloud-identity-transformer-plugins.yml
@@ -1,5 +1,5 @@
-message: >
-  **AI Transformer plugins**: Fixed an issue where Cloud Identity authentication
+message: |
+  **AI-Transformer-Plugins**: Fixed a bug where cloud identity authentication 
   was not used in `ai-request-transformer` and `ai-response-transformer` plugins.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-fix-model-parameter.yml
+++ b/changelog/3.8.0/kong/ai-proxy-fix-model-parameter.yml
@@ -1,5 +1,5 @@
 message: |
-  **AI-proxy**: Fixed an issue where Cohere and Anthropic providers didn't read the `model` parameter properly
+  **AI-proxy-plugin**: Fixed a bug where Cohere and Anthropic providers don't read the `model` parameter properly 
   from the caller's request body.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-fix-nil-response-token-count.yml
+++ b/changelog/3.8.0/kong/ai-proxy-fix-nil-response-token-count.yml
@@ -1,4 +1,5 @@
 message: |
-  **AI-proxy**: Fixed an issue where using OpenAI Function inference requests would log a request error, and then hang until timeout.
+  **AI-proxy-plugin**: Fixed a bug where using "OpenAI Function" inference requests would log a 
+  request error, and then hang until timeout.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-fix-sending-own-model.yml
+++ b/changelog/3.8.0/kong/ai-proxy-fix-sending-own-model.yml
@@ -1,5 +1,5 @@
 message: |
-  **AI-proxy**: Fixed an issue where AI Proxy would still allow callers to specify their own model,
+  **AI-proxy-plugin**: Fixed a bug where AI Proxy would still allow callers to specify their own model,  
   ignoring the plugin-configured model name.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-fix-tuning-parameter-precedence.yml
+++ b/changelog/3.8.0/kong/ai-proxy-fix-tuning-parameter-precedence.yml
@@ -1,5 +1,5 @@
 message: |
-  **AI-proxy**: Fixed an issue where AI Proxy would not take precedence of the
-  plugin's configured model tuning options over those in the user's LLM request.
+  **AI-proxy-plugin**: Fixed a bug where AI Proxy would not take precedence of the 
+  plugin's configured model tuning options, over those in the user's LLM request.
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/ai-proxy-mistral-ai.yml
+++ b/changelog/3.8.0/kong/ai-proxy-mistral-ai.yml
@@ -1,4 +1,3 @@
-message: >
-  **ai-proxy**: The Mistral provider can now use mistral.ai-managed services by omitting the `upstream_url`.
+message: '**ai-proxy**: Allowed mistral provider to use mistral.ai managed service by omitting upstream_url'
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/ai-proxy-model-header.yml
+++ b/changelog/3.8.0/kong/ai-proxy-model-header.yml
@@ -1,4 +1,3 @@
-message: >
-  **ai-proxy**: Added the new response header `X-Kong-LLM-Model`, which displays the name of the language model used in the AI Proxy plugin.
+message: '**ai-proxy**: Added a new response header X-Kong-LLM-Model that displays the name of the language model used in the AI-Proxy plugin.'
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/ai-proxy-proper-model-assignment.yml
+++ b/changelog/3.8.0/kong/ai-proxy-proper-model-assignment.yml
@@ -1,5 +1,5 @@
 message: |
-  **AI-proxy**: Fixed an issue where setting OpenAI SDK model parameter "null" caused analytics
+  **AI-proxy-plugin**: Fixed a bug where setting OpenAI SDK model parameter "null" caused analytics 
   to not be written to the logging plugin(s).
 scope: Plugin
 type: bugfix

--- a/changelog/3.8.0/kong/bump-lua-resty-aws.yml
+++ b/changelog/3.8.0/kong/bump-lua-resty-aws.yml
@@ -1,3 +1,3 @@
-message: "Bumped lua-resty-aws to 1.5.3 to fix a bug related to the STS regional endpoint."
+message: "Bumped lua-resty-aws to 1.5.3 to fix a bug related to STS regional endpoint."
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/bump-lua-resty-events.yml
+++ b/changelog/3.8.0/kong/bump-lua-resty-events.yml
@@ -1,3 +1,5 @@
-message: "Bumped lua-resty-events to 0.3.0"
-type: dependency
+message: >
+  Bumped lua-resty-events to 0.3.0 to fix an
+  issue that was preventing the
+  configuration from being updated to the latest version
 scope: Core

--- a/changelog/3.8.0/kong/bump-lua-resty-healthcheck.yml
+++ b/changelog/3.8.0/kong/bump-lua-resty-healthcheck.yml
@@ -1,3 +1,5 @@
-message: "Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0 to reduce active healthcheck timer usage."
+message: >
+  Bumped lua-resty-healthcheck from 3.0.1 to 3.1.0
+  to fix an issue that was causing high memory usage
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/bump-lua-resty-lmdb.yml
+++ b/changelog/3.8.0/kong/bump-lua-resty-lmdb.yml
@@ -1,3 +1,7 @@
-message: "Bumped lua-resty-lmdb to 1.4.3 (lmdb 0.9.33)"
+message: >
+  Bumped lua-resty-lmdb to 1.4.3 to
+  get fixes from the upstream (lmdb 0.9.33),
+  which resolved numerous race conditions and
+  fixed a cursor issue.
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/bump-lua-resty-openssl.yml
+++ b/changelog/3.8.0/kong/bump-lua-resty-openssl.yml
@@ -1,3 +1,6 @@
-message: "Bumped lua-resty-openssl to 1.5.1."
+message: >
+  Bumped lua-resty-openssl to 1.5.1
+  to fix some issues including a potential
+  use-after-free issue.
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/bump-openresty.yml
+++ b/changelog/3.8.0/kong/bump-openresty.yml
@@ -1,3 +1,5 @@
-message: "Bumped OpenResty to 1.25.3.2"
+message: >
+  Bumped OpenResty to 1.25.3.2 to improve
+  the performance of the LuaJIT hash computation.
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/bump-pcre.yml
+++ b/changelog/3.8.0/kong/bump-pcre.yml
@@ -1,3 +1,3 @@
-message: "Bumped PCRE2 to 10.44 to fix some bugs and tidy up the release."
+message: "Bumped PCRE2 to 10.44 to fix some bugs and tidy-up the release (nothing important)"
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/feat-ai-prompt-guard-all-roles.yml
+++ b/changelog/3.8.0/kong/feat-ai-prompt-guard-all-roles.yml
@@ -1,4 +1,3 @@
-message: >
-  **AI-Prompt-Guard**: Added the `match_all_roles` option to allow matching all roles in addition to `user`.
+message: "**AI-Prompt-Guard**: add `match_all_roles` option to allow match all roles in addition to `user`."
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/feat-aws-lambda-decode-empty-array.yml
+++ b/changelog/3.8.0/kong/feat-aws-lambda-decode-empty-array.yml
@@ -1,6 +1,4 @@
-message: >
-    **AWS-Lambda**: Added the configuration field `empty_arrays_mode` to
-    control whether Kong should send `[]` empty arrays (returned by Lambda function)
-    as `[]` empty arrays or `{}` empty objects in JSON responses.
+message: |
+    **AWS-Lambda**: A new configuration field `empty_arrays_mode` is now added to control whether Kong should send `[]` empty arrays (returned by Lambda function) as `[]` empty arrays or `{}` empty objects in JSON responses.`
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/feat-queue-concurrency-limit.yml
+++ b/changelog/3.8.0/kong/feat-queue-concurrency-limit.yml
@@ -1,5 +1,5 @@
 message: |
-  Added the new configuration parameter `concurrency_limit` (integer, defaults to 1), which lets you specify the number of delivery timers in the queue.
+  Added a new configuration `concurrency_limit`(integer, default to 1) for Queue to specify the number of delivery timers.
   Note that setting `concurrency_limit` to `-1` means no limit at all, and each HTTP log entry would create an individual timer for sending.
 type: feature
 scope: Core

--- a/changelog/3.8.0/kong/feat-response-transformer-json-rename.yml
+++ b/changelog/3.8.0/kong/feat-response-transformer-json-rename.yml
@@ -1,4 +1,4 @@
 message: |
-  **response-transformer**: Added support for `json_body` rename.
+  Added support for json_body rename in response-transformer plugin
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/feat-via.yml
+++ b/changelog/3.8.0/kong/feat-via.yml
@@ -1,6 +1,6 @@
 message: |
-  Kong Gateway now appends gateway info to the upstream `Via` header in the format `1.1 kong/3.8.0`, and optionally to the
-  response `Via` header if it is present in the `headers` config of `kong.conf`, in the format `2 kong/3.8.0`.
-  This follows standards defined in RFC7230 and RFC9110.
+  Append gateway info to upstream `Via` header like `1.1 kong/3.8.0`, and optionally to
+  response `Via` header if it is present in the `headers` config of "kong.conf", like `2 kong/3.8.0`,
+  according to `RFC7230` and `RFC9110`.
 type: feature
 scope: Core

--- a/changelog/3.8.0/kong/fix-acme-misleading-deprecation-logs.yml
+++ b/changelog/3.8.0/kong/fix-acme-misleading-deprecation-logs.yml
@@ -1,5 +1,3 @@
-message: >
-  **ACME**: Fixed an issue where the DP would report that deprecated
-  config fields were used when configuration was pushed from the CP.
+message: "**ACME**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-ai-gzip-content.yml
+++ b/changelog/3.8.0/kong/fix-ai-gzip-content.yml
@@ -1,4 +1,4 @@
 message: |
-   **AI-Proxy**: Fixed issue when response was gzipped even if the client didn't accept the format.
+   **AI-Proxy**: Fixed issue when response is gzipped even if client doesn't accept.
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-ai-metrics-prometheus-compat.yml
+++ b/changelog/3.8.0/kong/fix-ai-metrics-prometheus-compat.yml
@@ -1,4 +1,4 @@
 message: >
-  **Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
+  "**Prometheus**: Fixed an issue where CP/DP compatibility check was missing for the new configuration field `ai_metrics`.
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-ai-plugin-no-consumer.yml
+++ b/changelog/3.8.0/kong/fix-ai-plugin-no-consumer.yml
@@ -1,5 +1,4 @@
-message: >
-  Fixed an issue where certain AI plugins couldn't be applied per consumer or per service.
+message: "Fixed certain AI plugins cannot be applied per consumer or per service."
 type: bugfix
 scope: Plugin
 

--- a/changelog/3.8.0/kong/fix-ai-prompt-guard-order.yml
+++ b/changelog/3.8.0/kong/fix-ai-prompt-guard-order.yml
@@ -1,5 +1,3 @@
-message: >
-  **AI-Prompt-Guard**: Fixed an issue which occurred when `allow_all_conversation_history`
-  was set to false, and caused the first user request to be selected instead of the last one.
+message: "**AI-Prompt-Guard**: Fixed an issue when `allow_all_conversation_history` is set to false, the first user request is selected instead of the last one."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-ai-proxy-shared-state.yml
+++ b/changelog/3.8.0/kong/fix-ai-proxy-shared-state.yml
@@ -1,4 +1,3 @@
-message: >
-  **AI-Proxy**: Resolved an issue where the object constructor would set data on the class instead of the instance.
+message: "**AI-Proxy**: Resolved a bug where the object constructor would set data on the class instead of the instance"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-aws-lambda-empty-array-mutli-value.yml
+++ b/changelog/3.8.0/kong/fix-aws-lambda-empty-array-mutli-value.yml
@@ -1,5 +1,3 @@
-message: >
-  **AWS-Lambda**: Fixed an issue where the plugin didn't work with multiValueHeaders
-  defined in proxy integration and legacy `empty_arrays_mode`.
+message: "**AWS-Lambda**: Fixed an issue that the plugin does not work with multiValueHeaders defined in proxy integration and legacy empty_arrays_mode."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-aws-lambda-gateway-compat-version-field.yml
+++ b/changelog/3.8.0/kong/fix-aws-lambda-gateway-compat-version-field.yml
@@ -1,5 +1,3 @@
-message: >
-  **AWS-Lambda**: Fixed an issue where the `version` field wasn't
-  set in the request payload when `awsgateway_compatible` was enabled.
+message: "**AWS-Lambda**: Fixed an issue that the `version` field is not set in the request payload when `awsgateway_compatible` is enabled."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-clustering-forward-proxy-authentication.yml
+++ b/changelog/3.8.0/kong/fix-clustering-forward-proxy-authentication.yml
@@ -1,6 +1,3 @@
-message: >
-  Fixed an issue where hybrid mode wasn't working
-  if the forward proxy password contained the special character `#`.
-  Note that the `proxy_server` configuration parameter still needs to be url-encoded.
+message: Fixed an issue where hybrid mode not working if the forward proxy password contains special character(#). Note that the `proxy_server` configuration parameter still needs to be url-encoded.
 type: bugfix
 scope: Clustering

--- a/changelog/3.8.0/kong/fix-cors-wildcard.yml
+++ b/changelog/3.8.0/kong/fix-cors-wildcard.yml
@@ -1,5 +1,3 @@
-message: >
-  **CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header
-  was not sent when `conf.origins` had multiple entries but included `*`.
+message: "**CORS**: Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` has multiple entries but includes `*`."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-deprecate-shorthands-precedence.yml
+++ b/changelog/3.8.0/kong/fix-deprecate-shorthands-precedence.yml
@@ -1,5 +1,3 @@
-message: >
-  Fixed an issue with deprecated shorthand fields so that
-  they don't take precedence over replacement fields when both are specified.
+message: Deprecated shorthand fields don't take precedence over replacement fields when both are specified.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-filter-finalize-in-send-header-clear-context.yml
+++ b/changelog/3.8.0/kong/fix-filter-finalize-in-send-header-clear-context.yml
@@ -1,6 +1,3 @@
-message: >
-  Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()`
-  triggered `filter_finalize`.
-  [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
+message: Fixed an issue where `lua-nginx-module` context was cleared when `ngx.send_header()` triggered `filter_finalize` [openresty/lua-nginx-module#2323](https://github.com/openresty/lua-nginx-module/pull/2323).
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-for-null-aware-shorthand.yml
+++ b/changelog/3.8.0/kong/fix-for-null-aware-shorthand.yml
@@ -1,5 +1,5 @@
-message: >
+message: |
   Changed the way deprecated shorthand fields are used with new fields.
-  If the new field contains null, it allows for deprecated field to overwrite it if both are present in the request.
+  If the new field contains null it allows for deprecated field to overwrite it if both are present in the request.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-http-log-host-header.yml
+++ b/changelog/3.8.0/kong/fix-http-log-host-header.yml
@@ -1,6 +1,4 @@
-message: >
-  **HTTP-Log**: Fixed an issue where the plugin didn't include
-  port information in the HTTP host header when sending requests to the log server.
+message: "**HTTP-Log**: Fix an issue where the plugin doesn't include port information in the HTTP host header when sending requests to the log server."
 type: bugfix
 scope: Plugin
 

--- a/changelog/3.8.0/kong/fix-log-upstream-status-nil-subrequest.yml
+++ b/changelog/3.8.0/kong/fix-log-upstream-status-nil-subrequest.yml
@@ -1,4 +1,4 @@
 message: |
-  **PDK**: Fixed an issue where the log serializer logged `upstream_status` as nil in the requests that contained subrequests.
+  **PDK**: Fixed a bug that log serializer will log `upstream_status` as nil in the requests that contains subrequest
 type: bugfix
 scope: PDK

--- a/changelog/3.8.0/kong/fix-multi-modal.yml
+++ b/changelog/3.8.0/kong/fix-multi-modal.yml
@@ -1,4 +1,4 @@
 message: >
-  **AI Plugins**: Fixed an issue where multi-modal inputs weren't properly validated and calculated.
+  "**AI Plugins**: Fixed an issue for multi-modal inputs are not properly validated and calculated.
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-otel-migrations-exception.yml
+++ b/changelog/3.8.0/kong/fix-otel-migrations-exception.yml
@@ -1,4 +1,3 @@
-message: >
-  **OpenTelemetry:** Fixed an issue where migration failed when upgrading from below version 3.3 to 3.7.
+message: "**OpenTelemetry:** Fixed an issue where migration fails when upgrading from below version 3.3 to 3.7."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-propagation-remove-redundant-warnings.yml
+++ b/changelog/3.8.0/kong/fix-propagation-remove-redundant-warnings.yml
@@ -1,4 +1,3 @@
-message: >
-  **OpenTelemetry and Zipkin**: Removed redundant deprecation warnings.
+message: "**OpenTelemetry / Zipkin**: remove redundant deprecation warnings"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-realm-compat-changes-basic-auth.yml
+++ b/changelog/3.8.0/kong/fix-realm-compat-changes-basic-auth.yml
@@ -1,5 +1,3 @@
-message: >
-  **Basic-Auth**: Fixed an issue where the realm field
-  wasn't recognized for older Kong Gateway versions (before 3.6).
+message: "**Basic-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.6)"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-realm-compat-changes-key-auth.yml
+++ b/changelog/3.8.0/kong/fix-realm-compat-changes-key-auth.yml
@@ -1,5 +1,3 @@
-message: >
-  **Key-Auth**: Fixed an issue where the realm field wasn't
-  recognized for older Kong Gateway versions (before 3.7).
+message: "**Key-Auth**: Fix an issue of realm field not recognized for older kong versions (before 3.7)"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-reports-uninitialized-variable-in-400.yml
+++ b/changelog/3.8.0/kong/fix-reports-uninitialized-variable-in-400.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue where an unnecessary uninitialized variable error log was reported when 400 bad requests were received.
+  Fixed an issue where unnecessary uninitialized variable error log is reported when 400 bad requests were received.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
+++ b/changelog/3.8.0/kong/fix-request-size-limiting-with-chunked-transfer-encoding-and-no-content-length.yml
@@ -1,5 +1,3 @@
-message: >
-  **Request Size Limiting**: Fixed an issue where the body size
-  didn't get checked when the request body was buffered to a temporary file.
+message: "**Request Size Limiting**: Fixed an issue where the body size doesn't get checked when the request body is buffered to a temporary file."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-request-transformer-uri-replace.yml
+++ b/changelog/3.8.0/kong/fix-request-transformer-uri-replace.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue where the URI captures were unavailable when the first capture group was absent.
+  Fixed an issue where the URI captures are unavailable when the first capture group is absent.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-response-rl-misleading-deprecation-logs.yml
+++ b/changelog/3.8.0/kong/fix-response-rl-misleading-deprecation-logs.yml
@@ -1,6 +1,3 @@
-message: >
-  **Response-RateLimiting**: Fixed an issue where the DP would
-  report that deprecated config fields were used
-  when configuration was pushed from the CP.
+message: "**Response-RateLimiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-rl-misleading-deprecation-logs.yml
+++ b/changelog/3.8.0/kong/fix-rl-misleading-deprecation-logs.yml
@@ -1,6 +1,3 @@
-message: >
-  **Rate-Limiting**: Fixed an issue where the DP would
-  report that deprecated config fields were used
-  when configuration was pushed from the CP.
+message: "**Rate-Limiting**: Fixed an issue of DP reporting that deprecated config fields are used when configuration from CP is pushed"
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/fix-route-set-priority-with-others.yml
+++ b/changelog/3.8.0/kong/fix-route-set-priority-with-others.yml
@@ -1,5 +1,5 @@
-message: >
-  Fixed an issue where the priority field could be set in a traditional mode route
-  when `router_flavor` was configured as `expressions`.
+message: |
+  Fixed an issue where the priority field can be set in a traditional mode route
+  When 'router_flavor' is configured as 'expressions'.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-sni-cache-invalidate.yml
+++ b/changelog/3.8.0/kong/fix-sni-cache-invalidate.yml
@@ -1,4 +1,4 @@
 message: |
-  Fixed an issue where the SNI cache wasn't invalidated when an SNI was updated.
+  Fixed an issue where the sni cache isn't invalidated when a sni is updated.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-type-of-logrotate.yml
+++ b/changelog/3.8.0/kong/fix-type-of-logrotate.yml
@@ -1,6 +1,5 @@
-message: >
-    The `kong.logrotate` configuration file will no longer be overwritten during upgrade.
-    When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu
-    to avoid any interactive prompts and enable fully automatic upgrades.
+message: |
+    The kong.logrotate configuration file will no longer be overwritten during upgrade.
+    When upgrading, set the environment variable `DEBIAN_FRONTEND=noninteractive` on Debian/Ubuntu to avoid any interactive prompts and enable fully automatic upgrades.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/fix-vault-reference-parsing-endslash.yml
+++ b/changelog/3.8.0/kong/fix-vault-reference-parsing-endslash.yml
@@ -1,4 +1,4 @@
 message: |
-   **Vault**: References ending with a slash, when parsed, will no longer return a key.
+   **Vault**: Reference ending with slash when parsed should not return a key.
 type: bugfix
 scope: PDK

--- a/changelog/3.8.0/kong/fix-vault-secret-rotation-log-level.yml
+++ b/changelog/3.8.0/kong/fix-vault-secret-rotation-log-level.yml
@@ -1,3 +1,3 @@
-message: Error logs produced during Vault secret rotation are now logged at the `notice` level instead of `warn`.
+message: Error logs during Vault secret rotation are now logged at the `notice` level instead of `warn`.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/hmac_www_authenticate.yml
+++ b/changelog/3.8.0/kong/hmac_www_authenticate.yml
@@ -1,4 +1,3 @@
-message: >
-  **hmac-auth**: Added WWW-Authenticate headers to 401 responses.
+message: "**hmac-auth**: Add WWW-Authenticate headers to 401 responses."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/host_header.yml
+++ b/changelog/3.8.0/kong/host_header.yml
@@ -1,5 +1,3 @@
-message: >
-  Fixed an issue where the `host_header` attribute of the upstream entity
-  wouldn't be set correctly as a Host header in requests to the upstream during connection retries.
+message: fix a bug that the `host_header` attribute of upstream entity can not be set correctly in requests to upstream as Host header when retries to upstream happen.
 scope: Core
 type: bugfix

--- a/changelog/3.8.0/kong/jwt_www_authenticate.yml
+++ b/changelog/3.8.0/kong/jwt_www_authenticate.yml
@@ -1,4 +1,3 @@
-message: >
-  **jwt**: Added WWW-Authenticate headers to 401 responses.
+message: "**jwt**: Add WWW-Authenticate headers to 401 responses."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/ldap_www_authenticate.yml
+++ b/changelog/3.8.0/kong/ldap_www_authenticate.yml
@@ -1,4 +1,3 @@
-message: >
-  **ldap-auth**: Added WWW-Authenticate headers to all 401 responses.
+message: "**ldap-auth**: Add WWW-Authenticate headers to all 401 responses."
 type: bugfix
 scope: Plugin

--- a/changelog/3.8.0/kong/migration_of_ai_proxy_plugin.yml
+++ b/changelog/3.8.0/kong/migration_of_ai_proxy_plugin.yml
@@ -1,5 +1,5 @@
-message: >
-  **AI-proxy**: Added a configuration validation to prevent `log_statistics` from being enabled upon
+message: |
+  **AI-proxy**: A configuration validation is added to prevent from enabling `log_statistics` upon
   providers not supporting statistics. Accordingly, the default of `log_statistics` is changed from
   `true` to `false`, and a database migration is added as well for disabling `log_statistics` if it
   has already been enabled upon unsupported providers.

--- a/changelog/3.8.0/kong/oauth2_www_authenticate.yml
+++ b/changelog/3.8.0/kong/oauth2_www_authenticate.yml
@@ -1,5 +1,4 @@
-message: >
-  **OAuth2**: Added WWW-Authenticate headers to all 401 responses and realm option.
+message: "**OAuth2**: Add WWW-Authenticate headers to all 401 responses and realm option."
 type: bugfix
 scope: Plugin
 

--- a/changelog/3.8.0/kong/pdk-log-error.yml
+++ b/changelog/3.8.0/kong/pdk-log-error.yml
@@ -1,5 +1,3 @@
-message: >
-  Fixed an issue where `pdk.log.serialize()` threw an error
-  when the JSON entity set by `serialize_value` contained `json.null`.
+message: Fixed an issue that pdk.log.serialize() will throw an error when JSON entity set by serialize_value contains json.null
 type: bugfix
 scope: PDK

--- a/changelog/3.8.0/kong/pdk-read-file.yml
+++ b/changelog/3.8.0/kong/pdk-read-file.yml
@@ -1,3 +1,3 @@
-message: "Extended `kong.request.get_body` and `kong.request.get_raw_body` to read from buffered files."
+message: "extend kong.request.get_body and kong.request.get_raw_body to read from buffered file"
 type: feature
 scope: "PDK"

--- a/changelog/3.8.0/kong/pdk-telemetry-log.yml
+++ b/changelog/3.8.0/kong/pdk-telemetry-log.yml
@@ -1,5 +1,5 @@
 message: |
-  Added a new PDK module `kong.telemetry` and the function `kong.telemetry.log`
+  Added a new PDK module `kong.telemetry` and function: `kong.telemetry.log`
   to generate log entries to be reported via the OpenTelemetry plugin.
 type: feature
 scope: PDK

--- a/changelog/3.8.0/kong/refactor_dns_client.yml
+++ b/changelog/3.8.0/kong/refactor_dns_client.yml
@@ -1,13 +1,7 @@
 message: >
-  Starting from this version, a new DNS client library has been implemented and added into Kong.
-  This library is disabled by default, and can be enabled by setting the `new_dns_client` parameter to `on`.
-
-  The new DNS client library provides the following:
-
-   - Global caching for DNS records across workers, significantly reducing the query load on DNS servers.
-
-   - Observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
-
-   - Simplified and standardized logic.
+  Starting from this version, a new DNS client library has been implemented and added into Kong, which is disabled by default. The new DNS client library has the following changes
+  - Introduced global caching for DNS records across workers, significantly reducing the query load on DNS servers.
+  - Introduced observable statistics for the new DNS client, and a new Status API `/status/dns` to retrieve them.
+  - Simplified the logic and make it more standardized
 type: feature
 scope: Core

--- a/changelog/3.8.0/kong/reject-config-on-deprecated-fields-mismatch.yml
+++ b/changelog/3.8.0/kong/reject-config-on-deprecated-fields-mismatch.yml
@@ -1,5 +1,5 @@
-message: >
+message: |
   Changed the behaviour of shorthand fields that are used to describe deprecated fields. If
-  both fields are sent in the request and their values mismatch, the request will be rejected.
+  both fields are sent in the request and their values mismatch - the request will be rejected.
 type: bugfix
 scope: Core

--- a/changelog/3.8.0/kong/remove_eol_debian_rhel.yml
+++ b/changelog/3.8.0/kong/remove_eol_debian_rhel.yml
@@ -1,2 +1,2 @@
-message: Debian 10 and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
+message: Debian 10, CentOS 7, and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. As of version 3.8.0.0 onward, Kong is not building installation packages or Docker images for these operating systems. Kong is no longer providing official support for any Kong version running on these systems.
 type: deprecation

--- a/changelog/3.8.0/kong/req-trans-rename.yml
+++ b/changelog/3.8.0/kong/req-trans-rename.yml
@@ -1,7 +1,3 @@
-message: >
-  **Request-Transformer**: Fixed an issue where renamed query parameters,
-  url-encoded body parameters,
-  and JSON body parameters were not handled properly
-  when the target name was the same as the source name in the request.
+message: "**Request-Transformer**: Fixed an issue where renamed query parameters, url-encoded body parameters, and json body parameters were not handled properly when target name is the same as the source name in the request."
 type: feature
 scope: Plugin

--- a/changelog/3.8.0/kong/resty-simdjson.yml
+++ b/changelog/3.8.0/kong/resty-simdjson.yml
@@ -1,5 +1,5 @@
 message: |
   Introduced a yieldable JSON library `lua-resty-simdjson`,
-  which significantly improves latency.
+  which would improve the latency significantly.
 type: dependency
 scope: Core

--- a/changelog/3.8.0/kong/revert-dns-behavior.yml
+++ b/changelog/3.8.0/kong/revert-dns-behavior.yml
@@ -1,5 +1,4 @@
-message: >
-  Reverted the DNS client to the original behavior of ignoring ADDITIONAL SECTION in DNS responses.
+message: "Reverted DNS client to original behaviour of ignoring ADDITIONAL SECTION in DNS responses."
 type: bugfix
 scope: Core
 

--- a/changelog/3.8.0/kong/wasm-module-cache.yml
+++ b/changelog/3.8.0/kong/wasm-module-cache.yml
@@ -1,3 +1,3 @@
-message: You can now configure the Wasmtime module cache when Wasm is enabled.
+message: Configure Wasmtime module cache when Wasm is enabled
 type: feature
 scope: Configuration


### PR DESCRIPTION
### Summary

Backport https://github.com/Kong/kong/pull/13748

This is to sync the CE changelogs between CE and EE.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-5216]_


[KAG-5216]: https://konghq.atlassian.net/browse/KAG-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ