### PR TITLE
chore: added replaced_with path in otel plugin schema

### DIFF
--- a/changelog/unreleased/kong/otel-plugin-schema-update.yml
+++ b/changelog/unreleased/kong/otel-plugin-schema-update.yml
@@ -1,0 +1,3 @@
+message: Added replaced_with in deprecation fields to show the new config path to use instead of the deprecated fields in the schema
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/otel-plugin-schema-update.yml
+++ b/changelog/unreleased/kong/otel-plugin-schema-update.yml
@@ -1,5 +1,5 @@
 message: |
-  Added "replaced_with" in deprecation fields to show the new config path to use instead 
+  Added "replaced_with" in deprecation fields to show the new config path to use instead
   of the deprecated fields in the opentelemetry plugin schema.
 type: bugfix
 scope: Plugin

--- a/changelog/unreleased/kong/otel-plugin-schema-update.yml
+++ b/changelog/unreleased/kong/otel-plugin-schema-update.yml
@@ -1,3 +1,5 @@
-message: Added replaced_with in deprecation fields to show the new config path to use instead of the deprecated fields in the schema
+message: |
+  Added "replaced_with" in deprecation fields to show the new config path to use instead 
+  of the deprecated fields in the opentelemetry plugin schema.
 type: bugfix
 scope: Plugin

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -104,6 +104,7 @@ return {
           endpoint = typedefs.url {
             referenceable = true,
             deprecation = {
+              replaced_with = { { path = { 'traces_endpoint' } } },
               message = "OpenTelemetry: config.endpoint is deprecated, please use config.traces_endpoint instead",
               removal_in_version = "4.0", },
             func = function(value)

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -808,7 +808,7 @@ for _, strategy in helpers.each_strategy() do
         }, { "opentelemetry" }))
 
         setup_instrumentations("all", {
-          endpoint = "{vault://env/test_otel_endpoint}",
+          traces_endpoint = "{vault://env/test_otel_endpoint}",
           headers = {
             ["X-Access-Key"] = "{vault://env/test_otel_access_key}",
             ["X-Access-Secret"] = "{vault://env/test_otel_access_secret}",


### PR DESCRIPTION
### Summary
Opentelemetery plugin schema has a deprecated field endpoint, that is now replaced with "traces_endpoint". The schema is missing information which can be used by other tools, like deck to understand the new field, that should be used in place of the deprecated one. This change adds the path as per the new convention of using replaced_with path.

With this change, otel plugin schema would show the necessary replacement paths for shorthand_fields that are deprecated.

### Checklist

- [NA] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [NA] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE - NA

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [deck #1404](https://github.com/Kong/deck/issues/1404)
Corresponding PR: https://github.com/Kong/go-kong/pull/472
