### PR TITLE
chore(build): rename rust target wasm32-wasi to wasm32-wasip1

### DIFF
--- a/.github/actions/build-wasm-test-filters/action.yml
+++ b/.github/actions/build-wasm-test-filters/action.yml
@@ -37,7 +37,7 @@ runs:
         toolchain: stable
         override: true
         components: cargo
-        target: wasm32-wasi
+        target: wasm32-wasip1
 
     - name: cargo build
       if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -50,7 +50,7 @@ runs:
           --manifest-path "${{ env.WASM_FILTER_PATH }}/Cargo.toml"
           --workspace
           --lib
-          --target wasm32-wasi
+          --target wasm32-wasip1
           --release
 
     - name: Save cache
@@ -71,7 +71,7 @@ runs:
       run: |
         ln -sfv \
           --no-target-directory \
-          "${{ env.WASM_FILTER_PATH }}"/target/wasm32-wasi/release \
+          "${{ env.WASM_FILTER_PATH }}"/target/wasm32-wasip1/release \
           "${{ env.WASM_FIXTURE_PATH }}"
 
     - name: debug

--- a/.github/actions/build-wasm-test-filters/action.yml
+++ b/.github/actions/build-wasm-test-filters/action.yml
@@ -47,7 +47,7 @@ runs:
         toolchain: stable
         override: true
         components: cargo
-        target: wasm32-wasip1
+        target: ${{ env.WASM_FILTER_TARGET }}
 
     - name: cargo build
       if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -60,7 +60,7 @@ runs:
           --manifest-path "${{ env.WASM_FILTER_PATH }}/Cargo.toml"
           --workspace
           --lib
-          --target wasm32-wasip1
+          --target "${{ env.WASM_FILTER_TARGET }}"
           --release
 
     - name: Save cache
@@ -81,7 +81,7 @@ runs:
       run: |
         ln -sfv \
           --no-target-directory \
-          "${{ env.WASM_FILTER_PATH }}"/target/wasm32-wasip1/release \
+          "${{ env.WASM_FILTER_PATH }}"/target/"${{ env.WASM_FILTER_TARGET }}"/release \
           "${{ env.WASM_FIXTURE_PATH }}"
 
     - name: debug

--- a/.github/actions/build-wasm-test-filters/action.yml
+++ b/.github/actions/build-wasm-test-filters/action.yml
@@ -14,7 +14,17 @@ runs:
         echo "WASM_FILTER_PATH=$WASM_FILTER_PATH" >> $GITHUB_ENV
         echo "WASM_FIXTURE_PATH=$WASM_FILTER_PATH/build" >> $GITHUB_ENV
         echo "WASM_FILTER_CARGO_LOCK=$WASM_FILTER_PATH/Cargo.lock" >> $GITHUB_ENV
-        echo "WASM_FILTER_CACHE_PREFIX=wasm-test-filters::v3::${{ runner.os }}" >> $GITHUB_ENV
+        echo "WASM_FILTER_TARGET=wasm32-wasip1" >> "$GITHUB_ENV"
+
+    - name: Setup cache key
+      shell: bash
+      env:
+        FILE_HASH: "${{ hashFiles(env.WASM_FILTER_CARGO_LOCK, format('{0}/**/*.rs', env.WASM_FILTER_PATH)) }}"
+        CACHE_VERSION: "4"
+      run: |
+        CACHE_PREFIX="wasm-test-filters::v${CACHE_VERSION}::${{ runner.os }}::${WASM_FILTER_TARGET}"
+        echo "CACHE_PREFIX=${CACHE_PREFIX}" >> $GITHUB_ENV
+        echo "CACHE_KEY=${CACHE_PREFIX}::${FILE_HASH}" >> $GITHUB_ENV
 
     - name: Restore Cache
       uses: actions/cache/restore@v4
@@ -26,8 +36,8 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           ${{ env.WASM_FILTER_PATH }}/target
-        key: ${{ env.WASM_FILTER_CACHE_PREFIX }}::${{ hashFiles(env.WASM_FILTER_CARGO_LOCK, format('{0}/**/*.rs', env.WASM_FILTER_PATH)) }}
-        restore-keys: ${{ env.WASM_FILTER_CACHE_PREFIX }}
+        key: ${{ env.CACHE_KEY }}
+        restore-keys: ${{ env.CACHE_PREFIX }}
 
     - name: Install Rust Toolchain
       if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -64,7 +74,7 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           ${{ env.WASM_FILTER_PATH }}/target
-        key: ${{ env.WASM_FILTER_CACHE_PREFIX }}::${{ hashFiles(env.WASM_FILTER_CARGO_LOCK, format('{0}/**/*.rs', env.WASM_FILTER_PATH)) }}
+        key: ${{ env.CACHE_KEY }}
 
     - name: Create a symlink to the target directory
       shell: bash

--- a/scripts/build-wasm-test-filters.sh
+++ b/scripts/build-wasm-test-filters.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-readonly BUILD_TARGET=wasm32-wasi
+readonly BUILD_TARGET=wasm32-wasip1
 readonly FIXTURE_PATH=${PWD}/spec/fixtures/proxy_wasm_filters
 
 readonly INSTALL_ROOT=${PWD}/bazel-bin/build/${BUILD_NAME:-kong-dev}


### PR DESCRIPTION
See https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html and https://github.com/rust-lang/rust/pull/126662/

Note: this only affects filters built/used for integration tests.