### PR TITLE
fix(incremental): initial default workspace for importing declarative config

### DIFF
--- a/kong/db/dao/workspaces.lua
+++ b/kong/db/dao/workspaces.lua
@@ -5,7 +5,6 @@ local constants = require("kong.constants")
 local lmdb = require("resty.lmdb")
 
 
-local DECLARATIVE_DEFAULT_WORKSPACE_ID = constants.DECLARATIVE_DEFAULT_WORKSPACE_ID
 local DECLARATIVE_DEFAULT_WORKSPACE_KEY = constants.DECLARATIVE_DEFAULT_WORKSPACE_KEY
 
 
@@ -28,8 +27,12 @@ end
 
 function Workspaces:select_by_name(key, options)
   if kong.configuration.database == "off" and key == "default" then
+    -- We can ensure that when starting in dbless mode, lmdb will by default
+    -- insert a 'default' workspace. If this Kong is a dataplane, it will later
+    -- synchronize the configuration from the CP and overwrite this default one.
+    --
     -- it should be a table, not a single string
-    return { id = lmdb.get(DECLARATIVE_DEFAULT_WORKSPACE_KEY) or DECLARATIVE_DEFAULT_WORKSPACE_ID, }
+    return { id = lmdb.get(DECLARATIVE_DEFAULT_WORKSPACE_KEY), }
   end
 
   return self.super.select_by_name(self, key, options)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
