### PR TITLE
fix(ci): verify manifest fails with OpenSSL 3.2.3

### DIFF
--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-amd64.txt
@@ -173,7 +173,7 @@
   - lua-resty-lmdb
   - ngx_brotli
   - ngx_wasmx_module
-  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  OpenSSL   : OpenSSL 3.2.3 3 Sep 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
 
@@ -188,4 +188,3 @@
   - libstdc++.so.6
   - libgcc_s.so.1
   - libc.so.6
-


### PR DESCRIPTION
### Summary

Fixes CI verify manifest.