### PR TITLE
chore(deps): install lua-messagepack 0.5.2 by rock directly

### DIFF
--- a/build/luarocks/BUILD.luarocks.bazel
+++ b/build/luarocks/BUILD.luarocks.bazel
@@ -170,9 +170,9 @@ genrule(
         export LDOC=true
 
         # Install lua-messagepack
-        $(location :luarocks_exec) install $(location :prepare_lua_messagepack) 2>&1 >$@.tmp
+        $(location :luarocks_exec) install $(location :prepare_lua_messagepack) >>$@.tmp 2>&1
 
-        $(location :luarocks_exec) make --no-doc 2>&1 >$@.tmp
+        $(location :luarocks_exec) make --no-doc >>$@.tmp 2>&1
 
         # only generate the output when the command succeeds
         mv $@.tmp $@

--- a/build/luarocks/BUILD.luarocks.bazel
+++ b/build/luarocks/BUILD.luarocks.bazel
@@ -141,11 +141,20 @@ EOF
 )
 
 genrule(
+    name = "prepare_lua_messagepack",
+    srcs = ["@lua_messagepack_src//file"],
+    outs = ["lua-messagepack-0.5.2-1.src.rock"],
+    cmd = "cp $(location @lua_messagepack_src//file) $@",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "luarocks_make",
     srcs = [
         "@kong//:rockspec_srcs",
         ":luarocks_exec",
         ":luarocks_target",  # to avoid concurrency issue, run this after luarocks_target
+        ":prepare_lua_messagepack",
     ],
     outs = ["luarocks_make.log"],
     cmd = """
@@ -159,6 +168,9 @@ genrule(
         # env var just to let ldoc happy
         # alias LDOC command to true(1) command
         export LDOC=true
+
+        # Install lua-messagepack
+        $(location :luarocks_exec) install $(location :prepare_lua_messagepack) 2>&1 >$@.tmp
 
         $(location :luarocks_exec) make --no-doc 2>&1 >$@.tmp
 

--- a/build/luarocks/luarocks_repositories.bzl
+++ b/build/luarocks/luarocks_repositories.bzl
@@ -1,6 +1,6 @@
 """A module defining the third party dependency luarocks"""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@kong_bindings//:variables.bzl", "KONG_VAR")
 
@@ -16,4 +16,12 @@ def luarocks_repositories():
         urls = [
             "https://luarocks.org/releases/luarocks-" + version + ".tar.gz",
         ],
+    )
+
+    http_file(
+        name = "lua_messagepack_src",
+        urls = [
+            "https://luarocks.org/manifests/fperrad/lua-messagepack-0.5.2-1.src.rock",
+        ],
+        sha256 = "cbb1b7b12834b7f49fd20621446ec4d76eff67d324b8182b7988324b10830a43",
     )


### PR DESCRIPTION
since lua-messagepack 0.5.2 has been archived, we can only install it directly via rock.

Fix: [FTI-6417](https://konghq.atlassian.net/browse/FTI-6417)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_


[FTI-6417]: https://konghq.atlassian.net/browse/FTI-6417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ