### PR TITLE
fix(core): add `tls_verify`, `tls_verify_depth`, `ca_certificates` of a service into the upstream keepalive pool name

### DIFF
--- a/changelog/unreleased/kong/fix-upstream-keep-alive-pool-name.yml
+++ b/changelog/unreleased/kong/fix-upstream-keep-alive-pool-name.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where `tls_verify`, `tls_verify_depth` and `ca_certificates` of a service were not included in the upstream keepalive pool name.
+type: bugfix
+scope: Core

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1387,8 +1387,14 @@ function Kong.balancer()
       -- upstream_host is SNI
       pool = pool .. "|" .. var.upstream_host
 
-      if ctx.service and ctx.service.client_certificate then
-        pool = pool .. "|" .. ctx.service.client_certificate.id
+      local ctx_service = ctx.service
+      if ctx_service then
+        pool = string.format("%s|%s|%s|%s|%s",
+              pool,
+              ctx_service.tls_verify ~= nil and tostring(ctx_service.tls_verify) or "",
+              ctx_service.tls_verify_depth or "",
+              ctx_service.ca_certificates and table.concat(ctx_service.ca_certificates, ",") or "",
+              ctx_service.client_certificate and ctx_service.client_certificate.id or "")
       end
     end
 


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/FTI-6380
