### PR TITLE
feat(clustering/rpc): stop ngx.timer.every if no sync.v2

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -108,15 +108,10 @@ function _M:init_worker(basic_info)
 
     -- cp supports kong.sync.v2
     if has_sync_v2 then
+      -- notify communicate() to exit
+      self.write_exit = true
       return
     end
-
-    -- we only check once
-    if self.inited then
-      return
-    end
-
-    self.inited = true
 
     ngx_log(ngx_WARN, "sync v1 is enabled due to rpc sync can not work.")
 
@@ -332,6 +327,12 @@ function _M:communicate(premature)
       counter = counter - 1
 
       ngx_sleep(1)
+
+      -- outside flag will stop the communicate() loop
+      if self.write_exit then
+        self.write_exit = false
+        return
+      end
     end
   end)
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -263,7 +263,8 @@ function _M:communicate(premature)
   local config_err_t
 
   local config_thread = ngx.thread.spawn(function()
-    while not exiting() and not config_exit do
+    -- outside flag will stop the communicate() loop
+    while not exiting() and not config_exit and self.run_communicate do
       local ok, err = config_semaphore:wait(1)
 
       if not ok then
@@ -333,11 +334,6 @@ function _M:communicate(premature)
       counter = counter - 1
 
       ngx_sleep(1)
-
-      -- outside flag will stop the communicate() loop
-      if not self.run_communicate then
-        return
-      end
     end
   end)
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -108,15 +108,10 @@ function _M:init_worker(basic_info)
 
     -- cp supports kong.sync.v2
     if has_sync_v2 then
+      -- notify communicate() to exit
+      self.config_exit = true
       return
     end
-
-    -- we only check once
-    if self.inited then
-      return
-    end
-
-    self.inited = true
 
     ngx_log(ngx_WARN, "sync v1 is enabled due to rpc sync can not work.")
 
@@ -256,13 +251,15 @@ function _M:communicate(premature)
   -- * write_thread: it is the only thread that receives WS frames from the CP,
   --                 and is also responsible for handling timeout detection
 
+  -- the flag that outside could stop the loop forcely
+  self.config_exit = false
+
   local ping_immediately
-  local config_exit
   local next_data
   local config_err_t
 
   local config_thread = ngx.thread.spawn(function()
-    while not exiting() and not config_exit do
+    while not exiting() and not self.config_exit do
       local ok, err = config_semaphore:wait(1)
 
       if not ok then
@@ -406,7 +403,7 @@ function _M:communicate(premature)
 
   -- the config thread might be holding a lock if it's in the middle of an
   -- update, so we need to give it a chance to terminate gracefully
-  config_exit = true
+  self.config_exit = true
 
   ok, err, perr = ngx.thread.wait(config_thread)
   if not ok then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -88,6 +88,9 @@ function _M:init_worker(basic_info)
 
   -- does not config rpc sync
   if not kong.sync then
+    -- start communicate()
+    self.run_communicate = true
+
     start_communicate()
     return
   end

--- a/kong/clustering/services/sync/init.lua
+++ b/kong/clustering/services/sync/init.lua
@@ -70,18 +70,12 @@ function _M:init_worker()
     -- cp does not support kong.sync.v2
     if not has_sync_v2 then
       ngx.log(ngx.WARN, "rpc sync is disabled in CP.")
+      assert(self.rpc:sync_every(EACH_SYNC_DELAY), true)  -- stop timer
       return
     end
 
     -- sync to CP ASAP
     assert(self.rpc:sync_once(FIRST_SYNC_DELAY))
-
-    -- we only check once
-    if self.inited then
-      return
-    end
-
-    self.inited = true
 
     assert(self.rpc:sync_every(EACH_SYNC_DELAY))
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -415,13 +415,13 @@ end
 
 function _M:sync_every(delay, stop)
   local name = "rpc_sync_v2_every"
-  local is_managed = ngx.timer.is_managed(name)
+  local is_managed = kong.timer:is_managed(name)
 
   -- we only start or stop once
 
   if stop then
     if is_managed then
-      ngx.timer.cancel(name)
+      kong.timer:cancel(name)
     end
     return true
   end
@@ -430,7 +430,7 @@ function _M:sync_every(delay, stop)
     return true
   end
 
-  return ngx.timer.named_every(name, delay, sync_handler)
+  return kong.timer:named_every(name, delay, sync_handler)
 end
 
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -415,10 +415,19 @@ end
 
 function _M:sync_every(delay, stop)
   local name = "rpc_sync_v2_every"
+  local is_managed = ngx.timer.is_managed(name)
 
-  if stop and ngx.timer.is_managed(name) then
-    ngx.timer.cancel(name)
-    return
+  -- we only start or stop once
+
+  if stop then
+    if is_managed then
+      ngx.timer.cancel(name)
+    end
+    return true
+  end
+
+  if is_managed then
+    return true
   end
 
   return ngx.timer.named_every(name, delay, sync_handler)

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -421,7 +421,7 @@ function _M:sync_every(delay, stop)
 
   if stop then
     if is_managed then
-      kong.timer:cancel(name)
+      assert(kong.timer:cancel(name))
     end
     return true
   end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -413,8 +413,15 @@ function _M:sync_once(delay)
 end
 
 
-function _M:sync_every(delay)
-  return ngx.timer.every(delay, sync_handler)
+function _M:sync_every(delay, stop)
+  local name = "rpc_sync_v2_every"
+
+  if stop and ngx.timer.is_managed(name) then
+    ngx.timer.cancel(name)
+    return
+  end
+
+  return ngx.timer.named_every(name, delay, sync_handler)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5891

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
