### PR TITLE
perf(router): load service with route.ws_id while building routers

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -256,8 +256,9 @@ local function should_process_route(route)
 end
 
 
-local function load_service_from_db(service_pk)
-  local service, err = kong.db.services:select(service_pk, GLOBAL_QUERY_OPTS)
+local function load_service_from_db(service_pk, ws_id)
+  local options = ws_id and { workspace = ws_id, show_ws_id = true }
+  local service, err = kong.db.services:select(service_pk, options)
   if service == nil then
     -- the third value means "do not cache"
     return nil, err, -1
@@ -299,20 +300,21 @@ local function get_service_for_route(db, route, services_init_cache)
   end
 
   local err
+  local ws_id = route.ws_id
 
   -- kong.core_cache is available, not in init phase
   if kong.core_cache and db.strategy ~= "off" then
     local cache_key = db.services:cache_key(service_pk.id, nil, nil, nil, nil,
-                                            route.ws_id)
+                                            ws_id)
     service, err = kong.core_cache:get(cache_key, TTL_ZERO,
-                                       load_service_from_db, service_pk)
+                                       load_service_from_db, service_pk, ws_id)
 
   else -- dbless or init phase, kong.core_cache not needed/available
 
     -- A new service/route has been inserted while the initial route
     -- was being created, on init (perhaps by a different Kong node).
     -- Load the service individually and update services_init_cache with it
-    service, err = load_service_from_db(service_pk)
+    service, err = load_service_from_db(service_pk, ws_id)
     services_init_cache[id] = service
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

1. From the perspective of more precise searching for services from `select` API, the route here already has a ws_id, so we should directly search for the service under the specific workspace
2. LMDB has removed all the global query keys (see https://github.com/Kong/kong/pull/14028), if we select services without ws_id, it will search it through all the workspace, which has a performance issue.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests - reuse original tests that could test router building 
- [x] Skip changelog because we could reuse `changelog/unreleased/kong/perf-lmdb-remove-global-query-key.yml`
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6087, KAG-5704
