### PR TITLE
docs: describe storage limitations in hybrid and Konnect for ACME plugin

### DIFF
--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -190,7 +190,7 @@ local schema = {
           -- Kong doesn't support multiple certificate chains yet
           {
             cert_type = {
-              description = "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate.",
+              description = "The certificate type to create. The possible values are `rsa` for RSA certificate or `ecc` for EC certificate.",
               type = "string",
               default = 'rsa',
               one_of = CERT_TYPES,
@@ -228,7 +228,7 @@ local schema = {
           },
           {
             storage = {
-              description = "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well.",
+              description = "The backend storage type to use. In DB-less mode and Konnect, `kong` storage is unavailable. In hybrid mode and Konnect, `shm` storage is unavailable. `shm` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `kong`, `redis`, `consul`, or `vault` in production.",
               type = "string",
               default = "shm",
               one_of = STORAGE_TYPES,


### PR DESCRIPTION
### Summary

Updating the ACME plugin's `config.storage` parameter description to:
* Mention that shm is not supported in hybrid, and kong storage is not supported in Konnect.
* Remove the line about supported backends, as those as listed in the `one_of` field in the schema.

Resolves the last piece of https://konghq.atlassian.net/browse/DOCU-2910. Issue recently came up with a user, see link to slack convo in ticket.

### Checklist

- [ N/ A ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/7996


