### PR TITLE
tests(db): Always do schema reset in `get_db_utils` 

### DIFF
--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -11,11 +11,6 @@ for _, strategy in helpers.each_strategy() do
       local _
       _, db = helpers.get_db_utils(strategy)
 
-      -- This is a special case, where some DB states could be corrupted by DB truncation in `lazy_teardown()`.
-      -- We manually bootstrap the DB here to ensure the creation of a table is done correctly
-      db:schema_reset()
-      helpers.bootstrap_database(db)
-
       _G.kong.db = db
       assert(helpers.start_kong({
         database   = strategy,

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -214,16 +214,14 @@ local function truncate_tables(db, tables)
 end
 
 
-local function bootstrap_database(db, reset)
+local function bootstrap_database(db)
+  -- Drop all schema and data
+  assert(db:schema_reset())
   local schema_state = assert(db:schema_state())
-
-  if reset then
-    assert(db:schema_reset())
-    schema_state = assert(db:schema_state())
-  end
 
   if schema_state.needs_bootstrap then
     assert(db:schema_bootstrap())
+    schema_state = assert(db:schema_state())
   end
 
   if schema_state.new_migrations then
@@ -281,7 +279,7 @@ end
 --   route = { id = route1.id },
 --   config = {},
 -- }
-local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations, reset_schema)
+local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
   strategy = strategy or conf.database
   conf.database = strategy  -- overwrite kong.configuration.database
 
@@ -319,7 +317,7 @@ local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations, 
   assert(db:init_connector())
 
   if not skip_migrations then
-    bootstrap_database(db, reset_schema)
+    bootstrap_database(db)
   end
 
   db:truncate("plugins")

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -215,8 +215,6 @@ end
 
 
 local function bootstrap_database(db)
-  -- Drop all schema and data
-  assert(db:schema_reset())
   local schema_state = assert(db:schema_state())
 
   if schema_state.needs_bootstrap then
@@ -317,6 +315,8 @@ local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
   assert(db:init_connector())
 
   if not skip_migrations then
+    -- Drop all schema and data
+    assert(db:schema_reset())
     bootstrap_database(db)
   end
 

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -214,8 +214,14 @@ local function truncate_tables(db, tables)
 end
 
 
-local function bootstrap_database(db)
+local function bootstrap_database(db, reset)
   local schema_state = assert(db:schema_state())
+
+  if reset then
+    assert(db:schema_reset())
+    schema_state = assert(db:schema_state())
+  end
+
   if schema_state.needs_bootstrap then
     assert(db:schema_bootstrap())
   end
@@ -275,7 +281,7 @@ end
 --   route = { id = route1.id },
 --   config = {},
 -- }
-local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
+local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations, reset_schema)
   strategy = strategy or conf.database
   conf.database = strategy  -- overwrite kong.configuration.database
 
@@ -313,7 +319,7 @@ local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
   assert(db:init_connector())
 
   if not skip_migrations then
-    bootstrap_database(db)
+    bootstrap_database(db, reset_schema)
   end
 
   db:truncate("plugins")


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
We have some tests that polluted schema after run.
This is to guarantee no leftover dirty schema for the follow-up tests which may not tolerate that.

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-5040
