### PR TITLE
doc(changelog): fix grammar in lua-resty-lmdb update

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-lmdb.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-lmdb.yml
@@ -1,3 +1,3 @@
-message: Bumped lua-resty-lmdb to 1.5.0, introducing a new feature that adds page_size parameter to allow overriding page size from caller side
+message: Bumped lua-resty-lmdb to 1.5.0. Added page_size parameter to allow overriding page size from caller side.
 type: dependency
 scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Fixed grammar of lua-resty-lmdb bumping changelog entry.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5568
