### PR TITLE
fix(cd): install config-manager for rhel9 (#10796)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
       if: matrix.package == 'rpm' && matrix.image != ''
       run: |
         yum groupinstall -y 'Development Tools'
+        dnf install -y 'dnf-command(config-manager)'
         dnf config-manager --set-enabled powertools || true # enable devel packages on rockylinux:8
         dnf config-manager --set-enabled crb || true # enable devel packages on rockylinux:9
         yum install -y libyaml-devel

--- a/scripts/explain_manifest/main.py
+++ b/scripts/explain_manifest/main.py
@@ -86,10 +86,12 @@ def gather_files(path: str, image: str):
         elif ext == ".rpm":
             # rpm2cpio is needed
             # rpm2archive ships with rpm2cpio on debians
+            # https://github.com/rpm-software-management/rpm/commit/37b963fa51d6ad31086a6e345ce6701afda5afff
+            # rpm2archive has changed the behaviour to extract to stdout if stdout is not tty
             code = os.system(
                 """
-                    rpm2archive %s && tar -C %s -xf %s.tgz
-                """ % (path, t.name, path))
+                    rpm2archive %s | tar -C %s -xz
+                """ % (path, t.name))
         elif ext == ".gz":
             code = os.system("tar -C %s -xf %s" % (t.name, path))
 


### PR DESCRIPTION
it's recently removed from t he rockylinux:9 baseimage

* fix(explain_manifest): pipe output of rpm2archive

cherry-picked from https://github.com/Kong/kong-ee/pull/10796
