### PR TITLE
test(ai-proxy): fix red test due to other feature break http protocol behavior

### DIFF
--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -63,9 +63,8 @@ local _EXPECTED_CHAT_STATS = {
   },
 }
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
 
     lazy_setup(function()
@@ -826,13 +825,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
       -- Note: if file is removed instead of trunacted, file-log ends writing to a unlinked file handle
       truncate_file(FILE_LOG_PATH_STATS_ONLY)
       truncate_file(FILE_LOG_PATH_NO_LOGS)
@@ -1702,4 +1695,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
@@ -6,9 +6,8 @@ local deepcompare  = require("pl.tablex").deepcompare
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
 
     lazy_setup(function()
@@ -516,13 +515,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, true)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -788,4 +781,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
@@ -5,9 +5,8 @@ local pl_file = require "pl.file"
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()    local client
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()    local client
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
@@ -390,13 +389,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -630,4 +623,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
@@ -5,9 +5,8 @@ local pl_file = require "pl.file"
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
 
     lazy_setup(function()
@@ -408,13 +407,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -657,4 +650,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
@@ -5,9 +5,8 @@ local pl_file = require "pl.file"
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
 
     lazy_setup(function()
@@ -344,13 +343,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -519,4 +512,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
@@ -5,10 +5,9 @@ local pl_file = require "pl.file"
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
 
     lazy_setup(function()
@@ -193,13 +192,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -451,4 +444,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
@@ -110,9 +110,8 @@ local plugin_conf = {
   },
 }
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
 
     lazy_setup(function()
@@ -242,13 +241,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -376,4 +369,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   ----
 
 end end
-end -- for _, client_protocol

--- a/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
@@ -7,9 +7,8 @@ local http = require("resty.http")
 local PLUGIN_NAME = "ai-proxy"
 local MOCK_PORT = helpers.get_available_port()
 
-for _, client_protocol in ipairs({ "http", "https", "http2" }) do
 for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
-  describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "] [#" .. client_protocol .. "]", function()
+  describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
 
     lazy_setup(function()
@@ -501,13 +500,7 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
     end)
 
     before_each(function()
-      if client_protocol == "http" then
-        client = helpers.proxy_client()
-      elseif client_protocol == "https" then
-        client = helpers.proxy_ssl_client()
-      elseif client_protocol == "http2" then
-        client = helpers.proxy_ssl_client(nil, nil, 2)
-      end
+      client = helpers.proxy_client()
     end)
 
     after_each(function()
@@ -819,4 +812,3 @@ for _, strategy in helpers.all_strategies() do if strategy ~= "cassandra" then
   end)
 
 end end
-end -- for _, client_protocol


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
In https://github.com/Kong/kong/commit/7d71b6b83601b541f6335cd06c09cc8e3d169138, we introduce disable http2 alpn in ai-proxy plugin, now all http2 force protocol test will failed, so do not need http2 test in ai-proxy anymore, because we have been disabled http2.


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
