### PR TITLE
chore(clustering): adjust error log levels for control plane connections

### DIFF
--- a/changelog/unreleased/kong/chore-clustering-log-level.yml
+++ b/changelog/unreleased/kong/chore-clustering-log-level.yml
@@ -1,0 +1,3 @@
+message: "**Clustering**: Adjust error log levels for control plane connections."
+type: bugfix
+scope: Clustering

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -153,7 +153,7 @@ function _M:communicate(premature)
 
   local c, uri, err = clustering_utils.connect_cp(self, "/v1/outlet")
   if not c then
-    ngx_log(ngx_ERR, _log_prefix, "connection to control plane ", uri, " broken: ", err,
+    ngx_log(ngx_WARN, _log_prefix, "connection to control plane ", uri, " broken: ", err,
                  " (retrying after ", reconnection_delay, " seconds)", log_suffix)
 
     assert(ngx.timer.at(reconnection_delay, function(premature)


### PR DESCRIPTION




<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Changed error log level from ERROR to WARN for better clarity and to avoid alarming users unnecessarily when control plane connections break. This adjustment enhances user experience under connection interruptions.
### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix:[FTI-6238](https://konghq.atlassian.net/browse/FTI-6238)


[FTI-6238]: https://konghq.atlassian.net/browse/FTI-6238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ