### PR TITLE
fix(ai): fix Azure streaming with raw JSON transmission mode

### DIFF
--- a/changelog/unreleased/kong/fix-ai-azure-streaming.yml
+++ b/changelog/unreleased/kong/fix-ai-azure-streaming.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed a bug where Azure streaming responses would be missing individual tokens."
+type: bugfix
+scope: Plugin

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -353,7 +353,7 @@ function _M.frame_to_events(frame, content_type)
   -- some new LLMs return the JSON object-by-object,
   -- because that totally makes sense to parse?!
   local frame_start = frame and frame:sub(1, 1)
-  if frame_start == "," or frame_start == "[" then
+  if (not kong or not kong.ctx.plugin.truncated_frame) and (frame_start == "," or frame_start == "[") then
     local done = false
 
     -- if this is the first frame, it will begin with array opener '['
@@ -416,7 +416,7 @@ function _M.frame_to_events(frame, content_type)
       if #dat > 0 and #event_lines == i then
         ngx.log(ngx.DEBUG, "[ai-proxy] truncated sse frame head")
         if kong then
-          kong.ctx.plugin.truncated_frame = dat
+          kong.ctx.plugin.truncated_frame = fmt("%s%s", (kong.ctx.plugin.truncated_frame or ""), dat)
         end
 
         break  -- stop parsing immediately, server has done something wrong


### PR DESCRIPTION
### Summary

Fixes Azure streaming when "JSON mode" is used (i.e. when inline content safety is enabled).

It broke because the SSE chunk would start with `[` or `'` and be caught by the wrong switch statement in the parser.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[FTI-6419](https://konghq.atlassian.net/browse/FTI-6419)


[FTI-6419]: https://konghq.atlassian.net/browse/FTI-6419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ