### PR TITLE
fix(balancer): handle hyphenated-Pascal-case headers in consistent hashing

### DIFF
--- a/changelog/unreleased/kong/fix-consistent-hashing-for-hyphenated-pascal-case-headers.yml
+++ b/changelog/unreleased/kong/fix-consistent-hashing-for-hyphenated-pascal-case-headers.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where consistent hashing did not correctly handle hyphenated-Pascal-case headers, leading to uneven distribution of requests across upstream targets."
+type: bugfix
+scope: Core

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -12,7 +12,7 @@ local targets = require "kong.runloop.balancer.targets"
 
 -- due to startup/require order, cannot use the ones from 'kong' here
 local dns_client = require "kong.resty.dns.client"
-
+local replace_dashes_lower  = require("kong.tools.string").replace_dashes_lower
 
 local toip = dns_client.toip
 local sub = string.sub
@@ -132,7 +132,8 @@ local function get_value_to_hash(upstream, ctx)
     elseif hash_on == "header" then
       -- since nginx 1.23.0/openresty 1.25.3.1
       -- ngx.var will automatically combine all header values with identical name
-      identifier = var["http_" .. upstream[header_field_name]]
+      local header_name = replace_dashes_lower(upstream[header_field_name])
+      identifier = var["http_" .. header_name]
 
     elseif hash_on == "cookie" then
       identifier = var["cookie_" .. upstream.hash_on_cookie]


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Consistent hashing was not correctly handling headers with hyphens and PascalCase formatting, resulting in uneven distribution of requests across upstream targets.
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix: [FTI-6431](https://konghq.atlassian.net/browse/FTI-6431)



[FTI-6431]: https://konghq.atlassian.net/browse/FTI-6431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ