### PR TITLE
fix(sync): full sync not working if dedicated disabled

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -892,7 +892,8 @@ function Kong.init_worker()
         kong.clustering:init_worker()
         return
 
-      elseif not using_dedicated then
+      end
+      if not using_dedicated then
         -- full sync dp
         kong.clustering:init_worker()
       end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -890,16 +890,12 @@ function Kong.init_worker()
       if using_dedicated and process.type() == "privileged agent" then
         -- full sync dp agent
         kong.clustering:init_worker()
+        return
 
       elseif not using_dedicated then
         -- full sync dp
         kong.clustering:init_worker()
       end
-    end
-
-    -- DP full sync agent skips the rest of the init_worker
-    if is_dp_full_sync_agent then
-      return
     end
   end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -893,6 +893,7 @@ function Kong.init_worker()
         return
 
       end
+
       if not using_dedicated then
         -- full sync dp
         kong.clustering:init_worker()

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -881,14 +881,20 @@ function Kong.init_worker()
   end
 
   if kong.clustering then
-    -- full sync dp
-
-    local is_dp_full_sync_agent = process.type() == "privileged agent" and not kong.sync
-
-    if is_control_plane(kong.configuration) or -- CP needs to support both full and incremental sync
-      is_dp_full_sync_agent -- full sync is only enabled for DP if incremental sync is disabled
-    then
+    if is_control_plane(kong.configuration) then-- CP needs to support both full and incremental sync
       kong.clustering:init_worker()
+    
+    -- full sync is only enabled for DP if incremental sync is disabled
+    elseif is_data_plane(kong.configuration) and not kong.sync then
+      local using_dedicated = kong.configuration.dedicated_config_processing
+      if using_dedicated and process.type() == "privileged agent" then
+        -- full sync dp agent
+        kong.clustering:init_worker()
+
+      elseif not using_dedicated then
+        -- full sync dp
+        kong.clustering:init_worker()
+      end
     end
 
     -- DP full sync agent skips the rest of the init_worker


### PR DESCRIPTION
### Summary

Clustering initialization needs to be handled when dedicated worker is off

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-5807
