### PR TITLE
fix(llm): fix nil error when identity_interface error

### DIFF
--- a/kong/llm/proxy/handler.lua
+++ b/kong/llm/proxy/handler.lua
@@ -459,7 +459,7 @@ function _M:access(conf)
   local identity_interface = _KEYBASTION[conf]
 
   if identity_interface and identity_interface.error then
-    llm_state.set_response_transformer_skipped()
+    llm_state.disable_ai_proxy_response_transform()
     kong.log.err("error authenticating with cloud-provider, ", identity_interface.error)
     return bail(500, "LLM request failed before proxying")
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Misconfigured ai-proxy causes unexpected nil error, instead of usual error, due to calling missing function.
It is occurred when bedrock model provider is configured without `aws_region` configuration.
In this PR, it's fixed by calling proper function.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
   - no test exists for bedrock configuration
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference
Fix #13666
