### PR TITLE
refactor(clustering/sync): use CLUSTERING_PING_INTERVAL as sync delay

### DIFF
--- a/kong/clustering/services/sync/init.lua
+++ b/kong/clustering/services/sync/init.lua
@@ -2,13 +2,14 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
+local constants = require("kong.constants")
 local events = require("kong.clustering.events")
 local strategy = require("kong.clustering.services.sync.strategies.postgres")
 local rpc = require("kong.clustering.services.sync.rpc")
 
 
 local FIRST_SYNC_DELAY = 0.2  -- seconds
-local EACH_SYNC_DELAY  = 30   -- seconds
+local EACH_SYNC_DELAY  = constants.CLUSTERING_PING_INTERVAL   -- 30 seconds
 
 
 function _M.new(db, is_cp)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5919

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
