### PR TITLE
refactor(clustering): dont generate event for full sync

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -277,7 +277,10 @@ local function do_sync()
               ", version: ", delta_version,
               ", type: ", delta_type)
 
-      ev = { delta_type, crud_event_type, delta_entity, old_entity, }
+      -- wipe the whole lmdb, should not have events
+      if not wipe then
+        ev = { delta_type, crud_event_type, delta_entity, old_entity, }
+      end
 
     else
       -- delete the entity
@@ -299,11 +302,17 @@ local function do_sync()
               ", version: ", delta_version,
               ", type: ", delta_type)
 
-      ev = { delta_type, "delete", old_entity, }
-    end
+      -- wipe the whole lmdb, should not have events
+      if not wipe then
+        ev = { delta_type, "delete", old_entity, }
+      end
+    end -- if delta_entity ~= nil and delta_entity ~= ngx_null
 
-    crud_events_n = crud_events_n + 1
-    crud_events[crud_events_n] = ev
+    -- wipe the whole lmdb, should not have events
+    if not wipe then
+      crud_events_n = crud_events_n + 1
+      crud_events[crud_events_n] = ev
+    end
 
     -- delta.version should not be nil or ngx.null
     assert(type(delta_version) == "number")

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -257,8 +257,6 @@ local function do_sync()
         return nil, err
       end
 
-      local crud_event_type = old_entity and "update" or "create"
-
       -- If we will wipe lmdb, we don't need to delete it from lmdb.
       if old_entity and not wipe then
         local res, err = delete_entity_for_txn(t, delta_type, old_entity, opts)
@@ -279,7 +277,7 @@ local function do_sync()
 
       -- wipe the whole lmdb, should not have events
       if not wipe then
-        ev = { delta_type, crud_event_type, delta_entity, old_entity, }
+        ev = { delta_type, old_entity and "update" or "create", delta_entity, old_entity, }
       end
 
     else


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5804

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
