### PR TITLE
tests(*): remove useless strategy arg from reload_kong helper function

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -739,7 +739,7 @@ describe("kong start/stop #" .. strategy, function()
         local body = assert.response(res).has.jsonbody()
         assert.equal("no Route matched with those values", body.message)
 
-        assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+        assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
           database = "off",
           vaults = "mocksocket",
           plugins = "session",
@@ -825,7 +825,7 @@ describe("kong start/stop #" .. strategy, function()
         local body = assert.response(res).has.jsonbody()
         assert.equal("no Route matched with those values", body.message)
 
-        assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+        assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
           database = "off",
           vaults = "mocksocket",
           plugins = "session",
@@ -916,7 +916,7 @@ describe("kong start/stop #" .. strategy, function()
         local body = assert.response(res).has.jsonbody()
         assert.equal("no Route matched with those values", body.message)
 
-        assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+        assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
           database = "off",
           vaults = "mocksocket",
           plugins = "session",
@@ -1005,7 +1005,7 @@ describe("kong start/stop #" .. strategy, function()
         local body = assert.response(res).has.jsonbody()
         assert.equal("no Route matched with those values", body.message)
 
-        assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+        assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
           database = "off",
           vaults = "mocksocket",
           plugins = "session",

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -24,7 +24,7 @@ describe("kong reload #" .. strategy, function()
     local nginx_pid = wait_for_file_contents(helpers.test_conf.nginx_pid, 10)
 
     -- kong_exec uses test conf too, so same prefix
-    assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+    assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix))
 
     local nginx_pid_after = wait_for_file_contents(helpers.test_conf.nginx_pid, 10)
 
@@ -133,7 +133,7 @@ describe("kong reload #" .. strategy, function()
     local pids_1 = json.pids
     client:close()
 
-    assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+    assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix))
 
     client = helpers.admin_client()
     local res = assert(client:get("/"))
@@ -170,7 +170,7 @@ describe("kong reload #" .. strategy, function()
     local node_id_1 = json.node_id
     client:close()
 
-    assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+    assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix))
 
     client = helpers.admin_client()
     local res = assert(client:get("/"))
@@ -246,7 +246,7 @@ describe("kong reload #" .. strategy, function()
             - example.test
       ]], yaml_file)
 
-      assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix, {
+      assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
         declarative_config = yaml_file,
       }))
 
@@ -316,7 +316,7 @@ describe("kong reload #" .. strategy, function()
         return true
       end)
 
-      assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+      assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix))
 
       admin_client = assert(helpers.admin_client())
       local res = assert(admin_client:send {
@@ -413,7 +413,7 @@ describe("kong reload #" .. strategy, function()
         return true
       end)
 
-      assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+      assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix))
 
       admin_client = assert(helpers.admin_client())
       local res = assert(admin_client:send {
@@ -504,7 +504,7 @@ describe("kong reload #" .. strategy, function()
             weight: 100
       ]], yaml_file)
 
-      assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix, {
+      assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
         declarative_config = yaml_file,
       }))
 
@@ -655,7 +655,7 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
         keyauth_credentials:
         - key: my-new-key
     ]], yaml_file)
-    assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+    assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
       database = "off",
       declarative_config = yaml_file,
     }))
@@ -743,7 +743,7 @@ describe("Admin GUI config", function ()
 
     client:close()
 
-    assert(helpers.reload_kong("off", "reload --conf " .. helpers.test_conf_path, {
+    assert(helpers.reload_kong("reload --conf " .. helpers.test_conf_path, {
       database = "off",
       admin_gui_listen = "127.0.0.1:9012",
       admin_gui_url = "http://test2.example.com",

--- a/spec/02-integration/04-admin_api/22-debug_spec.lua
+++ b/spec/02-integration/04-admin_api/22-debug_spec.lua
@@ -520,7 +520,7 @@ describe("Admin API - Kong debug route with strategy #" .. strategy, function()
       end, 3)
 
       local prefix = helpers.test_conf.prefix
-      assert(helpers.reload_kong(strategy, "reload --prefix " .. prefix))
+      assert(helpers.reload_kong("reload --prefix " .. prefix))
 
       -- Wait for new workers to spawn
       helpers.pwait_until(function()

--- a/spec/02-integration/11-dbless/03-config_persistence_spec.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence_spec.lua
@@ -141,7 +141,7 @@ describe("dbless persistence with a declarative config #off", function()
   end)
 
   it("doesn't load the persisted lmdb config if a declarative config is set on reload", function()
-    assert(helpers.reload_kong("off", "reload --prefix " .. helpers.test_conf.prefix, {
+    assert(helpers.reload_kong("reload --prefix " .. helpers.test_conf.prefix, {
       database = "off",
       declarative_config = yaml_file,
     }))

--- a/spec/internal/wait.lua
+++ b/spec/internal/wait.lua
@@ -589,7 +589,7 @@ do
 end
 
 
-local function wait_until_no_common_workers(workers, expected_total, strategy)
+local function wait_until_no_common_workers(workers, expected_total)
   wait_until(function()
     local pok, admin_client = pcall(client.admin_client)
     if not pok then
@@ -665,11 +665,11 @@ end
 
 
 --- Reload Kong and wait all workers are restarted.
-local function reload_kong(strategy, ...)
+local function reload_kong(...)
   local workers = get_kong_workers()
   local ok, err = shell.kong_exec(...)
   if ok then
-    wait_until_no_common_workers(workers, 1, strategy)
+    wait_until_no_common_workers(workers, 1)
   end
   return ok, err
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR removes an useless `strategy` argument from one the helpers function `reload_kong`, as well as another related function `wait_until_no_common_workers`.

This argument(and the `reload_kong` function itself) was made a helpers function in PR #8670 (see the diff [here](https://github.com/Kong/kong/commit/fe20857b0edd52f6f1f977d28269535e3c976746#diff-5ef8552b54a226fa973a6c33644d117aba05c008e8e60efcc8508629eed713afR2805), which used to be a local helper function inside a test case. The argument `strategy` was only for sleeping a bit more time when the test was running under a Cassandra deployment and there was no other use besides this.

This argument was removed in EE earlier in another PR https://github.com/Kong/kong-ee/pull/3420, in commit https://github.com/Kong/kong-ee/commit/28850266ee35f7bc4f37d0b53edade4a39aabd55, but it was not removed in CE and caused divergence between the helpers function since then.

After the investigation, I see no meaning for us to keep this argument any longer, so I created this PR to totally remove it from CE test suites and to keep a consistent function signature between CE/EE repo.


NOTE: there is no need to cherry-pick this PR to EE, or my expectation is cherry-picking will create an empty commit 

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/FTI-5922
