### PR TITLE
tests(busted): make all setup() and teardown() calls lazy

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,5 +1,7 @@
 return {
   default = {
-    lpath = "./?.lua;./?/init.lua;"
+    lpath = "./?.lua;./?/init.lua;",
+    -- make setup() and teardown() behave like their lazy_ variants
+    lazy = true,
   }
 }


### PR DESCRIPTION
This adds the `lazy` setting to our `.busted` file. This is the equivalent of adding the `--lazy` flag when running the busted CLI, which essentially causes every `setup()` and `teardown()` invocation to behave like `lazy_setup()` and `lazy_teardown()`.

We have a bunch of test files that are using `setup()`/`teardown()` instead of the `lazy_` variants, and making one small change to the `.busted` file saves us the trouble of updating all of them (including EE).

> what's the difference between `setup()` and `lazy_setup()`?

`setup()` always runs, whereas `lazy_setup()` only runs if at least one test case (`it(...)`) is scheduled to run:

```lua
describe("strict", function()
  setup(function()
    -- I always run, even if the following test is skipped
    print("[strict] doing setup things")
  end)

  it("my test #skipme", function() end)
end)

describe("lazy", function()
  lazy_setup(function()
    -- I only run when the following test is not skipped
    print("[lazy] doing setup things")
  end)

  it("my test #skipme", function() end)
end)
```

We commonly filter out tests with the `--exclude-tags` CLI option in CI. The `strict` behavior is not ideal in this case, because it means that expensive setup/teardown tasks run even if we've completely filtered out all accompanied tests:

```
$ busted -o htest test_spec.lua  --exclude-tags skipme
======= Running tests from scanned files.
------- Global test environment setup.
------- Running tests from test_spec.lua :
[strict] doing setup things
------- 0 tests from test_spec.lua (0.24 ms total)

------- Global test environment teardown.
======= 0 tests from 1 test file ran. (0.41 ms total)
PASSED  0 tests.
```

If any test authors specifically need the strictness of `setup()`/`teardown()`, they can use `strict_setup()`/`strict_teardown()`:

https://lunarmodules.github.io/busted/#defining-tests

---
KAG-5962