### PR TITLE
limit keys in redis to only configured rate limit values

### DIFF
--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -206,8 +206,8 @@ return {
       local expirations = {}
       local idx = 0
       local periods = timestamp.get_timestamps(current_timestamp)
-      for period, period_date in pairs(periods) do
-        local cache_key = get_local_key(conf, identifier, name, period, period_date)
+      for period, _ in pairs(conf.limits[name]) do
+        local cache_key = get_local_key(conf, identifier, name, period, periods[period])
         local exists, err = red:exists(cache_key)
         if err then
           kong.log.err("failed to query Redis: ", err)


### PR DESCRIPTION
### Summary

As of now the response rate limit plugin creates and updates in redis all limit parameter keys(sec, min, hour, day and year) irrespective of whether they are defined.
This change aims to restrict keys in redis to only the configured rate limit parameters.

It will help:

- Optimize redis key space. If only one rate limit parameter(f.e minute) is defined then we will have only 1 key instead of earlier 5 keys.

- More importantly, since the key is only created in redis when the limit is defined, any past value will not be considered for new rate limit. For example, if we initially configured to limit at 10 req/min and now we add new limit of 50 req/hour then as per current plugin the if 50 req have been exhausted before the new limit is defined, then it will be considered and the rate limit will be immediately applied where as the expectation would be to consider the new limit from now on.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
