### PR TITLE
refactor(plugins/session): remove seemingly useless log

### DIFF
--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -23,8 +23,6 @@ local _M = {}
 --- Open a session based on plugin config
 -- @returns resty.session session object
 function _M.open_session(conf)
-  kong.log.inspect(conf.response_headers)
-
   return resty_session.open({
     secret                    = conf.secret,
     audience                  = conf.audience,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This log line in the session plugin does seem like a leftover for debugging purpose.

<!--- Why is this change required? What problem does it solve? -->

