### PR TITLE
fix(ci): update repository name for datakit filter in WASM filters list

### DIFF
--- a/build/openresty/wasmx/filters/variables.bzl
+++ b/build/openresty/wasmx/filters/variables.bzl
@@ -5,7 +5,7 @@ A list of wasm filters.
 WASM_FILTERS = [
     {
         "name": "datakit-filter",
-        "repo": "Kong/datakit-filter",
+        "repo": "Kong/datakit",
         "tag": "0.1.0",
         "files": {
             "datakit.meta.json": "b9f3b6d51d9566fae1a34c0e5c00f0d5ad5dc8f6ce7bf81931fd0be189de205d",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Changed the repository name from "Kong/datakit-filter" to "Kong/datakit" in the variables.bzl file to reflect the correct repository structure.

releated to: [`a2e20ed` (#13922)](https://github.com/Kong/kong/pull/13922/commits/a2e20ed0c0449e9b562d4e10b67b6f8ac45b8231)

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
