### PR TITLE
feat(cors): add an option to skip return ACAO  when no origin in request

### DIFF
--- a/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
+++ b/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
@@ -1,0 +1,3 @@
+message: "**CORS**: add an option to skip return ACAO when request don't have Origin Header"
+type: feature
+scope: Plugin

--- a/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
+++ b/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
@@ -1,3 +1,3 @@
-message: "**CORS**: add an option to skip return ACAO when request don't have Origin Header"
+message: "**CORS**: Added an option to skip returning the Access-Control-Allow-Origin response headeer when requests don't have the Origin Header"
 type: feature
 scope: Plugin

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -232,7 +232,7 @@ return {
   -- Any dataplane older than 3.10.0
   [3010000000] = {
     cors = {
-      "skip_cors_when_origin_is_empty",
+      "allow_origin_absent",
     },
     session = {
       "hash_subject",

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -231,6 +231,9 @@ return {
 
   -- Any dataplane older than 3.10.0
   [3010000000] = {
+    cors = {
+      "skip_cors_when_origin_is_empty",
+    },
     session = {
       "hash_subject",
       "store_metadata",

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -248,7 +248,7 @@ function CorsHandler:header_filter(conf)
   end
 
   local req_origin = kong.request.get_header("origin")
-  if not req_origin and conf.skip_cors_when_origin_is_empty then
+  if not req_origin and not conf.allow_origin_absent then
     return
   end
 

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -65,11 +65,6 @@ local function configure_origin(conf, header_filter)
   local n_origins = conf.origins ~= nil and #conf.origins or 0
   local set_header = kong.response.set_header
 
-  local req_origin = kong.request.get_header("origin")
-  if not req_origin and conf.skip_cors_when_origin_is_empty then
-    return false
-  end
-
   if n_origins == 0 or (n_origins == 1 and conf.origins[1] == "*") then
     set_header("Access-Control-Allow-Origin", "*")
     return true
@@ -94,6 +89,7 @@ local function configure_origin(conf, header_filter)
     end
   end
 
+  local req_origin = kong.request.get_header("origin")
   if req_origin then
     local cached_domains = config_cache[conf]
     if not cached_domains then
@@ -178,11 +174,6 @@ local function configure_credentials(conf, allow_all, header_filter)
     return
   end
 
-  local req_origin = kong.request.get_header("origin")
-  if not req_origin and conf.skip_cors_when_origin_is_empty then
-    return
-  end
-
   if not allow_all then
     set_header("Access-Control-Allow-Credentials", true)
     return
@@ -190,6 +181,7 @@ local function configure_credentials(conf, allow_all, header_filter)
 
   -- Access-Control-Allow-Origin is '*', must change it because ACAC cannot
   -- be 'true' if ACAO is '*'.
+  local req_origin = kong.request.get_header("origin")
   if req_origin then
     add_vary_header(header_filter)
     set_header("Access-Control-Allow-Origin", req_origin)
@@ -255,13 +247,14 @@ function CorsHandler:header_filter(conf)
     return
   end
 
-  local allow_all = configure_origin(conf, true)
-  configure_credentials(conf, allow_all, true)
-
   local req_origin = kong.request.get_header("origin")
   if not req_origin and conf.skip_cors_when_origin_is_empty then
     return
   end
+
+  local allow_all = configure_origin(conf, true)
+  configure_credentials(conf, allow_all, true)
+
   if conf.exposed_headers and #conf.exposed_headers > 0 then
     kong.response.set_header("Access-Control-Expose-Headers",
                              concat(conf.exposed_headers, ","))

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -259,7 +259,10 @@ function CorsHandler:header_filter(conf)
   configure_credentials(conf, allow_all, true)
 
   local req_origin = kong.request.get_header("origin")
-  if req_origin and conf.exposed_headers and #conf.exposed_headers > 0 then
+  if not req_origin and conf.skip_cors_when_origin_is_empty then
+    return
+  end
+  if conf.exposed_headers and #conf.exposed_headers > 0 then
     kong.response.set_header("Access-Control-Expose-Headers",
                              concat(conf.exposed_headers, ","))
   end

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -48,6 +48,7 @@ return {
           { credentials = { description = "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value.", type = "boolean", required = true, default = false }, },
           { private_network = { description = "Flag to determine whether the `Access-Control-Allow-Private-Network` header should be sent with `true` as the value.", type = "boolean", required = true, default = false }, },
           { preflight_continue = { description = "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.", type = "boolean", required = true, default = false }, },
+          { skip_cors_when_origin_is_empty = { description = "A boolean value that skip cors response headers when origin header of request is empty", type = "boolean", required = true, default = false }, },
     }, }, },
   },
 }

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -48,7 +48,7 @@ return {
           { credentials = { description = "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value.", type = "boolean", required = true, default = false }, },
           { private_network = { description = "Flag to determine whether the `Access-Control-Allow-Private-Network` header should be sent with `true` as the value.", type = "boolean", required = true, default = false }, },
           { preflight_continue = { description = "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.", type = "boolean", required = true, default = false }, },
-          { skip_cors_when_origin_is_empty = { description = "A boolean value that skip cors response headers when origin header of request is empty", type = "boolean", required = true, default = false }, },
+          { allow_origin_absent = { description = "A boolean value that skip cors response headers when origin header of request is empty", type = "boolean", required = true, default = true }, },
     }, }, },
   },
 }

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -209,7 +209,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           enabled = true,
           config = {
             -- [[ new fields 3.10.0
-            skip_cors_when_origin_is_empty = false,
+            allow_origin_absent = true,
             -- ]]
             -- [[ new fields 3.5.0
             private_network = false
@@ -217,10 +217,10 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           }
         }
 
-        assert.not_nil(cors.config.skip_cors_when_origin_is_empty)
+        assert.not_nil(cors.config.allow_origin_absent)
         local expected_cors = cycle_aware_deep_copy(cors)
         do_assert(uuid(), "3.10.0", expected_cors)
-        expected_cors.config.skip_cors_when_origin_is_empty = nil
+        expected_cors.config.allow_origin_absent = nil
 
         assert.not_nil(cors.config.private_network)
         expected_cors = cycle_aware_deep_copy(expected_cors)
@@ -237,7 +237,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           enabled = true,
           config = {
             -- [[ new fields 3.10.0
-            skip_cors_when_origin_is_empty = false,
+            allow_origin_absent = true,
             -- ]]
             -- [[ new fields 3.5.0
             private_network = false
@@ -245,7 +245,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           }
         }
         do_assert(uuid(), "3.10.0", cors)
-        cors.config.skip_cors_when_origin_is_empty = nil
+        cors.config.allow_origin_absent = nil
 
         do_assert(uuid(), "3.5.0", cors)
 

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -476,7 +476,7 @@ for _, strategy in helpers.each_strategy() do
         name = "cors",
         route = { id = route15.id },
         config = {
-          skip_cors_when_origin_is_empty = true,
+          allow_origin_absent = false,
           origins = { "foo.bar" },
           exposed_headers    = { "x-auth-token" },
           credentials     = true
@@ -487,7 +487,7 @@ for _, strategy in helpers.each_strategy() do
         name = "cors",
         route = { id = route16.id },
         config = {
-          skip_cors_when_origin_is_empty = false,
+          allow_origin_absent = true,
           origins = { "foo.bar" },
           exposed_headers    = { "x-auth-token" },
           credentials     = true
@@ -1161,7 +1161,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("disallowed-domain.test", json.headers["origin"])
       end)
 
-      it("when enable skip_cors_when_origin_is_empty, no ACAO", function()
+      it("when disable allow_origin_absent, no ACAO", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           headers = {
@@ -1174,7 +1174,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
       end)
 
-      it("when disable skip_cors_when_origin_is_empty, ACAO is returned", function()
+      it("when enable allow_origin_absent, ACAO is returned", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           headers = {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6314
