### PR TITLE
feat(clustering/sync): validate deltas when syncing

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -64,6 +64,10 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
   -- create shared dict
   resty_flags = resty_flags .. require("spec.fixtures.shared_dict")
 
+  -- create lmdb environment
+  local lmdb_env = os.tmpname()
+  resty_flags = resty_flags .. string.format(' --main-conf "lmdb_environment_path %s;" ', lmdb_env)
+
   if resty_flags then
     table.insert(cmd, cmd_prefix_count+1, resty_flags)
   end

--- a/kong-3.10.0-0.rockspec
+++ b/kong-3.10.0-0.rockspec
@@ -101,6 +101,7 @@ build = {
     ["kong.clustering.services.sync"] = "kong/clustering/services/sync/init.lua",
     ["kong.clustering.services.sync.rpc"] = "kong/clustering/services/sync/rpc.lua",
     ["kong.clustering.services.sync.hooks"] = "kong/clustering/services/sync/hooks.lua",
+    ["kong.clustering.services.sync.validate"] = "kong/clustering/services/sync/validate.lua",
     ["kong.clustering.services.sync.strategies.postgres"] = "kong/clustering/services/sync/strategies/postgres.lua",
 
     ["kong.cluster_events"] = "kong/cluster_events/init.lua",

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -10,6 +10,7 @@ local isempty = require("table.isempty")
 local events = require("kong.runloop.events")
 
 
+local validate_deltas = require("kong.clustering.services.sync.validate").validate_deltas
 local insert_entity_for_txn = declarative.insert_entity_for_txn
 local delete_entity_for_txn = declarative.delete_entity_for_txn
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
@@ -194,6 +195,7 @@ local function do_sync()
     return nil, "default namespace does not exist inside params"
   end
 
+  local wipe = ns_delta.wipe
   local deltas = ns_delta.deltas
 
   if not deltas then
@@ -219,9 +221,14 @@ local function do_sync()
   end
   assert(type(kong.default_workspace) == "string")
 
+  -- validate deltas
+  local ok, err = validate_deltas(deltas, wipe)
+  if not ok then
+    return nil, err
+  end
+
   local t = txn.begin(512)
 
-  local wipe = ns_delta.wipe
   if wipe then
     t:db_drop(false)
   end

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -32,12 +32,16 @@ local function validate_deltas(deltas, is_full_sync)
       -- validate entity
       local dao = kong.db[delta_type]
       if dao then
-        local ws_id = delta_entity.ws_id  -- bypass ws_id field for validation
-        delta_entity.ws_id = nil
+        -- CP will insert ws_id into the entity, which will be validated as an
+        -- unknown field.
+        -- TODO: On the CP side, remove ws_id from the entity and set it only
+        -- in the delta.
+        local ws_id = delta_entity.ws_id
+        delta_entity.ws_id = nil      -- clear ws_id
 
         local ok, err_t = dao.schema:validate(delta_entity)
 
-        delta_entity.ws_id = ws_id
+        delta_entity.ws_id = ws_id    -- restore ws_id
 
         if not ok then
           errs[#errs + 1] = { [delta_type] = err_t }

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -11,7 +11,7 @@ local pretty_print_error = declarative.pretty_print_error
 
 local function validate_deltas(deltas, is_full_sync)
 
-  -- genearte deltas table mapping primary key string to entity item
+  -- generate deltas table mapping primary key string to entity item
   local deltas_map = {}
 
   -- generate declarative config table

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,6 +1,7 @@
 local declarative = require("kong.db.declarative")
 local declarative_config = require("kong.db.schema.others.declarative_config")
 
+
 local null = ngx.null
 local tb_insert = table.insert
 local validate = declarative_config.validate

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,6 +1,7 @@
 local declarative = require("kong.db.declarative")
 local declarative_config = require("kong.db.schema.others.declarative_config")
 
+local null = ngx.null
 local tb_insert = table.insert
 local validate = declarative_config.validate
 local pk_string = declarative_config.pk_string
@@ -23,7 +24,7 @@ local function validate_deltas(deltas, is_full_sync)
     local delta_type = delta.type
     local delta_entity = delta.entity
 
-    if delta_entity ~= nil and delta_entity ~= ngx.null then
+    if delta_entity ~= nil and delta_entity ~= null then
       dc_table[delta_type] = dc_table[delta_type] or {}
 
       tb_insert(dc_table[delta_type], delta_entity)

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,0 +1,67 @@
+local errors = require("kong.db.errors")
+local declarative_config = require("kong.db.schema.others.declarative_config")
+
+local validate = declarative_config.validate
+local pk_string = declarative_config.pk_string
+local validate_references_full = declarative_config.validate_references_full
+local validate_references_sync = declarative_config.validate_references_sync
+
+
+local function validate_deltas(deltas, is_full_sync)
+
+  -- genearte deltas table mapping primary key string to entity item
+  local deltas_map = {}
+
+  -- generate declarative config table
+  local dc_table = { _format_version = "3.0", }
+
+  for _, delta in ipairs(deltas) do
+    local delta_type = delta.type
+    local delta_entity = delta.entity
+
+    if delta_entity ~= nil and delta_entity ~= ngx.null then
+      dc_table[delta_type] = dc_table[delta_type] or {}
+
+      table.insert(dc_table[delta_type], delta_entity)
+
+      -- table: primary key string -> entity
+      if not is_full_sync then
+        local schema = kong.db[delta_type].schema
+        local pk = schema:extract_pk_values(delta_entity)
+        local pks = pk_string(schema, pk)
+
+        deltas_map[pks] = delta_entity
+      end
+    end
+  end
+
+  -- validate schema
+  local dc_schema = kong.db.declarative_config.schema
+
+  local ok, err_t = validate(dc_schema, dc_table)
+  if not ok then
+    return nil, errors:schema_violation(err_t)
+  end
+
+  -- validate references for full sync
+  if is_full_sync then
+    local ok, err_t = validate_references_full(dc_schema, dc_table)
+    if not ok then
+      return nil, errors:schema_violation(err_t)
+    end
+    return true
+  end
+
+  -- validate references for non full sync
+  local ok, err_t = validate_references_sync(deltas, deltas_map)
+  if not ok then
+    return nil, errors:schema_violation(err_t)
+  end
+
+  return true
+end
+
+
+return {
+  validate_deltas = validate_deltas,
+}

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -6,7 +6,6 @@ local null = ngx.null
 local tb_insert = table.insert
 local validate = declarative_config.validate
 local pk_string = declarative_config.pk_string
-local validate_references_full = declarative_config.validate_references_full
 local validate_references_sync = declarative_config.validate_references_sync
 local pretty_print_error = declarative.pretty_print_error
 
@@ -31,13 +30,11 @@ local function validate_deltas(deltas, is_full_sync)
       tb_insert(dc_table[delta_type], delta_entity)
 
       -- table: primary key string -> entity
-      if not is_full_sync then
-        local schema = db[delta_type].schema
-        local pk = schema:extract_pk_values(delta_entity)
-        local pks = pk_string(schema, pk)
+      local schema = db[delta_type].schema
+      local pk = schema:extract_pk_values(delta_entity)
+      local pks = pk_string(schema, pk)
 
-        deltas_map[pks] = delta_entity
-      end
+      deltas_map[pks] = delta_entity
     end
   end
 
@@ -49,17 +46,8 @@ local function validate_deltas(deltas, is_full_sync)
     return nil, pretty_print_error(err_t)
   end
 
-  -- validate references for full sync
-  if is_full_sync then
-    local ok, err_t = validate_references_full(dc_schema, dc_table)
-    if not ok then
-      return nil, pretty_print_error(err_t)
-    end
-    return true
-  end
-
-  -- validate references for non full sync
-  local ok, err_t = validate_references_sync(deltas, deltas_map)
+  -- validate references
+  local ok, err_t = validate_references_sync(deltas, deltas_map, is_full_sync)
   if not ok then
     return nil, pretty_print_error(err_t)
   end

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,6 +1,7 @@
 local declarative = require("kong.db.declarative")
 local declarative_config = require("kong.db.schema.others.declarative_config")
 
+local tb_insert = table.insert
 local validate = declarative_config.validate
 local pk_string = declarative_config.pk_string
 local validate_references_full = declarative_config.validate_references_full
@@ -23,7 +24,7 @@ local function validate_deltas(deltas, is_full_sync)
     if delta_entity ~= nil and delta_entity ~= ngx.null then
       dc_table[delta_type] = dc_table[delta_type] or {}
 
-      table.insert(dc_table[delta_type], delta_entity)
+      tb_insert(dc_table[delta_type], delta_entity)
 
       -- table: primary key string -> entity
       if not is_full_sync then

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -17,6 +17,8 @@ local function validate_deltas(deltas, is_full_sync)
   -- generate declarative config table
   local dc_table = { _format_version = "3.0", }
 
+  local db = kong.db
+
   for _, delta in ipairs(deltas) do
     local delta_type = delta.type
     local delta_entity = delta.entity
@@ -28,7 +30,7 @@ local function validate_deltas(deltas, is_full_sync)
 
       -- table: primary key string -> entity
       if not is_full_sync then
-        local schema = kong.db[delta_type].schema
+        local schema = db[delta_type].schema
         local pk = schema:extract_pk_values(delta_entity)
         local pks = pk_string(schema, pk)
 
@@ -38,7 +40,7 @@ local function validate_deltas(deltas, is_full_sync)
   end
 
   -- validate schema
-  local dc_schema = kong.db.declarative_config.schema
+  local dc_schema = db.declarative_config.schema
 
   local ok, err_t = validate(dc_schema, dc_table)
   if not ok then

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,10 +1,11 @@
-local errors = require("kong.db.errors")
+local declarative = require("kong.db.declarative")
 local declarative_config = require("kong.db.schema.others.declarative_config")
 
 local validate = declarative_config.validate
 local pk_string = declarative_config.pk_string
 local validate_references_full = declarative_config.validate_references_full
 local validate_references_sync = declarative_config.validate_references_sync
+local pretty_print_error = declarative.pretty_print_error
 
 
 local function validate_deltas(deltas, is_full_sync)
@@ -40,14 +41,14 @@ local function validate_deltas(deltas, is_full_sync)
 
   local ok, err_t = validate(dc_schema, dc_table)
   if not ok then
-    return nil, errors:schema_violation(err_t)
+    return nil, pretty_print_error(err_t)
   end
 
   -- validate references for full sync
   if is_full_sync then
     local ok, err_t = validate_references_full(dc_schema, dc_table)
     if not ok then
-      return nil, errors:schema_violation(err_t)
+      return nil, pretty_print_error(err_t)
     end
     return true
   end
@@ -55,7 +56,7 @@ local function validate_deltas(deltas, is_full_sync)
   -- validate references for non full sync
   local ok, err_t = validate_references_sync(deltas, deltas_map)
   if not ok then
-    return nil, errors:schema_violation(err_t)
+    return nil, pretty_print_error(err_t)
   end
 
   return true

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -4,7 +4,7 @@ local declarative_config = require("kong.db.schema.others.declarative_config")
 
 local null = ngx.null
 local tb_insert = table.insert
-local validate = declarative_config.validate
+local validate_schema = declarative_config.validate_schema
 local pk_string = declarative_config.pk_string
 local validate_references_sync = declarative_config.validate_references_sync
 local pretty_print_error = declarative.pretty_print_error
@@ -38,10 +38,10 @@ local function validate_deltas(deltas, is_full_sync)
     end
   end
 
-  -- validate schema
+  -- validate schema (same logic as the sync v1 full-sync schema validation)
   local dc_schema = db.declarative_config.schema
 
-  local ok, err_t = validate(dc_schema, dc_table)
+  local ok, err_t = validate_schema(dc_schema, dc_table)
   if not ok then
     return nil, pretty_print_error(err_t)
   end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -34,9 +34,7 @@ local _MT = { __index = _M, }
 -- of the database (e.g. for db_import)
 -- @treturn table A Config schema adjusted for this configuration
 function _M.new_config(kong_config, partial, include_foreign)
-  local schema, err = declarative_config.load(kong_config.loaded_plugins,
-                                              kong_config.loaded_vaults,
-                                              include_foreign, kong.sync ~= nil)
+  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults, include_foreign)
   if not schema then
     return nil, err
   end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -32,13 +32,11 @@ local _MT = { __index = _M, }
 -- @tparam table kong_config The Kong configuration table
 -- @tparam boolean partial Input is not a full representation
 -- of the database (e.g. for db_import)
--- @tparam is_sync It generates full schema and foreign references to validate
--- schema and references for sync.v2
 -- @treturn table A Config schema adjusted for this configuration
-function _M.new_config(kong_config, partial, include_foreign, is_sync)
+function _M.new_config(kong_config, partial, include_foreign)
   local schema, err = declarative_config.load(kong_config.loaded_plugins,
                                               kong_config.loaded_vaults,
-                                              include_foreign, is_sync)
+                                              include_foreign, kong.sync ~= nil)
   if not schema then
     return nil, err
   end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -263,5 +263,8 @@ _M.delete_entity_for_txn       = declarative_import.delete_entity_for_txn
 _M.workspace_id                = declarative_import.workspace_id
 _M.GLOBAL_WORKSPACE_TAG        = declarative_import.GLOBAL_WORKSPACE_TAG
 
+-- helpful function
+_M.pretty_print_error          = pretty_print_error
+
 
 return _M

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -33,8 +33,8 @@ local _MT = { __index = _M, }
 -- @tparam boolean partial Input is not a full representation
 -- of the database (e.g. for db_import)
 -- @treturn table A Config schema adjusted for this configuration
-function _M.new_config(kong_config, partial)
-  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults)
+function _M.new_config(kong_config, partial, include_foreign)
+  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults, include_foreign)
   if not schema then
     return nil, err
   end
@@ -42,6 +42,7 @@ function _M.new_config(kong_config, partial)
   local self = {
     schema = schema,
     partial = partial,
+    include_foreign = include_foreign,
   }
 
   setmetatable(self, _MT)

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -32,9 +32,13 @@ local _MT = { __index = _M, }
 -- @tparam table kong_config The Kong configuration table
 -- @tparam boolean partial Input is not a full representation
 -- of the database (e.g. for db_import)
+-- @tparam is_sync It generates full schema and foreign references to validate
+-- schema and references for sync.v2
 -- @treturn table A Config schema adjusted for this configuration
-function _M.new_config(kong_config, partial)
-  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults)
+function _M.new_config(kong_config, partial, include_foreign, is_sync)
+  local schema, err = declarative_config.load(kong_config.loaded_plugins,
+                                              kong_config.loaded_vaults,
+                                              include_foreign, is_sync)
   if not schema then
     return nil, err
   end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -33,8 +33,8 @@ local _MT = { __index = _M, }
 -- @tparam boolean partial Input is not a full representation
 -- of the database (e.g. for db_import)
 -- @treturn table A Config schema adjusted for this configuration
-function _M.new_config(kong_config, partial, include_foreign)
-  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults, include_foreign)
+function _M.new_config(kong_config, partial)
+  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults)
   if not schema then
     return nil, err
   end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -33,8 +33,8 @@ local _MT = { __index = _M, }
 -- @tparam boolean partial Input is not a full representation
 -- of the database (e.g. for db_import)
 -- @treturn table A Config schema adjusted for this configuration
-function _M.new_config(kong_config, partial, include_foreign)
-  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults, include_foreign)
+function _M.new_config(kong_config, partial)
+  local schema, err = declarative_config.load(kong_config.loaded_plugins, kong_config.loaded_vaults)
   if not schema then
     return nil, err
   end
@@ -42,7 +42,6 @@ function _M.new_config(kong_config, partial, include_foreign)
   local self = {
     schema = schema,
     partial = partial,
-    include_foreign = include_foreign,
   }
 
   setmetatable(self, _MT)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -1051,10 +1051,19 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
     return nil, err
   end
 
-  -- we replace the "foreign"-type fields at the top-level
-  -- with "string"-type fields only after the subschemas have been loaded,
-  -- otherwise they will detect the mismatch.
-  if not include_foreign then
+  -- If sync.v2 enabled, it generates foreign_references and does not replace
+  -- replace the "foreign"-type fields with "string"-type fields.
+  --
+  -- For sync.v2,
+  -- * The "foreign"-type fields are used to validate schema.
+  -- * The foreign_references are used to validate references.
+  if is_sync then
+    reference_foreign_by_name_sync(known_entities, records)
+
+  elseif not include_foreign then
+    -- we replace the "foreign"-type fields at the top-level
+    -- with "string"-type fields only after the subschemas have been loaded,
+    -- otherwise they will detect the mismatch.
     reference_foreign_by_name(known_entities, records)
   end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -854,10 +854,6 @@ function DeclarativeConfig.validate(self, input)
   if not ok then
     yield()
 
-    if self.include_foreign then
-      return nil, err
-    end
-
     -- the error may be due entity validation that depends on foreign entity,
     -- and that is the reason why we try to validate the input again with the
     -- filled foreign keys

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -507,12 +507,7 @@ local function validate_references(self, input)
 end
 
 
-function DeclarativeConfig.validate_references_full(self, input)
-  return validate_references(self, input)
-end
-
-
-function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
+function DeclarativeConfig.validate_references_sync(deltas, deltas_map, is_full_sync)
   local errs = {}
 
   for _, delta in ipairs(deltas) do
@@ -543,7 +538,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
         local fvalue = deltas_map[pks]
 
         -- try to find it in DB (LMDB)
-        if not fvalue then
+        if not fvalue and not is_full_sync then
           fvalue = dao:select(v, { workspace = ws_id })
         end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -507,6 +507,9 @@ local function validate_references(self, input)
 end
 
 
+-- TODO: Completely implement validate_references_sync without associating it
+-- to declarative config. Currently, we will use the dc-generated
+-- foreign_references table to accelerate iterating over entity foreign keys.
 function DeclarativeConfig.validate_references_sync(deltas, deltas_map, is_full_sync)
   local errs = {}
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -565,7 +565,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
     end
 
     ::continue::
-  end
+  end  -- for _, delta in ipairs(deltas)
 
 
   if next(errs) then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -562,7 +562,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
       end
 
       ::found::
-    end
+    end   -- for k, v in pairs(item)
 
     ::continue::
   end  -- for _, delta in ipairs(deltas)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -849,7 +849,7 @@ local function get_unique_key(schema, entity, field, value)
 end
 
 
-function DeclarativeConfig.validate(self, input)
+function DeclarativeConfig.validate_schema(self, input)
   local ok, err = self:validate(input)
   if not ok then
     yield()
@@ -885,7 +885,7 @@ local function flatten(self, input)
     input._transform = true
   end
 
-  local ok, err = DeclarativeConfig.validate(self, input)
+  local ok, err = DeclarativeConfig.validate_schema(self, input)
   if not ok then
     return nil, err
   end

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -844,7 +844,15 @@ local function get_unique_key(schema, entity, field, value)
 end
 
 
-function DeclarativeConfig.validate_schema(self, input)
+local function flatten(self, input)
+  -- manually set transform here
+  -- we can't do this in the schema with a `default` because validate
+  -- needs to happen before process_auto_fields, which
+  -- is the one in charge of filling out default values
+  if input._transform == nil then
+    input._transform = true
+  end
+
   local ok, err = self:validate(input)
   if not ok then
     yield()
@@ -865,24 +873,6 @@ function DeclarativeConfig.validate_schema(self, input)
     end
 
     yield()
-  end
-
-  return true
-end
-
-
-local function flatten(self, input)
-  -- manually set transform here
-  -- we can't do this in the schema with a `default` because validate
-  -- needs to happen before process_auto_fields, which
-  -- is the one in charge of filling out default values
-  if input._transform == nil then
-    input._transform = true
-  end
-
-  local ok, err = DeclarativeConfig.validate_schema(self, input)
-  if not ok then
-    return nil, err
   end
 
   generate_ids(input, self.known_entities)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -528,6 +528,10 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
 
     for k, v in pairs(item) do
 
+      -- Try to check if item's some foreign key exists in the deltas or LMDB.
+      -- For example, `item[k]` could be `<router_entity>["service"]`, we need
+      -- to find the referenced foreign service entity for this router entity.
+
       local foreign_entity = foreign_refs[k]
 
       if foreign_entity and v ~= null then  -- k is foreign key

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -558,7 +558,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
 
           insert(errs[item_type][foreign_entity], msg)
         end
-      end
+      end  -- if foreign_entity and v ~= null
 
     end  -- for k, v in pairs(item)
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -546,7 +546,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
         end
 
         -- try to find it in DB (LMDB)
-        fvalue, _ = db:select(v, { workspace = ws_id })
+        fvalue = db:select(v, { workspace = ws_id })
 
         -- could not find its foreign reference
         if not fvalue then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -854,6 +854,10 @@ function DeclarativeConfig.validate(self, input)
   if not ok then
     yield()
 
+    if self.include_foreign then
+      return nil, err
+    end
+
     -- the error may be due entity validation that depends on foreign entity,
     -- and that is the reason why we try to validate the input again with the
     -- filled foreign keys

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -980,9 +980,9 @@ local function load_entity_subschemas(entity_name, entity)
 end
 
 
--- @tparam is_sync It generates full schema and foreign references to validate
--- schema and references for sync.v2
-function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
+-- @tparam sync_v2_enabled It generates full schema and foreign references to
+-- validate schema and references for sync.v2
+function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, sync_v2_enabled)
   all_schemas = {}
   local schemas_array = {}
   for _, entity in ipairs(constants.CORE_ENTITIES) do
@@ -1017,7 +1017,7 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
     known_entities[i] = schema.name
   end
 
-  local fields, records = build_fields(known_entities, include_foreign or is_sync)
+  local fields, records = build_fields(known_entities, include_foreign or sync_v2_enabled)
   -- assert(no_foreign(fields))
 
   local ok, err = load_plugin_subschemas(fields, plugin_set)
@@ -1035,7 +1035,7 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
   -- due to load_plugin_subschemas().
   local full_schema
 
-  if is_sync then
+  if sync_v2_enabled then
     local def = {
       name = "declarative_config",
       primary_key = {},
@@ -1043,6 +1043,7 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
       -- reference_foreign_by_name()
       fields = kong_table.cycle_aware_deep_copy(fields, true),
     }
+
     full_schema = Schema.new(def)
 
     full_schema.known_entities = known_entities
@@ -1073,7 +1074,7 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
   schema.plugin_set = plugin_set
   schema.vault_set = vault_set
 
-  if is_sync then
+  if sync_v2_enabled then
     schema.full_schema = full_schema
   end
 

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -980,6 +980,8 @@ local function load_entity_subschemas(entity_name, entity)
 end
 
 
+-- @tparam is_sync It generates full schema and foreign references to validate
+-- schema and references for sync.v2
 function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
   all_schemas = {}
   local schemas_array = {}

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -1028,7 +1028,9 @@ function DeclarativeConfig.load(plugin_set, vault_set, include_foreign, is_sync)
     return nil, err
   end
 
-  -- Pre-load full schema to validate schema for sync.v2:
+  -- Pre-load the full schema to validate the schema for sync.v2. Lazy loading
+  -- the full schema with DeclarativeConfig.load() will consume a lot of time
+  -- due to load_plugin_subschemas().
   local full_schema
 
   if is_sync then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -332,7 +332,7 @@ end
 
 
 local function ws_id_for(item)
-  if item.ws_id == nil or item.ws_id == ngx.null then
+  if item.ws_id == nil or item.ws_id == null then
     return "*"
   end
   return item.ws_id
@@ -414,7 +414,7 @@ local function populate_references(input, known_entities, by_id, by_key, expecte
       local key = use_key and item[endpoint_key]
 
       local failed = false
-      if key and key ~= ngx.null then
+      if key and key ~= null then
         local ok = add_to_by_key(by_key, entity_schema, item, entity, key)
         if not ok then
           add_error(errs, parent_entity, parent_idx, entity, i,
@@ -522,7 +522,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map)
 
     local foreign_refs = foreign_references[item_type]
 
-    if not item or item == ngx.null or not foreign_refs then
+    if not item or item == null or not foreign_refs then
       goto continue
     end
 
@@ -936,7 +936,7 @@ local function flatten(self, input)
 
         if field.unique then
           local flat_value = flat_entry[name]
-          if flat_value and flat_value ~= ngx.null then
+          if flat_value and flat_value ~= null then
             local unique_key = get_unique_key(schema, entry, field, flat_value)
             uniques[name] = uniques[name] or {}
             if uniques[name][unique_key] then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -549,7 +549,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map, is_full_
 
           local msg = fmt("could not find %s's foreign refrences %s (%s)",
                           item_type, foreign_entity,
-                          (type(v) == "string" and v or cjson_encode(v)))
+                          type(v) == "string" and v or cjson_encode(v))
 
           insert(errs[item_type][foreign_entity], msg)
         end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -712,10 +712,7 @@ function Kong.init()
   end
 
   if is_dbless(config) then
-    -- If sync is enabled, we need to genearte full schema (including complete
-    -- foreign entity) for declarative config. Therefore, sync deltas validation
-    -- could work as expected to check full schema entities.
-    local dc, err = declarative.new_config(config, nil, not not kong.sync)
+    local dc, err = declarative.new_config(config)
     if not dc then
       error(err)
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -712,7 +712,7 @@ function Kong.init()
   end
 
   if is_dbless(config) then
-    local dc, err = declarative.new_config(config, nil, nil, kong.sync ~= nil)
+    local dc, err = declarative.new_config(config)
     if not dc then
       error(err)
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -712,7 +712,7 @@ function Kong.init()
   end
 
   if is_dbless(config) then
-    local dc, err = declarative.new_config(config, nil, nil, not not kong.sync)
+    local dc, err = declarative.new_config(config, nil, nil, kong.sync ~= nil)
     if not dc then
       error(err)
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -712,7 +712,10 @@ function Kong.init()
   end
 
   if is_dbless(config) then
-    local dc, err = declarative.new_config(config)
+    -- If sync is enabled, we need to genearte full schema (including complete
+    -- foreign entity) for declarative config. Therefore, sync deltas validation
+    -- could work as expected to check full schema entities.
+    local dc, err = declarative.new_config(config, nil, not not kong.sync)
     if not dc then
       error(err)
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -712,7 +712,7 @@ function Kong.init()
   end
 
   if is_dbless(config) then
-    local dc, err = declarative.new_config(config)
+    local dc, err = declarative.new_config(config, nil, nil, not not kong.sync)
     if not dc then
       error(err)
     end

--- a/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
@@ -21,7 +21,7 @@ local function get_http_node_id()
   local client = helpers.proxy_client(nil, 9002)
   finally(function() client:close() end)
 
-  -- wait until 30s: Its original value is 5s. Since we added delta validation
+  -- wait until 45s: Its original value is 5s. Since we added delta validation
   -- logic, the foreign entity in the deltas items is complete, like
   -- { id = "uuid" }. If it uses kong.db.declarative_config to validate
   -- deltas, it will fail. Then, declarative_config will load a full schema to
@@ -35,7 +35,7 @@ local function get_http_node_id()
       res:read_body()
     end
     return res and res.status == 200
-  end, 30, 0.5)
+  end, 45, 0.5)
 
   helpers.wait_for_file("file", PREFIX .. "/kong.id.http")
   return helpers.file.read(PREFIX .. "/kong.id.http")

--- a/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
@@ -21,7 +21,7 @@ local function get_http_node_id()
   local client = helpers.proxy_client(nil, 9002)
   finally(function() client:close() end)
 
-  -- wait until 15s: Its original value is 5s. Since we added delta validation
+  -- wait until 30s: Its original value is 5s. Since we added delta validation
   -- logic, the foreign entity in the deltas items is complete, like
   -- { id = "uuid" }. If it uses kong.db.declarative_config to validate
   -- deltas, it will fail. Then, declarative_config will load a full schema to
@@ -35,7 +35,7 @@ local function get_http_node_id()
       res:read_body()
     end
     return res and res.status == 200
-  end, 15, 0.5)
+  end, 30, 0.5)
 
   helpers.wait_for_file("file", PREFIX .. "/kong.id.http")
   return helpers.file.read(PREFIX .. "/kong.id.http")

--- a/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
@@ -21,11 +21,6 @@ local function get_http_node_id()
   local client = helpers.proxy_client(nil, 9002)
   finally(function() client:close() end)
 
-  -- wait until 45s: Its original value is 5s. Since we added delta validation
-  -- logic, the foreign entity in the deltas items is complete, like
-  -- { id = "uuid" }. If it uses kong.db.declarative_config to validate
-  -- deltas, it will fail. Then, declarative_config will load a full schema to
-  -- re-validate, which consumes a large amount of extra time.
   helpers.wait_until(function()
     local res = client:get("/request", {
       headers = { host = "http.node-id.test" },
@@ -35,7 +30,7 @@ local function get_http_node_id()
       res:read_body()
     end
     return res and res.status == 200
-  end, 45, 0.5)
+  end, 5, 0.5)
 
   helpers.wait_for_file("file", PREFIX .. "/kong.id.http")
   return helpers.file.read(PREFIX .. "/kong.id.http")

--- a/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-node-id-persistence_spec.lua
@@ -93,7 +93,7 @@ for _, v in ipairs({ {"off", "off"}, {"on", "off"}, {"on", "on"}, }) do
   local rpc, rpc_sync = v[1], v[2]
 
 for _, strategy in helpers.each_strategy() do
-  describe("node id persistence " .. " rpc_sync=" .. rpc_sync, function()
+  describe("node id persistence rpc_sync = " .. rpc_sync, function()
 
     local control_plane_config = {
       role = "control_plane",

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -1,0 +1,190 @@
+local helpers = require "spec.helpers"
+local pl_file = require "pl.file"
+local txn = require "resty.lmdb.transaction"
+local declarative = require "kong.db.declarative"
+
+local insert_entity_for_txn = declarative.insert_entity_for_txn
+local validate_deltas = require("kong.clustering.services.sync.validate").validate_deltas
+
+
+local function lmdb_drop()
+  local t = txn.begin(512)
+  t:db_drop(false)
+  t:commit()
+end
+
+
+local function lmdb_insert(name, entity)
+  local t = txn.begin(512)
+  local res, err = insert_entity_for_txn(t, name, entity, nil)
+  if not res then
+    error("lmdb insert failed: " .. err)
+  end
+
+  local ok, err = t:commit()
+  if not ok then
+    error("lmdb t:commit() failed: " .. err)
+  end
+end
+
+
+-- insert into LMDB
+local function db_insert(bp, name, entity)
+  -- insert into dc blueprints
+  entity = bp[name]:insert(entity)
+
+  -- insert into LMDB
+  lmdb_insert(name, entity)
+
+  assert(kong.db[name]:select({id = entity.id}))
+
+  return entity
+end
+
+
+local function setup_bp()
+  -- reset lmdb
+  lmdb_drop()
+
+  -- init bp / db ( true for expand_foreigns)
+  bp, db = helpers.get_db_utils("off", nil, nil, nil, nil, true)
+
+  -- init workspaces
+  local workspaces = require "kong.workspaces"
+  workspaces.upsert_default(db)
+
+  -- init declarative config
+  local dc, err = declarative.new_config(kong.configuration)
+  assert(dc, err)
+  kong.db.declarative_config = dc
+
+  return bp, db
+end
+
+
+describe("[delta validations]",function()
+
+  it("workspace id", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+    local service = db_insert(bp, "services", { name = "service-001", })
+    local route = db_insert(bp, "routes", {
+      name = "route-001",
+      paths = { "/mock" },
+      service = { id = service.id },
+    })
+
+    local deltas = declarative.export_config_sync()
+
+    for _, delta in ipairs(deltas) do
+      local delta_entity = delta.entity
+      local delta_type = delta.type
+      local ws_id = delta.ws_id
+      assert(ws_id)
+    end
+  end)
+
+  it("route has foreign service", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+    local service = db_insert(bp, "services", { name = "service-001", })
+    local route = db_insert(bp, "routes", {
+      name = "route-001",
+      paths = { "/mock" },
+      service = { id = service.id },
+    })
+
+    local deltas = declarative.export_config_sync()
+
+    local ok, err = validate_deltas(deltas)
+    assert(ok, "validate should not fail: " .. tostring(err))
+  end)
+
+  it("route has unmatched foreign service", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+    local service = db_insert(bp, "services", { name = "service-001", })
+    local route = db_insert(bp, "routes", {
+      name = "route-001",
+      paths = { "/mock" },
+      -- unmatched service
+      service = { id = "00000000-0000-0000-0000-000000000000" },
+    })
+
+    local deltas = declarative.export_config_sync()
+  end)
+
+  it("100 routes -> 1 services: matched foreign keys", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+    local service = db_insert(bp, "services", { name = "service-001", })
+
+    for i = 1, 100 do
+      local route = db_insert(bp, "routes", {
+        name = "route-001",
+        paths = { "/mock" },
+        -- unmatched service
+        service = { id = service.id },
+      })
+    end
+
+    local deltas = declarative.export_config_sync()
+    local ok, err = validate_deltas(deltas, false)
+    assert(ok, "validate should not fail: " .. tostring(err))
+  end)
+
+  it("100 routes -> 100 services: matched foreign keys", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+
+    for i = 1, 100 do
+      local service = db_insert(bp, "services", { name = "service-001", })
+
+      local route = db_insert(bp, "routes", {
+        name = "route-001",
+        paths = { "/mock" },
+        -- unmatched service
+        service = { id = service.id },
+      })
+    end
+
+    local deltas = declarative.export_config_sync()
+    local ok, err = validate_deltas(deltas, false)
+    assert(ok, "validate should not fail: " .. tostring(err))
+  end)
+
+  it("100 routes: unmatched foreign service", function()
+    local bp = setup_bp()
+
+    -- add entities
+    local ws = db_insert(bp, "workspaces", { name = "ws-001" })
+
+    for i = 1, 100 do
+      local route = db_insert(bp, "routes", {
+        name = "route-001",
+        paths = { "/mock" },
+        -- unmatched service
+        service = { id = "00000000-0000-0000-0000-000000000000" },
+      })
+    end
+
+    local deltas = declarative.export_config_sync()
+    local ok, err = validate_deltas(deltas, false)
+    for i = 1, 100 do
+      assert.matches(
+        "entry " .. i .. " of 'services': " ..
+        "could not find routes's foreign refrences services",
+        err)
+    end
+  end)
+end)

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -80,7 +80,7 @@ describe("[delta validations]",function()
 
     for _, delta in ipairs(deltas) do
       local ws_id = delta.ws_id
-      assert(ws_id)
+      assert(ws_id and ws_id ~= ngx.null)
     end
   end)
 
@@ -99,7 +99,7 @@ describe("[delta validations]",function()
     local deltas = declarative.export_config_sync()
 
     local ok, err = validate_deltas(deltas)
-    assert(ok, "validate should not fail: " .. tostring(err))
+    assert.is_true(ok, "validate should not fail: " .. tostring(err))
   end)
 
   it("route has unmatched foreign service", function()

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 local txn = require "resty.lmdb.transaction"
 local declarative = require "kong.db.declarative"
 
+
 local insert_entity_for_txn = declarative.insert_entity_for_txn
 local validate_deltas = require("kong.clustering.services.sync.validate").validate_deltas
 

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -60,7 +60,6 @@ local function setup_bp()
 
   -- init declarative config
   if not cached_dc then
-    kong.sync = "fake sync to generate dc with sync_v2_enabled"
     local err
     cached_dc, err = declarative.new_config(kong.configuration)
     assert(cached_dc, err)

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -61,7 +61,7 @@ local function setup_bp()
   -- init declarative config
   if not cached_dc then
     local err
-    cached_dc, err = declarative.new_config(kong.configuration)
+    cached_dc, err = declarative.new_config(kong.configuration, nil, nil, true)
     assert(cached_dc, err)
   end
 

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -139,7 +139,7 @@ describe("[delta validations]",function()
 
     local deltas = declarative.export_config_sync()
     local ok, err = validate_deltas(deltas, false)
-    assert(ok, "validate should not fail: " .. tostring(err))
+    assert.is_true(ok, "validate should not fail: " .. tostring(err))
   end)
 
   it("100 routes -> 100 services: matched foreign keys", function()
@@ -161,7 +161,7 @@ describe("[delta validations]",function()
 
     local deltas = declarative.export_config_sync()
     local ok, err = validate_deltas(deltas, false)
-    assert(ok, "validate should not fail: " .. tostring(err))
+    assert.is_true(ok, "validate should not fail: " .. tostring(err))
   end)
 
   it("100 routes: unmatched foreign service", function()

--- a/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/06-validate_deltas_spec.lua
@@ -60,8 +60,9 @@ local function setup_bp()
 
   -- init declarative config
   if not cached_dc then
+    kong.sync = "fake sync to generate dc with sync_v2_enabled"
     local err
-    cached_dc, err = declarative.new_config(kong.configuration, nil, nil, true)
+    cached_dc, err = declarative.new_config(kong.configuration)
     assert(cached_dc, err)
   end
 

--- a/spec/fixtures/dc_blueprints.lua
+++ b/spec/fixtures/dc_blueprints.lua
@@ -28,7 +28,7 @@ local function remove_nulls(tbl)
 end
 
 
-local function wrap_db(db)
+local function wrap_db(db, expand_foreigns)
   local dc_as_db = {}
 
   local config = new_config()
@@ -43,7 +43,7 @@ local function wrap_db(db)
         local schema = db.daos[name].schema
         tbl = schema:process_auto_fields(tbl, "insert")
         for fname, field in schema:each_field() do
-          if field.type == "foreign" then
+          if not expand_foreigns and field.type == "foreign" then
             tbl[fname] = type(tbl[fname]) == "table"
                          and tbl[fname].id
                          or nil
@@ -110,8 +110,8 @@ local function wrap_db(db)
 end
 
 
-function dc_blueprints.new(db)
-  local dc_as_db = wrap_db(db)
+function dc_blueprints.new(db, expand_foreigns)
+  local dc_as_db = wrap_db(db, expand_foreigns)
 
   local save_dc = new_config()
 

--- a/spec/fixtures/dc_blueprints.lua
+++ b/spec/fixtures/dc_blueprints.lua
@@ -28,6 +28,8 @@ local function remove_nulls(tbl)
 end
 
 
+-- tparam boolean expand_foreigns expand the complete "foreign"-type fields, not
+-- replacing it with "string"-type fields
 local function wrap_db(db, expand_foreigns)
   local dc_as_db = {}
 

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -261,6 +261,10 @@ end
 -- custom plugins as loaded.
 -- @param vaults (optional) vault configuration to use.
 -- @param skip_migrations (optional) if true, migrations will not be run.
+-- @param expand_foreigns (optional) If true, it will prevent converting foreign
+-- keys from primary key value pairs to strings. For example, it will keep the
+-- foreign key of the router entity as `service = { id = "<uuid>" }` instead of
+-- converting it to `service = "<uuid>"`.
 -- @return BluePrint, DB
 -- @usage
 -- local PLUGIN_NAME = "my_fancy_plugin"

--- a/spec/internal/db.lua
+++ b/spec/internal/db.lua
@@ -277,7 +277,7 @@ end
 --   route = { id = route1.id },
 --   config = {},
 -- }
-local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
+local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations, expand_foreigns)
   strategy = strategy or conf.database
   conf.database = strategy  -- overwrite kong.configuration.database
 
@@ -343,7 +343,7 @@ local function get_db_utils(strategy, tables, plugins, vaults, skip_migrations)
     bp = assert(Blueprints.new(db))
     dcbp = nil
   else
-    bp = assert(dc_blueprints.new(db))
+    bp = assert(dc_blueprints.new(db, expand_foreigns))
     dcbp = bp
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
1. validate entity schema
   * call `kong.db[entity].validate(entity)` over all the entities from deltas
2. validate entity's references (foreign references)
   * re-implemented logic: traverse delta -> try to find delta's foreign entity in config & LMDB
   * TODO: decouple this logic completely from declarative config logic: https://konghq.atlassian.net/browse/KAG-6231
3. TODO: report error if deleting delta operation could not find its associated entity in LMDB and deltas: https://konghq.atlassian.net/browse/KAG-6238

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5897
