### PR TITLE
docs(changelog): remove the incorrect merge conflict line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,6 @@ database contains invalid Wasm filters.
  [#289](https://github.com/Kong/kong-manager/issues/289)
 
 
->>>>>>> 4fb6d639ab (docs(changelog): update 3.9.0 changelog (#14016))
 ## 3.8.1
 
 ## Kong


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Remove the incorrect merge conflict line from the CHANGELOG.md.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
