### PR TITLE
fix(ai-proxy): fix ai-proxy plugin processing gzip response content l…

### DIFF
--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -175,7 +175,7 @@ _M.operation_map = {
 }
 
 _M.clear_response_headers = {
-  shared = {
+  shared = { -- deprecared, not using
     "Content-Length",
   },
   openai = {

--- a/kong/llm/plugin/base.lua
+++ b/kong/llm/plugin/base.lua
@@ -113,6 +113,9 @@ function MetaPlugin:header_filter(sub_plugin, conf)
       -- for gzip response, don't set content-length at all to align with upstream
       kong.response.clear_header("Content-Length")
       kong.response.set_header("Content-Encoding", "gzip")
+
+    else
+      kong.response.clear_header("Content-Encoding")
     end
 
   else

--- a/kong/llm/plugin/base.lua
+++ b/kong/llm/plugin/base.lua
@@ -110,6 +110,8 @@ function MetaPlugin:header_filter(sub_plugin, conf)
       -- and seems nginx doesn't support it
 
     elseif get_global_ctx("accept_gzip") then
+      -- for gzip response, don't set content-length at all to align with upstream
+      kong.response.clear_header("Content-Length")
       kong.response.set_header("Content-Encoding", "gzip")
     end
 

--- a/kong/llm/plugin/shared-filters/normalize-json-response.lua
+++ b/kong/llm/plugin/shared-filters/normalize-json-response.lua
@@ -2,7 +2,6 @@ local cjson = require("cjson")
 
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local ai_plugin_o11y = require("kong.llm.plugin.observability")
-local ai_shared = require("kong.llm.drivers.shared")
 
 local _M = {
   NAME = "normalize-json-response",
@@ -57,6 +56,8 @@ local function transform_body(conf)
   end
 
   set_global_ctx("response_body", response_body) -- to be sent out later or consumed by other plugins
+
+  return #response_body
 end
 
 function _M:run(conf)
@@ -81,8 +82,9 @@ function _M:run(conf)
   -- if not streaming, prepare the response body buffer
   -- this must be called before sending any response headers so that
   -- we can modify status code if needed
+  local body_length
   if not get_global_ctx("stream_mode") then
-    transform_body(conf)
+    body_length = transform_body(conf)
   end
 
   -- populate cost
@@ -94,11 +96,10 @@ function _M:run(conf)
     ai_plugin_o11y.metrics_set("llm_usage_cost", 0)
   end
 
-  -- clear shared restricted headers
-  for _, v in ipairs(ai_shared.clear_response_headers.shared) do
-    kong.response.clear_header(v)
+  if not get_global_ctx("accept_gzip") and not get_global_ctx("stream_mode") then
+    -- otherwise use our transformed body length
+    kong.response.set_header("Content-Length", body_length)
   end
-
 
   if ngx.var.http_kong_debug or conf.model_name_header then
     local model_t = ai_plugin_ctx.get_request_model_table_inuse()


### PR DESCRIPTION
…enth issue

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

When Kong tried to compress the upstream response with gzip in Kong body_filter, the response HTTP header content-length was set to uncompress response content length in header_filter . So kong tells the downstream client HTTP body length bigger than the real content that kong returns. it will let the HTTP client wait some time for data that doesn't exist. So I choose to clear content-length header in the header filter to tell nginx using the chunk transfer encoding method to process the body data.

before:
![image](https://github.com/user-attachments/assets/0efa40a1-15f8-403a-bedf-d52ad6248940)

After:
![image](https://github.com/user-attachments/assets/ab849c87-bac1-423f-9b80-78e5e5cefc24)


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix AG-182
