### PR TITLE
fix(core): set correct permissions for socket path when umask is set to `0027`

### DIFF
--- a/changelog/unreleased/kong/fix-socket-path-permissions.yml
+++ b/changelog/unreleased/kong/fix-socket-path-permissions.yml
@@ -1,3 +1,3 @@
-message: "Fix issue where `socket_path` permissions are not correctly set to `755` when umask is `0027`"
+message: "Fix issue where `socket_path` permissions are not correctly set to `755` when the umask setting does not give enough permission"
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-socket-path-permissions.yml
+++ b/changelog/unreleased/kong/fix-socket-path-permissions.yml
@@ -1,3 +1,3 @@
-message: "Fix issue where `socket_path` permissions are not correctly set to `755` when the umask setting does not give enough permission"
+message: "Fixed an issue where `socket_path` permissions were not correctly set to `755` when the umask setting did not give enough permission"
 type: bugfix
 scope: Core

--- a/changelog/unreleased/kong/fix-socket-path-permissions.yml
+++ b/changelog/unreleased/kong/fix-socket-path-permissions.yml
@@ -1,0 +1,3 @@
+message: "Fix issue where `socket_path` permissions are not correctly set to `755` when umask is `0027`"
+type: bugfix
+scope: Core

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -509,6 +509,11 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     if not ok then
       return nil, err
     end
+
+    local success = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
+    if not success then
+      return nil, "can not set correct permissions for socket path: " .. kong_config.socket_path
+    end
   end
 
   -- create directories in prefix

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -510,8 +510,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
       return nil, err
     end
 
-    local _, _, stderr
-    ok, _, _, stderr = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
+    local ok, _, _, stderr = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
     if not ok then
       return nil, "can not set correct permissions for socket path: " .. kong_config.socket_path
                   .. " (" .. stderr .. ")"

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -510,9 +510,11 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
       return nil, err
     end
 
-    local success = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
-    if not success then
+    local stderr
+    ok, _, _, stderr = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
+    if not ok then
       return nil, "can not set correct permissions for socket path: " .. kong_config.socket_path
+                  .. " (" .. stderr .. ")"
     end
   end
 

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -510,7 +510,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
       return nil, err
     end
 
-    local stderr
+    local _, _, stderr
     ok, _, _, stderr = pl_utils.executeex("chmod 755 " .. kong_config.socket_path)
     if not ok then
       return nil, "can not set correct permissions for socket path: " .. kong_config.socket_path


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
When umask is configured to `0027`, the newly created `kong_config.socket_path` directory inherits permissions `750`, which restricts access for worker processes. This commit ensures that the `socket_path` directory is explicitly set to permissions `755` using `chmod 755`, thereby preventing permission-related errors and allowing proper access for all necessary processes.
### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix: [FTI-6298](https://konghq.atlassian.net/browse/FTI-6298)


[FTI-6298]: https://konghq.atlassian.net/browse/FTI-6298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ