### PR TITLE
docs(*): update the changelog PR title to include the docs(release) scope

### DIFF
--- a/changelog/create_pr
+++ b/changelog/create_pr
@@ -18,7 +18,7 @@ if [[ -z "${response:+x}" ]] ; then
          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
          -H "X-GitHub-Api-Version: 2022-11-28" \
          "https://api.github.com/repos/${1}/pulls" \
-         -d '{"base":"'"${2}"'", "title":"'"Generate ${3} changelog"'","body":"'"Generate ${3} changelog"'","head":"'"${4}"'"}' \
+         -d '{"base":"'"${2}"'", "title":"'"docs(release): generate ${3} changelog"'","body":"'"Generate ${3} changelog"'","head":"'"${4}"'"}' \
          | jq -r '[.html_url, .head.ref] | @tsv'
 else
     printf 'Updated existing PR: %s\n' "${response}"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The tool didn't include the "docs(release)" scope in the changelog PR title previously and sometime it leads to incorrect commit messages when moderators try to use "squash and merge". This change is to add the scope to the PR title.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5216

<!--- If it fixes an open issue, please link to the issue here. -->

