### PR TITLE
fix(clustering/rpc): dont start too many timers for sync

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -369,7 +369,7 @@ local sync_once_impl
 
 
 local function start_sync_once_timer(retry_count)
-  local ok, err = ngx.timer.at(0, sync_once_impl, retry_count or 0)
+  local ok, err = kong.timer:at(0, sync_once_impl, retry_count or 0)
   if not ok then
     return nil, err
   end
@@ -384,6 +384,8 @@ function sync_once_impl(premature, retry_count)
   end
 
   sync_handler()
+
+  -- check if "kong.sync.v2.notify_new_version" updates the latest version
 
   local latest_notified_version = ngx.shared.kong:get(CLUSTERING_DATA_PLANES_LATEST_VERSION_KEY)
   if not latest_notified_version then

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -409,7 +409,15 @@ end
 
 
 function _M:sync_once(delay)
-  return ngx.timer.at(delay or 0, sync_once_impl, 0)
+  local name = "rpc_sync_v2_once"
+  local is_managed = kong.timer:is_managed(name)
+
+  -- we are running a sync handler
+  if is_managed then
+    return true
+  end
+
+  return kong.timer:named_at(name, delay or 0, sync_once_impl, 0)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6114

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
