### PR TITLE
fix(clustering/rpc): invoke `notify_new_version` on events `clustering, push_config`

### DIFF
--- a/kong/clustering/services/sync/init.lua
+++ b/kong/clustering/services/sync/init.lua
@@ -44,6 +44,12 @@ function _M:init_worker()
   if self.is_cp then
     events.init()
 
+    -- When "clustering", "push_config" worker event is received by a worker,
+    -- it will notify the connected data planes
+    events.clustering_push_config(function(_)
+      self.hooks:notify_all_nodes()
+    end)
+
     self.strategy:init_worker()
     return
   end


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6100

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
