### PR TITLE
chore(deps): bump `lua-resty-ljsonschema` to 1.2.0

### DIFF
--- a/changelog/unreleased/kong/bump-lua-resty-ljsonschema.yml
+++ b/changelog/unreleased/kong/bump-lua-resty-ljsonschema.yml
@@ -1,0 +1,2 @@
+message: "Bumped lua-resty-ljsonschema to 1.2.0, adding support for `null` as a valid option in `enum` types and properly calculation of utf8 string length instead of byte count"
+type: dependency

--- a/kong-3.9.0-0.rockspec
+++ b/kong-3.9.0-0.rockspec
@@ -42,7 +42,7 @@ dependencies = {
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.7",
   "lpeg == 1.1.0",
-  "lua-resty-ljsonschema == 1.1.6-2",
+  "lua-resty-ljsonschema == 1.2.0-1",
   "lua-resty-snappy == 1.0-1",
   "lua-resty-ada == 1.1.0",
 }

--- a/kong-3.9.0-0.rockspec
+++ b/kong-3.9.0-0.rockspec
@@ -42,7 +42,7 @@ dependencies = {
   "lua-resty-session == 4.0.5",
   "lua-resty-timer-ng == 0.2.7",
   "lpeg == 1.1.0",
-  "lua-resty-ljsonschema == 1.2.0-1",
+  "lua-resty-ljsonschema == 1.2.0",
   "lua-resty-snappy == 1.0-1",
   "lua-resty-ada == 1.1.0",
 }


### PR DESCRIPTION
### Summary
Changelog for ljsonschema-1.2.0:

> 1.2.0 (23-Oct-2024)
> fix: properly calculate utf8 sequence lengths instead of byte count (https://github.com/Tieske/lua-resty-ljsonschema/pull/30)
> fix: support null as an option in enum types (https://github.com/Tieske/lua-resty-ljsonschema/pull/26)
> chore: update the test suite to a more recent version; 23.2.0 (https://github.com/Tieske/lua-resty-ljsonschema/pull/27)
> chore: list all disabled tests as pending (to make them visible) (https://github.com/Tieske/lua-resty-ljsonschema/pull/27)
> fix: fix numeric overflow (new case from updated test-suite) (https://github.com/Tieske/lua-resty-ljsonschema/pull/27)
> chore: restructure documentation and more repo-maintenance (https://github.com/Tieske/lua-resty-ljsonschema/pull/25)


### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-5870, FTI-6171
