### PR TITLE
docs(request-debug): Add special note for request debug

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2264,8 +2264,11 @@
                                  #
                                  # - `X-Kong-Request-Debug-Token`:
                                  #   Token for authenticating the client making the debug
-                                 #   request to prevent abuse. Debug requests originating from loopback
-                                 #   addresses do not require this header.
+                                 #   request to prevent abuse.
+                                 #   ** Note: Debug requests originating from loopback
+                                 #   addresses do not require this header. Deploying Kong behind
+                                 #   other proxies may result in exposing the debug interface to
+                                 #   the public.**
                                  #
 #request_debug_token = <random>  # The Request Debug Token is used in the
                                  # `X-Kong-Request-Debug-Token` header to prevent abuse.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Add a special note for `kong.conf.default` to mention that request debug is not authenticated with `X-Request-Debug-Token` when requests are originating from loopback.

### Checklist

- [N/A] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/7949

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
KAG-5418