### PR TITLE
fix(schema): schema validation to handle potential `nil` field case

### DIFF
--- a/changelog/unreleased/kong/fix-schema-validation-with-nil-field.yml
+++ b/changelog/unreleased/kong/fix-schema-validation-with-nil-field.yml
@@ -1,0 +1,3 @@
+message: "Fix schema validation to handle potential `nil` field case."
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix-schema-validation-with-nil-field.yml
+++ b/changelog/unreleased/kong/fix-schema-validation-with-nil-field.yml
@@ -1,3 +1,3 @@
-message: "Fix schema validation to handle potential `nil` field case."
+message: "Fixed a 500 error triggered by unhandled nil fields during schema validation."
 type: bugfix
 scope: Core

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1273,7 +1273,7 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
 
       -- Don't run if any of the values is a reference in a referenceable field
       local field = get_schema_field(self, fname)
-      if field.type == "string" and field.referenceable and is_reference(value) then
+      if field and field.type == "string" and field.referenceable and is_reference(value) then
         return
       end
     end

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1800,3 +1800,34 @@ describe("routes schema (flavor = expressions)", function()
     end
   end)
 end)
+
+
+describe("routes schema (flavor = traditional_compatible)", function()
+  local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
+  local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
+
+  reload_flavor("traditional_compatible")
+  setup_global_env()
+
+  it("validates a route with only expression field", function()
+    local route = {
+      id             = a_valid_uuid,
+      name           = "my_route",
+      protocols      = { "http" },
+      hosts           = { "example.com" },
+      expression     = [[(http.method == "GET")]],
+      priority       = 100,
+      service        = { id = another_uuid },
+    }
+    route = Routes:process_auto_fields(route, "insert")
+    assert.truthy(route.created_at)
+    assert.truthy(route.updated_at)
+    assert.same(route.created_at, route.updated_at)
+    local ok, errs = Routes:validate(route)
+    assert.falsy(ok)
+    assert.same({
+      ["expression"] = 'unknown field',
+      ["priority"] = 'unknown field'
+    }, errs)
+  end)
+end)


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Adjusted schema validation logic to account for `nil` field scenario, ensuring proper handling of fields to prevent errors.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix:[FTI-6336](https://konghq.atlassian.net/browse/FTI-6336)


[FTI-6336]: https://konghq.atlassian.net/browse/FTI-6336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ