### PR TITLE
fix(vault): fix vault config neg_ttl behavior

### DIFF
--- a/changelog/unreleased/kong/fix-vault-neg-ttl.yml
+++ b/changelog/unreleased/kong/fix-vault-neg-ttl.yml
@@ -1,3 +1,3 @@
-message: "**vault**: Fixed a bug where neg_ttl config doesn't work"
+message: "**vault**: Fixed an issue where neg_ttl config doesn't work"
 type: bugfix
-scope: Plugin
+scope: Core

--- a/changelog/unreleased/kong/fix-vault-neg-ttl.yml
+++ b/changelog/unreleased/kong/fix-vault-neg-ttl.yml
@@ -1,0 +1,3 @@
+message: "**vault**: Fixed a bug where neg_ttl config doesn't work"
+type: bugfix
+scope: Plugin

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -1281,6 +1281,8 @@ local function new(self)
     -- negatively cached.
     local resurrect
     local ttl = SECRETS_CACHE:ttl(new_cache_key)
+    -- Note that `ttl` variable means remaining time in shdict, and there's an extra time in the shdict ttl
+    -- to make sure that the cache entry doesn't expire when after actual ttl.
     if ttl then
       local resurrect_ttl = max(config.resurrect_ttl or DAO_MAX_TTL, SECRETS_CACHE_MIN_TTL)
       -- the secret is still within ttl, no need to refresh
@@ -1293,9 +1295,7 @@ local function new(self)
       -- can be resurrected
       resurrect = ttl > SECRETS_CACHE_MIN_TTL
 
-      -- Only refresh negatively cached values after neg_ttl (not every minute).
-      -- Note that `ttl` variable means remaining time in shdict, and the ttl in the shdict for negatively values adds
-      -- an extra SECRETS_CACHE_MIN_TTL to make sure the value doesn't expire when after neg_ttl.
+      -- Only refresh negatively cached values after neg_ttl.
       if ttl > SECRETS_CACHE_MIN_TTL and SECRETS_CACHE:get(new_cache_key) == NEGATIVELY_CACHED_VALUE then
         return true
       end


### PR DESCRIPTION
As per documentation, neg_ttl specifies the time to cache a vault miss. However in the current implementation the secret miss is not cached for this duration and is fetched from vault backend every minute.

This PR first fixes the check in the secret rotation timer to not fetch negatively cached vaules unconditionally, but only after the neg_ttl. Then it changes the shdict ttl for negative cache from neg_ttl to neg_ttl + SECRETS_CACHE_MIN_TTL, or else the negative cache will expire from shdict and there's no chance to update it after neg_ttl.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6240
