### PR TITLE
chore(build): fix exec script of LuaRocks on macOS

### DIFF
--- a/build/luarocks/templates/luarocks_exec.sh
+++ b/build/luarocks/templates/luarocks_exec.sh
@@ -34,13 +34,26 @@ OPENSSL_DIR=$root_path/$openssl_path
 # but the linker expects `libexpat.so` to be present.
 # So we create a symlink to the actual file
 # if it doesn't exist.
-if ! test -e $EXPAT_DIR/lib/libexpat.so; then
-    so=$(ls $EXPAT_DIR/lib/libexpat.*)
-    if [[ -z $so ]]; then
-        echo "No expat library found in $EXPAT_DIR/lib"
-        exit 1
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS uses `.dylib``
+    if ! test -e $EXPAT_DIR/lib/libexpat.dylib; then
+        dylib=$(ls $EXPAT_DIR/lib/libexpat.*)
+        if [[ -z $dylib ]]; then
+            echo "No expat library found in $EXPAT_DIR/lib"
+            exit 1
+        fi
+        ln -s $dylib $EXPAT_DIR/lib/libexpat.dylib
     fi
-    ln -s $so $EXPAT_DIR/lib/libexpat.so
+else
+    # Linux uses `.so``
+    if ! test -e $EXPAT_DIR/lib/libexpat.so; then
+        so=$(ls $EXPAT_DIR/lib/libexpat.*)
+        if [[ -z $so ]]; then
+            echo "No expat library found in $EXPAT_DIR/lib"
+            exit 1
+        fi
+        ln -s $so $EXPAT_DIR/lib/libexpat.so
+    fi
 fi
 
 # we use system libyaml on macos


### PR DESCRIPTION
### Summary

Create symbolic links against `.dylib` instead of `.so` on macOS.

Cherry-pick to EE: https://github.com/Kong/kong-ee/pull/10522

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-5571]_


[KAG-5571]: https://konghq.atlassian.net/browse/KAG-5571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ