### PR TITLE
feat(prometheus): expose controlplane connectivity state as a gauge

### DIFF
--- a/changelog/unreleased/kong/add-cp-connectivity-metric-prometheus.yml
+++ b/changelog/unreleased/kong/add-cp-connectivity-metric-prometheus.yml
@@ -1,0 +1,4 @@
+message: |
+  **Prometheus**: Added gauge to expose connectivity state to controlplane.
+type: feature
+scope: Plugin

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -74,11 +74,20 @@ function _M.new(clustering)
 end
 
 
+local function set_control_plane_connected(reachable)
+  local ok, err = ngx.shared.kong:safe_set("control_plane_connected", reachable, PING_WAIT)
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, "failed to set control_plane_connected key in shm to ", reachable, " :", err)
+  end
+end
+
+
 function _M:init_worker(basic_info)
   -- ROLE = "data_plane"
 
   self.plugins_list = basic_info.plugins
   self.filters = basic_info.filters
+  set_control_plane_connected(false)
 
   local function start_communicate()
     assert(ngx.timer.at(0, function(premature)
@@ -139,13 +148,17 @@ local function send_ping(c, log_suffix)
 
   local _, err = c:send_ping(hash)
   if err then
+    set_control_plane_connected(false)
     ngx_log(is_timeout(err) and ngx_NOTICE or ngx_WARN, _log_prefix,
             "unable to send ping frame to control plane: ", err, log_suffix)
 
-  -- only log a ping if the hash changed
-  elseif hash ~= prev_hash then
-    prev_hash = hash
-    ngx_log(ngx_INFO, _log_prefix, "sent ping frame to control plane with hash: ", hash, log_suffix)
+  else
+    set_control_plane_connected(true)
+    -- only log a ping if the hash changed
+    if hash ~= prev_hash then
+      prev_hash = hash
+      ngx_log(ngx_INFO, _log_prefix, "sent ping frame to control plane with hash: ", hash, log_suffix)
+    end
   end
 end
 
@@ -197,6 +210,7 @@ function _M:communicate(premature)
 
   local c, uri, err = clustering_utils.connect_cp(self, "/v1/outlet")
   if not c then
+    set_control_plane_connected(false)
     ngx_log(ngx_WARN, _log_prefix, "connection to control plane ", uri, " broken: ", err,
                  " (retrying after ", reconnection_delay, " seconds)", log_suffix)
 
@@ -229,6 +243,7 @@ function _M:communicate(premature)
                                        filters = self.filters,
                                        labels = labels, }))
   if err then
+    set_control_plane_connected(false)
     ngx_log(ngx_ERR, _log_prefix, "unable to send basic information to control plane: ", uri,
                      " err: ", err, " (retrying after ", reconnection_delay, " seconds)", log_suffix)
 
@@ -238,6 +253,7 @@ function _M:communicate(premature)
     end))
     return
   end
+  set_control_plane_connected(true)
 
   local config_semaphore = semaphore.new(0)
 
@@ -344,16 +360,19 @@ function _M:communicate(premature)
       local data, typ, err = c:recv_frame()
       if err then
         if not is_timeout(err) then
+          set_control_plane_connected(false)
           return nil, "error while receiving frame from control plane: " .. err
         end
 
         local waited = ngx_time() - last_seen
         if waited > PING_WAIT then
+          set_control_plane_connected(false)
           return nil, "did not receive pong frame from control plane within " .. PING_WAIT .. " seconds"
         end
 
         goto continue
       end
+      set_control_plane_connected(true)
 
       if typ == "close" then
         ngx_log(ngx_DEBUG, _log_prefix, "received close frame from control plane", log_suffix)

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -10,6 +10,7 @@ local lower = string.lower
 local ngx_timer_pending_count = ngx.timer.pending_count
 local ngx_timer_running_count = ngx.timer.running_count
 local get_all_upstreams = balancer.get_all_upstreams
+
 if not balancer.get_all_upstreams then -- API changed since after Kong 2.5
   get_all_upstreams = require("kong.runloop.balancer.upstreams").get_all_upstreams
 end
@@ -65,6 +66,14 @@ local function init()
                                           "0 is unreachable",
                                           nil,
                                           prometheus.LOCAL_STORAGE)
+  if role == "data_plane" then
+    metrics.cp_connected = prometheus:gauge("control_plane_connected",
+                                            "Kong connected to control plane, " ..
+                                            "0 is unconnected",
+                                            nil,
+                                            prometheus.LOCAL_STORAGE)
+  end
+
   metrics.node_info = prometheus:gauge("node_info",
                                        "Kong Node metadata information",
                                        {"node_id", "version"},
@@ -448,6 +457,15 @@ local function metric_data(write_fn)
       metrics.db_reachable:set(0)
       kong.log.err("prometheus: failed to reach database while processing",
                   "/metrics endpoint: ", err)
+    end
+
+    if role == "data_plane" then
+      local cp_reachable = ngx.shared.kong:get("control_plane_connected")
+      if cp_reachable then
+        metrics.cp_connected:set(1)
+      else
+        metrics.cp_connected:set(0)
+      end
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Add a new Prometheus gauge metric `control_plane_connected`. Similar to `datastore_reachable` gauge, 0 means the connection is not healthy; 1 means that the connection is healthy. We mark the connection as unhealthy under the following circumstances:
* Failure while establihing a websocket connection
* Failure while sending basic information to controlplane
* Failure while sending ping to controlplane
* Failure while receiving a packet from the websocket connection

This is helpful for users running a signficant number of gateways to be alerted about potential issues any gateway(s) may be facing while talking to the controlplane.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
