### PR TITLE
fix(core): initialize route to avoid race (500)

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -437,7 +437,7 @@ local function build_router(version)
     local err
     ROUTER, err = Router.new(EMPTY, ROUTER_CACHE, ROUTER_CACHE_NEG, ROUTER)
     if not ROUTER then
-      log(ERR, "could not initialize router: ", err)
+      log(ERR, "could not create an empty router: ", err)
     end
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -51,6 +51,7 @@ local request_id_get    = request_id.get
 local escape            = require("kong.tools.uri").escape
 local encode            = require("string.buffer").encode
 local uuid              = require("kong.tools.uuid").uuid
+local EMPTY            = require("kong.tools.table").EMPTY
 
 local req_dyn_hook_run_hook = req_dyn_hook.run_hook
 
@@ -429,6 +430,17 @@ end
 
 
 local function build_router(version)
+  -- as new_router may be interrupted, and after init_worker we assume
+  -- the ROUTE is never nil, we create an empty router which cannot be
+  -- interrupted and will be replaced by the new_router
+  if version == "init" then
+    local err
+    ROUTER, err = Router.new(EMPTY, ROUTER_CACHE, ROUTER_CACHE_NEG, ROUTER)
+    if not ROUTER then
+      log(ERR, "could not initialize router: ", err)
+    end
+  end
+
   local router, err = new_router(version)
   if not router then
     return nil, err


### PR DESCRIPTION
### Summary

The init router creation could be interrupted and we assume it will always be a non-nil value after the `init_worker` phase, which may cause 500 to proxy requests.

Let's create an empty router before creating the initial router.

As the issue occurs at this version I omitted the changelog.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix KAG-5815
