### PR TITLE
fix(certificate): unable to refresh certificate entity with vault reference when initial with an invalid string

### DIFF
--- a/changelog/unreleased/kong-ee/fix-certificate-reference.yml
+++ b/changelog/unreleased/kong-ee/fix-certificate-reference.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue that certificate entity configured with vault reference may not get refreshed on time when initial with an invalid string.
+type: bugfix
+scope: Core

--- a/spec/02-integration/13-vaults/05-ttl_spec.lua
+++ b/spec/02-integration/13-vaults/05-ttl_spec.lua
@@ -375,158 +375,319 @@ describe("#hybrid mode dp vault ttl and rotation (#" .. strategy .. ") #" .. vau
   local vault_fixtures = vault:fixtures()
   vault_fixtures.dns_mock = tls_fixtures.dns_mock
 
-  lazy_setup(function()
-    helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
-    helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
+  describe("rotation", function()
+    lazy_setup(function()
+      helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
+      helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
 
-    vault:setup()
-    vault:create_secret(secret, ssl_fixtures.key_alt)
+      vault:setup()
+      vault:create_secret(secret, ssl_fixtures.key_alt)
 
-    local bp = helpers.get_db_utils(strategy,
-                                    { "vaults", "routes", "services", "certificates", "ca_certificates" },
-                                    {},
-                                    { vault.name })
+      local bp = helpers.get_db_utils(strategy,
+                                      { "vaults", "routes", "services", "certificates", "ca_certificates" },
+                                      {},
+                                      { vault.name })
 
 
-    assert(bp.vaults:insert({
-      name     = vault.name,
-      prefix   = vault.prefix,
-      config   = vault.config,
-    }))
+      assert(bp.vaults:insert({
+        name     = vault.name,
+        prefix   = vault.prefix,
+        config   = vault.config,
+      }))
 
-    -- Prepare TLS upstream service
-    -- cert_alt & key_alt pair is not a correct client certificate
-    -- and it will fail the client TLS verification on server side
-    --
-    -- On the other hand, cert_client & key_client pair is a correct
-    -- client certificate
-    certificate = assert(bp.certificates:insert({
-      key = ssl_fixtures.key_alt,
-      cert = ssl_fixtures.cert_alt,
-    }))
+      -- Prepare TLS upstream service
+      -- cert_alt & key_alt pair is not a correct client certificate
+      -- and it will fail the client TLS verification on server side
+      --
+      -- On the other hand, cert_client & key_client pair is a correct
+      -- client certificate
+      certificate = assert(bp.certificates:insert({
+        key = ssl_fixtures.key_alt,
+        cert = ssl_fixtures.cert_alt,
+      }))
 
-    local service_tls = assert(bp.services:insert({
-      name = "tls-service",
-      url = "https://example.com:16799",
-      client_certificate = certificate,
-    }))
+      local service_tls = assert(bp.services:insert({
+        name = "tls-service",
+        url = "https://example.com:16799",
+        client_certificate = certificate,
+      }))
 
-    assert(bp.routes:insert({
-      name      = "tls-route",
-      hosts     = { "example.com" },
-      paths = { "/tls", },
-      service   = { id = service_tls.id },
-    }))
+      assert(bp.routes:insert({
+        name      = "tls-route",
+        hosts     = { "example.com" },
+        paths = { "/tls", },
+        service   = { id = service_tls.id },
+      }))
 
-    assert(helpers.start_kong({
-      role = "control_plane",
-      cluster_cert = "spec/fixtures/kong_clustering.crt",
-      cluster_cert_key = "spec/fixtures/kong_clustering.key",
-      database = strategy,
-      prefix = "vault_ttl_test_cp",
-      cluster_listen = "127.0.0.1:9005",
-      admin_listen = "127.0.0.1:9001",
-      nginx_conf = "spec/fixtures/custom_nginx.template",
-      vaults         = vault.name,
-      plugins        = "dummy",
-      log_level      = "debug",
-    }, nil, nil, tls_fixtures ))
+      assert(helpers.start_kong({
+        role = "control_plane",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        database = strategy,
+        prefix = "vault_ttl_test_cp",
+        cluster_listen = "127.0.0.1:9005",
+        admin_listen = "127.0.0.1:9001",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        vaults         = vault.name,
+        plugins        = "dummy",
+        log_level      = "debug",
+      }, nil, nil, tls_fixtures ))
 
-    assert(helpers.start_kong({
-      role = "data_plane",
-      database = "off",
-      prefix = "vault_ttl_test_dp",
-      vaults         = vault.name,
-      plugins        = "dummy",
-      log_level      = "debug",
-      nginx_conf = "spec/fixtures/custom_nginx.template",
-      cluster_cert = "spec/fixtures/kong_clustering.crt",
-      cluster_cert_key = "spec/fixtures/kong_clustering.key",
-      cluster_control_plane = "127.0.0.1:9005",
-      proxy_listen = "127.0.0.1:9002",
-      nginx_worker_processes = 1,
-    }, nil, nil, vault_fixtures ))
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "vault_ttl_test_dp",
+        vaults         = vault.name,
+        plugins        = "dummy",
+        log_level      = "debug",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        proxy_listen = "127.0.0.1:9002",
+        nginx_worker_processes = 1,
+      }, nil, nil, vault_fixtures ))
 
-    admin_client = helpers.admin_client(nil, 9001)
-    client = helpers.proxy_client(nil, 9002)
+      admin_client = helpers.admin_client(nil, 9001)
+      client = helpers.proxy_client(nil, 9002)
+    end)
+
+    lazy_teardown(function()
+      if client then
+        client:close()
+      end
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong("vault_ttl_test_cp")
+      helpers.stop_kong("vault_ttl_test_dp")
+      vault:teardown()
+
+      helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")
+    end)
+
+    it("updates plugin config references (backend: #" .. vault.name .. ")", function()
+      helpers.wait_for_all_config_update({
+        forced_admin_port = 9001,
+        forced_proxy_port = 9002,
+      })
+      -- Wrong cert-key pair is being used in the pre-configured cert object
+      local res = client:get("/tls", {
+        headers = {
+          host = "example.com",
+        },
+        timeout = 2,
+      })
+      local body = assert.res_status(400, res)
+      assert.matches("The SSL certificate error", body)
+
+      -- Switch to vault referenced key field
+      local res = assert(admin_client:patch("/certificates/"..certificate.id, {
+        body = {
+          key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 2),
+          cert = ssl_fixtures.cert_client,
+        },
+        headers = {
+          ["Content-Type"] = "application/json",
+        },
+      }))
+      assert.res_status(200, res)
+      helpers.wait_for_all_config_update({
+        forced_admin_port = 9001,
+        forced_proxy_port = 9002,
+      })
+
+      -- Assume wrong cert-key pair still being used
+      local res = client:get("/tls", {
+        headers = {
+          host = "example.com",
+        },
+        timeout = 2,
+      })
+
+      local body = assert.res_status(400, res)
+      assert.matches("No required SSL certificate was sent", body)
+
+      -- Update secret value and let cert be correct
+      vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 2 })
+      assert.with_timeout(7)
+            .with_step(0.5)
+            .ignore_exceptions(true)
+            .eventually(function()
+              local res = client:get("/tls", {
+                headers = {
+                  host = "example.com",
+                },
+                timeout = 2,
+              })
+
+              local body = assert.res_status(200, res)
+              assert.matches("it works", body)
+              return true
+            end).is_truthy("Expected certificate being refreshed")
+    end)
   end)
 
+  describe("rotation", function()
+    lazy_setup(function()
+      helpers.setenv("KONG_LUA_PATH_OVERRIDE", LUA_PATH)
+      helpers.setenv("KONG_VAULT_ROTATION_INTERVAL", "1")
 
-  lazy_teardown(function()
-    if client then
-      client:close()
-    end
-    if admin_client then
-      admin_client:close()
-    end
+      vault:setup()
+      vault:create_secret(secret, ssl_fixtures.key_alt)
 
-    helpers.stop_kong("vault_ttl_test_cp")
-    helpers.stop_kong("vault_ttl_test_dp")
-    vault:teardown()
-
-    helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")
-  end)
+      local bp = helpers.get_db_utils(strategy,
+                                      { "vaults", "routes", "services", "certificates", "ca_certificates" },
+                                      {},
+                                      { vault.name })
 
 
-  it("updates plugin config references (backend: #" .. vault.name .. ")", function()
-    helpers.wait_for_all_config_update({
-      forced_admin_port = 9001,
-      forced_proxy_port = 9002,
-    })
-    -- Wrong cert-key pair is being used in the pre-configured cert object
-    local res = client:get("/tls", {
-      headers = {
-        host = "example.com",
-      },
-      timeout = 2,
-    })
-    local body = assert.res_status(400, res)
-    assert.matches("The SSL certificate error", body)
+      assert(bp.vaults:insert({
+        name     = vault.name,
+        prefix   = vault.prefix,
+        config   = vault.config,
+      }))
 
-    -- Switch to vault referenced key field
-    local res = assert(admin_client:patch("/certificates/"..certificate.id, {
-      body = {
-        key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 2),
-        cert = ssl_fixtures.cert_client,
-      },
-      headers = {
-        ["Content-Type"] = "application/json",
-      },
-    }))
-    assert.res_status(200, res)
-    helpers.wait_for_all_config_update({
-      forced_admin_port = 9001,
-      forced_proxy_port = 9002,
-    })
+      -- Prepare TLS upstream service
+      -- cert_alt & key_alt pair is not a correct client certificate
+      -- and it will fail the client TLS verification on server side
+      --
+      -- On the other hand, cert_client & key_client pair is a correct
+      -- client certificate
+      certificate = assert(bp.certificates:insert({
+        key = ssl_fixtures.key_alt,
+        cert = ssl_fixtures.cert_alt,
+      }))
 
-    -- Assume wrong cert-key pair still being used
-    local res = client:get("/tls", {
-      headers = {
-        host = "example.com",
-      },
-      timeout = 2,
-    })
+      local service_tls = assert(bp.services:insert({
+        name = "tls-service",
+        url = "https://example.com:16799",
+        client_certificate = certificate,
+      }))
 
-    local body = assert.res_status(400, res)
-    assert.matches("No required SSL certificate was sent", body)
+      assert(bp.routes:insert({
+        name      = "tls-route",
+        hosts     = { "example.com" },
+        paths = { "/tls", },
+        service   = { id = service_tls.id },
+      }))
 
-    -- Update secret value and let cert be correct
-    vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 2 })
-    assert.with_timeout(7)
-          .with_step(0.5)
-          .ignore_exceptions(true)
-          .eventually(function()
-            local res = client:get("/tls", {
-              headers = {
-                host = "example.com",
-              },
-              timeout = 2,
-            })
+      assert(helpers.start_kong({
+        role = "control_plane",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        database = strategy,
+        prefix = "vault_ttl_test_cp",
+        cluster_listen = "127.0.0.1:9005",
+        admin_listen = "127.0.0.1:9001",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        vaults         = vault.name,
+        plugins        = "dummy",
+        log_level      = "debug",
+      }, nil, nil, tls_fixtures ))
 
-            local body = assert.res_status(200, res)
-            assert.matches("it works", body)
-            return true
-          end).is_truthy("Expected certificate being refreshed")
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "vault_ttl_test_dp",
+        vaults         = vault.name,
+        plugins        = "dummy",
+        log_level      = "debug",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        proxy_listen = "127.0.0.1:9002",
+        nginx_worker_processes = 1,
+      }, nil, nil, vault_fixtures ))
+
+      admin_client = helpers.admin_client(nil, 9001)
+      client = helpers.proxy_client(nil, 9002)
+    end)
+
+    lazy_teardown(function()
+      if client then
+        client:close()
+      end
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong("vault_ttl_test_cp")
+      helpers.stop_kong("vault_ttl_test_dp")
+      vault:teardown()
+
+      helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")
+    end)
+
+    it("updates plugin config references while initial with an invalid string (backend: #" .. vault.name .. ")", function()
+      helpers.wait_for_all_config_update({
+        forced_admin_port = 9001,
+        forced_proxy_port = 9002,
+      })
+
+      -- Switch to vault referenced key field
+      local res = assert(admin_client:patch("/certificates/"..certificate.id, {
+        body = {
+          key = fmt("{vault://%s/%s?ttl=%s}", vault.prefix, secret, 2),
+          cert = ssl_fixtures.cert_client,
+        },
+        headers = {
+          ["Content-Type"] = "application/json",
+        },
+      }))
+      assert.res_status(200, res)
+      helpers.wait_for_all_config_update({
+        forced_admin_port = 9001,
+        forced_proxy_port = 9002,
+      })
+
+      -- Update secret value to an invalid key format
+      vault:update_secret(secret, "an invalid string", { ttl = 2 })
+
+      -- Wait until the invalid key is being cached
+      assert.with_timeout(7)
+            .with_step(0.5)
+            .ignore_exceptions(true)
+            .eventually(function()
+              helpers.clean_logfile("vault_ttl_test_dp/logs/error.log")
+
+              local res = client:get("/tls", {
+                headers = {
+                  host = "example.com",
+                },
+                timeout = 2,
+              })
+
+              local body = assert.res_status(400, res)
+              assert.matches("No required SSL certificate was sent", body)
+
+              assert.logfile("vault_ttl_test_dp/logs/error.log").has.line(
+              'failed to get from node cache: could not parse PEM private key:', true)
+
+              return true
+            end).is_truthy("Invalid certificate being cached")
+
+      -- Update secret value and let cert be correct
+      vault:update_secret(secret, ssl_fixtures.key_client, { ttl = 2 })
+
+      assert.with_timeout(7)
+            .with_step(0.5)
+            .ignore_exceptions(true)
+            .eventually(function()
+              local res = client:get("/tls", {
+                headers = {
+                  host = "example.com",
+                },
+                timeout = 2,
+              })
+
+              local body = assert.res_status(200, res)
+              assert.matches("it works", body)
+              return true
+            end).is_truthy("Expected certificate being refreshed")
+    end)
   end)
 end)
 


### PR DESCRIPTION
Manual backport https://github.com/Kong/kong-ee/pull/10984 to CE

## Original description

### Summary

When set the cert to an invalid string in the vault, and then correct the string, kong will not start to use the correct certificate even though `kong vault` command shows the correct certiticate being returned.

This is because the initial invalid string has already been cached in the L2 cache by mlcache, and it will not be updated via the L3 cache callback afterward.

When mlcache fails during the execution of the `l1_serializer`, it caches the result retrieved from the L3 cache callback the first time in the L2 cache permanently. This means that subsequent calls to `cache.get()` will never fetch data from the L3 cache but will directly retrieve it from the L2 cache.

To avoid this situation, when the `l1_serializer` fails, we no longer allow mlcache to store the data retrieved from L3 into L2.

---

~I believe this is more of a defect in mlcache. When mlcache fails during the execution of the `l1_serializer`, it caches the  result retrieved from the L3 cache callback the first time in the L2 cache  permanently. This means that subsequent calls to `cache.get()` will never fetch  data from the L3 cache but will directly retrieve it from the L2 cache.~

From the perspective of mlcache, this doesn't seem to be an issue. When the data is updated, the invalidation should be explicitly triggered by the "data owner" themselves. This design allows mlcache to maximize its cache hit rate. However, in the case of Kong, this doesn't seem practical, as some data is stored in external systems, which cannot conveniently invalidate mlcache's cache, resulting in our inability to retrieve the most up-to-date data in a timely manner.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6392
