### PR TITLE
chore(clustering): adjust control plane log level when client closes the connection

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -76,6 +76,11 @@ local function is_timeout(err)
 end
 
 
+local function is_closed(err)
+  return err and sub(err, -6) == "closed"
+end
+
+
 local function extract_dp_cert(cert)
   local expiry_timestamp = cert:get_not_after()
   -- values in cert_details must be strings
@@ -495,7 +500,12 @@ function _M:handle_cp_websocket(cert)
   end
 
   if perr then
-    ngx_log(ngx_ERR, _log_prefix, perr, log_suffix)
+    if is_closed(perr) then
+      ngx_log(ngx_DEBUG, _log_prefix, "data plane closed the connection", log_suffix)
+    else
+      ngx_log(ngx_ERR, _log_prefix, perr, log_suffix)
+    end
+
     return ngx_exit(ngx_ERROR)
   end
 


### PR DESCRIPTION
### Summary

Currently controlplane logs at ERROR level when dataplane closes the connection. This commit lowers the log level to `DEBUG` in this common case.

KAG-5476

### Checklist

- [ ] ~The Pull Request has tests~
- [ ] ~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)~
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~