### PR TITLE
fix(sync): extend wait time for RPC layer initialization

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -185,7 +185,9 @@ end
 
 -- check if rpc connection is ready
 local function is_rpc_ready()
-  for i = 1, 5 do
+  -- TODO: find a better way to detect when the RPC layer, including caps list,
+  --       has been fully initialized, instead of waiting for up to 5.5 seconds
+  for i = 1, 10 do
     local res = kong.rpc:get_peers()
 
     -- control_plane is ready


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

When we start up DP, we need to make a meta call to CP first, so the first `do_sync` during the initial sync fails. It reports an ERR error: `rpc.lua:432: unable to create worker mutex and sync: rpc is not ready`. This experience is not ideal.

The initialization of the configuration also fails, and we have to wait for ourselves to wait 30 seconds (`sync_every(30s)`) before the configuration can sync successfully. This means that the DP will be unable to function for a period of time after connecting.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5922
