### PR TITLE
fix(schema): run check on invalid field

### DIFF
--- a/changelog/unreleased/kong/fix-nil-reference-schema-checker.yml
+++ b/changelog/unreleased/kong/fix-nil-reference-schema-checker.yml
@@ -1,0 +1,3 @@
+message: "Fix issue where the schema library would error with a nil reference if an entity checker referred to an inexistent field"
+type: bugfix
+scope: Core

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1264,7 +1264,7 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
       if (not checker.run_with_missing_fields) and
          (not arg.run_with_missing_fields) and
          (required_fields and required_fields[fname]) and
-         (not get_schema_field(self, fname).nilable) then
+         (not (get_schema_field(self, fname) or {}).nilable) then
         missing = missing or {}
         insert(missing, fname)
       end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1407,6 +1407,26 @@ describe("schema", function()
 
     describe("entity_checkers", function()
 
+      describe("at_least_one_of", function()
+        local Test = Schema.new({
+          fields = {
+            { a = { type = "number" }, },
+            { b = { type = "string" }, },
+            { c = { type = "string" }, },
+          },
+          entity_checks = {
+            { at_least_one_of = {"d"} },
+          }
+        })
+
+        it("runs check on invalid fields", function()
+          local ok, errs = Test:validate_insert({ a = 1 })
+          assert.is_nil(ok)
+          assert.same({
+            "at least one of these fields must be non-empty: 'd'"
+          }, errs["@entity"])
+        end)
+      end)
       describe("conditional_at_least_one_of", function()
         local Test = Schema.new({
           fields = {


### PR DESCRIPTION
This fixes a nil reference if a checker referred to an inexistent field.

```
./kong/db/schema/init.lua:1267: attempt to index a nil value
stack traceback:
	./kong/db/schema/init.lua: in function 'run_entity_check'
	./kong/db/schema/init.lua:1384: in function 'run_checks'
	./kong/db/schema/init.lua:1400: in function 'run_entity_checks'
	./kong/db/schema/init.lua:2101: in function 'validate'
	./kong/db/schema/init.lua:957: in function 'validate_field'
	./kong/db/schema/init.lua:1187: in function 'validate_fields'
	./kong/db/schema/init.lua:2091: in function 'validate_insert'
	./kong/db/dao/init.lua:470: in function 'check_insert'
	./kong/db/dao/init.lua:1155: in function 'insert_entity'
	./kong/api/endpoints.lua:409: in function 'fn'
	./kong/api/api_helpers.lua:329: in function <./kong/api/api_helpers.lua:307>
```
