### PR TITLE
tests(router): remove duplicated `reload_router()`

### DIFF
--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -143,24 +143,7 @@ end)
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2673,24 +2673,7 @@ end
 -- http expression 'http.queries.*'
 do
   local function reload_router(flavor)
-    _G.kong = {
-      configuration = {
-        router_flavor = flavor,
-      },
-    }
-
-    helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-    package.loaded["spec.helpers"] = nil
-    package.loaded["kong.global"] = nil
-    package.loaded["kong.cache"] = nil
-    package.loaded["kong.db"] = nil
-    package.loaded["kong.db.schema.entities.routes"] = nil
-    package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-    helpers = require "spec.helpers"
-
-    helpers.unsetenv("KONG_ROUTER_FLAVOR")
+    helpers = require("spec.internal.module").reload_helpers(flavor)
   end
 
 

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -34,24 +34,7 @@ local fixtures = {
 }
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 
   fixtures.dns_mock = helpers.dns_mock.new({ mocks_only = true })
   fixtures.dns_mock:A {

--- a/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/06-stream_spec.lua
@@ -2,24 +2,7 @@ local helpers = require "spec.helpers"
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -75,24 +75,7 @@ local fixtures = {
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 
   fixtures.dns_mock = helpers.dns_mock.new({ mocks_only = true })
   fixtures.dns_mock:A {

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -6,24 +6,7 @@ local FILE_LOG_PATH = os.tmpname()
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -6,24 +6,7 @@ local TEST_CONF = helpers.test_conf
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/23-context_spec.lua
+++ b/spec/02-integration/05-proxy/23-context_spec.lua
@@ -3,24 +3,7 @@ local null = ngx.null
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/26-udp_spec.lua
+++ b/spec/02-integration/05-proxy/26-udp_spec.lua
@@ -5,24 +5,7 @@ local UDP_PROXY_PORT = 26001
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -75,24 +75,7 @@ end
 
 
 local function reload_router(flavor)
-  _G.kong = {
-    configuration = {
-      router_flavor = flavor,
-    },
-  }
-
-  helpers.setenv("KONG_ROUTER_FLAVOR", flavor)
-
-  package.loaded["spec.helpers"] = nil
-  package.loaded["kong.global"] = nil
-  package.loaded["kong.cache"] = nil
-  package.loaded["kong.db"] = nil
-  package.loaded["kong.db.schema.entities.routes"] = nil
-  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
-
-  helpers = require "spec.helpers"
-
-  helpers.unsetenv("KONG_ROUTER_FLAVOR")
+  helpers = require("spec.internal.module").reload_helpers(flavor)
 end
 
 

--- a/spec/internal/misc.lua
+++ b/spec/internal/misc.lua
@@ -9,7 +9,6 @@
 -- miscellaneous
 
 
-local ffi = require("ffi")
 local pl_path = require("pl.path")
 local pl_dir = require("pl.dir")
 local pkey = require("resty.openssl.pkey")
@@ -18,12 +17,7 @@ local shell = require("spec.internal.shell")
 
 
 local CONSTANTS = require("spec.internal.constants")
-
-
-ffi.cdef [[
-  int setenv(const char *name, const char *value, int overwrite);
-  int unsetenv(const char *name);
-]]
+local sys = require("spec.internal.sys")
 
 
 local pack = function(...) return { n = select("#", ...), ... } end
@@ -120,28 +114,6 @@ local function make_yaml_file(content, filename)
     assert(shell.kong_exec("config db_export --conf "..CONSTANTS.TEST_CONF_PATH.." "..filename))
   end
   return filename
-end
-
-
---- Set an environment variable
--- @function setenv
--- @param env (string) name of the environment variable
--- @param value the value to set
--- @return true on success, false otherwise
-local function setenv(env, value)
-  assert(type(env) == "string", "env must be a string")
-  assert(type(value) == "string", "value must be a string")
-  return ffi.C.setenv(env, value, 1) == 0
-end
-
-
---- Unset an environment variable
--- @function unsetenv
--- @param env (string) name of the environment variable
--- @return true on success, false otherwise
-local function unsetenv(env)
-  assert(type(env) == "string", "env must be a string")
-  return ffi.C.unsetenv(env) == 0
 end
 
 
@@ -304,10 +276,10 @@ local function use_old_plugin(name)
 
   local origin_lua_path = os.getenv("LUA_PATH")
   -- put the old plugin path at first
-  assert(setenv("LUA_PATH", old_plugin_path .. "/?.lua;" .. old_plugin_path .. "/?/init.lua;" .. origin_lua_path), "failed to set LUA_PATH env")
+  assert(sys.setenv("LUA_PATH", old_plugin_path .. "/?.lua;" .. old_plugin_path .. "/?/init.lua;" .. origin_lua_path), "failed to set LUA_PATH env")
 
   return function ()
-    setenv("LUA_PATH", origin_lua_path)
+    sys.setenv("LUA_PATH", origin_lua_path)
     if temp_dir then
       pl_dir.rmtree(temp_dir)
     end
@@ -323,8 +295,8 @@ return {
   openresty_ver_num = openresty_ver_num(),
   unindent = unindent,
   make_yaml_file = make_yaml_file,
-  setenv = setenv,
-  unsetenv = unsetenv,
+  setenv = sys.setenv,
+  unsetenv = sys.unsetenv,
   deep_sort = deep_sort,
 
   generate_keys = generate_keys,

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -21,9 +21,13 @@ do
 
     sys.setenv("KONG_ROUTER_FLAVOR", flavor)
 
+    -- reload db and global module
     reload("kong.db.schema.entities.routes_subschemas")
     reload("kong.db.schema.entities.routes")
+    reload("kong.cache")
+    reload("kong.global")
 
+    -- reload helpers module
     local helpers = reload("spec.helpers")
 
     sys.unsetenv("KONG_ROUTER_FLAVOR")

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -6,6 +6,36 @@ local function reload(name)
 end
 
 
+local reload_helpers
+do
+  local misc = require("spec.internal.misc")
+
+  -- flavor could be "traditional","traditional_compatible" or "expressions"
+  -- changing flavor will change db's schema
+  reload_helpers= function(flavor)
+    _G.kong = {
+      configuration = {
+        router_flavor = flavor,
+      },
+    }
+
+    misc.setenv("KONG_ROUTER_FLAVOR", flavor)
+
+    reload("kong.global")
+    reload("kong.cache")
+    reload("kong.db")
+    reload("kong.db.schema.entities.routes_subschemas")
+
+    local helpers = reload("spec.helpers")
+
+    misc.unsetenv("KONG_ROUTER_FLAVOR")
+
+    return helpers
+  end
+end
+
+
 return {
   reload = reload,
+  reload_helpers = reload_helpers,
 }

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -8,7 +8,7 @@ end
 
 local reload_helpers
 do
-  local misc = require("spec.internal.misc")
+  local sys = require("spec.internal.sys")
 
   -- flavor could be "traditional","traditional_compatible" or "expressions"
   -- changing flavor will change db's schema
@@ -19,14 +19,14 @@ do
       },
     }
 
-    misc.setenv("KONG_ROUTER_FLAVOR", flavor)
+    sys.setenv("KONG_ROUTER_FLAVOR", flavor)
 
     reload("kong.db.schema.entities.routes_subschemas")
     reload("kong.db.schema.entities.routes")
 
     local helpers = reload("spec.helpers")
 
-    misc.unsetenv("KONG_ROUTER_FLAVOR")
+    sys.unsetenv("KONG_ROUTER_FLAVOR")
 
     return helpers
   end

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -23,9 +23,6 @@ do
 
     reload("kong.db.schema.entities.routes_subschemas")
     reload("kong.db.schema.entities.routes")
-    reload("kong.db")
-    reload("kong.cache")
-    reload("kong.global")
 
     local helpers = reload("spec.helpers")
 

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -21,10 +21,11 @@ do
 
     misc.setenv("KONG_ROUTER_FLAVOR", flavor)
 
-    reload("kong.global")
-    reload("kong.cache")
-    reload("kong.db")
     reload("kong.db.schema.entities.routes_subschemas")
+    reload("kong.db.schema.entities.routes")
+    reload("kong.db")
+    reload("kong.cache")
+    reload("kong.global")
 
     local helpers = reload("spec.helpers")
 

--- a/spec/internal/module.lua
+++ b/spec/internal/module.lua
@@ -12,7 +12,7 @@ do
 
   -- flavor could be "traditional","traditional_compatible" or "expressions"
   -- changing flavor will change db's schema
-  reload_helpers= function(flavor)
+  reload_helpers = function(flavor)
     _G.kong = {
       configuration = {
         router_flavor = flavor,

--- a/spec/internal/sys.lua
+++ b/spec/internal/sys.lua
@@ -1,0 +1,43 @@
+------------------------------------------------------------------
+-- Collection of utilities to help testing Kong features and plugins.
+--
+-- @copyright Copyright 2016-2022 Kong Inc. All rights reserved.
+-- @license [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+-- @module spec.helpers
+
+
+local ffi = require("ffi")
+
+
+ffi.cdef [[
+  int setenv(const char *name, const char *value, int overwrite);
+  int unsetenv(const char *name);
+]]
+
+
+--- Set an environment variable
+-- @function setenv
+-- @param env (string) name of the environment variable
+-- @param value the value to set
+-- @return true on success, false otherwise
+local function setenv(env, value)
+  assert(type(env) == "string", "env must be a string")
+  assert(type(value) == "string", "value must be a string")
+  return ffi.C.setenv(env, value, 1) == 0
+end
+
+
+--- Unset an environment variable
+-- @function unsetenv
+-- @param env (string) name of the environment variable
+-- @return true on success, false otherwise
+local function unsetenv(env)
+  assert(type(env) == "string", "env must be a string")
+  return ffi.C.unsetenv(env) == 0
+end
+
+
+return {
+  setenv = setenv,
+  unsetenv = unsetenv,
+}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5423

Separate `setenv/unsetenv` from misc to sys, then they will not depend on `intenal.constants`.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
