### PR TITLE
feat(gui): add a new feature to support multiple domains for KM GUI

### DIFF
--- a/changelog/unreleased/kong/add_multiple_domain_for_gui.yml
+++ b/changelog/unreleased/kong/add_multiple_domain_for_gui.yml
@@ -1,0 +1,4 @@
+message: |
+  Added a new feature for Kong Manager that supports multiple domains, enabling dynamic cross-origin access for Admin API requests.
+type: feature
+scope: "Core"

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1994,7 +1994,7 @@
 
 #admin_gui_url =        # Kong Manager URL
                         #
-                        # Comma-separated list of addresses(the lookup or balancer) for Kong Manager.
+                        # Comma-separated list of addresses (the lookup or balancer) for Kong Manager.
                         #
                         # Accepted format (items in square brackets are optional):
                         #

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1998,7 +1998,7 @@
                         #
                         # Accepted format (items in square brackets are optional):
                         #
-                        #   `<scheme>://<IP / HOSTNAME>[:PORT/PATH][, <scheme>://<IP / HOSTNAME>:PORT/PATH]`
+                        #   `<scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>][, <scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>]]`
                         #
                         # Examples:
                         #

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1994,21 +1994,18 @@
 
 #admin_gui_url =        # Kong Manager URL
                         #
-                        # The lookup, or balancer, address for Kong Manager.
+                        # Comma-separated list of addresses(the lookup or balancer) for Kong Manager.
                         #
-                        # Accepted format (items in parentheses are optional):
+                        # Accepted format (items in square brackets are optional):
                         #
-                        #   `<scheme>://<IP / HOSTNAME>(:<PORT>)`
+                        #   `<scheme>://<IP / HOSTNAME>[:PORT/PATH][, <scheme>://<IP / HOSTNAME>:PORT/PATH]`
                         #
                         # Examples:
                         #
                         # - `http://127.0.0.1:8003`
                         # - `https://kong-admin.test`
                         # - `http://dev-machine`
-                        #
-                        # By default, Kong Manager will use the window request
-                        # host and append the resolved listener port depending
-                        # on the requested protocol.
+                        # - `http://127.0.0.1:8003, https://exmple.com/manager`
 
 #admin_gui_path = /     # Kong Manager base path
                         #

--- a/kong/admin_gui/init.lua
+++ b/kong/admin_gui/init.lua
@@ -17,7 +17,6 @@ function _M.generate_kconfig(kong_config)
   local api_ssl_port = api_ssl_listen and api_ssl_listen.port
 
   local configs = {
-    ADMIN_GUI_URL = prepare_variable(kong_config.admin_gui_url),
     ADMIN_GUI_PATH = prepare_variable(kong_config.admin_gui_path),
     ADMIN_API_URL = prepare_variable(kong_config.admin_gui_api_url),
     ADMIN_API_PORT = prepare_variable(api_port),

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -562,9 +562,9 @@ local CONF_PARSERS = {
   error_template_xml = { typ = "string" },
   error_template_plain = { typ = "string" },
 
-  admin_gui_url = {typ = "string"},
-  admin_gui_path = {typ = "string"},
-  admin_gui_api_url = {typ = "string"},
+  admin_gui_url = { typ = "array" },
+  admin_gui_path = { typ = "string" },
+  admin_gui_api_url = { typ = "string" },
 
   request_debug = { typ = "boolean" },
   request_debug_token = { typ = "string" },

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -935,9 +935,13 @@ local function load(path, custom_conf, opts)
   -- to make it suitable to be used as an origin in headers, we need to
   -- parse and reconstruct the admin_gui_url to ensure it only contains
   -- the scheme, host, and port
-  if conf.admin_gui_url then
-    local parsed_url = socket_url.parse(conf.admin_gui_url)
-    conf.admin_gui_origin = parsed_url.scheme .. "://" .. parsed_url.authority
+  if conf.admin_gui_url and #conf.admin_gui_url > 0 then
+    local admin_gui_origin = {}
+    for _, url in ipairs(conf.admin_gui_url) do
+      local parsed_url = socket_url.parse(url)
+      table.insert(admin_gui_origin, parsed_url.scheme .. "://" .. parsed_url.authority)
+    end
+    conf.admin_gui_origin = admin_gui_origin
   end
 
   -- hybrid mode HTTP tunneling (CONNECT) proxy inside HTTPS

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -323,7 +323,7 @@ describe("Configuration loader", function()
     assert.is_nil(errors)
     assert.is_not_nil(conf)
     assert.is_not_nil(conf.admin_gui_origin)
-    assert.equal("http://localhost:8002", conf.admin_gui_origin)
+    assert.same({ "http://localhost:8002" }, conf.admin_gui_origin)
 
     conf, _, errors = conf_loader(nil, {
       admin_gui_url = "https://localhost:8002",
@@ -331,7 +331,7 @@ describe("Configuration loader", function()
     assert.is_nil(errors)
     assert.is_not_nil(conf)
     assert.is_not_nil(conf.admin_gui_origin)
-    assert.equal("https://localhost:8002", conf.admin_gui_origin)
+    assert.same({ "https://localhost:8002" }, conf.admin_gui_origin)
 
     conf, _, errors = conf_loader(nil, {
       admin_gui_url = "http://localhost:8002/manager",
@@ -339,7 +339,16 @@ describe("Configuration loader", function()
     assert.is_nil(errors)
     assert.is_not_nil(conf)
     assert.is_not_nil(conf.admin_gui_origin)
-    assert.equal("http://localhost:8002", conf.admin_gui_origin)
+    assert.same({ "http://localhost:8002" }, conf.admin_gui_origin)
+    
+    conf, _, errors = conf_loader(nil, {
+      admin_gui_url = "http://localhost:8002/manager, https://localhost:8445/manager",
+    })
+    assert.is_nil(errors)
+    assert.is_not_nil(conf)
+    assert.is_not_nil(conf.admin_gui_origin)
+    assert.is_table(conf.admin_gui_origin)
+    assert.same({ "http://localhost:8002", "https://localhost:8445" }, conf.admin_gui_origin)
   end)
   it("strips comments ending settings", function()
     local _os_getenv = os.getenv

--- a/spec/01-unit/29-admin_gui/02-admin_gui_template_spec.lua
+++ b/spec/01-unit/29-admin_gui/02-admin_gui_template_spec.lua
@@ -64,7 +64,6 @@ describe("admin_gui template", function()
     it("should generates the appropriate kconfig", function()
       local kconfig_content = admin_gui.generate_kconfig(conf)
 
-      assert.matches("'ADMIN_GUI_URL': 'http://0.0.0.0:8002'", kconfig_content, nil, true)
       assert.matches("'ADMIN_GUI_PATH': '/manager'", kconfig_content, nil, true)
       assert.matches("'ADMIN_API_URL': 'https://admin-reference.kong-cloud.test'", kconfig_content, nil, true)
       assert.matches("'ADMIN_API_PORT': '8001'", kconfig_content, nil, true)
@@ -83,7 +82,6 @@ describe("admin_gui template", function()
       local new_content = admin_gui.generate_kconfig(new_conf)
 
       -- test configuration values against template
-      assert.matches("'ADMIN_GUI_URL': 'http://admin-test.example.com'", new_content, nil, true)
       assert.matches("'ADMIN_GUI_PATH': '/manager'", new_content, nil, true)
       assert.matches("'ADMIN_API_URL': 'http://localhost:8001'", new_content, nil, true)
       assert.matches("'ADMIN_API_PORT': '8001'", new_content, nil, true)
@@ -146,7 +144,6 @@ describe("admin_gui template", function()
     it("should generates the appropriate kconfig", function()
       local kconfig_content = admin_gui.generate_kconfig(conf)
 
-      assert.matches("'ADMIN_GUI_URL': 'http://0.0.0.0:8002'", kconfig_content, nil, true)
       assert.matches("'ADMIN_API_URL': '0.0.0.0:8001'", kconfig_content, nil, true)
       assert.matches("'ADMIN_API_PORT': '8001'", kconfig_content, nil, true)
       assert.matches("'ADMIN_API_SSL_PORT': '8444'", kconfig_content, nil, true)
@@ -164,7 +161,6 @@ describe("admin_gui template", function()
       local new_content = admin_gui.generate_kconfig(new_conf)
 
       -- test configuration values against template
-      assert.matches("'ADMIN_GUI_URL': 'http://admin-test.example.com'", new_content, nil, true)
       assert.matches("'ADMIN_API_URL': '0.0.0.0:8001'", new_content, nil, true)
       assert.matches("'ADMIN_API_PORT': '8001'", new_content, nil, true)
       assert.matches("'ADMIN_API_SSL_PORT': '8444'", new_content, nil, true)

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -739,7 +739,7 @@ describe("Admin GUI config", function ()
       path = "/kconfig.js",
     })
     res = assert.res_status(200, res)
-    assert.matches("'ADMIN_GUI_URL': 'http://test1.example.com'", res, nil, true)
+    assert.matches("'ADMIN_GUI_PATH': '/'", res, nil, true)
 
     client:close()
 
@@ -764,7 +764,7 @@ describe("Admin GUI config", function ()
       path = "/manager/kconfig.js",
     })
     res = assert.res_status(200, res)
-    assert.matches("'ADMIN_GUI_URL': 'http://test2.example.com'", res, nil, true)
+    assert.matches("'ADMIN_GUI_PATH': '/manager'", res, nil, true)
     client:close()
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
1. By default, set the origin retrieved from the request header or '*'.
2. If the `admin_gui_url` has more than one domain, the origin from the request header must match one of the `admin_gui_url`. Otherwise, It can't access the Admin API via the Kong Manager. 
For example: 
`admin_gui_url=http://example.com,http://km.konghq.com/manager`
These addresses access Kong Manager works well. http://example.com and http://km.konghq.com/manager.
Others can't.

EE's PR is here: https://github.com/Kong/kong-ee/pull/10260
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
https://github.com/Kong/docs.konghq.com/pull/7976
### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KM-516
