### PR TITLE
chore(tools): show PR title in the changelog/verify-prs report

### DIFF
--- a/changelog/verify-prs
+++ b/changelog/verify-prs
@@ -261,7 +261,7 @@ function get_commits_prs () {
                      -H "Accept: application/vnd.github+json" \
                      -H "X-GitHub-Api-Version: 2022-11-28" \
                      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                     "https://api.github.com/search/issues?q=$full_q" | jq -r '.items[].html_url' | tee -a "$prs_file"
+                     "https://api.github.com/search/issues?q=$full_q" | jq -r '.items[]|"\(.html_url) - \(.title)"' | tee -a "$prs_file"
 
                 full_q="$BASE_Q"
             fi
@@ -276,7 +276,8 @@ function check_pr_changelog () {
 
     local changelog_pattern="changelog/unreleased/kong*/*.yml"
     local req_url="https://api.github.com/repos/${ORG_REPO}/pulls/PR_NUMBER/files"
-    local pr_number="${1##https*/}"
+    local pr_number="${1%% - *}"
+    pr_number="${pr_number##https*/}"
     req_url="${req_url/PR_NUMBER/$pr_number}"
     mapfile -t < <( curl -sSL \
                          -H "User-Agent: ${USER_AGENT}" \
@@ -300,7 +301,7 @@ function check_changelog () {
         parallel -j "$BULK" check_pr_changelog <"$1"
     else
         warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
-        <"$1" xargs -P "$BULK" -n1 bash -c 'check_pr_changelog "$@"' _
+        cat "$1" | tr '\n' '\0'| xargs -0 -P "$BULK" -n1 bash -c 'check_pr_changelog "$@"' _
     fi
     sort -uo "$prs_no_changelog_file" "$prs_no_changelog_file"
 }
@@ -310,7 +311,8 @@ function check_cherrypick_label () {
 
     local label_pattern="cherry-pick kong-ee"
     local req_url="https://api.github.com/repos/${ORG_REPO}/issues/PR_NUMBER/labels"
-    local pr_number="${1##https://*/}"
+    local pr_number="${1%% - *}"
+    pr_number="${pr_number##https*/}"
     req_url="${req_url/PR_NUMBER/$pr_number}"
     mapfile -t < <( curl -sSL \
                          -H "User-Agent: ${USER_AGENT}" \
@@ -330,7 +332,8 @@ function check_cross_reference () {
     if [[ -z "${1:+x}" ]] ; then return ; fi
 
     local req_url="https://api.github.com/repos/${ORG_REPO}/issues/PR_NUMBER/timeline"
-    local pr_number="${1##https://*/}"
+    local pr_number="${1%% - *}"
+    pr_number="${pr_number##https*/}"
     req_url="${req_url/PR_NUMBER/$pr_number}"
 
     local first_paged_response
@@ -391,7 +394,7 @@ function check_cross_reference () {
 }
 
 function check_ce2ee () {
-    if [[ "$ORG_REPO" != "kong/kong" && "$ORG_REPO" != "Kong/kong" ]] ; then
+    if [[ "${ORG_REPO,,}" != "kong/kong" ]] ; then
         warn "WARNING: only check CE2EE for CE repo. Skip $ORG_REPO"
         return
     fi
@@ -403,7 +406,7 @@ function check_ce2ee () {
         parallel -j "$BULK" check_cherrypick_label <"$1"
     else
         warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
-        <"$1" xargs -P "$BULK" -n1 bash -c 'check_cherrypick_label "$@"' _
+        cat "$1" |tr '\n' '\0' | xargs -0 -P "$BULK" -n1 bash -c 'check_cherrypick_label "$@"' _
     fi
     sort -uo "$prs_no_cherrypick_label_file" "$prs_no_cherrypick_label_file"
 
@@ -429,7 +432,7 @@ function check_ce2ee () {
             parallel -j "$BULK" check_cross_reference <"$1"
         else
             warn "WARNING: GNU 'parallel' is not available, fallback to 'xargs'"
-            <"$1" xargs -P "$BULK" -n1 bash -c 'check_cross_reference "$@"' _
+            cat "$1" |tr '\n' '\0' | xargs -0 -P "$BULK" -n1 bash -c 'check_cross_reference "$@"' _
         fi
     fi
     sort -uo "$prs_no_cross_reference_file" "$prs_no_cross_reference_file"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The PR title helps the release runners a lot when analyzing the `changelog/verify-prs` report to speed up the process. This PR is to add the title in the report and the title and PR URL are concatenated with ` - `.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-5972
