### PR TITLE
tests(clustering/rpc): add cases for sync.v2.notify_new_version

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -141,6 +141,8 @@ function _M:init_dp(manager)
       return self:sync_once()
     end
 
+    ngx_log(ngx_DEBUG, "no sync runs, version is ", version)
+
     return true
   end)
 end

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -57,6 +57,8 @@ for _, strategy in helpers.each_strategy() do
 
         assert.logfile(name).has.line(
           "no sync runs, version is " .. rep(".", 32), true, 10)
+        assert.logfile(name).has.line(
+          "no sync runs, version is " .. rep("0", 32), true, 10)
 
         assert.logfile(name).has.line(
           "sync_once retry count exceeded. retry_count: 6", true, 10)
@@ -66,7 +68,7 @@ for _, strategy in helpers.each_strategy() do
         local name = nil
 
         -- cp logs
-        for i = 1, 7 do
+        for i = 0, 6 do
           assert.logfile(name).has.line(
             "kong.sync.v2.get_delta ok: " .. i, true, 10)
         end

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -1,0 +1,78 @@
+local helpers = require "spec.helpers"
+
+
+-- register a rpc connected event in custom plugin rpc-notify-new-version-test
+-- DISABLE rpc sync on cp side
+-- ENABLE rpc sync on dp side
+for _, strategy in helpers.each_strategy() do
+  describe("Hybrid Mode RPC #" .. strategy, function()
+
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {
+        "clustering_data_planes",
+      }) -- runs migrations
+
+      assert(helpers.start_kong({
+        role = "control_plane",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        database = strategy,
+        cluster_listen = "127.0.0.1:9005",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "bundled,rpc-notify-new-version-test",
+        nginx_worker_processes = 4, -- multiple workers
+        cluster_rpc = "on", -- enable rpc
+        cluster_rpc_sync = "off", -- disable rpc sync
+      }))
+
+      assert(helpers.start_kong({
+        role = "data_plane",
+        database = "off",
+        prefix = "servroot2",
+        cluster_cert = "spec/fixtures/kong_clustering.crt",
+        cluster_cert_key = "spec/fixtures/kong_clustering.key",
+        cluster_control_plane = "127.0.0.1:9005",
+        proxy_listen = "0.0.0.0:9002",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "bundled,rpc-notify-new-version-test",
+        nginx_worker_processes = 4, -- multiple workers
+        cluster_rpc = "on", -- enable rpc
+        cluster_rpc_sync = "on", -- enable rpc sync
+      }))
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong("servroot2")
+      helpers.stop_kong()
+    end)
+
+    describe("sync.v2.notify_new_version works", function()
+      it("on dp side", function()
+        local name = "servroot2/logs/error.log"
+
+        -- dp logs
+        helpers.pwait_until(function()
+          assert.logfile(name).has.line(
+            "kong.sync.v2.get_delta ok", true)
+          assert.logfile(name).has.no.line(
+            "assertion failed", true)
+          assert.logfile(name).has.no.line(
+            "[error]", true)
+          return true
+        end, 10)
+
+        local name = nil
+
+        -- cp logs
+        helpers.pwait_until(function()
+          assert.logfile(name).has.no.line(
+            "assertion failed", true)
+          assert.logfile(name).has.no.line(
+            "[error]", true)
+          return true
+        end, 10)
+
+      end)
+    end)
+  end)
+end -- for _, strategy

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -1,4 +1,4 @@
-local fmt = string.format
+local rep = string.rep
 local helpers = require "spec.helpers"
 
 
@@ -56,9 +56,7 @@ for _, strategy in helpers.each_strategy() do
           "kong.test.notify_new_version ok", true, 10)
 
         assert.logfile(name).has.line(
-          "no sync runs, version is " .. fmt("v02_%028x", 10), true, 10)
-        assert.logfile(name).has.line(
-          "no sync runs, version is " .. fmt("v02_%028x", 5), true, 10)
+          "no sync runs, version is " .. rep(".", 32), true, 10)
 
         assert.logfile(name).has.line(
           "sync_once retry count exceeded. retry_count: 6", true, 10)

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -62,7 +62,11 @@ for _, strategy in helpers.each_strategy() do
 
         -- cp logs
         assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok", true, 10)
+          "kong.sync.v2.get_delta ok: 1", true, 10)
+        assert.logfile(name).has.line(
+          "kong.test.notify_new_version ok", true, 10)
+        assert.logfile(name).has.no.line(
+          "kong.sync.v2.get_delta ok: 2", true, 0)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
         assert.logfile(name).has.no.line(

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -1,3 +1,4 @@
+local fmt = string.format
 local helpers = require "spec.helpers"
 
 
@@ -48,16 +49,17 @@ for _, strategy in helpers.each_strategy() do
 
     describe("sync.v2.notify_new_version works", function()
       it("on dp side", function()
-        --local fmt = string.format
         local name = "servroot2/logs/error.log"
 
         -- dp logs
         assert.logfile(name).has.line(
           "kong.test.notify_new_version ok", true, 10)
-        --assert.logfile(name).has.line(
-        --  "no sync runs, version is " .. fmt("v02_%028x", 10), true, 10)
-        --assert.logfile(name).has.line(
-        --  "no sync runs, version is " .. fmt("v02_%028x", 5), true, 10)
+
+        assert.logfile(name).has.line(
+          "no sync runs, version is " .. fmt("v02_%028x", 10), true, 10)
+        assert.logfile(name).has.line(
+          "no sync runs, version is " .. fmt("v02_%028x", 5), true, 10)
+
         assert.logfile(name).has.line(
           "sync_once retry count exceeded. retry_count: 6", true, 10)
         assert.logfile(name).has.no.line(

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -52,7 +52,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- dp logs
         assert.logfile(name).has.line(
-          "kong.sync.v2.notify_new_version ok", true, 10)
+          "kong.test.notify_new_version ok", true, 10)
         assert.logfile(name).has.line(
           "sync_once retry count exceeded. retry_count: 6", true, 10)
         assert.logfile(name).has.no.line(
@@ -61,26 +61,14 @@ for _, strategy in helpers.each_strategy() do
         local name = nil
 
         -- cp logs
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 1", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 2", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 3", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 4", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 5", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 6", true, 10)
-        assert.logfile(name).has.line(
-          "kong.sync.v2.get_delta ok: 7", true, 10)
+        for i = 1, 7 do
+          assert.logfile(name).has.line(
+            "kong.sync.v2.get_delta ok: " .. i, true, 10)
+        end
 
         assert.logfile(name).has.line(
           "kong.test.notify_new_version ok", true, 10)
 
-        assert.logfile(name).has.no.line(
-          "kong.sync.v2.get_delta ok: 8", true, 0)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
         assert.logfile(name).has.no.line(

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -48,11 +48,16 @@ for _, strategy in helpers.each_strategy() do
 
     describe("sync.v2.notify_new_version works", function()
       it("on dp side", function()
+        --local fmt = string.format
         local name = "servroot2/logs/error.log"
 
         -- dp logs
         assert.logfile(name).has.line(
           "kong.test.notify_new_version ok", true, 10)
+        --assert.logfile(name).has.line(
+        --  "no sync runs, version is " .. fmt("v02_%028x", 10), true, 10)
+        --assert.logfile(name).has.line(
+        --  "no sync runs, version is " .. fmt("v02_%028x", 5), true, 10)
         assert.logfile(name).has.line(
           "sync_once retry count exceeded. retry_count: 6", true, 10)
         assert.logfile(name).has.no.line(

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -51,26 +51,22 @@ for _, strategy in helpers.each_strategy() do
         local name = "servroot2/logs/error.log"
 
         -- dp logs
-        helpers.pwait_until(function()
-          assert.logfile(name).has.line(
-            "kong.sync.v2.get_delta ok", true)
-          assert.logfile(name).has.no.line(
-            "assertion failed", true)
-          assert.logfile(name).has.no.line(
-            "[error]", true)
-          return true
-        end, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.notify_new_version ok", true, 10)
+        assert.logfile(name).has.no.line(
+          "assertion failed", true, 0)
+        assert.logfile(name).has.no.line(
+          "[error]", true, 0)
 
         local name = nil
 
         -- cp logs
-        helpers.pwait_until(function()
-          assert.logfile(name).has.no.line(
-            "assertion failed", true)
-          assert.logfile(name).has.no.line(
-            "[error]", true)
-          return true
-        end, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok", true, 10)
+        assert.logfile(name).has.no.line(
+          "assertion failed", true, 0)
+        assert.logfile(name).has.no.line(
+          "[error]", true, 0)
 
       end)
     end)

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -53,10 +53,10 @@ for _, strategy in helpers.each_strategy() do
         -- dp logs
         assert.logfile(name).has.line(
           "kong.sync.v2.notify_new_version ok", true, 10)
+        assert.logfile(name).has.line(
+          "sync_once retry count exceeded. retry_count: 6", true, 10)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
-        assert.logfile(name).has.no.line(
-          "[error]", true, 0)
 
         local name = nil
 
@@ -64,9 +64,23 @@ for _, strategy in helpers.each_strategy() do
         assert.logfile(name).has.line(
           "kong.sync.v2.get_delta ok: 1", true, 10)
         assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 2", true, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 3", true, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 4", true, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 5", true, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 6", true, 10)
+        assert.logfile(name).has.line(
+          "kong.sync.v2.get_delta ok: 7", true, 10)
+
+        assert.logfile(name).has.line(
           "kong.test.notify_new_version ok", true, 10)
+
         assert.logfile(name).has.no.line(
-          "kong.sync.v2.get_delta ok: 2", true, 0)
+          "kong.sync.v2.get_delta ok: 8", true, 0)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
         assert.logfile(name).has.no.line(

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -43,8 +43,24 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     return { default = { deltas = deltas, wipe = true, }, }
   end)
 
-  -- call dp's sync.v2.notify_new_version
+  -- test dp's sync.v2.notify_new_version
   kong.rpc.callbacks:register("kong.test.notify_new_version", function(node_id)
+
+    local dp_node_id = next(kong.rpc.clients)
+    local method = "kong.sync.v2.notify_new_version"
+
+    -- no default
+    local msg = {}
+    local res, err = kong.rpc:call(dp_node_id, method, msg)
+    assert(not res)
+    assert(err == "default namespace does not exist inside params")
+
+    -- no default.new_version
+    local msg = { default = {}, }
+    local res, err = kong.rpc:call(dp_node_id, method, msg)
+    assert(not res)
+    assert(err == "'new_version' key does not exist")
+
     return true
   end)
 
@@ -54,6 +70,7 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
   worker_events.register(function(capabilities_list)
     local node_id = "control_plane"
 
+    -- trigger cp's test
     local res, err = kong.rpc:call(node_id, "kong.test.notify_new_version")
     assert(res == true)
     assert(not err)

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -12,7 +12,7 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
 
   -- mock function on cp side
   kong.rpc.callbacks:register("kong.sync.v2.get_delta", function(node_id, current_versions)
-    local latest_version = fmt("v02_%028d", 10)
+    local latest_version = fmt("v02_%028x", 10)
 
     local fake_uuid = "00000000-0000-0000-0000-111111111111"
 
@@ -53,19 +53,19 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     assert(err == "'new_version' key does not exist")
 
     -- same version number
-    local msg = { default = { new_version = fmt("v02_%028d", 10), }, }
+    local msg = { default = { new_version = fmt("v02_%028x", 10), }, }
     local res, err = kong.rpc:call(dp_node_id, method, msg)
     assert(res)
     assert(not err)
 
     -- less version number
-    local msg = { default = { new_version = fmt("v02_%028d", 5), }, }
+    local msg = { default = { new_version = fmt("v02_%028x", 5), }, }
     local res, err = kong.rpc:call(dp_node_id, method, msg)
     assert(res)
     assert(not err)
 
     -- greater version number
-    local msg = { default = { new_version = fmt("v02_%028d", 20), }, }
+    local msg = { default = { new_version = fmt("v02_%028x", 20), }, }
     local res, err = kong.rpc:call(dp_node_id, method, msg)
     assert(res)
     assert(not err)

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -1,0 +1,39 @@
+local rep = string.rep
+local isempty = require("table.isempty")
+
+
+local RpcSyncV2NotifyNewVersioinTestHandler = {
+  VERSION = "1.0",
+  PRIORITY = 1000,
+}
+
+
+function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
+  -- mock function on cp side
+  kong.rpc.callbacks:register("kong.sync.v2.get_delta", function(node_id, current_versions)
+    local latest_version = "v02_" .. string.rep("1", 28)
+
+    local deltas = {}
+
+    return { default = { deltas = deltas, wipe = true, }, }
+  end)
+
+  -- call dp's sync.v2.notify_new_version
+  kong.rpc.callbacks:register("kong.test.notify_new_version", function(node_id)
+  end)
+
+  local worker_events = assert(kong.worker_events)
+
+  -- if rpc is ready we will send test calls
+  worker_events.register(function(capabilities_list)
+    local node_id = "control_plane"
+
+    local res, err = kong.rpc:call(node_id, "kong.test.notify_new_version")
+
+    ngx.log(ngx.DEBUG, "kong.sync.v2.notify_new_version ok")
+
+  end, "clustering:jsonrpc", "connected")
+end
+
+
+return RpcSyncV2NotifyNewVersioinTestHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -30,8 +30,8 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
       },
     }
 
-    counter = counter + 1
     ngx.log(ngx.DEBUG, "kong.sync.v2.get_delta ok: ", counter)
+    counter = counter + 1
 
     return { default = { deltas = deltas, wipe = true, }, }
   end)
@@ -56,6 +56,13 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     -- less version string
     -- "....." < "00000" < "v02_xx"
     local msg = { default = { new_version = rep(".", 32), }, }
+    local res, err = kong.rpc:call(dp_node_id, method, msg)
+    assert(res)
+    assert(not err)
+
+    -- less or equal version string
+    -- "00000" < "v02_xx"
+    local msg = { default = { new_version = rep("0", 32), }, }
     local res, err = kong.rpc:call(dp_node_id, method, msg)
     assert(res)
     assert(not err)

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -13,7 +13,30 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
   kong.rpc.callbacks:register("kong.sync.v2.get_delta", function(node_id, current_versions)
     local latest_version = "v02_" .. string.rep("1", 28)
 
-    local deltas = {}
+    local fake_uuid1 = "00000000-0000-0000-0000-111111111111"
+    local fake_uuid2 = "00000000-0000-0000-0000-222222222222"
+
+    -- a basic config data
+    local deltas = {
+      {
+        entity = {
+          id = fake_uuid1,
+          name = "default",
+        },
+        type = "workspaces",
+        version = latest_version,
+        ws_id = fake_uuid1,
+      },
+      {
+        entity = {
+          key = "cluster_id",
+          value = fake_uuid2,
+        },
+        type = "parameters",
+        version = latest_version,
+        ws_id = fake_uuid1,
+      }
+    }
 
     return { default = { deltas = deltas, wipe = true, }, }
   end)

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -65,6 +65,12 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     assert(res)
     assert(not err)
 
+    -- greater version number
+    local msg = { default = { new_version = fmt("v02_%028d", 20), }, }
+    local res, err = kong.rpc:call(dp_node_id, method, msg)
+    assert(res)
+    assert(not err)
+
     ngx.log(ngx.DEBUG, "kong.test.notify_new_version ok")
 
     return true

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -1,3 +1,7 @@
+local declarative = require("kong.db.declarative")
+local DECLARATIVE_EMPTY_CONFIG_HASH = require("kong.constants").DECLARATIVE_EMPTY_CONFIG_HASH
+
+
 local fmt = string.format
 
 
@@ -79,6 +83,17 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
 
   -- if rpc is ready we will send test calls
   worker_events.register(function(capabilities_list)
+    -- wait dp's first sync finish
+    for i = 1, 100 do
+      local ver = declarative.get_current_hash()
+      if ver ~= DECLARATIVE_EMPTY_CONFIG_HASH then
+        break
+      end
+      ngx.sleep(0.05)
+    end
+
+    -- now dp's version should be "v02_0000a"
+
     local node_id = "control_plane"
 
     -- trigger cp's test

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -8,9 +8,9 @@ local RpcSyncV2NotifyNewVersioinTestHandler = {
 
 
 function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
-  -- mock function on cp side
   local counter = 0
 
+  -- mock function on cp side
   kong.rpc.callbacks:register("kong.sync.v2.get_delta", function(node_id, current_versions)
     local latest_version = fmt("v02_%028d", 10)
 
@@ -35,9 +35,8 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     return { default = { deltas = deltas, wipe = true, }, }
   end)
 
-  -- test dp's sync.v2.notify_new_version
+  -- test dp's sync.v2.notify_new_version on cp side
   kong.rpc.callbacks:register("kong.test.notify_new_version", function(node_id)
-
     local dp_node_id = next(kong.rpc.clients)
     local method = "kong.sync.v2.notify_new_version"
 
@@ -87,7 +86,7 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     assert(res == true)
     assert(not err)
 
-    ngx.log(ngx.DEBUG, "kong.sync.v2.notify_new_version ok")
+    ngx.log(ngx.DEBUG, "kong.test.notify_new_version ok")
 
   end, "clustering:jsonrpc", "connected")
 end

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -11,7 +11,7 @@ local RpcSyncV2NotifyNewVersioinTestHandler = {
 function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
   -- mock function on cp side
   kong.rpc.callbacks:register("kong.sync.v2.get_delta", function(node_id, current_versions)
-    local latest_version = "v02_" .. string.rep("1", 28)
+    local latest_version = string.format("v02_%028d", 10)
 
     local fake_uuid1 = "00000000-0000-0000-0000-111111111111"
     local fake_uuid2 = "00000000-0000-0000-0000-222222222222"
@@ -38,11 +38,14 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
       }
     }
 
+    ngx.log(ngx.DEBUG, "kong.sync.v2.get_delta ok")
+
     return { default = { deltas = deltas, wipe = true, }, }
   end)
 
   -- call dp's sync.v2.notify_new_version
   kong.rpc.callbacks:register("kong.test.notify_new_version", function(node_id)
+    return true
   end)
 
   local worker_events = assert(kong.worker_events)
@@ -52,6 +55,8 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     local node_id = "control_plane"
 
     local res, err = kong.rpc:call(node_id, "kong.test.notify_new_version")
+    assert(res == true)
+    assert(not err)
 
     ngx.log(ngx.DEBUG, "kong.sync.v2.notify_new_version ok")
 

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "rpc-notify-new-version-test",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6205

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
