### PR TITLE
fix(jwt): remove chances to base64 decode a rsa_public_key

### DIFF
--- a/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded
+++ b/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded
@@ -1,3 +1,0 @@
-message: "**jwt**: make sure rsa_public_key will never get base64 decode."
-type: bugfix
-scope: Plugin

--- a/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded
+++ b/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded
@@ -1,0 +1,3 @@
+message: "**jwt**: make sure rsa_public_key will never get base64 decode."
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded.yml
+++ b/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded.yml
@@ -1,3 +1,3 @@
-message: "**jwt**: make sure rsa_public_key will never get base64 decoded."
+message: "**jwt**: ensure `rsa_public_key` isn't base64-decoded."
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded.yml
+++ b/changelog/unreleased/kong/fix-jwt-plugin-rsa-public-key-b64decoded.yml
@@ -1,0 +1,3 @@
+message: "**jwt**: make sure rsa_public_key will never get base64 decoded."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -205,11 +205,17 @@ local function do_authentication(conf)
     return false, unauthorized("Invalid algorithm", www_authenticate_with_error)
   end
 
-  local jwt_secret_value = algorithm ~= nil and algorithm:sub(1, 2) == "HS" and
-                           jwt_secret.secret or jwt_secret.rsa_public_key
+  local is_symmetric_algorithm = algorithm ~= nil and algorithm:sub(1, 2) == "HS" 
+  local jwt_secret_value
 
-  if conf.secret_is_base64 then
-    jwt_secret_value = jwt:base64_decode(jwt_secret_value)
+  if is_symmetric_algorithm and conf.secret_is_base64 then
+    jwt_secret_value = jwt:base64_decode(jwt_secret.secret)
+  elseif is_symmetric_algorithm then
+    jwt_secret_value = jwt_secret.secret
+  else
+    -- rsa_public_key is either nil or a valid plain text pem file, it can't be base64 decoded.
+    -- see #13710
+    jwt_secret_value = jwt_secret.rsa_public_key
   end
 
   if not jwt_secret_value then

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -735,6 +735,23 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("jwt_tests_rsa_consumer_2", body.headers["x-consumer-username"])
         assert.equal(rsa_jwt_secret_2.key, body.headers["x-credential-identifier"])
       end)
+      it("proxies the request if conf.secret is base64", function()
+        PAYLOAD.iss = rsa_jwt_secret_2.key
+        local jwt = jwt_encoder.encode(PAYLOAD, fixtures.rs256_private_key, 'RS256')
+        local authorization = "Bearer " .. jwt
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Authorization"] = authorization,
+            ["Host"]          = "jwt5.test"
+          }
+        })
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal(authorization, body.headers.authorization)
+        assert.equal("jwt_tests_rsa_consumer_2", body.headers["x-consumer-username"])
+        assert.equal(rsa_jwt_secret_2.key, body.headers["x-credential-identifier"])
+      end)
     end)
 
     describe("RS512", function()


### PR DESCRIPTION
### Summary
never base64 decode a rsa public key

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- ~~[ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~~

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #13710
