### PR TITLE
[backport -> release/3.9.x] fix(prometheus): add a toggle switch for wasm metrics export

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -228,4 +228,11 @@ return {
       "queue.concurrency_limit",
     },
   },
+
+  -- Any dataplane older than 3.9.0
+  [3009000000] = {
+    prometheus = {
+      "wasm_metrics",
+    },
+  },
 }

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -206,7 +206,19 @@ end
 
 
 local function configure(configs)
-  IS_PROMETHEUS_ENABLED = configs ~= nil
+  IS_PROMETHEUS_ENABLED = false
+  wasm.set_enabled(false)
+
+  if configs ~= nil then
+    IS_PROMETHEUS_ENABLED = true
+
+    for i = 1, #configs do
+      if configs[i].wasm_metrics then
+        wasm.set_enabled(true)
+        break
+      end
+    end
+  end
 end
 
 

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -22,6 +22,7 @@ return {
           { latency_metrics = { description = "A boolean value that determines if latency metrics should be collected. If enabled, `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` metrics will be exported.", type = "boolean", default = false }, },
           { bandwidth_metrics = { description = "A boolean value that determines if bandwidth metrics should be collected. If enabled, `bandwidth_bytes` and `stream_sessions_total` metrics will be exported.", type = "boolean", default = false }, },
           { upstream_health_metrics = { description = "A boolean value that determines if upstream metrics should be collected. If enabled, `upstream_target_health` metric will be exported.", type = "boolean", default = false }, },
+          { wasm_metrics = { description = "A boolean value that determines if Wasm metrics should be collected.", type = "boolean", default = false }, },
         },
         custom_validator = validate_shared_dict,
     }, },

--- a/kong/plugins/prometheus/wasmx.lua
+++ b/kong/plugins/prometheus/wasmx.lua
@@ -18,6 +18,7 @@ local _M = {}
 local FLUSH_EVERY = 100
 local GET_METRIC_OPTS = { prefix = false }
 
+local export_enabled = false
 
 local metrics_data_buf = buf_new()
 local labels_serialization_buf = buf_new()
@@ -181,7 +182,7 @@ end
 
 
 _M.metrics_data = function()
-  if not wasm.enabled() then
+  if not export_enabled or not wasm.enabled() then
     return
   end
 
@@ -230,5 +231,9 @@ _M.metrics_data = function()
   ngx_say(metrics_data_buf:get())
 end
 
+
+function _M.set_enabled(enabled)
+  export_enabled = enabled
+end
 
 return _M

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -1013,13 +1013,37 @@ describe("CP/DP config compat transformations #" .. strategy, function()
         }
         -- ]]
 
+        finally(function()
+          admin.plugins:remove({ id = prometheus.id })
+        end)
+
         local expected_prometheus_prior_38 = cycle_aware_deep_copy(prometheus)
         expected_prometheus_prior_38.config.ai_metrics = nil
+        expected_prometheus_prior_38.config.wasm_metrics = nil
 
         do_assert(uuid(), "3.7.0", expected_prometheus_prior_38)
+      end)
 
-        -- cleanup
-        admin.plugins:remove({ id = prometheus.id })
+      it("[prometheus] remove wasm_metrics property for versions below 3.9", function()
+        -- [[ 3.9.x ]] --
+        local prometheus = admin.plugins:insert {
+          name = "prometheus",
+          enabled = true,
+          config = {
+            wasm_metrics = true, -- becomes nil
+          },
+        }
+        -- ]]
+
+        finally(function()
+          admin.plugins:remove({ id = prometheus.id })
+        end)
+
+
+        local expected_prometheus_prior_39 = cycle_aware_deep_copy(prometheus)
+        expected_prometheus_prior_39.config.wasm_metrics = nil
+
+        do_assert(uuid(), "3.8.0", expected_prometheus_prior_39)
       end)
     end)
 

--- a/spec/03-plugins/26-prometheus/09-wasmx_spec.lua
+++ b/spec/03-plugins/26-prometheus/09-wasmx_spec.lua
@@ -90,7 +90,10 @@ for _, strategy in helpers.each_strategy() do
       add_filter_to_service(bp, "tests", service)
       add_filter_to_service(bp, "tests", service2)
 
-      bp.plugins:insert({ name = "prometheus" })
+      assert(bp.plugins:insert({
+        name = "prometheus",
+        config = { wasm_metrics = true },
+      }))
 
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",


### PR DESCRIPTION
This is a manual backport of https://github.com/Kong/kong/pull/13960

[KAG-5904](https://konghq.atlassian.net/browse/KAG-5904)

[KAG-5904]: https://konghq.atlassian.net/browse/KAG-5904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ