### PR TITLE
fix(admin-api): nested parameters can be parsed correctly when using form-urlencoded requests

### DIFF
--- a/changelog/unreleased/kong/fix-parse-nested-parameters.yml
+++ b/changelog/unreleased/kong/fix-parse-nested-parameters.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where nested parameters can not be parsed correctly when using form-urlencoded requests.
+type: bugfix
+scope: Admin API

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -6,7 +6,6 @@ local app_helpers = require "lapis.application"
 local arguments = require "kong.api.arguments"
 local Errors = require "kong.db.errors"
 local hooks = require "kong.hooks"
-local decode_args = require("kong.tools.http").decode_args
 
 
 local ngx = ngx

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -298,9 +298,6 @@ local function parse_params(fn)
 
         if is_json and not self.json then
           return kong.response.exit(400, { message = "Cannot parse JSON body" })
-
-        elseif find(content_type, "application/x-www-form-urlencode", 1, true) then
-          self.params = decode_args(self.params)
         end
       end
     end

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -6,6 +6,7 @@ local app_helpers = require "lapis.application"
 local arguments = require "kong.api.arguments"
 local Errors = require "kong.db.errors"
 local hooks = require "kong.hooks"
+local decode_args = require("kong.tools.http").decode_args
 
 
 local ngx = ngx
@@ -297,6 +298,9 @@ local function parse_params(fn)
 
         if is_json and not self.json then
           return kong.response.exit(400, { message = "Cannot parse JSON body" })
+
+        elseif find(content_type, "application/x-www-form-urlencode", 1, true) then
+          self.params = decode_args(self.params)
         end
       end
     end

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -141,6 +141,8 @@ do
   end
 
 
+  -- { ["1"] = "a", ["2"] = "b" } becomes {"a", "b"}
+  -- { "a", "b" }  becomes { "a", "b" }
   local function decode_array(t)
     local keys = {}
     local len  = 0
@@ -160,7 +162,7 @@ do
       if keys[i] ~= i then
         return nil
       end
-      new_t[i] = t[tostring(i)]
+      new_t[i] = t[tostring(i)] or t[i]
     end
 
     return new_t

--- a/spec/02-integration/04-admin_api/13-plugin-endpoints_spec.lua
+++ b/spec/02-integration/04-admin_api/13-plugin-endpoints_spec.lua
@@ -38,8 +38,22 @@ describe("Admin API endpoints added via plugins #" .. strategy, function()
       path = "/method_without_exit",
       headers = { ["Content-Type"] = "application/json" }
     })
-    local body = assert.res_status(201 , res)
+    local body = assert.res_status(201, res)
     assert.same("hello", body)
+  end)
+
+  it("nested parameters can be parsed correctly when using form-urlencoded requests", function()
+    local res = assert(client:send{
+      method = "POST",
+      path = "/parsed_params",
+      body = ngx.encode_args{
+        ["items[1]"] = "foo",
+        ["items[2]"] = "bar",
+      },
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" }
+    })
+    local body = assert.res_status(200, res)
+    assert.same('{"items":["foo","bar"]}', body)
   end)
 end)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
@@ -6,4 +6,9 @@ return {
       ngx.print("hello")
     end,
   },
+  ["/parsed_params"] = {
+    POST = function(self, db, helpers, parent)
+      kong.response.exit(200, self.params)
+    end,
+  },
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
@@ -7,6 +7,11 @@ return {
     end,
   },
   ["/parsed_params"] = {
+    -- The purpose of the dummy filter is to let `parse_params`
+    -- of api/api_helpers.lua to be called twice.
+    before = function(self, db, helpers, parent)
+    end,
+
     POST = function(self, db, helpers, parent)
       kong.response.exit(200, self.params)
     end,


### PR DESCRIPTION
### Summary

When using `curl` to send a form-urlencoded request with nested parameters, such as

```
$ curl -X POST http://localhost:8001/parsed_params \
   --data 'items[1]=foo' \
   --data 'items[2]=bar'
```

the expected response is `{"items":["foo","bar"]}`, but instead, it returns `{"items":{}}`.

This is actually an EE issue, but I see that there is a risk of this in CE even though it doesn't currently occur. So I initiated that fix on CE.

The cause of the problem is due to the fact that nested parameters are lost when the [decode_args](https://github.com/Kong/kong/blob/1c4b859be73f716b8e6796868cc35a9eee7413ca/kong/api/api_helpers.lua#L303) method is called twice, without this fix.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6165
