### PR TITLE
Fix: Replace missing systemd Unit File (2.8)

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -31,6 +31,8 @@ contents:
   dst: /etc/kong
 - src: bin/kong
   dst: /usr/local/bin/kong
+- src: build/package/kong.service
+  dst: /lib/systemd/system/kong.service
 - src: build/package/kong.logrotate
   dst: /etc/kong/kong.logrotate
 scripts:

--- a/changelog/unreleased/kong/fix_service_file.yml
+++ b/changelog/unreleased/kong/fix_service_file.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where the systemd service unit file was missing from packages."
+type: bugfix
+scope: Core

--- a/scripts/explain_manifest/fixtures/alpine-amd64.txt
+++ b/scripts/explain_manifest/fixtures/alpine-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
+++ b/scripts/explain_manifest/fixtures/amazonlinux-2023-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/debian-11-amd64.txt
+++ b/scripts/explain_manifest/fixtures/debian-11-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/el8-amd64.txt
+++ b/scripts/explain_manifest/fixtures/el8-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-20.04-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
+++ b/scripts/explain_manifest/fixtures/ubuntu-22.04-amd64.txt
@@ -1,5 +1,7 @@
 - Path      : /etc/kong/kong.logrotate
 
+- Path      : /lib/systemd/system/kong.service
+
 - Path      : /usr/local/kong/include/google
   Type      : directory
 

--- a/scripts/explain_manifest/suites.py
+++ b/scripts/explain_manifest/suites.py
@@ -16,6 +16,8 @@ def common_suites(expect, libxcrypt_no_obsolete_api: bool = False):
 
     expect("/etc/kong/kong.logrotate", "includes logrotate config").exists()
 
+    expect("/lib/systemd/system/kong.service", "includes systemd unit file").exists()
+
     expect("/usr/local/kong/include/openssl/**.h", "includes OpenSSL headers").exists()
 
     # binary correctness


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR fixes an issue where the systemd unit file, `kong.service`, had gone missing from packages produced from the 2.8 branch(es).

### Checklist

- [na] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [na] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-5648]_


[KAG-5648]: https://konghq.atlassian.net/browse/KAG-5648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ