### PR TITLE
fix(certificates):fix missing info when fields was absent

### DIFF
--- a/changelog/unreleased/kong/fix-missing-info-of-flatternd-errors.yml
+++ b/changelog/unreleased/kong/fix-missing-info-of-flatternd-errors.yml
@@ -1,0 +1,4 @@
+message: |
+  Fixed an issue where declarative flattened errors missed useful info when fields were absent.
+type: bugfix
+scope: Core

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -4,6 +4,7 @@ local nkeys = require("table.nkeys")
 local table_isarray = require("table.isarray")
 local uuid = require("kong.tools.uuid")
 local json = require("kong.tools.cjson")
+local kong_table = require "kong.tools.table"
 
 
 local type         = type
@@ -885,10 +886,6 @@ do
         local field_entity_type = ref.reference
         local field_err_t = err_t[field_name]
 
-        if type(field_err_t) == "string" then
-          field_err_t = entity_type..":"..field_err_t..":"..ref.field
-        end
-
         -- if the foreign value is _not_ a table, attempting to treat it like
         -- an entity or array of entities will only yield confusion.
         --
@@ -988,7 +985,7 @@ do
         -- same as the one-to-one case: if the field's value is not a table,
         -- we will let any errors related to it be categorized as a field-level
         -- error instead
-        if type(field_value) == "table" then
+        if type(field_value) == "table" and kong_table.is_array(field_value) then
           entity[field_name] = nil
           err_t[field_name] = nil
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -885,6 +885,10 @@ do
         local field_entity_type = ref.reference
         local field_err_t = err_t[field_name]
 
+        if type(field_err_t) == "string" then
+          field_err_t = entity_type..":"..field_err_t..":"..ref.field
+        end
+
         -- if the foreign value is _not_ a table, attempting to treat it like
         -- an entity or array of entities will only yield confusion.
         --

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -2359,7 +2359,7 @@ R6InCcH2Wh8wSeY5AuDXvu2tv9g/PW9wIJmPuKSHMA==
     
     local body = assert.response(res).has.status(400)
     local entities = cjson.decode(body)
-    assert.equals("snis:required field missing:certificate", entities.flattened_errors[1].errors[1].message)
+    assert.equals("expected an array", entities.flattened_errors[1].errors[1].message)
   end)
 
   it("flatten_errors1 when conflicting inputs", function()

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -2323,7 +2323,7 @@ R6InCcH2Wh8wSeY5AuDXvu2tv9g/PW9wIJmPuKSHMA==
     }, post_config(input))
   end)
 
-  it("snis in certificates without certificate", function()
+  it("basicauth_credentials in consumers expected be an array", function()
     local res = assert(client:send {
       method = "POST",
       path = "/config?flatten_errors=1",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
* More info of flattened_erros when field was absent.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6351