### PR TITLE
feat(api): support official media-type of yaml in /config endpoint

### DIFF
--- a/changelog/unreleased/kong/feat-api-yaml-media-type.yml
+++ b/changelog/unreleased/kong/feat-api-yaml-media-type.yml
@@ -1,0 +1,4 @@
+message: | 
+  **Admin API**: Added support for official YAML media-type (application/yaml) to /config endpoint.
+type: feature
+scope: Admin API

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -260,7 +260,9 @@ function _M.before_filter(self)
   elseif sub(content_type, 1, 16) == "application/json"
       or sub(content_type, 1, 19) == "multipart/form-data"
       or sub(content_type, 1, 33) == "application/x-www-form-urlencoded"
-      or (ACCEPTS_YAML[self.route_name] and sub(content_type, 1,  9) == "text/yaml")
+      or (ACCEPTS_YAML[self.route_name] and
+          (sub(content_type, 1,  16) == "application/yaml" or
+           sub(content_type, 1,  9)  == "text/yaml"))
   then
     return
   end

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -247,7 +247,7 @@ describe("Admin API #off", function()
               - username: "bobby_in_yaml_body"
           ]]),
           headers = {
-            ["Content-Type"] = "text/yaml"
+            ["Content-Type"] = "application/yaml"
           },
         })
 
@@ -3290,7 +3290,7 @@ describe("Admin API #off worker_consistency=eventual", function()
         - name: prometheus
       ]]),
       headers = {
-        ["Content-Type"] = "text/yaml"
+        ["Content-Type"] = "application/yaml"
       },
     })
     assert.response(res).has.status(201)
@@ -3320,7 +3320,7 @@ describe("Admin API #off worker_consistency=eventual", function()
         - name: prometheus
       ]]),
       headers = {
-        ["Content-Type"] = "text/yaml"
+        ["Content-Type"] = "application/yaml"
       },
     })
     assert.response(res).has.status(201)


### PR DESCRIPTION
### Symmary

The https://datatracker.ietf.org/doc/html/rfc9512 specifies the official media-type to YAML as `application/yaml`. We had support for `text/yaml` (which is kept for backward compatibility), but this commit adds support for `application/yaml` as well.

KAG-5474

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

