### PR TITLE
feat(opentelemetry): support variable resource attributes 

### DIFF
--- a/changelog/unreleased/kong/feat-variable-resource-attributes.yml
+++ b/changelog/unreleased/kong/feat-variable-resource-attributes.yml
@@ -1,0 +1,4 @@
+message: | 
+  **Opentelemetry**: Support variable resource attributes
+type: feature
+scope: Plugin

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -1,10 +1,14 @@
 
 local otel_traces = require "kong.plugins.opentelemetry.traces"
 local otel_logs = require "kong.plugins.opentelemetry.logs"
+local otel_utils = require "kong.plugins.opentelemetry.utils"
 local dynamic_hook = require "kong.dynamic_hook"
 local o11y_logs = require "kong.observability.logs"
 local kong_meta = require "kong.meta"
 
+local _log_prefix = otel_utils._log_prefix
+local ngx_log = ngx.log
+local ngx_WARN = ngx.WARN
 
 
 local OpenTelemetryHandler = {
@@ -42,14 +46,24 @@ end
 
 
 function OpenTelemetryHandler:log(conf)
+  -- Read resource attributes variable
+  local options = {}
+  if conf.resource_attributes then
+    local compiled, err = otel_utils.compile_resource_attributes(conf.resource_attributes)
+    if not compiled then
+      ngx_log(ngx_WARN, _log_prefix, "resource attributes template failed to compile: ", err)
+    end
+    options.compiled_resource_attributes = compiled
+  end
+
   -- Traces
   if conf.traces_endpoint then
-    otel_traces.log(conf)
+    otel_traces.log(conf, options)
   end
 
   -- Logs
   if conf.logs_endpoint then
-    otel_logs.log(conf)
+    otel_logs.log(conf, options)
   end
 end
 

--- a/kong/plugins/opentelemetry/utils.lua
+++ b/kong/plugins/opentelemetry/utils.lua
@@ -1,9 +1,17 @@
 local http = require "resty.http"
 local clone = require "table.clone"
-
+local sandbox = require "kong.tools.sandbox"
+local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
+local pl_template = require "pl.template"
+local lua_enabled = sandbox.configuration.enabled
+local sandbox_enabled = sandbox.configuration.sandbox_enabled
+local get_request_headers = kong.request.get_headers
+local get_uri_args = kong.request.get_query
+local rawset = rawset
+local str_find = string.find
 local tostring = tostring
 local null = ngx.null
-
+local EMPTY = require("kong.tools.table").EMPTY
 
 local CONTENT_TYPE_HEADER_NAME = "Content-Type"
 local DEFAULT_CONTENT_TYPE_HEADER = "application/x-protobuf"
@@ -48,8 +56,119 @@ local function get_headers(conf_headers)
 end
 
 
+local compile_opts = {
+  escape = "\xff", -- disable '#' as a valid template escape
+}
+
+local template_cache = setmetatable( {}, { __mode = "k" })
+
+local __meta_environment = {
+  __index = function(self, key)
+    local lazy_loaders = {
+      headers = function(self)
+        return get_request_headers() or EMPTY
+      end,
+      query_params = function(self)
+        return get_uri_args() or EMPTY
+      end,
+      uri_captures = function(self)
+        return (ngx.ctx.router_matches or EMPTY).uri_captures or EMPTY
+      end,
+      shared = function(self)
+        return ((kong or EMPTY).ctx or EMPTY).shared or EMPTY
+      end,
+    }
+    local loader = lazy_loaders[key]
+    if not loader then
+      if lua_enabled and not sandbox_enabled then
+        return _G[key]
+      end
+      return
+    end
+    -- set the result on the table to not load again
+    local value = loader()
+    rawset(self, key, value)
+    return value
+  end,
+  __newindex = function(self)
+    error("This environment is read-only.")
+  end,
+}
+
+
+local function param_value(source_template, resource_attributes, template_env)
+  if not source_template or source_template == "" then
+    return nil
+  end
+
+  if not lua_enabled then
+    -- Detect expressions in the source template
+    local expr = str_find(source_template, "%$%(.*%)")
+    if expr then
+      return nil, "loading of untrusted Lua code disabled because " ..
+                  "'untrusted_lua' config option is set to 'off'"
+    end
+    -- Lua is disabled, no need to render the template
+    return source_template
+  end
+
+  -- find compiled templates for this plugin-configuration array
+  local compiled_templates = template_cache[resource_attributes]
+  if not compiled_templates then
+    compiled_templates = {}
+    -- store it by `resource_attributes` which is part of the plugin `conf` table
+    -- it will be GC'ed at the same time as `conf` and hence invalidate the
+    -- compiled templates here as well as the cache-table has weak-keys
+    template_cache[resource_attributes] = compiled_templates
+  end
+
+  -- Find or compile the specific template
+  local compiled_template = compiled_templates[source_template]
+  if not compiled_template then
+    local res
+    compiled_template, res = pl_template.compile(source_template, compile_opts)
+    if res then
+      return source_template
+    end
+    compiled_templates[source_template] = compiled_template
+  end
+
+  return compiled_template:render(template_env)
+end
+
+local function compile_resource_attributes(resource_attributes)
+  if not resource_attributes then
+    return EMPTY
+  end
+
+  local template_env = {}
+  if lua_enabled and sandbox_enabled then
+    -- load the sandbox environment to be used to render the template
+    template_env = cycle_aware_deep_copy(sandbox.configuration.environment)
+    -- here we can optionally add functions to expose to the sandbox, eg:
+    -- tostring = tostring,
+    -- because headers may contain array elements such as duplicated headers
+    -- type is a useful function in these cases. See issue #25.
+    template_env.type = type
+  end
+  setmetatable(template_env, __meta_environment)
+  local compiled_resource_attributes = {}
+  for current_name, current_value in pairs(resource_attributes) do
+    local res, err = param_value(current_value, resource_attributes, template_env)
+    if not res then
+      return nil, err
+    end
+
+    compiled_resource_attributes[current_name] = res
+  end
+  return compiled_resource_attributes
+end
+
+
+
 return {
   http_export_request = http_export_request,
   get_headers = get_headers,
   _log_prefix = _log_prefix,
+  compile_resource_attributes = compile_resource_attributes,
 }

--- a/spec/03-plugins/37-opentelemetry/02-schema_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/02-schema_spec.lua
@@ -33,4 +33,16 @@ describe("Plugin: OpenTelemetry (schema)", function()
       }
     }, err)
   end)
+
+  it("accepts variable values", function()
+    local ok, err = validate_plugin_config_schema({
+      endpoint = "http://example.dev",
+      resource_attributes = {
+        foo = "$(headers.host)",
+      },
+    }, schema_def)
+
+    assert.truthy(ok)
+    assert.is_nil(err)
+  end)
 end)

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -567,6 +567,8 @@ for _, strategy in helpers.each_strategy() do
           resource_attributes = {
             ["service.name"] = "kong_oss",
             ["os.version"] = "debian",
+            ["host.name"] = "$(headers.host)",
+            ["validstr"] = "$($@#)",
           }
         })
         mock = helpers.http_mock(HTTP_SERVER_PORT_TRACES, { timeout = HTTP_MOCK_TIMEOUT })
@@ -608,13 +610,17 @@ for _, strategy in helpers.each_strategy() do
         local res_attr = decoded.resource_spans[1].resource.attributes
         sort_by_key(res_attr)
         -- resource attributes
-        assert.same("os.version", res_attr[1].key)
-        assert.same({string_value = "debian", value = "string_value"}, res_attr[1].value)
-        assert.same("service.instance.id", res_attr[2].key)
-        assert.same("service.name", res_attr[3].key)
-        assert.same({string_value = "kong_oss", value = "string_value"}, res_attr[3].value)
-        assert.same("service.version", res_attr[4].key)
-        assert.same({string_value = kong.version, value = "string_value"}, res_attr[4].value)
+        assert.same("host.name", res_attr[1].key)
+        assert.same({string_value = "0.0.0.0:" .. PROXY_PORT, value = "string_value"}, res_attr[1].value)
+        assert.same("os.version", res_attr[2].key)
+        assert.same({string_value = "debian", value = "string_value"}, res_attr[2].value)
+        assert.same("service.instance.id", res_attr[3].key)
+        assert.same("service.name", res_attr[4].key)
+        assert.same({string_value = "kong_oss", value = "string_value"}, res_attr[4].value)
+        assert.same("service.version", res_attr[5].key)
+        assert.same({string_value = kong.version, value = "string_value"}, res_attr[5].value)
+        assert.same("validstr", res_attr[6].key)
+        assert.same({string_value = "$($@#)", value = "string_value"}, res_attr[6].value)
 
         local scope_spans = decoded.resource_spans[1].scope_spans
         assert.is_true(#scope_spans > 0, scope_spans)

--- a/spec/03-plugins/37-opentelemetry/07-utils_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/07-utils_spec.lua
@@ -1,0 +1,53 @@
+require("spec.helpers")
+local LOG_PHASE = require("kong.pdk.private.phases").phases.log
+
+describe("compile_resource_attributes()", function()
+    local mock_request
+    local old_ngx
+    local compile_resource_attributes
+
+    setup(function()
+        old_ngx = _G.ngx
+        _G.ngx = {
+            ctx = {
+                KONG_PHASE = LOG_PHASE
+            },
+            req = {
+              get_headers = function() return mock_request.headers end,
+            },
+            get_phase = function() return "log" end,
+        }
+        package.loaded["kong.pdk.request"] = nil
+        package.loaded["kong.plugins.opentelemetry.utils"] = nil
+        
+        local pdk_request = require "kong.pdk.request"
+        kong.request = pdk_request.new(kong)
+        compile_resource_attributes = require "kong.plugins.opentelemetry.utils".compile_resource_attributes
+    end)
+
+    lazy_teardown(function()
+        _G.ngx = old_ngx
+    end)
+
+
+    it("accepts valid template and valid string", function()
+        mock_request = {
+            headers = {
+                host = "kong-test",
+            },    
+        }
+        local resource_attributes = {
+            ["valid_variable"] = "$(headers.host)",
+            ["nonexist_variable"] = "$($@#)",
+            ["valid_string"] = "valid",
+        }
+        local rendered_resource_attributes, err = compile_resource_attributes(resource_attributes)
+        
+        assert.is_nil(err)
+        assert.same(rendered_resource_attributes["valid_variable"], "kong-test")
+
+        -- take as a normal string if variable does not exist
+        assert.same(rendered_resource_attributes["nonexist_variable"], "$($@#)")
+        assert.same(rendered_resource_attributes["valid_string"], "valid")
+    end)
+end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This change allows render resource attributes as lua code.
For example,
```
  config:
    traces_endpoint: "https://otlp-red-saas.instana.io:4318/v1/traces"
    resource_attributes:
      host.id: "$(headers.host)"
```
`host.id` is `0.0.0.0:9000` or depends on `headers.host` value. 
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #12538 
