### PR TITLE
tests(wasm): add missing filter tags

### DIFF
--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -237,7 +237,7 @@ describe("#wasm - hybrid mode #postgres" .. " inc_sync=" .. inc_sync, function()
           res:read_body()
 
           if res.status ~= 200 then
-            return {
+            return nil, {
               msg = "bad http status",
               exp = 200,
               got = res.status,
@@ -269,7 +269,7 @@ describe("#wasm - hybrid mode #postgres" .. " inc_sync=" .. inc_sync, function()
           res:read_body()
 
           if res.status ~= 200 then
-            return {
+            return nil, {
               msg = "bad http status",
               exp = 200,
               got = res.status,

--- a/spec/02-integration/20-wasm/08-declarative_spec.lua
+++ b/spec/02-integration/20-wasm/08-declarative_spec.lua
@@ -72,7 +72,7 @@ local function expect_field_error(res, field, err)
 end
 
 
-describe("#wasm declarative config", function()
+describe("#wasm declarative config (db = #off)", function()
   local admin
   local proxy
   local header_name = "x-wasm-dbless"
@@ -172,7 +172,7 @@ describe("#wasm declarative config", function()
 end)
 
 
-describe("#wasm declarative config (no installed filters)", function()
+describe("#wasm declarative config (no installed filters) (db = #off)", function()
   local tmp_dir
 
   lazy_setup(function()
@@ -265,7 +265,7 @@ describe("#wasm declarative config (no installed filters)", function()
   end)
 end)
 
-describe("#wasm declarative config (wasm = off)", function()
+describe("#wasm declarative config (wasm = off) (db = #off)", function()
   describe("POST /config", function()
     local client
 

--- a/spec/02-integration/20-wasm/10-wasmtime_spec.lua
+++ b/spec/02-integration/20-wasm/10-wasmtime_spec.lua
@@ -6,7 +6,7 @@ for _, v in ipairs({ {"off", "off"}, {"on", "off"}, {"on", "on"}, }) do
 
 for _, role in ipairs({"traditional", "control_plane", "data_plane"}) do
 
-describe("#wasm wasmtime (role: " .. role .. ")", function()
+describe("#wasm wasmtime (role: " .. role .. ") (#postgres, #db)", function()
   describe("kong prepare", function()
     local conf
     local prefix = "./wasm"


### PR DESCRIPTION
* fixed a couple logic bugs in usage of `assert.eventually()`
* added missing `#off`, `#postgres`, and `#db` tags that are used for filtering in CI

KAG-5962