### PR TITLE
chore(release): use docker image to facilitate update-copyright step

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:latest AS expat-build
+
+ARG expat_version=2.6.3
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /workspace
+
+RUN apt update \
+    && apt install -y curl
+
+RUN curl -L https://github.com/libexpat/libexpat/releases/download/R_${expat_version//./_}/expat-${expat_version}.tar.gz | tar -xz \
+    && cd expat-${expat_version} \
+    && apt install -y build-essential \
+    && ./configure --prefix=/expat_lib \
+    && make && make install
+
+FROM ubuntu:latest
+
+COPY --from=expat-build /expat_lib /expat_lib
+
+RUN apt update && apt install -y curl libssl-dev libyaml-dev lua5.4 luarocks
+
+WORKDIR /workspace
+CMD ["/bin/bash", "-c", "OPENSSL_DIR=/usr EXPAT_DIR=/expat_lib scripts/update-copyright"]
+
+VOLUME /workspace

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -120,7 +120,9 @@ function commit_changelog() {
 function update_copyright() {
   version=$1
 
-  if ! "$scripts_folder/update-copyright"
+  PDIR=$(dirname "$scripts_folder")
+
+  if ! (docker build -t kong/update-copyright ${scripts_folder} && docker run -v ${PDIR}:/workspace --rm kong/update-copyright)
   then
     die "Could not update copyright file. Check logs for missing licenses, add hardcoded ones if needed"
   fi


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It was not easy to install and figure out all the dependencies for the update-copyright script. This PR aims to install all the required dependencies into a docker image and use it to execute the update-copyright script.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5297

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
