### PR TITLE
fix(clustering/rpc): support `cluster_use_proxy` option for clustering rpc protocol

### DIFF
--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -30,6 +30,7 @@ local cjson_encode = cjson.encode
 local cjson_decode = cjson.decode
 local validate_client_cert = clustering_tls.validate_client_cert
 local CLUSTERING_PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
+local parse_proxy_url = require("kong.clustering.utils").parse_proxy_url
 
 
 local RPC_MATA_V1 = "kong.meta.v1"

--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -474,6 +474,17 @@ function _M:connect(premature, node_id, host, path, cert, key)
 
   local c = assert(client:new(WS_OPTS))
 
+  if self.conf.cluster_use_proxy then
+    local proxy_opts = parse_proxy_url(self.conf.proxy_server)
+    opts.proxy_opts = {
+      wss_proxy = proxy_opts.proxy_url,
+      wss_proxy_authorization = proxy_opts.proxy_authorization,
+    }
+
+    ngx_log(ngx_DEBUG, _log_prefix,
+            "using proxy ", proxy_opts.proxy_url, " to connect control plane")
+  end
+
   local ok, err = c:connect(uri, opts)
   if not ok then
     ngx_log(ngx_ERR, "[rpc] unable to connect to peer: ", err)

--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -481,8 +481,8 @@ function _M:connect(premature, node_id, host, path, cert, key)
       wss_proxy_authorization = proxy_opts.proxy_authorization,
     }
 
-    ngx_log(ngx_DEBUG, _log_prefix,
-            "using proxy ", proxy_opts.proxy_url, " to connect control plane")
+    ngx_log(ngx_DEBUG, "[rpc] using proxy ", proxy_opts.proxy_url,
+                       " to connect control plane")
   end
 
   local ok, err = c:connect(uri, opts)

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -33,7 +33,7 @@ local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/%s",
 local _M = {}
 
 
-local function parse_proxy_url(proxy_server)
+function _M.parse_proxy_url(proxy_server)
   local ret = {}
 
   if proxy_server then
@@ -84,7 +84,7 @@ function _M.connect_cp(dp, endpoint, protocols)
   }
 
   if conf.cluster_use_proxy then
-    local proxy_opts = parse_proxy_url(conf.proxy_server)
+    local proxy_opts = _M.parse_proxy_url(conf.proxy_server)
     opts.proxy_opts = {
       wss_proxy = proxy_opts.proxy_url,
       wss_proxy_authorization = proxy_opts.proxy_authorization,

--- a/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
@@ -71,11 +71,13 @@ local proxy_configs = {
 -- if existing lmdb data is set, the service/route exists and
 -- test run too fast before the proxy connection is established
 
--- XXX FIXME: enable inc_sync = on
-for _, inc_sync in ipairs { "off" } do
+for _, v in ipairs({ {"off", "off"}, {"on", "off"}, {"on", "on"}, }) do
+  local rpc, inc_sync = v[1], v[2]
 for _, strategy in helpers.each_strategy() do
   for proxy_desc, proxy_opts in pairs(proxy_configs) do
-    describe("CP/DP sync through proxy (" .. proxy_desc .. ") works with #" .. strategy .. " inc_sync=" .. inc_sync .. " backend", function()
+    describe("CP/DP sync through proxy (" .. proxy_desc .. ") works with #"
+             .. strategy .. " rpc=" .. rpc .. " inc_sync=" .. inc_sync
+             .. " backend", function()
       lazy_setup(function()
         helpers.get_db_utils(strategy) -- runs migrations
 
@@ -87,6 +89,7 @@ for _, strategy in helpers.each_strategy() do
           db_update_frequency = 0.1,
           cluster_listen = "127.0.0.1:9005",
           nginx_conf = "spec/fixtures/custom_nginx.template",
+          cluster_rpc = rpc,
           cluster_incremental_sync = inc_sync,
         }))
 
@@ -108,6 +111,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_server_ssl_verify = proxy_opts.proxy_server_ssl_verify,
           lua_ssl_trusted_certificate = proxy_opts.lua_ssl_trusted_certificate,
 
+          cluster_rpc = rpc,
           cluster_incremental_sync = inc_sync,
 
           -- this is unused, but required for the template to include a stream {} block

--- a/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
@@ -172,13 +172,9 @@ for _, strategy in helpers.each_strategy() do
           end
 
           -- check the debug log of the `cluster_use_proxy` option
-          path = pl_path.join("servroot2", "logs", "error.log")
-          contents = pl_file.read(path)
-          if rpc == "on" and inc_sync == "on" then
-            assert.matches("%[rpc%] using proxy", contents)
-          else
-            assert.matches("%[clustering%] using proxy", contents)
-          end
+          local line = inc_sync == "on" and "[rpc] using proxy" or
+                                            "[clustering] using proxy"
+          assert.logfile("servroot2/logs/error.log").has.line(line, true)
         end)
       end)
     end)

--- a/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
@@ -170,6 +170,15 @@ for _, strategy in helpers.each_strategy() do
           if auth_on then
             assert.matches("accepted basic proxy%-authorization", contents)
           end
+
+          -- check the debug log of the `cluster_use_proxy` option
+          path = pl_path.join("servroot2", "logs", "error.log")
+          contents = pl_file.read(path)
+          if rpc == "on" and inc_sync == "on" then
+            assert.matches("%[rpc%] using proxy", contents)
+          else
+            assert.matches("%[clustering%] using proxy", contents)
+          end
         end)
       end)
     end)

--- a/spec/02-integration/09-hybrid_mode/14-dp_privileged_agent_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/14-dp_privileged_agent_spec.lua
@@ -20,6 +20,7 @@ describe("DP diabled Incremental Sync RPC #" .. strategy, function()
       cluster_listen = "127.0.0.1:9005",
       nginx_conf = "spec/fixtures/custom_nginx.template",
 
+      cluster_rpc = "on",
       cluster_incremental_sync = "on", -- ENABLE incremental sync
     }))
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
The original hybrid mode connections like full sync (sync v1) support forward proxy via the option `cluster_use_proxy`. While clustering RPC protocol does not support this, this commit introduces this feature to RPC protocol.
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5555
