### PR TITLE
fix(incremental): dont delete old entity from LMDB if we clear it already

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -219,7 +219,8 @@ local function do_sync()
 
   local t = txn.begin(512)
 
-  if ns_delta.wipe then
+  local wipe = ns_delta.wipe
+  if wipe then
     t:db_drop(false)
   end
 
@@ -245,9 +246,12 @@ local function do_sync()
       local crud_event_type = "create"
 
       if old_entity then
-        local res, err = delete_entity_for_txn(t, delta_type, old_entity, nil)
-        if not res then
-          return nil, err
+        -- If we need to wipe lmdb, we don't need to not delete it from lmdb.
+        if not wipe then
+          local res, err = delete_entity_for_txn(t, delta_type, old_entity, nil)
+          if not res then
+            return nil, err
+          end
         end
 
         crud_event_type = "update"
@@ -267,7 +271,8 @@ local function do_sync()
         return nil, err
       end
 
-      if old_entity then
+      -- If we need to wipe lmdb, we don't need to delete old entity.
+      if old_entity and not wipe then
         local res, err = delete_entity_for_txn(t, delta_type, old_entity, nil)
         if not res then
           return nil, err
@@ -292,7 +297,7 @@ local function do_sync()
     return nil, err
   end
 
-  if ns_delta.wipe then
+  if wipe then
     kong.core_cache:purge()
     kong.cache:purge()
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

fix this case failure:  FAIL spec/02-integration/09-hybrid_mode/01-sync_spec.lua:146: CP/DP communication #postgres inc_sync=on sync works proxy on DP follows CP config.

DP receive full sync deltas, but one of this operation needs it to delete a key from the lmdb, but this key does not exist in lmdb if the detals has wipe flag, so it trigger error: `2024/10/15 14:53:05 [error] 31827#0: *8 [lua] rpc.lua:329: unable to create worker mutex and sync: MDB_NOTFOUND: No matching key/data pair found`

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5551
