### PR TITLE
chore(ci): point to the more reliable Github distributions for Luarocks

### DIFF
--- a/build/luarocks/luarocks_repositories.bzl
+++ b/build/luarocks/luarocks_repositories.bzl
@@ -12,6 +12,6 @@ def luarocks_repositories():
         strip_prefix = "luarocks-" + version,
         sha256 = KONG_VAR["LUAROCKS_SHA256"],
         urls = [
-            "https://luarocks.org/releases/luarocks-" + version + ".tar.gz",
+            "https://luarocks.github.io/luarocks/releases/luarocks-" + version + ".tar.gz",
         ],
     )


### PR DESCRIPTION
Luarocks.org can be down, and when it's down our CI fails. This points to the same artifacts in a more reliable location on GitHub.

![Screenshot 2024-09-14 at 9 20 07 AM](https://github.com/user-attachments/assets/9ae60977-9d2f-4b6e-b53f-8958c7511095)
