### PR TITLE
fix(clustering/sync): notify declarative:reconfigure events for full sync

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -7,6 +7,7 @@ local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
 local concurrency = require("kong.concurrency")
 local isempty = require("table.isempty")
+local events = require("kong.runloop.events")
 
 
 local insert_entity_for_txn = declarative.insert_entity_for_txn
@@ -326,6 +327,16 @@ local function do_sync()
   if wipe then
     kong.core_cache:purge()
     kong.cache:purge()
+
+    -- Trigger other workers' callbacks like reconfigure_handler.
+    --
+    -- Full sync could rebuild route, plugins and balancer route, so their
+    -- hashes are nil.
+    local reconfigure_data = { kong.default_workspace, nil, nil, nil, }
+    local ok, err = events.declarative_reconfigure_notify(reconfigure_data)
+    if not ok then
+      return nil, err
+    end
 
   else
     for _, event in ipairs(crud_events) do


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

With full sync (`wipe = true` in `do_sync()`), if we dont notify other workers with `declarative:reconfigure`, the registered callbacks in other workers will not be called, like updating `kong.default_workerspace`.

Note that when an empty-configured CP and DP start with incremental sync enabled, the DP will rebuild routers, plugins, and the balancer twice. This occurs because the DP currently calls do_sync() twice during a single sync operation. With incremental sync disabled, it rebuilds these components only once.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5812
