### PR TITLE
refactor(db): restore default db page size

### DIFF
--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -5,8 +5,8 @@ local fmt = string.format
 local Connector = {
   defaults = {
     pagination = {
-      page_size     = 512,  -- work with lmdb
-      max_page_size = 512,  -- work with lmdb
+      page_size     = 1000,
+      max_page_size = 50000,
     },
   },
 }

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -113,6 +113,7 @@ end
 
 
 local LMDB_MIN_PAGE_SIZE = 2
+local LMDB_MAX_PAGE_SIZE = 512
 
 
 local function page_for_prefix(self, prefix, size, offset, options, follow)
@@ -122,7 +123,7 @@ local function page_for_prefix(self, prefix, size, offset, options, follow)
 
   -- LMDB 'page_size' can not be less than 2
   -- see: https://github.com/Kong/lua-resty-lmdb?tab=readme-ov-file#page
-  size = math.max(size, LMDB_MIN_PAGE_SIZE)
+  size = math.min(LMDB_MAX_PAGE_SIZE, math.max(size, LMDB_MIN_PAGE_SIZE))
 
   offset = offset or prefix
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5565

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
