### PR TITLE
fix(clustering/rpc): check return value of kong.timer

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -419,7 +419,12 @@ function _M:sync_once(delay)
     return true
   end
 
-  return kong.timer:named_at(name, delay or 0, sync_once_impl, 0)
+  local ok, err = kong.timer:named_at(name, delay or 0, sync_once_impl, 0)
+  if not ok then
+    return nil, err
+  end
+
+  return true
 end
 
 
@@ -440,7 +445,12 @@ function _M:sync_every(delay, stop)
     return true
   end
 
-  return kong.timer:named_every(name, delay, sync_handler)
+  local ok, err = kong.timer:named_every(name, delay, sync_handler)
+  if not ok then
+    return nil, err
+  end
+
+  return true
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

[KAG-6114](https://konghq.atlassian.net/browse/KAG-6114)
This PR follows #14089.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
