### PR TITLE
Fix: Fix broken link in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -451,7 +451,7 @@ assert.same(t1, t2)
 
 #### Writing changelog
 
-Please follow the guidelines in [Changelog Readme](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
+Please follow the guidelines in [Changelog Readme](https://github.com/Kong/kong/blob/master/changelog/README.md)
 on how to write a changelog for your change.
 
 [Back to TOC](#table-of-contents)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

https://github.com/Kong/kong/blob/master/CHANGELOG/README.md does not exist.

Fix the url. Although, should that point at [changelog-template.yaml](https://github.com/Kong/kong/blob/master/changelog/changelog-template.yaml) instead? 

I don't see anything in that readme directly relevant to contributors (who are not going to be generating a changelog themselves). Alternatively, as a new contributor, I'm not sure how to read these instructions and would be happy to update them :).

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
