### PR TITLE
chore(deps): bump lua-resty-aws to 1.5.4

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-aws.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-aws.yml
@@ -1,0 +1,2 @@
+message: "Bumped lua-resty-aws to 1.5.4, to fix a bug inside region prefix generating"
+type: dependency

--- a/kong-3.9.0-0.rockspec
+++ b/kong-3.9.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-protobuf == 0.5.2",
   "lua-resty-healthcheck == 3.1.0",
   "lua-messagepack == 0.5.4",
-  "lua-resty-aws == 1.5.3",
+  "lua-resty-aws == 1.5.4",
   "lua-resty-openssl == 1.5.1",
   "lua-resty-gcp == 0.0.13",
   "lua-resty-counter == 0.2.1",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

> 1.5.4 (23-Sep-2024)
> fix: fix configure endpoint bug in getRegionPrefix https://github.com/Kong/lua-resty-aws/pull/129


Bump the library to fix a bug inside the underlying region prefix-generating logic. This bug will cause the library to use a wrong generated service endpoint in certain regions.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-6159