### PR TITLE
chore(ci): deck integration tests checkout secret

### DIFF
--- a/.github/workflows/deck-integration.yml
+++ b/.github/workflows/deck-integration.yml
@@ -8,6 +8,7 @@ on:
     - 'kong/plugins/**/daos.lua'
     - 'kong/db/dao/*.lua'
     - 'kong/api/**/*.lua'
+    - '.github/workflows/deck-integration.yml'
 
 permissions:
   pull-requests: write
@@ -53,7 +54,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.GHA_KONG_BOT_READ_TOKEN }}
 
       - name: Lookup build cache
         id: cache-deps


### PR DESCRIPTION
**note:** do **not** cherry-pick to EE

### Summary

The checkout step of these tests was using a secret that is not available to PRs opened from forks, which made it fail. This commit removes the token (not needed in CE), which makes the action fall back to the default github token.

### Checklist

- [x] (no) The Pull Request has tests
- [x] (no) A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

