### PR TITLE
fix(clustering): CP should support both v1 and v2

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -884,12 +884,21 @@ function Kong.init_worker()
     kong.cache:invalidate_local(constants.ADMIN_GUI_KCONFIG_CACHE_KEY)
   end
 
-  if process.type() == "privileged agent" and not kong.sync then
-    if kong.clustering then
-      -- full sync cp/dp
+  if kong.clustering then
+    -- full sync dp
+    
+    local is_dp_full_sync_agent = process.type() == "privileged agent" and not kong.sync
+
+    if is_control_plane(kong.configuration) or -- CP needs to support both full and incremental sync
+      is_dp_full_sync_agent -- full sync is only enabled for DP if incremental sync is disabled
+    then
       kong.clustering:init_worker()
     end
-    return
+  
+    -- DP full sync agent skips the rest of the init_worker
+    if is_dp_full_sync_agent then
+      return
+    end
   end
 
   kong.vault.init_worker()
@@ -987,12 +996,6 @@ function Kong.init_worker()
   end
 
   if kong.clustering then
-
-    -- full sync cp/dp
-    if not kong.sync then
-      kong.clustering:init_worker()
-    end
-
     -- rpc and incremental sync
     if kong.rpc and is_http_module then
 

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -12,8 +12,7 @@ local uuid = require("kong.tools.uuid").uuid
 local KEY_AUTH_PLUGIN
 
 
---- XXX FIXME: enable inc_sync = on
-for _, inc_sync in ipairs { "off"  } do
+for _, inc_sync in ipairs { "on", "off"  } do
 for _, strategy in helpers.each_strategy() do
 
 describe("CP/DP communication #" .. strategy .. " inc_sync=" .. inc_sync, function()
@@ -624,7 +623,11 @@ describe("CP/DP #version check #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP config sync #" .. strategy, function()
+--- XXX FIXME: enable inc_sync = on
+-- skips the rest of the tests. We will fix them in a follow-up PR
+local skip_inc_sync = inc_sync == "on" and pending or describe
+
+skip_inc_sync("CP/DP config sync #" .. strategy, function()
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
 
@@ -736,7 +739,7 @@ describe("CP/DP config sync #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP labels #" .. strategy, function()
+skip_inc_sync("CP/DP labels #" .. strategy, function()
 
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
@@ -799,7 +802,7 @@ describe("CP/DP labels #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP cert details(cluster_mtls = shared) #" .. strategy, function()
+skip_inc_sync("CP/DP cert details(cluster_mtls = shared) #" .. strategy, function()
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
 
@@ -856,7 +859,7 @@ describe("CP/DP cert details(cluster_mtls = shared) #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP cert details(cluster_mtls = pki) #" .. strategy, function()
+skip_inc_sync("CP/DP cert details(cluster_mtls = pki) #" .. strategy, function()
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
 


### PR DESCRIPTION
### Summary

Let's fix the rest of the tests in another PR.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-5551