### PR TITLE
fix(loggly): fix the error caused by the missing /bin/hostname

### DIFF
--- a/changelog/unreleased/kong/fix-loggly-hostname-notfound.yml
+++ b/changelog/unreleased/kong/fix-loggly-hostname-notfound.yml
@@ -1,2 +1,2 @@
-message: "**loggly**: fixed the error caused by the missing `/bin/hostname`."
+message: "**Loggly**: Fixed an issue where `/bin/hostname` missing caused an error warning on startup."
 type: bugfix

--- a/changelog/unreleased/kong/fix-loggly-hostname-notfound.yml
+++ b/changelog/unreleased/kong/fix-loggly-hostname-notfound.yml
@@ -1,0 +1,2 @@
+message: "**loggly**: fixed the error caused by the missing `/bin/hostname`."
+type: bugfix

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -57,7 +57,9 @@ end
 
 
 local function new(self)
-  local _NODE = {}
+  local _NODE = {
+    hostname = nil,
+  }
 
 
   ---
@@ -247,20 +249,23 @@ local function new(self)
   -- @usage
   -- local hostname = kong.node.get_hostname()
   function _NODE.get_hostname()
-    local SIZE = 253 -- max number of chars for a hostname
+    if not _NODE.hostname then
+      local SIZE = 253 -- max number of chars for a hostname
 
-    local buf = ffi_new("unsigned char[?]", SIZE)
-    local res = C.gethostname(buf, SIZE)
+      local buf = ffi_new("unsigned char[?]", SIZE)
+      local res = C.gethostname(buf, SIZE)
 
-    if res ~= 0 then
-      -- Return an empty string "" instead of nil and error message,
-      -- because strerror is not thread-safe and the behavior of strerror_r
-      -- is inconsistent across different systems.
-      return ""
+      if res ~= 0 then
+        -- Return an empty string "" instead of nil and error message,
+        -- because strerror is not thread-safe and the behavior of strerror_r
+        -- is inconsistent across different systems.
+        return ""
+      end
+
+      _NODE.hostname = gsub(ffi_str(buf, SIZE), "%z+$", "")
     end
 
-    local hostname = ffi_str(buf, SIZE)
-    return gsub(hostname, "%z+$", "")
+    return _NODE.hostname
   end
 
 

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -252,15 +252,15 @@ local function new(self)
     local buf = ffi_new("unsigned char[?]", SIZE)
     local res = C.gethostname(buf, SIZE)
 
-    if res == 0 then
-      local hostname = ffi_str(buf, SIZE)
-      return gsub(hostname, "%z+$", "")
+    if res ~= 0 then
+      -- Return an empty string "" instead of nil and error message,
+      -- because strerror is not thread-safe and the behavior of strerror_r
+      -- is inconsistent across different systems.
+      return ""
     end
 
-    local f = io.popen("/bin/hostname")
-    local hostname = f:read("*a") or ""
-    f:close()
-    return gsub(hostname, "\n$", "")
+    local hostname = ffi_str(buf, SIZE)
+    return gsub(hostname, "%z+$", "")
   end
 
 

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -1,6 +1,7 @@
 local cjson = require "cjson"
 local sandbox = require "kong.tools.sandbox".sandbox
 local kong_meta = require "kong.meta"
+local get_host_name = kong.node.get_hostname
 
 
 local kong = kong
@@ -14,15 +15,6 @@ local insert = table.insert
 
 
 local sandbox_opts = { env = { kong = kong, ngx = ngx } }
-
-
-local function get_host_name()
-  local f = io.popen("/bin/hostname")
-  local hostname = f:read("*a") or ""
-  f:close()
-  hostname = string.gsub(hostname, "\n$", "")
-  return hostname
-end
 
 
 local HOSTNAME = get_host_name()


### PR DESCRIPTION
### Summary

1. Refactor the PDK's `get_hostname` to use only the `gethostname` system call to retrieve the hostname.
2. Loggly uses the PDK's `get_hostname` to retrieve the hostname.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6046
