### PR TITLE
refactor(clustering/rpc): move is_valid_version() to strategies

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -23,7 +23,6 @@ local MAX_RETRY = 5
 
 local assert = assert
 local ipairs = ipairs
-local sub = string.sub
 local ngx_null = ngx.null
 local ngx_log = ngx.log
 local ngx_ERR = ngx.ERR
@@ -57,17 +56,6 @@ end
 
 local function get_current_version()
   return declarative.get_current_hash() or DECLARATIVE_EMPTY_CONFIG_HASH
-end
-
-
-local is_valid_version
-do
-  local VER_PREFIX = "v02_"
-
-  -- version string must start with 'v02_'
-  is_valid_version = function(v)
-    return sub(v, 1, 4) == VER_PREFIX
-  end
 end
 
 
@@ -118,7 +106,7 @@ function _M:init_cp(manager)
     end
 
     --  string comparison effectively does the same as number comparison
-    if not is_valid_version(default_namespace_version) or
+    if not self.strategy:is_valid_version(default_namespace_version) or
        default_namespace_version ~= latest_version then
       return full_sync_result()
     end

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -9,6 +9,7 @@ local ngx_null = ngx.null
 
 -- version string should look like: "v02_0000"
 local VER_PREFIX = "v02_"
+local VER_PREFIX_LEN = #VER_PREFIX
 local VERSION_FMT = VER_PREFIX .. "%028x"
 
 
@@ -59,7 +60,7 @@ end
 
 
 function _M:is_valid_version(str)
-  return sub(str, 1, 4) == VER_PREFIX
+  return sub(str, 1, VER_PREFIX_LEN) == VER_PREFIX
 end
 
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -59,7 +59,7 @@ end
 
 
 function _M:is_valid_version(str)
-  return sub(v, 1, 4) == VER_PREFIX
+  return sub(str, 1, 4) == VER_PREFIX
 end
 
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -2,12 +2,14 @@ local _M = {}
 local _MT = { __index = _M }
 
 
+local sub = string.sub
 local fmt = string.format
 local ngx_null = ngx.null
 
 
 -- version string should look like: "v02_0000"
-local VERSION_FMT = "v02_%028x"
+local VER_PREFIX = "v02_"
+local VERSION_FMT = VER_PREFIX .. "%028x"
 
 
 function _M.new(db)
@@ -53,6 +55,11 @@ function _M:get_latest_version()
   end
 
   return fmt(VERSION_FMT, ver)
+end
+
+
+function _M:is_valid_version(str)
+  return sub(v, 1, 4) == VER_PREFIX
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5894
Clean the code of #14078

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
