### PR TITLE
fix(rate-limiting): do not set response headers if  `conf.hide_client_headers` is `true`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ bin/grpcurl
 *.bak
 *.rock
 
-bazel-*
-
 worktree/
 bin/bazel
 bin/h2client
@@ -41,3 +39,8 @@ bin/h2client
 *.wasm
 spec/fixtures/proxy_wasm_filters/build
 spec/fixtures/proxy_wasm_filters/target
+
+# bazel
+bazel-*
+# remove it after migrating from WORKSPACE to Bzlmod
+MODULE.bazel.lock

--- a/changelog/unreleased/kong/fix-rl-plugin-resp-hdr.yml
+++ b/changelog/unreleased/kong/fix-rl-plugin-resp-hdr.yml
@@ -1,0 +1,6 @@
+message: >
+  **Rate-Limiting**: Fixed an issue that caused an
+  HTTP 500 error when `hide_client_headers`
+  is set to `true` and the request exceeds the rate limit.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -192,12 +192,17 @@ function RateLimitingHandler:access(conf)
 
     -- If limit is exceeded, terminate the request
     if stop then
-      pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
-      pdk_rl_apply_response_headers(ngx_ctx)
+      if not conf.hide_client_headers then
+        pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
+        pdk_rl_apply_response_headers(ngx_ctx)
+      end
+
       return kong.response.error(conf.error_code, conf.error_message)
     end
 
-    pdk_rl_apply_response_headers(ngx_ctx)
+    if not conf.hide_client_headers then
+      pdk_rl_apply_response_headers(ngx_ctx)
+    end
   end
 
   if conf.sync_rate ~= SYNC_RATE_REALTIME and conf.policy == "redis" then

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -650,7 +650,22 @@ if limit_by == "ip" then
     })
 
     local res = assert(GET(test_path))
+    assert.res_status(200, res)
 
+    assert.is_nil(res.headers["X-Ratelimit-Limit-Minute"])
+    assert.is_nil(res.headers["X-Ratelimit-Remaining-Minute"])
+    assert.is_nil(res.headers["Ratelimit-Limit"])
+    assert.is_nil(res.headers["Ratelimit-Remaining"])
+    assert.is_nil(res.headers["Ratelimit-Reset"])
+    assert.is_nil(res.headers["Retry-After"])
+
+    -- repeat until get rate-limited
+    helpers.wait_until(function()
+      res = assert(GET(test_path))
+      return res.status == 429, "should be rate-limited (429), got " .. res.status
+    end, 10)
+
+    assert.res_status(429, res)
     assert.is_nil(res.headers["X-Ratelimit-Limit-Minute"])
     assert.is_nil(res.headers["X-Ratelimit-Remaining-Minute"])
     assert.is_nil(res.headers["Ratelimit-Limit"])


### PR DESCRIPTION
# Please **REBASE** and **MERGE**

### Summary

Fix #13715, we should not set the response header if `conf.hide_client_headers` is `true`.


### Checklist

- [X] The Pull Request has tests
- [X] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

#13715, _[KAG-5492]_

[KAG-5492]: https://konghq.atlassian.net/browse/KAG-5492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ