### PR TITLE
fix(plugins): Fixed the stale header cache that causes a break in `grpc-web` & `grpc-gateway` plugins

### DIFF
--- a/changelog/unreleased/kong/fix-header_cache.yml
+++ b/changelog/unreleased/kong/fix-header_cache.yml
@@ -1,0 +1,3 @@
+message: "**grpc-web** and **grpc-gateway**: Fixed a bug where the `TE` (transfer-encoding) header would not be sent to the upstream gRPC servers when `grpc-web` or `grpc-gateweay` are in use."
+type: bugfix
+scope: Plugin

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1455,8 +1455,9 @@ return {
         return exit(500)
       end
 
+      local header_cache = {}
       -- clear hop-by-hop request headers:
-      local http_connection = get_header("connection", ctx)
+      local http_connection = get_header("connection", header_cache)
       if http_connection ~= "keep-alive" and
          http_connection ~= "close"      and
          http_connection ~= "upgrade"
@@ -1477,7 +1478,7 @@ return {
       end
 
       -- add te header only when client requests trailers (proxy removes it)
-      local http_te = get_header("te", ctx)
+      local http_te = get_header("te", header_cache)
       if http_te then
         if http_te == "trailers" then
           var.upstream_te = "trailers"
@@ -1492,11 +1493,11 @@ return {
         end
       end
 
-      if get_header("proxy", ctx) then
+      if get_header("proxy", header_cache) then
         clear_header("Proxy")
       end
 
-      if get_header("proxy_connection", ctx) then
+      if get_header("proxy_connection", header_cache) then
         clear_header("Proxy-Connection")
       end
     end

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -48,10 +48,50 @@ for _, strategy in helpers.each_strategy() do
         },
       })
 
-      assert(helpers.start_kong {
+      local mock_grpc_service = assert(bp.services:insert {
+        name = "mock_grpc_service",
+        url = "http://localhost:8765",
+      })
+
+      local mock_grpc_route = assert(bp.routes:insert {
+        protocols = { "http" },
+        hosts = { "grpc_mock.example" },
+        service = mock_grpc_service,
+        preserve_host = true,
+      })
+
+      assert(bp.plugins:insert {
+        route = mock_grpc_route,
+        name = "grpc-gateway",
+        config = {
+          proto = "./spec/fixtures/grpc/targetservice.proto",
+        },
+      })
+
+      local fixtures = {
+        http_mock = {}
+      }
+      fixtures.http_mock.my_server_block = [[
+        server {
+          server_name myserver;
+          listen 8765;
+
+          location ~ / {
+            content_by_lua_block {
+              local headers = ngx.req.get_headers()
+              ngx.header.content_type = "application/grpc"
+              ngx.header.received_host = headers["Host"]
+              ngx.header.received_te = headers["te"]
+            }
+          }
+        }
+      ]]
+
+      assert(helpers.start_kong({
         database = strategy,
         plugins = "bundled,grpc-gateway",
-      })
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }, nil, nil, fixtures))
     end)
 
     before_each(function()
@@ -61,6 +101,34 @@ for _, strategy in helpers.each_strategy() do
     lazy_teardown(function()
       helpers.stop_kong()
       helpers.stop_grpc_target()
+    end)
+
+    test("#new Sets 'TE: trailers'", function()
+      local res, err = proxy_client:post("/v1/echo", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/json",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
+    end)
+
+    test("#new Ignores user-agent TE", function()
+      -- in grpc-gateway, kong acts as a grpc client on behalf of the client
+      -- (which generally is a web-browser); as such, the Te header must be
+      -- set by kong, which will append trailers to the response body
+      local res, err = proxy_client:post("/v1/echo", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/json",
+          ["TE"] = "chunked",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
     end)
 
     test("main entrypoint", function()

--- a/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
+++ b/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
@@ -49,6 +49,25 @@ for _, strategy in helpers.each_strategy() do
         service = service1,
       })
 
+      local mock_grpc_service = assert(bp.services:insert {
+        name = "mock_grpc_service",
+        url = "http://localhost:8765",
+      })
+
+      local mock_grpc_route = assert(bp.routes:insert {
+        protocols = { "http" },
+        hosts = { "grpc_mock.example" },
+        service = mock_grpc_service,
+        preserve_host = true,
+      })
+
+      assert(bp.plugins:insert {
+        route = mock_grpc_route,
+        name = "grpc-web",
+        config = {
+        },
+      })
+
       assert(bp.plugins:insert {
         route = route1,
         name = "grpc-web",
@@ -66,10 +85,29 @@ for _, strategy in helpers.each_strategy() do
         },
       })
 
-      assert(helpers.start_kong {
+      local fixtures = {
+        http_mock = {}
+      }
+      fixtures.http_mock.my_server_block = [[
+        server {
+          server_name myserver;
+          listen 8765;
+          location ~ / {
+            content_by_lua_block {
+              local headers = ngx.req.get_headers()
+              ngx.header.content_type = "application/grpc"
+              ngx.header.received_host = headers["Host"]
+              ngx.header.received_te = headers["te"]
+            }
+          }
+        }
+      ]]
+
+      assert(helpers.start_kong({
         database = strategy,
         plugins = "bundled,grpc-web",
-      })
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }, nil, nil, fixtures))
     end)
 
     before_each(function()
@@ -81,6 +119,34 @@ for _, strategy in helpers.each_strategy() do
       helpers.stop_kong()
     end)
 
+
+    test("Sets 'TE: trailers'", function()
+      local res, err = proxy_client:post("/", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/grpc-web-text",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
+    end)
+
+    test("Ignores user-agent TE", function()
+      -- in grpc-web, kong acts as a grpc client on behalf of the client
+      -- (which generally is a web-browser); as such, the Te header must be
+      -- set by kong, which will append trailers to the response body
+      local res, err = proxy_client:post("/", {
+        headers = {
+          ["Host"] = "grpc_mock.example",
+          ["Content-Type"] = "application/grpc-web-text",
+          ["TE"] = "chunked",
+        },
+      })
+
+      assert.equal("trailers", res.headers["received-te"])
+      assert.is_nil(err)
+    end)
 
     test("Call gRCP-base64 via HTTP", function()
       local res, err = proxy_client:post("/hello.HelloService/SayHello", {


### PR DESCRIPTION
### Summary

A regression in kong.tools.http.get_header() where the header cache was probably a stale one was causing `grpc-web` or `grpc-gateweay` plugins unable to work.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6410