### PR TITLE
fix(core): `node_id` in configuration is deprecated in this PR

### DIFF
--- a/changelog/unreleased/kong/deprecate_node_id.yml
+++ b/changelog/unreleased/kong/deprecate_node_id.yml
@@ -1,0 +1,3 @@
+message: "`node_id` in configuration has been deprecated."
+scope: Core
+type: deprecation

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -272,9 +272,9 @@ local function new(self)
     -- 1. user provided node id
     local configuration_node_id = self and self.configuration and self.configuration.node_id
     if configuration_node_id then
-      ngx.log(ngx.WARN, "The `node_id`, which has been deprecated since 3.9, is not recommended to be specified manually!!!\n",
-        "Please make sure it is unique across the cluster.\n",
-        "Please note that it will be removed from configuration since 4.x.")
+      ngx.log(ngx.WARN, "Manually specifying a `node_id` via configuration is deprecated as of 3.9 and will be removed in the 4.x.\n",
+      "We strongly recommend avoiding this practice.\n",
+      "Please note that if specified manually it must be unique across the cluster to ensure proper functionality.")
       node_id = configuration_node_id
     end
     -- 2. node id (if any) on file-system

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -272,6 +272,9 @@ local function new(self)
     -- 1. user provided node id
     local configuration_node_id = self and self.configuration and self.configuration.node_id
     if configuration_node_id then
+      ngx.log(ngx.WARN, "The `node_id`, which has been deprecated since 3.9, is not recommended to be specified manually!!!\n",
+        "Please make sure it is unique across the cluster.\n",
+        "Please note that it will be removed from configuration since 4.x.")
       node_id = configuration_node_id
     end
     -- 2. node id (if any) on file-system


### PR DESCRIPTION
### Summary

`node_id` in configuration is deprecated in this PR, which means it is not recommended to be specified manually.
A warning message is printed in error log if the `node_id` is recognized in the configuration.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6221
