### PR TITLE
fix(dbless): construct right pk string for entity with multiple primary keys

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -41,11 +41,6 @@ local foreign_children = {}
 
 do
   local tb_nkeys = require("table.nkeys")
-  local tb_clear = require("table.clear")
-
-  -- We couldn't use "kong.tools.request_aware_table" as an upvalue table here
-  -- because its :clear() couldn't actually clear its contents in debug mode.
-  local CACHED_OUT = {}
 
   -- Generate a stable and unique string key from primary key defined inside
   -- schema, supports both non-composite and composite primary keys
@@ -57,10 +52,11 @@ do
       return tostring(object[primary_key[1]])
     end
 
-    tb_clear(CACHED_OUT)
+    local CACHED_OUT = {}
 
     -- The logic comes from get_cache_key_value(), which uses `id` directly to
     -- extract foreign key.
+    -- TODO: extract primary key recursively using pk_string(), KAG-5750
     for i = 1, count do
       local k = primary_key[i]
       local v = object[k]

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -41,7 +41,7 @@ local foreign_children = {}
 
 do
   local tb_nkeys = require("table.nkeys")
-  local tb_pool = require("tablepool")
+  local buffer = require("string.buffer")
 
   -- Generate a stable and unique string key from primary key defined inside
   -- schema, supports both non-composite and composite primary keys
@@ -53,8 +53,7 @@ do
       return tostring(object[primary_key[1]])
     end
 
-    -- get a table for reuse purpose
-    local CACHED_OUT = tb_pool.fetch("dc_cached_pk", 2, 0)
+    local buf = buffer.new()
 
     -- The logic comes from get_cache_key_value(), which uses `id` directly to
     -- extract foreign key.
@@ -67,15 +66,14 @@ do
         v = v.id
       end
 
-      insert(CACHED_OUT, tostring(v or ""))
+      buf:put(tostring(v or ""))
+
+      if i < count then
+        buf:put(":")
+      end
     end
 
-    local str = concat(CACHED_OUT, ":")
-
-    -- release table for next usage
-    tb_pool.release("dc_cached_pk", CACHED_OUT)
-
-    return str
+    return buf:get()
   end
 end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -41,9 +41,11 @@ local foreign_children = {}
 
 do
   local tb_nkeys = require("table.nkeys")
-  local request_aware_table = require("kong.tools.request_aware_table")
+  local tb_clear = require("table.clear")
 
-  local CACHED_OUT
+  -- We couldn't use "kong.tools.request_aware_table" as an upvalue table here
+  -- because its :clear() couldn't actually clear its contents in debug mode.
+  local CACHED_OUT = {}
 
   -- Generate a stable and unique string key from primary key defined inside
   -- schema, supports both non-composite and composite primary keys
@@ -55,11 +57,7 @@ do
       return tostring(object[primary_key[1]])
     end
 
-    if not CACHED_OUT then
-      CACHED_OUT = request_aware_table.new()
-    end
-
-    CACHED_OUT:clear()
+    tb_clear(CACHED_OUT)
 
     -- The logic comes from get_cache_key_value(), which uses `id` directly to
     -- extract foreign key.

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -41,6 +41,7 @@ local foreign_children = {}
 
 do
   local tb_nkeys = require("table.nkeys")
+  local tb_pool = require("tablepool")
 
   -- Generate a stable and unique string key from primary key defined inside
   -- schema, supports both non-composite and composite primary keys
@@ -52,7 +53,8 @@ do
       return tostring(object[primary_key[1]])
     end
 
-    local CACHED_OUT = {}
+    -- get a table for reuse purpose
+    local CACHED_OUT = tb_pool.fetch("dc_cached_pk", 2, 0)
 
     -- The logic comes from get_cache_key_value(), which uses `id` directly to
     -- extract foreign key.
@@ -68,7 +70,12 @@ do
       insert(CACHED_OUT, tostring(v or ""))
     end
 
-    return concat(CACHED_OUT, ":")
+    local str = concat(CACHED_OUT, ":")
+
+    -- releae table for next usage
+    tb_pool.release("dc_cached_pk", CACHED_OUT)
+
+    return str
   end
 end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -60,9 +60,18 @@ do
     end
 
     CACHED_OUT:clear()
+
+    -- The logic comes from get_cache_key_value(), which uses `id` directly to
+    -- extract foreign key.
     for i = 1, count do
       local k = primary_key[i]
-      insert(CACHED_OUT, tostring(object[k]))
+      local v = object[k]
+
+      if type(v) == "table" and schema.fields[k].type == "foreign" then
+        v = v.id
+      end
+
+      insert(CACHED_OUT, tostring(v or ""))
     end
 
     return concat(CACHED_OUT, ":")

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -72,7 +72,7 @@ do
 
     local str = concat(CACHED_OUT, ":")
 
-    -- releae table for next usage
+    -- release table for next usage
     tb_pool.release("dc_cached_pk", CACHED_OUT)
 
     return str

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -1,7 +1,7 @@
 --- NOTE: tool is designed to assist with **detecting** request contamination
 -- issues on CI, during test runs. It does not offer security safeguards.
 --
--- In debug mode,
+-- TODO: need to resolve the following issues in debug mode,
 --  1. `:clear` could not clear elements inserted by `table.insert()`
 --  2. `table.concat()` couldn't work for elements assigned using `indexing`
 

--- a/kong/tools/request_aware_table.lua
+++ b/kong/tools/request_aware_table.lua
@@ -1,5 +1,9 @@
 --- NOTE: tool is designed to assist with **detecting** request contamination
 -- issues on CI, during test runs. It does not offer security safeguards.
+--
+-- In debug mode,
+--  1. `:clear` could not clear elements inserted by `table.insert()`
+--  2. `table.concat()` couldn't work for elements assigned using `indexing`
 
 local table_new = require("table.new")
 local table_clear = require("table.clear")


### PR DESCRIPTION

### Summary

For the entity with multiple primary keys, like consumer_group_consumers, the pk_string() function construct incorrect pk string like `table: 0x028a49eda0:table: 0x0289c257b8`. Because it does not extract the internal id value. Here, we fix it with original lmdb logic get_cache_key_value(). Note this method directly gets id field name.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5732
