### PR TITLE
chore(ci): fix luarocks script redirect typo

### DIFF
--- a/build/luarocks/templates/luarocks_make.sh
+++ b/build/luarocks/templates/luarocks_make.sh
@@ -15,7 +15,7 @@ mkdir -p $(dirname $@)
 # alias LDOC command to true(1) command
 export LDOC=true
 
-$luarocks_exec make --no-doc 2>&1 >$@.tmp
+$luarocks_exec make --no-doc >$@.tmp 2>&1
 
 # only generate the output when the command succeeds
 mv $@.tmp $@

--- a/build/luarocks/templates/luarocks_target.sh
+++ b/build/luarocks/templates/luarocks_target.sh
@@ -33,7 +33,7 @@ EOF
 export LUAROCKS_CONFIG=$ROCKS_CONFIG
 
 $host_luajit $luarocks_wrap_script \
-            luarocks $rocks_tree $install_destdir 2>&1 > $@.tmp
+            luarocks $rocks_tree $install_destdir > $@.tmp 2>&1
 
 # write the luarocks config with host configuration
 mkdir -p $rocks_tree/etc/luarocks


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix a typo in the luarocks script which will cause the loss of stderr output.

<!--- Why is this change required? What problem does it solve? -->