### PR TITLE
fix(llm): fixes code must be a number error

### DIFF
--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -638,7 +638,7 @@ function _M.pre_request(conf, request_table)
 
   local ok = check_multi_modal(conf, request_table)
   if not ok then
-    return kong.response.exit("multi-modal input is not supported by current provider")
+    return nil, "multi-modal input is not supported by current provider"
   end
 
   -- if enabled AND request type is compatible, capture the input for analytics


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
When I tried to use ai-proxy multimodal input with azure provider, I got a 500 error with a log like:

`[error] 147#0: *5356 [kong] init.lua:427 [ai-proxy] /usr/local/share/lua/5.1/kong/llm/proxy/handler.lua:458: code must be a number, client: 172.18.0.5, server: kong, request: "POST /test8-3-ai-proxy-gpt4o `

I have just recognized the azure provider doesn't support multimodal input yet (well, actually, AOAI supports multimodal input after api-version 2024-06-01).

However, I found that the error handling path is broken and it raises unexpected errors.

This change is to fix to return 400 error properly for multimodal input with unsupported providers.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
