### PR TITLE
fix(prometheus): add a toggle switch for wasm metrics export

### DIFF
--- a/changelog/unreleased/kong/prometheus-upstream-metrics-toggle.yml
+++ b/changelog/unreleased/kong/prometheus-upstream-metrics-toggle.yml
@@ -1,3 +1,4 @@
-message: "**Prometheus**: Use the :configure() handler to toggle upstream_health_metrics"
-type: bugfix
+message: |
+  **Prometheus**: Added the capability to enable/disable export of Proxy-Wasm metrics.
+type: feature
 scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -228,11 +228,15 @@ return {
       "queue.concurrency_limit",
     },
   },
+
   -- Any dataplane older than 3.10.0
   [3010000000] = {
     session = {
       "hash_subject",
       "store_metadata",
     },
-  }
+    prometheus = {
+      "wasm_metrics",
+    },
+  },
 }

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -216,21 +216,34 @@ end
 
 
 local function configure(configs)
-  -- everything disabled by default
   IS_PROMETHEUS_ENABLED = false
   export_upstream_health_metrics = false
+  local export_wasm_metrics = false
 
   if configs ~= nil then
     IS_PROMETHEUS_ENABLED = true
 
     for i = 1, #configs do
-      -- export upstream health metrics if any plugin has explicitly enabled them
+      -- `upstream_health_metrics` and `wasm_metrics` are global properties that
+      -- are disabled by default but will be enabled if any plugin instance has
+      -- explicitly enabled them
+
       if configs[i].upstream_health_metrics then
         export_upstream_health_metrics = true
+      end
+
+      if configs[i].wasm_metrics then
+        export_wasm_metrics = true
+      end
+
+      -- no need for further iteration since everyhing is enabled
+      if export_upstream_health_metrics and export_wasm_metrics then
         break
       end
     end
   end
+
+  wasm.set_enabled(export_wasm_metrics)
 end
 
 

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -22,6 +22,7 @@ return {
           { latency_metrics = { description = "A boolean value that determines if latency metrics should be collected. If enabled, `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` metrics will be exported.", type = "boolean", default = false }, },
           { bandwidth_metrics = { description = "A boolean value that determines if bandwidth metrics should be collected. If enabled, `bandwidth_bytes` and `stream_sessions_total` metrics will be exported.", type = "boolean", default = false }, },
           { upstream_health_metrics = { description = "A boolean value that determines if upstream metrics should be collected. If enabled, `upstream_target_health` metric will be exported.", type = "boolean", default = false }, },
+          { wasm_metrics = { description = "A boolean value that determines if Wasm metrics should be collected.", type = "boolean", default = false }, },
         },
         custom_validator = validate_shared_dict,
     }, },

--- a/kong/plugins/prometheus/wasmx.lua
+++ b/kong/plugins/prometheus/wasmx.lua
@@ -18,6 +18,7 @@ local _M = {}
 local FLUSH_EVERY = 100
 local GET_METRIC_OPTS = { prefix = false }
 
+local export_enabled = false
 
 local metrics_data_buf = buf_new()
 local labels_serialization_buf = buf_new()
@@ -181,7 +182,7 @@ end
 
 
 _M.metrics_data = function()
-  if not wasm.enabled() then
+  if not export_enabled or not wasm.enabled() then
     return
   end
 
@@ -230,5 +231,9 @@ _M.metrics_data = function()
   ngx_say(metrics_data_buf:get())
 end
 
+
+function _M.set_enabled(enabled)
+  export_enabled = enabled
+end
 
 return _M

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -1038,13 +1038,37 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         }
         -- ]]
 
+        finally(function()
+          admin.plugins:remove({ id = prometheus.id })
+        end)
+
         local expected_prometheus_prior_38 = cycle_aware_deep_copy(prometheus)
         expected_prometheus_prior_38.config.ai_metrics = nil
+        expected_prometheus_prior_38.config.wasm_metrics = nil
 
         do_assert(uuid(), "3.7.0", expected_prometheus_prior_38)
+      end)
 
-        -- cleanup
-        admin.plugins:remove({ id = prometheus.id })
+      it("[prometheus] remove wasm_metrics property for versions below 3.10", function()
+        -- [[ 3.10.x ]] --
+        local prometheus = admin.plugins:insert {
+          name = "prometheus",
+          enabled = true,
+          config = {
+            wasm_metrics = true, -- becomes nil
+          },
+        }
+        -- ]]
+
+        finally(function()
+          admin.plugins:remove({ id = prometheus.id })
+        end)
+
+
+        local expected_prometheus_prior_310 = cycle_aware_deep_copy(prometheus)
+        expected_prometheus_prior_310.config.wasm_metrics = nil
+
+        do_assert(uuid(), "3.9.0", expected_prometheus_prior_310)
       end)
     end)
 

--- a/spec/03-plugins/26-prometheus/09-wasmx_spec.lua
+++ b/spec/03-plugins/26-prometheus/09-wasmx_spec.lua
@@ -90,7 +90,10 @@ for _, strategy in helpers.each_strategy() do
       add_filter_to_service(bp, "tests", service)
       add_filter_to_service(bp, "tests", service2)
 
-      bp.plugins:insert({ name = "prometheus" })
+      assert(bp.plugins:insert({
+        name = "prometheus",
+        config = { wasm_metrics = true },
+      }))
 
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",


### PR DESCRIPTION
### Summary

Adds a toggle for wasm metrics export to the prometheus plugin.

### Issue reference

KAG-5904