### PR TITLE
perf(lmdb): remove the key with global workspace id *

### DIFF
--- a/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
+++ b/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
@@ -1,0 +1,3 @@
+message: "remove the key with the global workspace ID `*` from lmdb."
+type: performance
+scope: Core

--- a/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
+++ b/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
@@ -1,3 +1,3 @@
-message: "Optimize LMDB storage space by removing the key with the global workspace ID `*`."
+message: "Reduced the LMDB storage space by optimizing the key format."
 type: performance
 scope: Core

--- a/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
+++ b/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
@@ -1,3 +1,3 @@
-message: "remove the key with the global workspace ID `*` from lmdb."
+message: "Optimize LMDB storage space by removing the key with the global workspace ID `*` from LMDB."
 type: performance
 scope: Core

--- a/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
+++ b/changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml
@@ -1,3 +1,3 @@
-message: "Optimize LMDB storage space by removing the key with the global workspace ID `*` from LMDB."
+message: "Optimize LMDB storage space by removing the key with the global workspace ID `*`."
 type: performance
 scope: Core

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -616,6 +616,4 @@ return {
   load_into_cache_with_events = load_into_cache_with_events,
   insert_entity_for_txn = insert_entity_for_txn,
   delete_entity_for_txn = delete_entity_for_txn,
-
-  GLOBAL_WORKSPACE_TAG = GLOBAL_WORKSPACE_TAG,
 }

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -70,6 +70,7 @@ local function workspace_id(schema, options)
     return get_workspace_id()
   end
 
+  -- global query, like routes:each(page_size, GLOBAL_QUERY_OPTS)
   if options.workspace == null then
     return GLOBAL_WORKSPACE_TAG
   end
@@ -243,26 +244,39 @@ local function find_ws(entities, name)
 end
 
 
+-- unique key
 local function unique_field_key(schema_name, ws_id, field, value)
-  return string_format("%s|%s|%s|%s", schema_name, ws_id, field, sha256_hex(value))
+  return string_format("U|%s|%s|%s|%s", schema_name, field, ws_id, sha256_hex(value))
 end
 
 
+-- foreign key
 local function foreign_field_key_prefix(schema_name, ws_id, field, foreign_id)
-  return string_format("%s|%s|%s|%s|", schema_name, ws_id, field, foreign_id)
+  if ws_id == GLOBAL_WORKSPACE_TAG then
+    return string_format("F|%s|%s|%s|", schema_name, field, foreign_id)
+  end
+
+  return string_format("F|%s|%s|%s|%s|", schema_name, field, foreign_id, ws_id)
 end
 
 
 local function foreign_field_key(schema_name, ws_id, field, foreign_id, pk)
+  assert(ws_id ~= GLOBAL_WORKSPACE_TAG)
   return foreign_field_key_prefix(schema_name, ws_id, field, foreign_id) .. pk
 end
 
+-- item key
 local function item_key_prefix(schema_name, ws_id)
-  return string_format("%s|%s|*|", schema_name, ws_id)
+  if ws_id == GLOBAL_WORKSPACE_TAG then
+    return string_format("I|%s|", schema_name)
+  end
+
+  return string_format("I|%s|%s|", schema_name, ws_id)
 end
 
 
 local function item_key(schema_name, ws_id, pk_str)
+  assert(ws_id ~= GLOBAL_WORKSPACE_TAG)
   return item_key_prefix(schema_name, ws_id) .. pk_str
 end
 
@@ -307,10 +321,6 @@ local function _set_entity_for_txn(t, entity_name, item, options, is_delete)
   -- store serialized entity into lmdb
   t:set(itm_key, itm_value)
 
-  -- for global query
-  local global_key = item_key(entity_name, GLOBAL_WORKSPACE_TAG, pk)
-  t:set(global_key, idx_value)
-
   -- select_by_cache_key
   if schema.cache_key then
     local cache_key = dao:cache_key(item)
@@ -347,12 +357,9 @@ local function _set_entity_for_txn(t, entity_name, item, options, is_delete)
         value_str = pk_string(kong.db[fdata_reference].schema, value)
       end
 
-      for _, wid in ipairs {field_ws_id, GLOBAL_WORKSPACE_TAG} do
-        local key = unique_field_key(entity_name, wid, fname, value_str or value)
-
-        -- store item_key or nil into lmdb
-        t:set(key, idx_value)
-      end
+      local key = unique_field_key(entity_name, field_ws_id, fname, value_str or value)
+      -- store item_key or nil into lmdb
+      t:set(key, idx_value)
     end
 
     if is_foreign then
@@ -361,12 +368,9 @@ local function _set_entity_for_txn(t, entity_name, item, options, is_delete)
 
       value_str = pk_string(kong.db[fdata_reference].schema, value)
 
-      for _, wid in ipairs {field_ws_id, GLOBAL_WORKSPACE_TAG} do
-        local key = foreign_field_key(entity_name, wid, fname, value_str, pk)
-
-        -- store item_key or nil into lmdb
-        t:set(key, idx_value)
-      end
+      local key = foreign_field_key(entity_name, field_ws_id, fname, value_str, pk)
+      -- store item_key or nil into lmdb
+      t:set(key, idx_value)
     end
 
     ::continue::
@@ -380,18 +384,22 @@ end
 -- the provided LMDB txn object, this operation is only safe
 -- is the entity does not already exist inside the LMDB database
 --
--- The actual item key is: <entity_name>|<ws_id>|*|<pk_string>
+-- The actual item key is: I|<entity_name>|<ws_id>|<pk_string>
 --
--- This function sets the following:
+-- This function sets the following key-value pairs:
 --
--- * <entity_name>|<ws_id>|*|<pk_string> => serialized item
--- * <entity_name>|*|*|<pk_string> => actual item key
+-- key:   I|<entity_name>|<ws_id>|<pk_string>
+-- value: serialized item
 --
--- * <entity_name>|<ws_id>|<unique_field_name>|sha256(field_value) => actual item key
--- * <entity_name>|*|<unique_field_name>|sha256(field_value) => actual item key
+-- key:   U|<entity_name>|<unique_field_name>|<ws_id>|sha256(field_value)
+-- value: actual item key
 --
--- * <entity_name>|<ws_id>|<foreign_field_name>|<foreign_key>|<pk_string> => actual item key
--- * <entity_name>|*|<foreign_field_name>|<foreign_key>|<pk_string> => actual item key
+-- key:   F|<entity_name>|<foreign_field_name>|<foreign_key>|<ws_id>|<pk_string>
+-- value: actual item key
+--
+-- The format of the key string follows the sequence of the construction order:
+-- `item type > entity name > specific item info > workspace id > item uuid`
+-- This order makes it easier to query all entities using API lmdb_prefix.page().
 --
 -- DO NOT touch `item`, or else the entity will be changed
 local function insert_entity_for_txn(t, entity_name, item, options)

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -616,4 +616,6 @@ return {
   load_into_cache_with_events = load_into_cache_with_events,
   insert_entity_for_txn = insert_entity_for_txn,
   delete_entity_for_txn = delete_entity_for_txn,
+
+  GLOBAL_WORKSPACE_TAG = GLOBAL_WORKSPACE_TAG,
 }

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -261,6 +261,7 @@ _M.load_into_cache_with_events = declarative_import.load_into_cache_with_events
 _M.insert_entity_for_txn       = declarative_import.insert_entity_for_txn
 _M.delete_entity_for_txn       = declarative_import.delete_entity_for_txn
 _M.workspace_id                = declarative_import.workspace_id
+_M.GLOBAL_WORKSPACE_TAG        = declarative_import.GLOBAL_WORKSPACE_TAG
 
 
 return _M

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -215,11 +215,11 @@ end
 -- ws_id here.
 local function page_for_tags(self, size, offset, options)
   -- /:entitiy?tags=:tags
-  -- search all key-values: <entity_name>|*|*|<pk_string> => actual item key
+  -- search all key-values: I|<entity_name>|*|<pk_string> => actual item key
   if self.schema.name ~= "tags" then
-    local prefix = item_key_prefix(self.schema.name, "*") -- "<entity_name>|*|*|"
+    local prefix = item_key_prefix(self.schema.name, "*") -- "I|<entity_name>|"
     local items, err, offset = page_for_prefix(self, prefix, size, offset,
-                                              options, true)
+                                               options)
     if not items then
       return nil, err
     end
@@ -273,7 +273,7 @@ local function page_for_tags(self, size, offset, options)
   local rows, err
 
   rows, err, offset_token = page_for_prefix(self, prefix, size, offset_token,
-                                            options, true, dao.schema)
+                                            options, false, dao.schema)
   if not rows then
     return nil, err
   end

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -329,7 +329,7 @@ local function select(self, pk, options)
   local ws_id = workspace_id(schema, options)
   local pk = pk_string(schema, pk)
 
-  -- if no specific ws_id is provided, we nedd to search all workspace ids
+  -- if no specific ws_id is provided, we need to search all workspace ids
   if ws_id == "*" then
     for workspace, err in kong.db.workspaces:each() do
       if err then

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -21,6 +21,7 @@ local item_key_prefix = declarative.item_key_prefix
 local workspace_id = declarative.workspace_id
 local foreign_field_key_prefix = declarative.foreign_field_key_prefix
 
+
 local PROCESS_AUTO_FIELDS_OPTS = {
   no_defaults = true,
   show_ws_id = true,

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -20,7 +20,6 @@ local item_key = declarative.item_key
 local item_key_prefix = declarative.item_key_prefix
 local workspace_id = declarative.workspace_id
 local foreign_field_key_prefix = declarative.foreign_field_key_prefix
-local GLOBAL_WORKSPACE_TAG = declarative.GLOBAL_WORKSPACE_TAG
 
 
 local PROCESS_AUTO_FIELDS_OPTS = {
@@ -331,7 +330,7 @@ local function select(self, pk, options)
   local pk = pk_string(schema, pk)
 
   -- if no specific ws_id is provided, we need to search all workspace ids
-  if ws_id == GLOBAL_WORKSPACE_TAG then
+  if ws_id == "*" then
     for workspace, err in kong.db.workspaces:each() do
       if err then
         return nil, err

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -20,6 +20,7 @@ local item_key = declarative.item_key
 local item_key_prefix = declarative.item_key_prefix
 local workspace_id = declarative.workspace_id
 local foreign_field_key_prefix = declarative.foreign_field_key_prefix
+local GLOBAL_WORKSPACE_TAG = declarative.GLOBAL_WORKSPACE_TAG
 
 
 local PROCESS_AUTO_FIELDS_OPTS = {
@@ -330,7 +331,7 @@ local function select(self, pk, options)
   local pk = pk_string(schema, pk)
 
   -- if no specific ws_id is provided, we need to search all workspace ids
-  if ws_id == "*" then
+  if ws_id == GLOBAL_WORKSPACE_TAG then
     for workspace, err in kong.db.workspaces:each() do
       if err then
         return nil, err

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -53,14 +53,14 @@ keyauth_credentials:
     it("utilizes the schema name, workspace id, field name, and checksum of the field value", function()
       local key = unique_field_key("services", "123", "fieldname", "test", false)
       assert.is_string(key)
-      assert.equals("services|123|fieldname|" .. sha256_hex("test"), key)
+      assert.equals("U|services|fieldname|123|" .. sha256_hex("test"), key)
     end)
 
     -- since rpc sync the param `unique_across_ws` is useless
     -- this test case is just for compatibility
     it("does not omits the workspace id when 'unique_across_ws' is 'true'", function()
       local key = unique_field_key("services", "123", "fieldname", "test", true)
-      assert.equals("services|123|fieldname|" .. sha256_hex("test"), key)
+      assert.equals("U|services|fieldname|123|" .. sha256_hex("test"), key)
     end)
   end)
 

--- a/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
+++ b/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
@@ -203,10 +203,12 @@ describe("#off preserve nulls", function()
     local id, item = next(entities.basicauth_credentials)
 
     -- format changed after rpc sync
+    -- item key
     local cache_key = concat({
+      "I|",
       "basicauth_credentials|",
       item.ws_id,
-      "|*|",
+      "|",
       id
     })
 
@@ -226,13 +228,16 @@ describe("#off preserve nulls", function()
       if plugin.name == PLUGIN_NAME then
 
         -- format changed after rpc sync
+        -- foreign key:
         cache_key = concat({
+          "F|",
           "plugins|",
-          plugin.ws_id,
-          "|route|",
+          "route|",
           plugin.route.id,
           "|",
-          plugin.id
+          plugin.ws_id,
+          "|",
+          plugin.id,
         })
         value, err, hit_lvl = lmdb.get(cache_key)
         assert.is_nil(err)

--- a/spec/02-integration/04-admin_api/14-tags_spec.lua
+++ b/spec/02-integration/04-admin_api/14-tags_spec.lua
@@ -6,7 +6,7 @@ local cjson = require "cjson"
 -- This test we test on the correctness of the admin API response so that
 -- we can ensure the right function (page()) is executed.
 describe("Admin API - tags", function()
-   for _, strategy in helpers.all_strategies() do
+  for _, strategy in helpers.all_strategies() do
     describe("/entities?tags= with DB: #" .. strategy, function()
       local client, bp
 

--- a/spec/02-integration/04-admin_api/14-tags_spec.lua
+++ b/spec/02-integration/04-admin_api/14-tags_spec.lua
@@ -6,8 +6,7 @@ local cjson = require "cjson"
 -- This test we test on the correctness of the admin API response so that
 -- we can ensure the right function (page()) is executed.
 describe("Admin API - tags", function()
-  -- for _, strategy in helpers.all_strategies() do
-   for _, strategy in ipairs({"off"}) do
+   for _, strategy in helpers.all_strategies() do
     describe("/entities?tags= with DB: #" .. strategy, function()
       local client, bp
 
@@ -157,7 +156,7 @@ describe("Admin API - tags", function()
         assert.equals("invalid option (tags: invalid filter syntax)", json.message)
       end)
 
-      it("returns the correct 'next' arg #ttt", function()
+      it("returns the correct 'next' arg", function()
         local tags_arg = 'tags=corp_%20a'
         local res = assert(client:send {
           method = "GET",

--- a/spec/02-integration/04-admin_api/14-tags_spec.lua
+++ b/spec/02-integration/04-admin_api/14-tags_spec.lua
@@ -6,7 +6,8 @@ local cjson = require "cjson"
 -- This test we test on the correctness of the admin API response so that
 -- we can ensure the right function (page()) is executed.
 describe("Admin API - tags", function()
-  for _, strategy in helpers.all_strategies() do
+  -- for _, strategy in helpers.all_strategies() do
+   for _, strategy in ipairs({"off"}) do
     describe("/entities?tags= with DB: #" .. strategy, function()
       local client, bp
 
@@ -156,7 +157,7 @@ describe("Admin API - tags", function()
         assert.equals("invalid option (tags: invalid filter syntax)", json.message)
       end)
 
-      it("returns the correct 'next' arg", function()
+      it("returns the correct 'next' arg #ttt", function()
         local tags_arg = 'tags=corp_%20a'
         local res = assert(client:send {
           method = "GET",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
1. redesign the key format for LMDB
2. remove the key with * workspace
3. search all the workspaces if upper user calls `select()` API without providing the specific workspace id

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5704
