### PR TITLE
fix(response-ratelimiting): fix missing usage headers for upstream

### DIFF
--- a/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
+++ b/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
@@ -1,0 +1,3 @@
+message: "**response-ratelimiting**: Fixed missing upstream headers."
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
+++ b/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
@@ -1,3 +1,3 @@
-message: "**response-ratelimiting**: ensure rate-limiting headers are sent upstream."
+message: "**response-ratelimiting**: fixed an issue in response rate limiting plugin where usage headers ought to be sent to upstream are lost."
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
+++ b/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
@@ -1,3 +1,3 @@
-message: "**response-ratelimiting**: Fixed missing upstream headers."
+message: "**response-ratelimiting**: ensure rate-limiting headers are sent upstream."
 type: bugfix
 scope: Plugin

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -1,6 +1,5 @@
 local policies = require "kong.plugins.response-ratelimiting.policies"
 local timestamp = require "kong.tools.timestamp"
-local pdk_private_rl = require "kong.pdk.private.rate_limiting"
 
 
 local kong = kong
@@ -8,10 +7,6 @@ local next = next
 local pairs = pairs
 local error = error
 local tostring = tostring
-
-
-local pdk_rl_store_response_header = pdk_private_rl.store_response_header
-local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
 
 local EMPTY = require("kong.tools.table").EMPTY
@@ -89,7 +84,6 @@ function _M.execute(conf)
   end
 
   -- Append usage headers to the upstream request. Also checks "block_on_first_violation".
-  local ngx_ctx = ngx.ctx
   for k in pairs(conf.limits) do
     local remaining
     for _, lv in pairs(usage[k]) do
@@ -103,10 +97,8 @@ function _M.execute(conf)
       end
     end
 
-    pdk_rl_store_response_header(ngx_ctx, RATELIMIT_REMAINING .. "-" .. k, remaining)
+    kong.service.request.set_header(RATELIMIT_REMAINING .. "-" .. k, remaining)
   end
-
-  pdk_rl_apply_response_headers(ngx_ctx)
 
   kong.ctx.plugin.usage = usage -- For later use
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
`response-ratelimiting` plugin should send usage headers to upstream server.
But in Kong 3.8, there are no usage headers such as `X-RateLimit-Remaining-Videos: 10` for upstream requests.

In this change, it coming back usage headers for upstream.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
   - It seems to be already there are tests for this feature but are there passing? https://github.com/Kong/kong/blob/master/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua#L505
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #13682 
