### PR TITLE
tests(*): shutdown timerng instance after test completion

### DIFF
--- a/.busted
+++ b/.busted
@@ -3,5 +3,6 @@ return {
     lpath = "./?.lua;./?/init.lua;",
     -- make setup() and teardown() behave like their lazy_ variants
     lazy = true,
+    helper = "./spec/busted-ci-helper.lua",
   }
 }

--- a/kong-3.10.0-0.rockspec
+++ b/kong-3.10.0-0.rockspec
@@ -155,6 +155,7 @@ build = {
     ["kong.cmd.utils.prefix_handler"] = "kong/cmd/utils/prefix_handler.lua",
     ["kong.cmd.utils.process_secrets"] = "kong/cmd/utils/process_secrets.lua",
     ["kong.cmd.utils.inject_confs"] = "kong/cmd/utils/inject_confs.lua",
+    ["kong.cmd.utils.timer"] = "kong/cmd/utils/timer.lua",
 
     ["kong.api"] = "kong/api/init.lua",
     ["kong.api.api_helpers"] = "kong/api/api_helpers.lua",

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -4,13 +4,7 @@ math.randomseed() -- Generate PRNG seed
 
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
-
-local function stop_timers()
-  -- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
-  if _G.timerng then
-    _G.timerng:destroy()
-  end
-end
+local timer = require "kong.cmd.utils.timer"
 
 return function(cmd_name, args)
   local cmd = require("kong.cmd." .. cmd_name)
@@ -42,5 +36,6 @@ return function(cmd_name, args)
     pl_app.quit(nil, true)
   end)
 
-  stop_timers()
+  -- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
+  timer.shutdown()
 end

--- a/kong/cmd/utils/timer.lua
+++ b/kong/cmd/utils/timer.lua
@@ -1,0 +1,18 @@
+local _M = {}
+
+function _M.shutdown()
+  if _G.timerng then
+    pcall(_G.timerng.destroy, _G.timerng)
+  end
+
+  -- kong.init_worker() stashes the timerng instance within the kong global and
+  -- removes the _G.timerng reference, so check there too
+  if _G.kong and _G.kong.timer and _G.kong.timer ~= _G.timerng then
+    pcall(_G.kong.timer.destroy, _G.kong.timer)
+    _G.kong.timer = nil
+  end
+
+  _G.timerng = nil
+end
+
+return _M

--- a/spec/busted-ci-helper.lua
+++ b/spec/busted-ci-helper.lua
@@ -6,7 +6,13 @@ do
   assert(type(shutdown_timers) == "function")
 
   -- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
-  busted.subscribe({ 'exit' }, shutdown_timers)
+  busted.subscribe({ 'exit' }, function()
+    shutdown_timers()
+
+    -- second return value must be `true`, or else all other callbacks for this
+    -- event will be skipped
+    return nil, true
+  end)
 end
 
 local BUSTED_EVENT_PATH = os.getenv("BUSTED_EVENT_PATH")

--- a/spec/busted-ci-helper.lua
+++ b/spec/busted-ci-helper.lua
@@ -69,3 +69,6 @@ if busted_event_path then
     end)
   end
 end
+
+-- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
+busted.subscribe({ 'exit' }, require("kong.cmd.utils.timer").shutdown)


### PR DESCRIPTION
This takes the same fix that was applied to Kong's CLI framework in 26b2db7b94f3158e4ae1f5a8468b9bde832a19c7 and applies it to busted test runs.

## changes

* a7d3e8f963a590545e89f1934c1fc194d122863f - factor out the timer shutdown logic into `kong.cmd.utils.timer.shutdown()`
* c01e93dadd0ff8b16b929e61d21db42a2007ebc7
  - hook into busted's `exit` event to call `kong.cmd.utils.timer.shutdown()` at the end of execution
  - add `--helper spec/busted-ci-helper.lua` as a default option in `.busted` 
* ff03381af71d211985067db382dfb80af99ee461 - refactor `spec/busted-ci-helper.lua` to keep concerns separated

## why

Test performance. If the timer instance isn't explicitly torn down, it delays the worker process shutdown for ~1s. In CI where each test file is executed via a separate `busted` CLI invocation, this adds up quite a bit!

### master

```
$ time busted empty_spec.lua
●
1 success / 0 failures / 0 errors / 0 pending : 0.000278 seconds

real    0m1.073s
user    0m0.050s
sys     0m0.048s
```

### this branch

```
$ time busted empty_spec.lua
●
1 success / 0 failures / 0 errors / 0 pending : 0.000381 seconds

real    0m0.195s
user    0m0.045s
sys     0m0.048s
```

## issues

KAG-5962