### PR TITLE
fix(clustering/rpc): record the default workspace after the dropping the lmdb

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -318,8 +318,10 @@ local function do_sync()
   -- store current sync version
   t:set(DECLARATIVE_HASH_KEY, fmt("%032d", version))
 
-  -- store the correct default workspace uuid
-  if default_ws_changed then
+  -- record the default workspace into LMDB for any of the following case:
+  -- * wipe is false, but the default workspace has been changed
+  -- * wipe is true (full sync)
+  if default_ws_changed or wipe then
     t:set(DECLARATIVE_DEFAULT_WORKSPACE_KEY, kong.default_workspace)
   end
 


### PR DESCRIPTION
### Summary

This bug was found when I tried to fix some failed test cases, so we don't need to write extra tests.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-6176]


[KAG-6176]: https://konghq.atlassian.net/browse/KAG-6176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ