### PR TITLE
refactor(clustering/rpc): code clean of full sync in rpc

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -159,15 +159,31 @@ function _M:init_dp(manager)
       return nil, "default namespace does not exist inside params"
     end
 
+    ngx_log(ngx_INFO,
+            "[kong.sync.v2] notify_new_version: ", node_id,
+            ", new_version of CP is ", default_new_version)
+
     local version = default_new_version.new_version
     if not version then
       return nil, "'new_version' key does not exist"
     end
 
     local lmdb_ver = tonumber(declarative.get_current_hash()) or 0
+
+    ngx_log(ngx_INFO,
+            "[kong.sync.v2] notify_new_version: ", node_id,
+            ", current_version is ", lmdb_ver)
+
     if lmdb_ver < version then
+      ngx_log(ngx_INFO,
+              "[kong.sync.v2] notify_new_version: ", node_id,
+              ", start a sync.")
       return self:sync_once()
     end
+
+    ngx_log(ngx_INFO,
+            "[kong.sync.v2] notify_new_version: ", node_id,
+            ", dose not start a sync.")
 
     return true
   end)

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -46,6 +46,16 @@ function _M:init_cp(manager)
     return { default = { deltas = res, wipe = wipe, }, }
   end
 
+  local function full_sync_result()
+    local deltas, err = declarative.export_config_sync()
+    if not deltas then
+      return nil, err
+    end
+
+    -- wipe dp lmdb, full sync
+    return gen_delta_result(deltas, true)
+  end
+
   -- CP
   -- Method: kong.sync.v2.get_delta
   -- Params: versions: list of current versions of the database
@@ -97,14 +107,7 @@ function _M:init_cp(manager)
               ", current_version: ", default_namespace_version,
               ", forcing a full sync")
 
-
-      local deltas, err = declarative.export_config_sync()
-      if not deltas then
-        return nil, err
-      end
-
-      -- wipe dp lmdb, full sync
-      return gen_delta_result(deltas, true)
+      return full_sync_result()
     end
 
     local res, err = self.strategy:get_delta(default_namespace_version)
@@ -135,13 +138,7 @@ function _M:init_cp(manager)
             ", current_version: ", default_namespace_version,
             ", forcing a full sync")
 
-    local deltas, err = declarative.export_config_sync()
-    if not deltas then
-      return nil, err
-    end
-
-    -- wipe dp lmdb, full sync
-    return gen_delta_result(deltas, true)
+    return full_sync_result()
   end)
 end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -381,6 +381,8 @@ end
 
 
 function _M:sync_once(delay)
+  --- XXX TODO: check rpc connection is ready
+
   return start_sync_timer(ngx.timer.at, delay or 0)
 end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -159,31 +159,15 @@ function _M:init_dp(manager)
       return nil, "default namespace does not exist inside params"
     end
 
-    ngx_log(ngx_INFO,
-            "[kong.sync.v2] notify_new_version: ", node_id,
-            ", new_version of CP is ", default_new_version)
-
     local version = default_new_version.new_version
     if not version then
       return nil, "'new_version' key does not exist"
     end
 
     local lmdb_ver = tonumber(declarative.get_current_hash()) or 0
-
-    ngx_log(ngx_INFO,
-            "[kong.sync.v2] notify_new_version: ", node_id,
-            ", current_version is ", lmdb_ver)
-
     if lmdb_ver < version then
-      ngx_log(ngx_INFO,
-              "[kong.sync.v2] notify_new_version: ", node_id,
-              ", start a sync.")
       return self:sync_once()
     end
-
-    ngx_log(ngx_INFO,
-            "[kong.sync.v2] notify_new_version: ", node_id,
-            ", dose not start a sync.")
 
     return true
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5728

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
