### PR TITLE
tests(sync): reenable fixed test

### DIFF
--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 
 
 -- XXX FIXME: inc_sync = on flaky
-for _, inc_sync in ipairs { "off" } do
+for _, inc_sync in ipairs { "on", "off" } do
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("Plugin: key-auth (access) [#" .. strategy .. " inc_sync=" .. inc_sync .. "] auto-expiring keys", function()
     -- Give a bit of time to reduce test flakyness on slow setups


### PR DESCRIPTION
### Summary

The test is fixed

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-5560
