### PR TITLE
fix(incremental sync): fix incorrect return value from Workspace:select_by_name

### DIFF
--- a/kong/db/dao/workspaces.lua
+++ b/kong/db/dao/workspaces.lua
@@ -28,7 +28,8 @@ end
 function Workspaces:select_by_name(key, options)
   if kong.configuration.database == "off" and key == "default" then
     -- it should be a table, not a single string
-    return  { id = lmdb.get(DECLARATIVE_DEFAULT_WORKSPACE_KEY), }
+    local id = lmdb.get(DECLARATIVE_DEFAULT_WORKSPACE_KEY)
+    return id and { id = lmdb.get(DECLARATIVE_DEFAULT_WORKSPACE_KEY), } or nil
   end
 
   return self.super.select_by_name(self, key, options)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

If we could not get default id from lmdb, it should return nil from select_by_name API rather than returning empty table {}

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
