### PR TITLE
fix(core): always pass `ngx.ctx` to `log_init_worker_errors`

### DIFF
--- a/changelog/unreleased/kong/fix-core-pass-ctx-to-log-init-worker-errors.yml
+++ b/changelog/unreleased/kong/fix-core-pass-ctx-to-log-init-worker-errors.yml
@@ -1,0 +1,4 @@
+message: |
+   Fix to always pass `ngx.ctx` to `log_init_worker_errors` as otherwise it may runtime crash.
+type: bugfix
+scope: Core

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1952,10 +1952,12 @@ end
 Kong.status_header_filter = Kong.admin_header_filter
 
 
-function Kong.serve_cluster_listener(options)
-  log_init_worker_errors()
+function Kong.serve_cluster_listener()
+  local ctx = ngx.ctx
 
-  ngx.ctx.KONG_PHASE = PHASES.cluster_listener
+  log_init_worker_errors(ctx)
+
+  ctx.KONG_PHASE = PHASES.cluster_listener
 
   return kong.clustering:handle_cp_websocket()
 end
@@ -1966,10 +1968,12 @@ function Kong.stream_api()
 end
 
 
-function Kong.serve_cluster_rpc_listener(options)
-  log_init_worker_errors()
+function Kong.serve_cluster_rpc_listener()
+  local ctx = ngx.ctx
 
-  ngx.ctx.KONG_PHASE = PHASES.cluster_listener
+  log_init_worker_errors(ctx)
+
+  ctx.KONG_PHASE = PHASES.cluster_listener
 
   return kong.rpc:handle_websocket()
 end


### PR DESCRIPTION
### Summary

Just saw this on my local machine when started to kill -9 worker processes on a control plane. So just a tiny fix here. Not sure how easy this is to test, but it is quite an obvious fix and bug. Without this the `log_init_worker_errors` may runtime crash.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE