### PR TITLE
chore(ci): bump cross build toolchain from 0.8.0 to 0.8.2

### DIFF
--- a/build/toolchain/repositories.bzl
+++ b/build/toolchain/repositories.bzl
@@ -23,40 +23,40 @@ filegroup(
 def toolchain_repositories():
     http_archive(
         name = "aarch64-rhel9-linux-gnu-gcc-11",
-        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.0/aarch64-rhel9-linux-gnu-glibc-2.34-gcc-11.tar.gz",
-        sha256 = "b8f9573cb71d5556aea5a0e13c205786b5817f54273e2efcde71548e9eb297a2",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.2/aarch64-rhel9-linux-gnu-glibc-2.34-gcc-11.tar.gz",
+        sha256 = "bcf38c5221fe96978428e8a7e0255cb8285008378f627dad8ad5a219adf99493",
         strip_prefix = "aarch64-rhel9-linux-gnu",
         build_file_content = build_file_content,
     )
 
     http_archive(
         name = "aarch64-rhel8-linux-gnu-gcc-8",
-        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.0/aarch64-rhel8-linux-gnu-glibc-2.28-gcc-8.tar.gz",
-        sha256 = "f802d09c54f037f78198ff90bf847d822529ec3c6797a922e282453ad44321ef",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.2/aarch64-rhel8-linux-gnu-glibc-2.28-gcc-8.tar.gz",
+        sha256 = "44068f3c1ef59a9f1049c25c975c5180968321dea4f7333f640176abac95bc88",
         strip_prefix = "aarch64-rhel8-linux-gnu",
         build_file_content = build_file_content,
     )
 
     http_archive(
         name = "aarch64-aws2023-linux-gnu-gcc-11",
-        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.0/aarch64-aws2023-linux-gnu-glibc-2.34-gcc-11.tar.gz",
-        sha256 = "4b5ef1511035fcb4b95c543485dc7a72675abcb27c4d2b6a20ac4598f2717a9f",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.2/aarch64-aws2023-linux-gnu-glibc-2.34-gcc-11.tar.gz",
+        sha256 = "3d3cfa475052f841304e3a0d7943827f2a9e4fa0dacafbfb0aaa95921d682459",
         strip_prefix = "aarch64-aws2023-linux-gnu",
         build_file_content = build_file_content,
     )
 
     http_archive(
         name = "aarch64-aws2-linux-gnu-gcc-8",
-        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.0/aarch64-aws2-linux-gnu-glibc-2.26-gcc-8.tar.gz",
-        sha256 = "4bcf3e5448cca6c33f8d6d3e97da0378cfa57b116e5ba6f037e4fd11149ed37f",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.2/aarch64-aws2-linux-gnu-glibc-2.26-gcc-8.tar.gz",
+        sha256 = "73f15ccbe373604f817ee388cb4c1038c304507bdda7c0bc8234650b8ccde4fb",
         strip_prefix = "aarch64-aws2-linux-gnu",
         build_file_content = build_file_content,
     )
 
     http_archive(
         name = "x86_64-aws2-linux-gnu-gcc-8",
-        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.0/x86_64-aws2-linux-gnu-glibc-2.26-gcc-8.tar.gz",
-        sha256 = "bb742616c651900280ac63e926d941fa4bb851e648d011a04a29de62e818e516",
+        url = "https://github.com/Kong/crosstool-ng-actions/releases/download/0.8.2/x86_64-aws2-linux-gnu-glibc-2.26-gcc-8.tar.gz",
+        sha256 = "06b4900bb5922b74e8b4c11e237d45c1d7343ba694be6338c243d5a9d7f353f0",
         strip_prefix = "x86_64-aws2-linux-gnu",
         build_file_content = build_file_content,
     )

--- a/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-24.04-arm64.txt
@@ -190,7 +190,7 @@
   - lua-resty-lmdb
   - ngx_brotli
   - ngx_wasmx_module
-  OpenSSL   : OpenSSL 3.2.1 30 Jan 2024
+  OpenSSL   : OpenSSL 3.2.3 3 Sep 2024
   DWARF     : True
   DWARF - ngx_http_request_t related DWARF DIEs: True
 


### PR DESCRIPTION
Do not set `cherry-pick` label.
It will be cherry-picked in https://github.com/Kong/kong-ee/pull/10226.

KAG-5335

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
