### PR TITLE
fix(docs): fix a typo in bash commands of crate_locks readme

### DIFF
--- a/crate_locks/README.md
+++ b/crate_locks/README.md
@@ -14,7 +14,7 @@ please check out the [rules_rust](https://github.com/bazelbuild/rules_rust).
 
 ```bash
 crates="atc_router_crate_index"
-CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=$scrates bazel sync --only=$crates
+CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=$crates bazel sync --only=$crates
 unset crates
 ```
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6172
