### PR TITLE
fix(plugins): Improved the error message when an anonymous consumer was configured but did not exist

### DIFF
--- a/changelog/unreleased/kong/fix-nonexisting-anonymous-error-message.yml
+++ b/changelog/unreleased/kong/fix-nonexisting-anonymous-error-message.yml
@@ -1,0 +1,3 @@
+message: "**authentication-plugins**: Improved the error message when an anonymous consumer was configured but did not exist."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -218,6 +218,12 @@ function _M.execute(conf)
         return error(err)
       end
 
+      if not consumer then
+        local err_msg = "anonymous consumer " .. conf.anonymous .. " is configured but doesn't exist"
+        kong.log.err(err_msg)
+        return kong.response.error(500, err_msg)
+      end
+
       set_consumer(consumer)
 
     else

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -363,6 +363,12 @@ local function set_anonymous_consumer(anonymous)
     return error(err)
   end
 
+  if not consumer then
+    local err_msg = "anonymous consumer " .. anonymous .. " is configured but doesn't exist"
+    kong.log.err(err_msg)
+    return kong.response.error(500, err_msg)
+  end
+
   set_consumer(consumer)
 end
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -273,6 +273,12 @@ local function set_anonymous_consumer(anonymous)
     return error(err)
   end
 
+  if not consumer then
+    local err_msg = "anonymous consumer " .. anonymous .. " is configured but doesn't exist"
+    kong.log.err(err_msg)
+    return kong.response.error(500, err_msg)
+  end
+
   set_consumer(consumer)
 end
 

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -223,6 +223,12 @@ local function set_anonymous_consumer(anonymous)
     return error(err)
   end
 
+  if not consumer then
+    local err_msg = "anonymous consumer " .. anonymous .. " is configured but doesn't exist"
+    kong.log.err(err_msg)
+    return kong.response.error(500, err_msg)
+  end
+
   set_consumer(consumer)
 end
 

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -290,6 +290,12 @@ local function set_anonymous_consumer(anonymous)
     return error(err)
   end
 
+  if not consumer then
+    local err_msg = "anonymous consumer " .. anonymous .. " is configured but doesn't exist"
+    kong.log.err(err_msg)
+    return kong.response.error(500, err_msg)
+  end
+
   set_consumer(consumer)
 end
 

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1077,6 +1077,12 @@ local function set_anonymous_consumer(anonymous)
     return error(err)
   end
 
+  if not consumer then
+    local err_msg = "anonymous consumer " .. anonymous .. " is configured but doesn't exist"
+    kong.log.err(err_msg)
+    return kong.response.error(500, err_msg)
+  end
+
   set_consumer(consumer)
 end
 

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -9,6 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: key-auth (access) [#" .. strategy .. "]", function()
     local mock, proxy_client
     local kong_cred
+    local nonexisting_anonymous = uuid.uuid()  -- a nonexisting consumer id
 
     lazy_setup(function()
       mock = http_mock.new(MOCK_PORT)
@@ -117,7 +118,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "key-auth",
         route = { id = route4.id },
         config   = {
-          anonymous = uuid.uuid(),  -- unknown consumer
+          anonymous = nonexisting_anonymous,  -- a nonexisting consumer id
         },
       }
 
@@ -803,7 +804,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "key-auth4.test"
           }
         })
-        assert.response(res).has.status(500)
+        local body = cjson.decode(assert.res_status(500, res))
+        assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
       end)
     end)
   end)

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -6,6 +6,7 @@ local uuid    = require "kong.tools.uuid"
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: basic-auth (access) [#" .. strategy .. "]", function()
     local proxy_client
+    local nonexisting_anonymous = uuid.uuid() -- a non-existing consumer id
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -104,7 +105,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "basic-auth",
         route = { id = route4.id },
         config   = {
-          anonymous = uuid.uuid(), -- a non-existing consumer id
+          anonymous = nonexisting_anonymous, -- a non-existing consumer id
         },
       }
 
@@ -430,7 +431,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "basic-auth4.test"
           }
         })
-        assert.response(res).has.status(500)
+        local body = cjson.decode(assert.res_status(500, res))
+        assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
       end)
 
     end)

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -32,6 +32,7 @@ for _, strategy in helpers.each_strategy() do
     local hs_jwt_secret_2
     local proxy_client
     local admin_client
+    local nonexisting_anonymous = uuid.uuid() -- a nonexisting consumer id
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -121,7 +122,7 @@ for _, strategy in helpers.each_strategy() do
       plugins:insert({
         name     = "jwt",
         route = { id = routes[7].id },
-        config   = { anonymous = uuid.uuid() },
+        config   = { anonymous = nonexisting_anonymous }, -- a nonexisting consumer id
       })
 
       plugins:insert({
@@ -1243,7 +1244,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "jwt7.test"
           }
         })
-        assert.response(res).has.status(500)
+        local body = cjson.decode(assert.res_status(500, res))
+        assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
       end)
     end)
   end)

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -20,6 +20,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local consumer
     local credential
+    local nonexisting_anonymous = uuid.uuid() -- a nonexisting consumer id
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -96,7 +97,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "hmac-auth",
         route = { id = route3.id },
         config   = {
-          anonymous  = uuid.uuid(),  -- non existing consumer
+          anonymous  = nonexisting_anonymous,  -- a non existing consumer id
           clock_skew = 3000
         }
       }
@@ -1204,7 +1205,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "hmacauth3.test",
           },
         })
-        assert.response(res).has.status(500)
+        local body = cjson.decode(assert.res_status(500, res))
+        assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
       end)
 
       it("should pass with GET when body validation enabled", function()

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -37,6 +37,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         local admin_client
         local route2
         local plugin2
+        local nonexisting_anonymous = uuid.uuid() -- a non existing consumer id
 
         lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
@@ -141,7 +142,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
               base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
               attribute = "uid",
               cache_ttl = 2,
-              anonymous = uuid.uuid(), -- non existing consumer
+              anonymous = nonexisting_anonymous,  -- a non existing consumer id
             }
           }
 
@@ -597,7 +598,8 @@ for _, ldap_strategy in pairs(ldap_strategies) do
                 ["Host"] = "ldap4.test"
               }
             })
-            assert.response(res).has.status(500)
+            local body = cjson.decode(assert.res_status(500, res))
+            assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
           end)
         end)
       end)

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -172,6 +172,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
     local proxy_ssl_client
     local proxy_client
     local client1
+    local nonexisting_anonymous = uuid.uuid() -- a non existing consumer id
 
     lazy_setup(function()
 
@@ -511,7 +512,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         config   = {
           scopes             = { "email", "profile", "user.email" },
           global_credentials = true,
-          anonymous          = uuid.uuid(), -- a non existing consumer
+          anonymous          = nonexisting_anonymous, -- a non existing consumer id
         },
       })
 
@@ -3373,7 +3374,8 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
             ["Host"] = "oauth2_10.test"
           }
         })
-        assert.res_status(500, res)
+        local body = cjson.decode(assert.res_status(500, res))
+        assert.same("anonymous consumer " .. nonexisting_anonymous .. " is configured but doesn't exist", body.message)
       end)
       it("returns success and the token should have the right expiration when a custom header is passed", function()
         local res = assert(proxy_ssl_client:send {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-5392
