### PR TITLE
close socket connection when websocket connect failed to avoid potential leak

### DIFF
--- a/changelog/unreleased/kong/fix-potential-socket-connection-leak.yml
+++ b/changelog/unreleased/kong/fix-potential-socket-connection-leak.yml
@@ -1,3 +1,3 @@
-message: "Fix potential socket connection leak when websocket client connect fails"
+message: "Fix potential socket connection leak when websocket client connection fails"
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-potential-socket-connection-leak.yml
+++ b/changelog/unreleased/kong/fix-potential-socket-connection-leak.yml
@@ -1,0 +1,3 @@
+message: "Fix potential socket connection leak when websocket client connect fails"
+type: bugfix
+scope: Core

--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -559,6 +559,7 @@ function _M:connect(premature, node_id, host, path, cert, key)
   ::err::
 
   if not exiting() then
+    c:close()
     self:try_connect(reconnection_delay)
   end
 end

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -106,6 +106,7 @@ function _M.connect_cp(dp, endpoint, protocols)
 
   local ok, err = c:connect(uri, opts)
   if not ok then
+    c:close()
     return nil, uri, err
   end
 


### PR DESCRIPTION
For websocket client, we should close socket connection by `websocket.client.close()` when there's error on `websocket.client.connect`, because `connect` failure will leave an occupied socket. We should not rely on GC to release the socket connection.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-5361
