### PR TITLE
fix(sync): do not introduce router rebuild timer for full sync

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -359,22 +359,17 @@ local function new_router(version)
     end
   end
 
-  -- We need to force detecting router changes if there is some one modifying
-  -- the routers, like rebuild_router_timer.
+  -- We need to detect router changes if there is some one modifying the routers,
+  -- like rebuild_router_timer. And it relies on core_cache to detect changes.
   --
-  -- 1. stratey off
+  -- 1. stratey off (dbless)
   --      incremental_sync on:
   --             non init worker: true(kong.core_cache)
   --                 init worker: false
   --      incremental_sync off:   false
-  -- 2. strategy on:              true(kong.core_cache)
-  local detect_changes = kong.core_cache and true
-
-  if db.strategy == "off" and
-    ((kong.sync and get_phase() == "init_worker") or not kong.sync)
-  then
-    detect_changes = false
-  end
+  -- 2. strategy on (non dbless): true(kong.core_cache)
+  local detect_changes = kong.core_cache and
+          (db.strategy ~= "off" or (kong.sync and get_phase() ~= "init_worker"))
 
   local counter = 0
   local page_size = db.routes.pagination.max_page_size

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -359,10 +359,20 @@ local function new_router(version)
     end
   end
 
+  -- We need to force detecting router changes if there is some one modifying
+  -- the routers, like rebuild_router_timer.
+  --
+  -- 1. stratey off
+  --      incremental_sync on:
+  --             non init worker: true(kong.core_cache)
+  --                 init worker: false
+  --      incremental_sync off:   false
+  -- 2. strategy on:              true(kong.core_cache)
   local detect_changes = kong.core_cache and true
 
-  -- for dbless we will not check changes when initing
-  if db.strategy == "off" and get_phase() == "init_worker" then
+  if db.strategy == "off" and
+    ((kong.sync and get_phase() == "init_worker") or not kong.sync)
+  then
     detect_changes = false
   end
 
@@ -979,7 +989,11 @@ return {
         end
       end
 
-      do  -- start some rebuild timers
+      -- start some rebuild timers for
+      -- 1. traditional mode
+      -- 2. CP in hybrid mode
+      -- 3. DP with incremental sync on (dbless mode)
+      if strategy ~= "off" or kong.sync then
         local worker_state_update_frequency = kong.configuration.worker_state_update_frequency or 1
 
         local router_async_opts = {

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -986,8 +986,7 @@ return {
 
       -- start some rebuild timers for
       -- 1. traditional mode
-      -- 2. CP in hybrid mode
-      -- 3. DP with incremental sync on (dbless mode)
+      -- 2. DP with incremental sync on (dbless mode)
       if strategy ~= "off" or kong.sync then
         local worker_state_update_frequency = kong.configuration.worker_state_update_frequency or 1
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6006
