### PR TITLE
fix(clustering/rpc): rpc_capabilities should be encoded as array

### DIFF
--- a/kong/clustering/rpc/callbacks.lua
+++ b/kong/clustering/rpc/callbacks.lua
@@ -15,6 +15,9 @@ function _M.new()
     capabilities_list = {}, -- updated as register() is called
   }
 
+  -- it should always be an array when json encoding
+  setmetatable(self.capabilities_list, cjson.array_mt)
+
   return setmetatable(self, _MT)
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
