### PR TITLE
feat(sessions): store session's meatadata

### DIFF
--- a/changelog/unreleased/kong/session_store_metadata.yml
+++ b/changelog/unreleased/kong/session_store_metadata.yml
@@ -1,0 +1,4 @@
+message: |
+  **session**: Added two boolean configuration fields `hash_subject` (default `false`) and `store_metadata` (default `false`) to store session's metadata in the database.
+type: feature
+scope: "Plugin"

--- a/kong-3.10.0-0.rockspec
+++ b/kong-3.10.0-0.rockspec
@@ -566,10 +566,13 @@ build = {
     ["kong.plugins.session.header_filter"] = "kong/plugins/session/header_filter.lua",
     ["kong.plugins.session.session"] = "kong/plugins/session/session.lua",
     ["kong.plugins.session.daos"] = "kong/plugins/session/daos.lua",
+    ["kong.plugins.session.daos.session_metadatas"] = "kong/plugins/session/daos/session_metadatas.lua",
+    ["kong.plugins.session.strategies.postgres.session_metadatas"] = "kong/plugins/session/strategies/postgres/session_metadatas.lua",
     ["kong.plugins.session.storage.kong"] = "kong/plugins/session/storage/kong.lua",
     ["kong.plugins.session.migrations.000_base_session"] = "kong/plugins/session/migrations/000_base_session.lua",
     ["kong.plugins.session.migrations.001_add_ttl_index"] = "kong/plugins/session/migrations/001_add_ttl_index.lua",
     ["kong.plugins.session.migrations.002_320_to_330"] = "kong/plugins/session/migrations/002_320_to_330.lua",
+    ["kong.plugins.session.migrations.003_330_to_3100"] = "kong/plugins/session/migrations/003_330_to_3100.lua",
     ["kong.plugins.session.migrations"] = "kong/plugins/session/migrations/init.lua",
 
     ["kong.plugins.proxy-cache.handler"]              = "kong/plugins/proxy-cache/handler.lua",

--- a/kong/plugins/session/daos.lua
+++ b/kong/plugins/session/daos.lua
@@ -1,20 +1,39 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 
-return {
-  {
-    primary_key = { "id" },
-    endpoint_key = "session_id",
-    name = "sessions",
-    cache_key = { "session_id" },
-    ttl = true,
-    db_export = false,
-    fields = {
-      { id = typedefs.uuid },
-      { session_id = { type = "string", unique = true, required = true } },
-      { expires = { type = "integer" } },
-      { data = { type = "string" } },
-      { created_at = typedefs.auto_timestamp_s },
-    }
+local sessions = {
+  primary_key = { "id" },
+  endpoint_key = "session_id",
+  name = "sessions",
+  cache_key = { "session_id" },
+  ttl = true,
+  db_export = false,
+  fields = {
+    { id = typedefs.uuid },
+    { session_id = { type = "string", unique = true, required = true } },
+    { expires = { type = "integer" } },
+    { data = { type = "string" } },
+    { created_at = typedefs.auto_timestamp_s },
   }
+}
+
+local session_metadatas = {
+  primary_key = { "id" },
+  name = "session_metadatas",
+  dao  = "kong.plugins.session.daos.session_metadatas",
+  generate_admin_api = false,
+  db_export = false,
+  fields = {
+    { id = typedefs.uuid },
+    { session = { type = "foreign", reference = "sessions", required = true, on_delete = "cascade" } },
+    { sid = { type = "string" } },
+    { audience = { type = "string" } },
+    { subject = { type = "string" } },
+    { created_at = typedefs.auto_timestamp_s },
+  }
+}
+
+return {
+  sessions,
+  session_metadatas,
 }

--- a/kong/plugins/session/daos/session_metadatas.lua
+++ b/kong/plugins/session/daos/session_metadatas.lua
@@ -1,0 +1,7 @@
+local session_metadatas = {}
+
+function session_metadatas:select_by_audience_and_subject(audience, subject)
+  return self.strategy:select_by_audience_and_subject(audience, subject)
+end
+
+return session_metadatas

--- a/kong/plugins/session/migrations/003_330_to_3100.lua
+++ b/kong/plugins/session/migrations/003_330_to_3100.lua
@@ -1,0 +1,23 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS session_metadatas(
+        id            uuid,
+        session_id    uuid                    REFERENCES "sessions" ("id") ON DELETE CASCADE,
+        sid           text,
+        subject       text,
+        audience      text,
+        created_at    timestamp WITH TIME ZONE,
+        PRIMARY KEY (id)
+      );
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "session_id_idx" ON "session_metadatas" ("session_id");
+        CREATE INDEX IF NOT EXISTS "subject_audience_idx" ON "session_metadatas" ("subject", "audience");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+    ]],
+  },
+}

--- a/kong/plugins/session/migrations/init.lua
+++ b/kong/plugins/session/migrations/init.lua
@@ -2,4 +2,5 @@ return {
   "000_base_session",
   "001_add_ttl_index",
   "002_320_to_330",
+  "003_330_to_3100",
 }

--- a/kong/plugins/session/schema.lua
+++ b/kong/plugins/session/schema.lua
@@ -212,6 +212,21 @@ return {
               default = "session_logout"
             }
           },
+          {
+            hash_subject = {
+              description = "Whether to hash or not the subject when store_metadata is enabled.",
+              type = "boolean",
+              default = false
+            }
+          },
+          {
+            store_metadata = {
+              description =
+              "Whether to also store metadata of sessions, such as collecting data of sessions for a specific audience belonging to a specific subject.",
+              type = "boolean",
+              default = false
+            }
+          },
         },
         shorthand_fields = {
           -- TODO: deprecated forms, to be removed in Kong 4.0

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -43,6 +43,8 @@ function _M.open_session(conf)
     remember_absolute_timeout = conf.remember_absolute_timeout,
     response_headers          = conf.response_headers,
     request_headers           = conf.request_headers,
+    hash_subject              = conf.hash_subject,
+    store_metadata            = conf.store_metadata,
   })
 end
 

--- a/kong/plugins/session/strategies/postgres/session_metadatas.lua
+++ b/kong/plugins/session/strategies/postgres/session_metadatas.lua
@@ -1,0 +1,22 @@
+local fmt = string.format
+
+local session_metadatas = {}
+
+function session_metadatas:select_by_audience_and_subject(audience, subject)
+  if type(audience) ~= "string" then
+    error("audience must be string")
+  end
+
+  if type(subject) ~= "string" then
+    error("subject must be string")
+  end
+
+  local qs = fmt(
+    "SELECT * FROM session_metadatas WHERE audience = %s AND subject = %s;",
+    kong.db.connector:escape_literal(audience),
+    kong.db.connector:escape_literal(subject))
+
+  return kong.db.connector:query(qs, "read")
+end
+
+return session_metadatas

--- a/spec/05-migration/plugins/session/migrations/003_330_to_3100_spec.lua
+++ b/spec/05-migration/plugins/session/migrations/003_330_to_3100_spec.lua
@@ -1,0 +1,15 @@
+local uh = require "spec/upgrade_helpers"
+
+describe("database migration", function()
+  if uh.database_type() == "postgres" then
+    uh.all_phases("has created the \"session_metadatas\" table", function()
+      assert.database_has_relation("session_metadatas")
+      assert.table_has_column("session_metadatas", "id", "uuid")
+      assert.table_has_column("session_metadatas", "session_id", "uuid")
+      assert.table_has_column("session_metadatas", "sid", "text")
+      assert.table_has_column("session_metadatas", "subject", "text")
+      assert.table_has_column("session_metadatas", "audience", "text")
+      assert.table_has_column("session_metadatas", "created_at", "timestamp with time zone", "timestamp")
+    end)
+  end
+end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
<!--- Why is this change required? What problem does it solve? -->
Engineering brief:
https://docs.google.com/document/d/1r7nSZGOlTVhupoVGQ6Ymqsaw64eGHKSMibko8FgrwAQ/edit?tab=t.0
**### This PR won't bring a break change.**
Add two new configurations`hash_subject`(by default false) and `store_metadata`(by default false). Please ref [here](https://github.com/bungle/lua-resty-session?tab=readme-ov-file#session-configuration).
Add a new table `session_metadatas` to store the session's metadata.
```
CREATE TABLE IF NOT EXISTS session_metadatas(
        id            uuid,
        session_id    uuid                    REFERENCES "sessions" ("id") ON DELETE CASCADE,
        sid           text,
        subject       text,
        audience      text,
        created_at    timestamp WITH TIME ZONE,
        PRIMARY KEY (id)
      );
```

**Why to do this?**
Please check this PR's ticket.
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KM-788
