### PR TITLE
fix(pdk.service): corrects the error message in `pdk.service.set_retries`

### DIFF
--- a/changelog/unreleased/kong/fix-pdk-service-errmsg.yml
+++ b/changelog/unreleased/kong/fix-pdk-service-errmsg.yml
@@ -1,0 +1,3 @@
+message: "**PDK**: fix the error message in `kong.pdk.service.set_retries`"
+scope: PDK
+type: bugfix

--- a/kong/pdk/service.lua
+++ b/kong/pdk/service.lua
@@ -147,7 +147,7 @@ local function new()
       error("retries must be an integer", 2)
     end
     if retries < 0 or retries > 32767 then
-      error("port must be an integer between 0 and 32767: given " .. retries, 2)
+      error("retries must be an integer between 0 and 32767: given " .. retries, 2)
     end
 
     local ctx = ngx.ctx


### PR DESCRIPTION
### Summary

The message thrown from `set_retries` is an miswritten one in case that the argument is out of range.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6222
