### PR TITLE
refactor(clustering/sync): delta.ws_id is not necessary

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -242,9 +242,10 @@ local function do_sync()
     local delta_entity = delta.entity
     local ev
 
-    -- delta must have ws_id to generate the correct lmdb key
+    -- delta should have ws_id to generate the correct lmdb key
+    -- if entity is workspaceable
     -- set the correct workspace for item
-    opts.workspace = assert(delta.ws_id)
+    opts.workspace = delta.ws_id
 
     if delta_entity ~= nil and delta_entity ~= ngx_null then
       -- upsert the entity


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5759

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
