### PR TITLE
tests(dao): match versions greater than 9

### DIFF
--- a/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
+++ b/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
@@ -42,7 +42,7 @@ describe("kong.db.dao.plugins", function()
 
       for i = 1, #handlers do
         assert.is_number(handlers[i].handler.PRIORITY)
-        assert.matches("%d%.%d%.%d", handlers[i].handler.VERSION)
+        assert.matches("%d+%.%d+%.%d+", handlers[i].handler.VERSION)
         assert.is_function(handlers[i].handler.access)
       end
     end)


### PR DESCRIPTION
### Summary

If a plugin version field is greater than 9, the previous match sequence would not catch it. This change tests for `"\d+\.\d+\.\d+"` and not `"[0-9]\.[0-9]\.[0-9]"`,

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-5534