### PR TITLE
fix(sync) don't return value from timer callback

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -427,7 +427,7 @@ sync_handler = function(premature, try_counter)
   end
 
   -- retry if the version is not updated
-  return ngx.timer.at(0, sync_handler, try_counter - 1)
+  ngx.timer.at(0, sync_handler, try_counter - 1)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. timer's handler should not return value
2. If timer's handler return value, which triggers luajit modify this function type, then it will trigger a timerng bug: `2024/12/03 17:07:18 [error] 26989#0: *24 [lua] job.lua:290: execute(): [timer-ng] failed to run timer unix_timestamp=1733216838235.000000; counter=11:meta=@./kong/clustering/rpc/socket.lua:67:Lua(): ...l-bin/build/kong-dev/share/lua/5.1/resty/timerng/job.lua:109: bad argument #1 to 'string_len' (string expected, got nil), context: ngx.timer
`

 

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
