### PR TITLE
feat(clustering/rpc): change sync version to string

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -62,11 +62,11 @@ end
 local is_empty_version
 do
   local byte = string.byte
-  local CHAR_R = byte("R")
+  local CHAR_V = byte("V")
 
-  -- version string must start with char 'R'
+  -- version string must start with char 'V'
   is_empty_version = function(v)
-    return byte(v) ~= CHAR_R
+    return byte(v) ~= CHAR_V
   end
 end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -23,6 +23,7 @@ local MAX_RETRY = 5
 
 local assert = assert
 local ipairs = ipairs
+local sub = string.sub
 local ngx_null = ngx.null
 local ngx_log = ngx.log
 local ngx_ERR = ngx.ERR
@@ -61,7 +62,6 @@ end
 
 local is_valid_version
 do
-  local sub = string.sub
   local VER_PREFIX = "V02_"
 
   -- version string must start with 'V02_'

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -62,9 +62,9 @@ end
 
 local is_valid_version
 do
-  local VER_PREFIX = "V02_"
+  local VER_PREFIX = "v02_"
 
-  -- version string must start with 'V02_'
+  -- version string must start with 'v02_'
   is_valid_version = function(v)
     return sub(v, 1, 4) == VER_PREFIX
   end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -59,6 +59,11 @@ local function get_current_version()
 end
 
 
+local function is_empty_version(v)
+  return v == DECLARATIVE_EMPTY_CONFIG_HASH
+end
+
+
 function _M:init_cp(manager)
   local purge_delay = manager.conf.cluster_data_plane_purge_delay
 
@@ -105,7 +110,7 @@ function _M:init_cp(manager)
       return nil, err
     end
 
-    if default_namespace_version == DECLARATIVE_EMPTY_CONFIG_HASH or
+    if is_empty_version(default_namespace_version) or
        default_namespace_version < latest_version then
       return full_sync_result()
     end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -59,14 +59,14 @@ local function get_current_version()
 end
 
 
-local is_invalid_version
+local is_valid_version
 do
   local sub = string.sub
   local VER_PREFIX = "V02_"
 
   -- version string must start with 'V02_'
-  is_invalid_version = function(v)
-    return sub(v, 1, 4) ~= VER_PREFIX
+  is_valid_version = function(v)
+    return sub(v, 1, 4) == VER_PREFIX
   end
 end
 
@@ -118,7 +118,7 @@ function _M:init_cp(manager)
     end
 
     --  string comparison effectively does the same as number comparison
-    if is_invalid_version(default_namespace_version) or
+    if not is_valid_version(default_namespace_version) or
        default_namespace_version < latest_version then
       return full_sync_result()
     end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -54,7 +54,7 @@ local function full_sync_result()
 end
 
 
-local function get_current_hash()
+local function get_current_version()
   return declarative.get_current_hash() or DECLARATIVE_EMPTY_CONFIG_HASH
 end
 
@@ -133,7 +133,7 @@ function _M:init_dp(manager)
       return nil, "'new_version' key does not exist"
     end
 
-    local lmdb_ver = get_current_hash()
+    local lmdb_ver = get_current_version()
     if lmdb_ver < version then
       -- set lastest version to shm
       kong_shm:set(CLUSTERING_DATA_PLANES_LATEST_VERSION_KEY, version)
@@ -177,7 +177,7 @@ local function do_sync()
     return nil, "rpc is not ready"
   end
 
-  local msg = { default = { version = get_current_hash(), }, }
+  local msg = { default = { version = get_current_version(), }, }
 
   local ns_deltas, err = kong.rpc:call("control_plane", "kong.sync.v2.get_delta", msg)
   if not ns_deltas then
@@ -392,7 +392,7 @@ function sync_once_impl(premature, retry_count)
     return
   end
 
-  local current_version = get_current_hash()
+  local current_version = get_current_version()
   if current_version >= latest_notified_version then
     ngx_log(ngx_DEBUG, "version already updated")
     return

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -59,13 +59,13 @@ local function get_current_version()
 end
 
 
-local is_empty_version
+local is_invalid_version
 do
   local byte = string.byte
   local CHAR_V = byte("V")
 
   -- version string must start with char 'V'
-  is_empty_version = function(v)
+  is_invalid_version = function(v)
     return byte(v) ~= CHAR_V
   end
 end
@@ -117,7 +117,8 @@ function _M:init_cp(manager)
       return nil, err
     end
 
-    if is_empty_version(default_namespace_version) or
+    --  string comparison effectively does the same as number comparison
+    if is_invalid_version(default_namespace_version) or
        default_namespace_version < latest_version then
       return full_sync_result()
     end

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -128,7 +128,7 @@ function _M:init_dp(manager)
       return nil, "'new_version' key does not exist"
     end
 
-    local lmdb_ver = declarative.get_current_hash()
+    local lmdb_ver = declarative.get_current_hash() or DECLARATIVE_EMPTY_CONFIG_HASH
     if lmdb_ver < version then
       -- set lastest version to shm
       kong_shm:set(CLUSTERING_DATA_PLANES_LATEST_VERSION_KEY, version)
@@ -174,7 +174,7 @@ local function do_sync()
 
   local msg = { default =
                  { version =
-                   declarative.get_current_hash(),
+                   declarative.get_current_hash() or DECLARATIVE_EMPTY_CONFIG_HASH,
                  },
                }
 
@@ -391,7 +391,7 @@ function sync_once_impl(premature, retry_count)
     return
   end
 
-  local current_version = declarative.get_current_hash()
+  local current_version = declarative.get_current_hash() or DECLARATIVE_EMPTY_CONFIG_HASH
   if current_version >= latest_notified_version then
     ngx_log(ngx_DEBUG, "version already updated")
     return

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -59,8 +59,15 @@ local function get_current_version()
 end
 
 
-local function is_empty_version(v)
-  return v == DECLARATIVE_EMPTY_CONFIG_HASH
+local is_empty_version
+do
+  local byte = string.byte
+  local CHAR_R = byte("R")
+
+  -- version string must start with char 'R'
+  is_empty_version = function(v)
+    return byte(v) ~= CHAR_R
+  end
 end
 
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -61,12 +61,12 @@ end
 
 local is_invalid_version
 do
-  local byte = string.byte
-  local CHAR_V = byte("V")
+  local sub = string.sub
+  local VER_PREFIX = "V02_"
 
-  -- version string must start with char 'V'
+  -- version string must start with 'V02_'
   is_invalid_version = function(v)
-    return byte(v) ~= CHAR_V
+    return sub(v, 1, 4) ~= VER_PREFIX
   end
 end
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -8,7 +8,7 @@ local ngx_null = ngx.null
 
 -- version string should be greater than any hex string(ngx.md5)
 -- e.g.: "v02_0000" > "FFFFFFFF"
-local VERSION_FMT = "v02_%028d"
+local VERSION_FMT = "v02_%028x"
 
 
 function _M.new(db)

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -7,8 +7,8 @@ local ngx_null = ngx.null
 
 
 -- version string should be greater than any hex string(ngx.md5)
--- e.g.: "V000" > "FFFF"
-local VERSION_FMT = "V%031d"
+-- e.g.: "V02_0000" > "FFFFFFFF"
+local VERSION_FMT = "V02_%028d"
 
 
 function _M.new(db)

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -6,6 +6,11 @@ local fmt = string.format
 local ngx_null = ngx.null
 
 
+-- version string should be greater than any hex string(ngx.md5)
+-- e.g.: "R000" > "FFFF"
+local VERSION_FMT = "R%031d"
+
+
 function _M.new(db)
   local self = {
     connector = db.connector,
@@ -45,10 +50,10 @@ function _M:get_latest_version()
 
   local ver = res[1] and res[1].max
   if ver == ngx_null then
-    return fmt("%032d", 0)
+    return fmt(VERSION_FMT, 0)
   end
 
-  return fmt("%032d", ver)
+  return fmt(VERSION_FMT, ver)
 end
 
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -7,8 +7,8 @@ local ngx_null = ngx.null
 
 
 -- version string should be greater than any hex string(ngx.md5)
--- e.g.: "R000" > "FFFF"
-local VERSION_FMT = "R%031d"
+-- e.g.: "V000" > "FFFF"
+local VERSION_FMT = "V%031d"
 
 
 function _M.new(db)

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -7,8 +7,8 @@ local ngx_null = ngx.null
 
 
 -- version string should be greater than any hex string(ngx.md5)
--- e.g.: "V02_0000" > "FFFFFFFF"
-local VERSION_FMT = "V02_%028d"
+-- e.g.: "v02_0000" > "FFFFFFFF"
+local VERSION_FMT = "v02_%028d"
 
 
 function _M.new(db)

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -6,8 +6,7 @@ local fmt = string.format
 local ngx_null = ngx.null
 
 
--- version string should be greater than any hex string(ngx.md5)
--- e.g.: "v02_0000" > "FFFFFFFF"
+-- version string should look like: "v02_0000"
 local VERSION_FMT = "v02_%028x"
 
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -2,6 +2,7 @@ local _M = {}
 local _MT = { __index = _M }
 
 
+local fmt = string.format
 local ngx_null = ngx.null
 
 
@@ -44,10 +45,10 @@ function _M:get_latest_version()
 
   local ver = res[1] and res[1].max
   if ver == ngx_null then
-    return 0
+    return fmt("%032d", 0)
   end
 
-  return ver
+  return fmt("%032d", ver)
 end
 
 

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -231,7 +231,7 @@ end
 
 
 local function get_current_hash()
-  return lmdb.get(DECLARATIVE_HASH_KEY) or DECLARATIVE_EMPTY_CONFIG_HASH
+  return lmdb.get(DECLARATIVE_HASH_KEY)
 end
 
 

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -231,7 +231,7 @@ end
 
 
 local function get_current_hash()
-  return lmdb.get(DECLARATIVE_HASH_KEY)
+  return lmdb.get(DECLARATIVE_HASH_KEY) or DECLARATIVE_EMPTY_CONFIG_HASH
 end
 
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -9,7 +9,7 @@ local DP_PREFIX = "servroot_dp"
 
 -- now version must be a string
 local function fmt(v)
-  return string.format("R%031d", v)
+  return string.format("V%031d", v)
 end
 
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -6,6 +6,13 @@ local setup = require("spec.helpers.rpc_mock.setup")
 local get_node_id = misc.get_node_id
 local DP_PREFIX = "servroot_dp"
 
+
+-- now version must be a string
+local function fmt(v)
+  return string.format("%032d", v)
+end
+
+
 local function change_config()
   -- the initial sync is flaky. let's trigger a sync by creating a service
   local admin_client = helpers.admin_client()
@@ -74,12 +81,12 @@ describe("kong.sync.v2", function()
       local called = false
       mocked_cp:mock("kong.sync.v2.get_delta", function(node_id, payload)
         called = true
-        return { default = { version = "100", deltas = {} } }
+        return { default = { version = fmt(100), deltas = {} } }
       end)
 
       -- make a call from the mocked cp
       -- CP->DP: notify_new_version
-      assert(mocked_cp:call(node_id, "kong.sync.v2.notify_new_version", { default = { new_version = "100", } }))
+      assert(mocked_cp:call(node_id, "kong.sync.v2.notify_new_version", { default = { new_version = fmt(100), } }))
 
       -- DP->CP: get_delta
       -- the dp after receiving the notification will make a call to the cp
@@ -120,7 +127,7 @@ describe("kong.sync.v2", function()
       -- this is a workaround to registers the data plane node
       -- CP does not register the DP node until it receives a call from the DP
       function register_dp()
-        local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = "0",},})
+        local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = fmt(0),},})
         assert.is_nil(err)
         assert.is_table(res and res.default and res.default.deltas)
       end
@@ -132,7 +139,7 @@ describe("kong.sync.v2", function()
     end)
 
     it("rpc call", function()
-      local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = "0",},})
+      local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = fmt(0),},})
       assert.is_nil(err)
       assert.is_table(res and res.default and res.default.deltas)
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -9,7 +9,7 @@ local DP_PREFIX = "servroot_dp"
 
 -- now version must be a string
 local function fmt(v)
-  return string.format("V%031d", v)
+  return string.format("V02_%028d", v)
 end
 
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -1,3 +1,4 @@
+local constants = require("kong.constants")
 local helpers = require("spec.helpers")
 local misc = require("spec.internal.misc")
 local cp = require("spec.helpers.rpc_mock.cp")
@@ -5,6 +6,7 @@ local dp = require("spec.helpers.rpc_mock.dp")
 local setup = require("spec.helpers.rpc_mock.setup")
 local get_node_id = misc.get_node_id
 local DP_PREFIX = "servroot_dp"
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 local function change_config()
   -- the initial sync is flaky. let's trigger a sync by creating a service
@@ -74,12 +76,12 @@ describe("kong.sync.v2", function()
       local called = false
       mocked_cp:mock("kong.sync.v2.get_delta", function(node_id, payload)
         called = true
-        return { default = { version = 100, deltas = {} } }
+        return { default = { version = "100", deltas = {} } }
       end)
 
       -- make a call from the mocked cp
       -- CP->DP: notify_new_version
-      assert(mocked_cp:call(node_id, "kong.sync.v2.notify_new_version", { default = { new_version = 100, } }))
+      assert(mocked_cp:call(node_id, "kong.sync.v2.notify_new_version", { default = { new_version = "100", } }))
 
       -- DP->CP: get_delta
       -- the dp after receiving the notification will make a call to the cp
@@ -120,7 +122,7 @@ describe("kong.sync.v2", function()
       -- this is a workaround to registers the data plane node
       -- CP does not register the DP node until it receives a call from the DP
       function register_dp()
-        local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = 0,},})
+        local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = "0",},})
         assert.is_nil(err)
         assert.is_table(res and res.default and res.default.deltas)
       end
@@ -132,7 +134,7 @@ describe("kong.sync.v2", function()
     end)
 
     it("rpc call", function()
-      local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = 0,},})
+      local res, err = mocked_dp:call("control_plane", "kong.sync.v2.get_delta", { default = { version = "0",},})
       assert.is_nil(err)
       assert.is_table(res and res.default and res.default.deltas)
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -1,4 +1,3 @@
-local constants = require("kong.constants")
 local helpers = require("spec.helpers")
 local misc = require("spec.internal.misc")
 local cp = require("spec.helpers.rpc_mock.cp")
@@ -6,7 +5,6 @@ local dp = require("spec.helpers.rpc_mock.dp")
 local setup = require("spec.helpers.rpc_mock.setup")
 local get_node_id = misc.get_node_id
 local DP_PREFIX = "servroot_dp"
-local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 local function change_config()
   -- the initial sync is flaky. let's trigger a sync by creating a service

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -9,7 +9,7 @@ local DP_PREFIX = "servroot_dp"
 
 -- now version must be a string
 local function fmt(v)
-  return string.format("%032d", v)
+  return string.format("R%031d", v)
 end
 
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -9,7 +9,7 @@ local DP_PREFIX = "servroot_dp"
 
 -- now version must be a string
 local function fmt(v)
-  return string.format("v02_%028d", v)
+  return string.format("v02_%028x", v)
 end
 
 

--- a/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/05-sync-rpc_spec.lua
@@ -9,7 +9,7 @@ local DP_PREFIX = "servroot_dp"
 
 -- now version must be a string
 local function fmt(v)
-  return string.format("V02_%028d", v)
+  return string.format("v02_%028d", v)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5894

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
