### PR TITLE
chore(toolchain): bump rust toolchain to 1.82.0

### DIFF
--- a/build/kong_crate/deps.bzl
+++ b/build/kong_crate/deps.bzl
@@ -16,9 +16,19 @@ def kong_crate_repositories(cargo_home_isolated = True):
 
     rules_rust_dependencies()
 
+    # To get the sha256s, please check out the
+    # https://static.rust-lang.org/dist/channel-rust-stable.toml
     rust_register_toolchains(
         edition = "2021",
         extra_target_triples = ["aarch64-unknown-linux-gnu"],
+        sha256s = {
+            "rustc-1.82.0-x86_64-unknown-linux-gnu.tar.xz": "90b61494f5ccfd4d1ca9a5ce4a0af49a253ca435c701d9c44e3e44b5faf70cb8",
+            "clippy-1.82.0-x86_64-unknown-linux-gnu.tar.xz": "ea4fbf6fbd3686d4f6e2a77953e2d42a86ea31e49a5f79ec038762c413b15577",
+            "cargo-1.82.0-x86_64-unknown-linux-gnu.tar.xz": "97aeae783874a932c4500f4d36473297945edf6294d63871784217d608718e70",
+            "llvm-tools-1.82.0-x86_64-unknown-linux-gnu.tar.xz": "29f9becd0e5f83196f94779e9e06ab76e0bd3a14bcdf599fabedbd4a69d045be",
+            "rust-std-1.82.0-x86_64-unknown-linux-gnu.tar.xz": "2eca3d36f7928f877c334909f35fe202fbcecce109ccf3b439284c2cb7849594",
+        },
+        versions = ["1.82.0"],
     )
 
     rust_repository_set(
@@ -26,7 +36,14 @@ def kong_crate_repositories(cargo_home_isolated = True):
         edition = "2021",
         exec_triple = "x86_64-unknown-linux-gnu",
         extra_target_triples = ["aarch64-unknown-linux-gnu"],
-        versions = ["stable"],
+        sha256s = {
+            "rustc-1.82.0-aarch64-unknown-linux-gnu.tar.xz": "2958e667202819f6ba1ea88a2a36d7b6a49aad7e460b79ebbb5cf9221b96f599",
+            "clippy-1.82.0-aarch64-unknown-linux-gnu.tar.xz": "1e01808028b67a49f57925ea72b8a2155fbec346cd694d951577c63312ba9217",
+            "cargo-1.82.0-aarch64-unknown-linux-gnu.tar.xz": "05c0d904a82cddb8a00b0bbdd276ad7e24dea62a7b6c380413ab1e5a4ed70a56",
+            "llvm-tools-1.82.0-aarch64-unknown-linux-gnu.tar.xz": "db793edd8e8faef3c9f2aa873546c6d56b3421b2922ac9111ba30190b45c3b5c",
+            "rust-std-1.82.0-aarch64-unknown-linux-gnu.tar.xz": "1359ac1f3a123ae5da0ee9e47b98bb9e799578eefd9f347ff9bafd57a1d74a7f",
+        },
+        versions = ["1.82.0"],
     )
 
     crate_universe_dependencies()

--- a/crate_locks/atc_router.Cargo.lock
+++ b/crate_locks/atc_router.Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -103,9 +103,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "memchr"
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
 dependencies = [
  "unicode-ident",
 ]
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -213,18 +213,18 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -265,18 +265,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -297,9 +297,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "uuid"

--- a/crate_locks/atc_router.lock
+++ b/crate_locks/atc_router.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "71a528ead48a5f4f3d5eda359189caaecdd17e47fe58e6e0e5ab3a90d010e3d4",
+  "checksum": "a9a20974f77d4fa9001e79b35a202afc62efc5de414664912c347ea3475fe888",
   "crates": {
     "aho-corasick 1.1.3": {
       "name": "aho-corasick",
@@ -266,14 +266,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cpufeatures 0.2.14": {
+    "cpufeatures 0.2.15": {
       "name": "cpufeatures",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "package_url": "https://github.com/RustCrypto/utils",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cpufeatures/0.2.14/download",
-          "sha256": "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+          "url": "https://static.crates.io/crates/cpufeatures/0.2.15/download",
+          "sha256": "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
         }
       },
       "targets": [
@@ -300,32 +300,32 @@
           "selects": {
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.161",
+                "id": "libc 0.2.164",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.161",
+                "id": "libc 0.2.164",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.161",
+                "id": "libc 0.2.164",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.161",
+                "id": "libc 0.2.164",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.14"
+        "version": "0.2.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -614,14 +614,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "libc 0.2.161": {
+    "libc 0.2.164": {
       "name": "libc",
-      "version": "0.2.161",
+      "version": "0.2.164",
       "package_url": "https://github.com/rust-lang/libc",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libc/0.2.161/download",
-          "sha256": "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+          "url": "https://static.crates.io/crates/libc/0.2.164/download",
+          "sha256": "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
         }
       },
       "targets": [
@@ -655,17 +655,24 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.161",
+              "id": "libc 0.2.164",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.161"
+        "version": "0.2.164"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -818,7 +825,7 @@
               "target": "memchr"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 1.0.69",
               "target": "thiserror"
             },
             {
@@ -943,7 +950,7 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.89",
+              "id": "proc-macro2 1.0.91",
               "target": "proc_macro2"
             },
             {
@@ -951,7 +958,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.87",
+              "id": "syn 2.0.89",
               "target": "syn"
             }
           ],
@@ -1025,14 +1032,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "proc-macro2 1.0.89": {
+    "proc-macro2 1.0.91": {
       "name": "proc-macro2",
-      "version": "1.0.89",
+      "version": "1.0.91",
       "package_url": "https://github.com/dtolnay/proc-macro2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/proc-macro2/1.0.89/download",
-          "sha256": "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+          "url": "https://static.crates.io/crates/proc-macro2/1.0.91/download",
+          "sha256": "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
         }
       },
       "targets": [
@@ -1076,18 +1083,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.89",
+              "id": "proc-macro2 1.0.91",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.13",
+              "id": "unicode-ident 1.0.14",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.89"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1140,7 +1147,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.89",
+              "id": "proc-macro2 1.0.91",
               "target": "proc_macro2"
             }
           ],
@@ -1218,7 +1225,7 @@
               "target": "memchr"
             },
             {
-              "id": "regex-automata 0.4.8",
+              "id": "regex-automata 0.4.9",
               "target": "regex_automata"
             },
             {
@@ -1238,14 +1245,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-automata 0.4.8": {
+    "regex-automata 0.4.9": {
       "name": "regex-automata",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "package_url": "https://github.com/rust-lang/regex/tree/master/regex-automata",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-automata/0.4.8/download",
-          "sha256": "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+          "url": "https://static.crates.io/crates/regex-automata/0.4.9/download",
+          "sha256": "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
         }
       },
       "targets": [
@@ -1312,7 +1319,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.8"
+        "version": "0.4.9"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1418,7 +1425,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.14",
+                "id": "cpufeatures 0.2.15",
                 "target": "cpufeatures"
               }
             ]
@@ -1434,14 +1441,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "syn 2.0.87": {
+    "syn 2.0.89": {
       "name": "syn",
-      "version": "2.0.87",
+      "version": "2.0.89",
       "package_url": "https://github.com/dtolnay/syn",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.87/download",
-          "sha256": "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+          "url": "https://static.crates.io/crates/syn/2.0.89/download",
+          "sha256": "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
         }
       },
       "targets": [
@@ -1477,7 +1484,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.89",
+              "id": "proc-macro2 1.0.91",
               "target": "proc_macro2"
             },
             {
@@ -1485,14 +1492,14 @@
               "target": "quote"
             },
             {
-              "id": "unicode-ident 1.0.13",
+              "id": "unicode-ident 1.0.14",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.87"
+        "version": "2.0.89"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1501,14 +1508,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror 1.0.68": {
+    "thiserror 1.0.69": {
       "name": "thiserror",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/1.0.68/download",
-          "sha256": "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+          "url": "https://static.crates.io/crates/thiserror/1.0.69/download",
+          "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
         }
       },
       "targets": [
@@ -1545,7 +1552,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 1.0.69",
               "target": "build_script_build"
             }
           ],
@@ -1555,13 +1562,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.68",
+              "id": "thiserror-impl 1.0.69",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.68"
+        "version": "1.0.69"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1575,14 +1582,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 1.0.68": {
+    "thiserror-impl 1.0.69": {
       "name": "thiserror-impl",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/1.0.68/download",
-          "sha256": "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+          "url": "https://static.crates.io/crates/thiserror-impl/1.0.69/download",
+          "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
         }
       },
       "targets": [
@@ -1607,7 +1614,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.89",
+              "id": "proc-macro2 1.0.91",
               "target": "proc_macro2"
             },
             {
@@ -1615,14 +1622,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.87",
+              "id": "syn 2.0.89",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.68"
+        "version": "1.0.69"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1741,14 +1748,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "unicode-ident 1.0.13": {
+    "unicode-ident 1.0.14": {
       "name": "unicode-ident",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "package_url": "https://github.com/dtolnay/unicode-ident",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-ident/1.0.13/download",
-          "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+          "url": "https://static.crates.io/crates/unicode-ident/1.0.14/download",
+          "sha256": "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
         }
       },
       "targets": [
@@ -1771,14 +1778,10 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.13"
+        "version": "1.0.14"
       },
-      "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT",
-        "Unicode-DFS-2016"
-      ],
+      "license": "(MIT OR Apache-2.0) AND Unicode-3.0",
+      "license_ids": [],
       "license_file": "LICENSE-APACHE"
     },
     "uuid 1.11.0": {


### PR DESCRIPTION
### Summary
ATC-Router requires rust version >= 1.81.0 so we bump to 1.82.0

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
