### PR TITLE
tests(helpers): fixed incorrect conf.database setting in get_db_utils

### DIFF
--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -277,7 +277,7 @@ end
 -- }
 local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
   strategy = strategy or conf.database
-  conf.database = strategy
+  conf.database = strategy  -- overwrite kong.configuration.database
 
   if tables ~= nil and type(tables) ~= "table" then
     error("arg #2 must be a list of tables to truncate", 2)

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -277,6 +277,8 @@ end
 -- }
 local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
   strategy = strategy or conf.database
+  conf.database = strategy
+
   if tables ~= nil and type(tables) ~= "table" then
     error("arg #2 must be a list of tables to truncate", 2)
   end
@@ -312,12 +314,6 @@ local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
 
   if not skip_migrations then
     bootstrap_database(db)
-  end
-
-  do
-    local database = conf.database
-    conf.database = strategy
-    conf.database = database
   end
 
   db:truncate("plugins")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Original function get_db_utils does not set the right value of `conf.database(kong.confiuration.database)` from its first parameter `strategy`.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
