### PR TITLE
fix(clustering/rpc): try sync after rpc is ready

### DIFF
--- a/kong/clustering/services/sync/init.lua
+++ b/kong/clustering/services/sync/init.lua
@@ -7,8 +7,7 @@ local strategy = require("kong.clustering.services.sync.strategies.postgres")
 local rpc = require("kong.clustering.services.sync.rpc")
 
 
--- TODO: what is the proper value?
-local FIRST_SYNC_DELAY = 0.5  -- seconds
+local FIRST_SYNC_DELAY = 0.2  -- seconds
 local EACH_SYNC_DELAY  = 30   -- seconds
 
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -394,7 +394,18 @@ end
 
 
 function _M:sync_once(delay)
-  --- XXX TODO: check rpc connection is ready
+  --- check rpc connection is ready
+  for i = 1, 5 do
+    local res = kong.rpc:get_peers()
+
+    -- control_plane is ready
+    if res["control_plane"] then
+      break
+    end
+
+    -- retry later
+    ngx.sleep(0.1 * i)
+  end
 
   return start_sync_timer(ngx.timer.at, delay or 0)
 end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -181,18 +181,25 @@ function _M:init(manager, is_cp)
 end
 
 
-local function do_sync()
-  --- check rpc connection is ready
+-- check if rpc connection is ready
+local function is_rpc_ready()
   for i = 1, 5 do
     local res = kong.rpc:get_peers()
 
     -- control_plane is ready
     if res["control_plane"] then
-      break
+      return true
     end
 
     -- retry later
     ngx.sleep(0.1 * i)
+  end
+end
+
+
+local function do_sync()
+  if not is_rpc_ready() then
+    return nil, "rpc is not ready"
   end
 
   local ns_deltas, err = kong.rpc:call("control_plane", "kong.sync.v2.get_delta",

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -182,6 +182,19 @@ end
 
 
 local function do_sync()
+  --- check rpc connection is ready
+  for i = 1, 5 do
+    local res = kong.rpc:get_peers()
+
+    -- control_plane is ready
+    if res["control_plane"] then
+      break
+    end
+
+    -- retry later
+    ngx.sleep(0.1 * i)
+  end
+
   local ns_deltas, err = kong.rpc:call("control_plane", "kong.sync.v2.get_delta",
                                        { default =
                                          { version =
@@ -394,19 +407,6 @@ end
 
 
 function _M:sync_once(delay)
-  --- check rpc connection is ready
-  for i = 1, 5 do
-    local res = kong.rpc:get_peers()
-
-    -- control_plane is ready
-    if res["control_plane"] then
-      break
-    end
-
-    -- retry later
-    ngx.sleep(0.1 * i)
-  end
-
   return start_sync_timer(ngx.timer.at, delay or 0)
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5569
KAG-5724

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
