### PR TITLE
fix(sync): version start from 1 to avoid empty hash issue

### DIFF
--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -28,7 +28,7 @@ end
 
 local PURGE_QUERY = [[
   DELETE FROM clustering_sync_version
-  WHERE "version" < (
+  WHERE "version" > 1 AND "version" <= (
       SELECT MAX("version") - %d
       FROM clustering_sync_version
   );

--- a/kong/db/migrations/core/024_380_to_390.lua
+++ b/kong/db/migrations/core/024_380_to_390.lua
@@ -14,6 +14,9 @@ return {
         "entity" JSON,
         FOREIGN KEY (version) REFERENCES clustering_sync_version(version) ON DELETE CASCADE
       );
+      -- version starts at 1, as 0 indicates no sync has been performed
+      INSERT INTO clustering_sync_version (version) VALUES (1) ON CONFLICT DO NOTHING;
+      INSERT INTO clustering_sync_delta (version, type, pk, ws_id, entity) VALUES (1, 'init', '{}', '00000000-0000-0000-0000-000000000000', '{}') ON CONFLICT DO NOTHING;
       CREATE INDEX IF NOT EXISTS clustering_sync_delta_version_idx ON clustering_sync_delta (version);
       END;
       $$;

--- a/spec/02-integration/09-hybrid_mode/11-status_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/11-status_spec.lua
@@ -70,9 +70,6 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("dp status ready endpoint for no config", function()
-      -- XXX FIXME
-      local skip_inc_sync = inc_sync == "on" and pending or it
-
       lazy_setup(function()
         assert(start_kong_cp())
         assert(start_kong_dp())
@@ -104,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
 
       -- now dp receive config from cp, so dp should be ready
 
-      skip_inc_sync("should return 200 on data plane after configuring", function()
+      it("should return 200 on data plane after configuring", function()
         helpers.wait_until(function()
           local http_client = helpers.http_client('127.0.0.1', dp_status_port)
 


### PR DESCRIPTION
### Summary

Need to figure out how to deal with the default ws

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-5556
