### PR TITLE
fix(incremental sync): added comment for 2 times do_sync

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -334,10 +334,9 @@ local function sync_handler(premature)
   end
 
   local res, err = concurrency.with_worker_mutex(SYNC_MUTEX_OPTS, function()
-    -- must be 2 times for retrieving the latest delta version and latest deltas
-    --
-    -- The second call to do_sync() on `kong.sync.v2.get_delta` retrieves the
-    -- latest delta version directly, without requiring additional API calls.
+    -- `do_sync` is run twice in a row to report back new version number
+    -- to CP quickly. `kong.sync.v2.get_delta` is used for both pulling delta
+    -- as well as status reporting.
     for _ = 1, 2 do
       local ok, err = do_sync()
       if not ok then

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -334,9 +334,9 @@ local function sync_handler(premature)
   end
 
   local res, err = concurrency.with_worker_mutex(SYNC_MUTEX_OPTS, function()
-    -- `do_sync` is run twice in a row to report back new version number
-    -- to CP quickly. `kong.sync.v2.get_delta` is used for both pulling delta
-    -- as well as status reporting.
+    -- `do_sync()` is run twice in a row to report back new version number
+    -- to CP quickly after sync. (`kong.sync.v2.get_delta` is used for both pulling delta
+    -- as well as status reporting)
     for _ = 1, 2 do
       local ok, err = do_sync()
       if not ok then

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -334,7 +334,7 @@ local function sync_handler(premature)
   end
 
   local res, err = concurrency.with_worker_mutex(SYNC_MUTEX_OPTS, function()
-    -- here must be 2 times
+    -- must be 2 times for retrieving the latest delta version and latest deltas
     for _ = 1, 2 do
       local ok, err = do_sync()
       if not ok then

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -335,6 +335,9 @@ local function sync_handler(premature)
 
   local res, err = concurrency.with_worker_mutex(SYNC_MUTEX_OPTS, function()
     -- must be 2 times for retrieving the latest delta version and latest deltas
+    --
+    -- The second call to do_sync() on `kong.sync.v2.get_delta` retrieves the
+    -- latest delta version directly, without requiring additional API calls.
     for _ = 1, 2 do
       local ok, err = do_sync()
       if not ok then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Added comment for why we need to call synchronize the detlas twice.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5589
