### PR TITLE
fix(plugins): grpc-web, grpc-gateway: TE trailers

### DIFF
--- a/changelog/unreleased/kong/fix-grpc-web-and-gateway-trailers.yml
+++ b/changelog/unreleased/kong/fix-grpc-web-and-gateway-trailers.yml
@@ -1,0 +1,3 @@
+message: "**grpc-web** and **grpc-gateway**: Fixed a bug where the `TE` (transfer-encoding) header would not be sent to the upstream gRPC servers when `grpc-web` or `grpc-gateweay` are in use."
+type: bugfix
+scope: Plugin

--- a/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
+++ b/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
@@ -49,6 +49,25 @@ for _, strategy in helpers.each_strategy() do
         service = service1,
       })
 
+      local mock_grpc_service = assert(bp.services:insert {
+        name = "mock_grpc_service",
+        url = "http://localhost:8765",
+      })
+
+      local mock_grpc_route = assert(bp.routes:insert {
+        protocols = { "http" },
+        hosts = { "grpc_mock.example" },
+        service = mock_grpc_service,
+        preserve_host = true,
+      })
+
+      assert(bp.plugins:insert {
+        route = mock_grpc_route,
+        name = "grpc-web",
+        config = {
+        },
+      })
+
       assert(bp.plugins:insert {
         route = route1,
         name = "grpc-web",
@@ -66,10 +85,30 @@ for _, strategy in helpers.each_strategy() do
         },
       })
 
-      assert(helpers.start_kong {
+      local fixtures = {
+        http_mock = {}
+      }
+      fixtures.http_mock.my_server_block = [[
+        server {
+          server_name myserver;
+          listen 8765;
+
+          location ~ / {
+            content_by_lua_block {
+              local headers = ngx.req.get_headers()
+              ngx.header.content_type = "application/grpc"
+              ngx.header.received_host = headers["Host"]
+              ngx.header.received_te = headers["te"]
+            }
+          }
+        }
+      ]]
+
+      assert(helpers.start_kong({
         database = strategy,
         plugins = "bundled,grpc-web",
-      })
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }, nil, nil, fixtures))
     end)
 
     before_each(function()
@@ -81,6 +120,33 @@ for _, strategy in helpers.each_strategy() do
       helpers.stop_kong()
     end)
 
+    test("Sets 'TE: trailers'", function()
+      local res, err = proxy_client:post("/", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/grpc-web-text",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
+    end)
+
+    test("Ignores user-agent TE", function()
+      -- in grpc-web, kong acts as a grpc client on behalf of the client
+      -- (which generally is a web-browser); as such, the Te header must be
+      -- set by kong, which will append trailers to the response body
+      local res, err = proxy_client:post("/", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/grpc-web-text",
+          ["TE"] = "chunked",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
+    end)
 
     test("Call gRCP-base64 via HTTP", function()
       local res, err = proxy_client:post("/hello.HelloService/SayHello", {


### PR DESCRIPTION
Ensure `TE` headers is properly sent to gRPC upstream server in request generated from Kong by the `grpc-web` and `grpc-gateway` plugins. Previously, the call to `kong.service.request.set_headers` was not taking effect as the `TE` headers cannot be set through normal OpenResty APIs; this PR ensures it's set in a similar way as the `:authority` pseudo-header. This fix ensures our implementation complies with the gRPC spec, which mandates a `TE: trailers` header in [gRPPC over http/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) requests.