### PR TITLE
fix(ai): (FTI-6403) Fixed error with Azure path override formatting

### DIFF
--- a/changelog/unreleased/kong/fix-ai-azure-incorrect-path-overriding.yml
+++ b/changelog/unreleased/kong/fix-ai-azure-incorrect-path-overriding.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed a bug in the Azure provider where `model.options.upstream_path` overrides would always return 404."
+type: bugfix
+scope: Plugin

--- a/kong/llm/drivers/azure.lua
+++ b/kong/llm/drivers/azure.lua
@@ -143,7 +143,6 @@ function _M.configure_request(conf)
 
   local query_table = kong.request.get_query()
 
-  -- technically min supported version
   query_table["api-version"] = kong.request.get_query_arg("api-version")
                             or (conf.model.options and conf.model.options.azure_api_version)
 

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -82,6 +82,7 @@ _M._SUPPORTED_STREAMING_CONTENT_TYPES = {
   ["text/event-stream"] = true,
   ["application/vnd.amazon.eventstream"] = true,
   ["application/json"] = true,
+  ["application/stream+json"] = true,
 }
 
 _M.streaming_has_token_counts = {


### PR DESCRIPTION
### Summary

There was a bug found, where the Azure provider stopped parsing 'custom upstream path' overrides since Kong 3.9.0.

Every request would 404 due to incorrect parsing.

I've added a parser / config options test to prevent this from happening again!

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)

### Issue reference

FTI-6403
AG-191
