### PR TITLE
chore(wasm): remove bundled datakit filter

### DIFF
--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -2,17 +2,7 @@
 A list of wasm filters.
 """
 
-WASM_FILTERS = [
-    {
-        "name": "datakit-filter",
-        "repo": "Kong/datakit",
-        "tag": "0.3.1",
-        "files": {
-            "datakit.meta.json": "acd16448615ea23315e68d4516edd79135bae13469f7bf9129f7b1139cd2b873",
-            "datakit.wasm": "c086e6fb36a6ed8c9ff3284805485c7280380469b6a556ccf7e5bc06edce27e7",
-        },
-    },
-]
+WASM_FILTERS = []
 
 WASM_FILTERS_TARGETS = [
     "@%s-%s//file" % (filter["name"], file)

--- a/changelog/unreleased/kong/bump-datakit.yml
+++ b/changelog/unreleased/kong/bump-datakit.yml
@@ -1,2 +1,0 @@
-message: "Bumped the bundled `datakit` Wasm filter to `0.3.1`"
-type: dependency

--- a/changelog/unreleased/kong/remove-datakit.yml
+++ b/changelog/unreleased/kong/remove-datakit.yml
@@ -1,0 +1,2 @@
+message: "**Wasm**: Removed the experimental datakit Wasm filter"
+type: dependency

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -675,7 +675,7 @@ local function load(path, custom_conf, opts)
         bundled_filter_path = alt_path
 
       else
-        log.warn("Bundled proxy-wasm filters path (%s) does not exist " ..
+        log.debug("Bundled proxy-wasm filters path (%s) does not exist " ..
                  "or is not a directory. Bundled filters may not be " ..
                  "available", bundled_filter_path)
       end

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -340,7 +340,7 @@ describe("Configuration loader", function()
     assert.is_not_nil(conf)
     assert.is_not_nil(conf.admin_gui_origin)
     assert.same({ "http://localhost:8002" }, conf.admin_gui_origin)
-    
+
     conf, _, errors = conf_loader(nil, {
       admin_gui_url = "http://localhost:8002/manager, https://localhost:8445/manager",
     })
@@ -2062,12 +2062,7 @@ describe("Configuration loader", function()
         }))
 
         assert(conf.wasm_bundled_filters_path)
-        bundled_filters = {
-          {
-            name = "datakit",
-            path = conf.wasm_bundled_filters_path .. "/datakit.wasm",
-          },
-        }
+        bundled_filters = {}
       end
 
       all_filters = {}
@@ -2164,7 +2159,8 @@ describe("Configuration loader", function()
       assert.same(bundled_filters, conf.wasm_modules_parsed)
     end)
 
-    it("prefers user filters to bundled filters when a conflict exists", function()
+    -- XXX: we don't have any bundled filters to use for this test
+    pending("prefers user filters to bundled filters when a conflict exists", function()
       local user_filter = temp_dir .. "/datakit.wasm"
       assert(helpers.file.write(user_filter, "I'm a happy little wasm filter"))
       finally(function()

--- a/spec/02-integration/20-wasm/07-reports_spec.lua
+++ b/spec/02-integration/20-wasm/07-reports_spec.lua
@@ -82,7 +82,7 @@ for _, strategy in helpers.each_strategy() do
       local _, reports_data = assert(reports_server:join())
       reports_data = cjson.encode(reports_data)
 
-      assert.match("wasm_cnt=3", reports_data)
+      assert.match("wasm_cnt=2", reports_data)
     end)
 
     it("logs number of requests triggering a Wasm filter", function()


### PR DESCRIPTION
This filter will no longer be bundled with Kong. Wasm as a feature has not GA-ed yet, so its removal is not considered a breaking change.

KAG-6021