### PR TITLE
fix(core): separate plugin server runtime data from kong configuration

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
+++ b/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where fetching admin api root path returns 500 server error"
+type: bugfix
+scope: Core

--- a/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
+++ b/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
@@ -1,3 +1,3 @@
-message: "Fixed an issue where fetching admin api root path returns 500 server error"
+message: "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error"
 type: bugfix
 scope: Core


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Problem: There are  some runtime data like `proc` stored in `kong.configuration.pluginservers`, which is cdata type and could not be encoded by cjson. Thus when fetching the admin api "/", the response body encoding of configuration will fail and throws 500 error.
Solution: Separate runtime data from configuration, store runtime info like `proc` inside the plugin servers module, not global configuration.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-6088
