### PR TITLE
refactor(clustering/sync): clean the logic of sync_once_impl()

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -432,6 +432,7 @@ function sync_once_impl(premature, retry_count)
 
   local current_version = tonumber(declarative.get_current_hash()) or 0
   if current_version >= latest_notified_version then
+    ngx_log(ngx_DEBUG, "version already updated")
     return
   end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -422,26 +422,27 @@ function sync_once_impl(premature, retry_count)
     return
   end
 
-  sync_handler()  
-  
-  local latest_notified_version = ngx.shared.kong:get(CLUSTERING_DATA_PLANES_LATEST_VERSION_KEY)
-  local current_version = tonumber(declarative.get_current_hash()) or 0
+  sync_handler()
 
+  local latest_notified_version = ngx.shared.kong:get(CLUSTERING_DATA_PLANES_LATEST_VERSION_KEY)
   if not latest_notified_version then
     ngx_log(ngx_DEBUG, "no version notified yet")
     return
   end
 
-  -- retry if the version is not updated
-  if current_version < latest_notified_version then
-    retry_count = retry_count or 0
-    if retry_count > MAX_RETRY then
-      ngx_log(ngx_ERR, "sync_once retry count exceeded. retry_count: ", retry_count)
-      return
-    end
-
-    return start_sync_once_timer(retry_count + 1)
+  local current_version = tonumber(declarative.get_current_hash()) or 0
+  if current_version >= latest_notified_version then
+    return
   end
+
+  -- retry if the version is not updated
+  retry_count = retry_count or 0
+  if retry_count > MAX_RETRY then
+    ngx_log(ngx_ERR, "sync_once retry count exceeded. retry_count: ", retry_count)
+    return
+  end
+
+  return start_sync_once_timer(retry_count + 1)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

[KAG-5944](https://konghq.atlassian.net/browse/KAG-5944)
See https://github.com/Kong/kong/pull/13896 and https://github.com/Kong/kong/pull/13956

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_


[KAG-5944]: https://konghq.atlassian.net/browse/KAG-5944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ