### PR TITLE
refactor(clustering): use tools.table.EMPTY to avoid overhead

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -9,6 +9,7 @@ local compat = require("kong.clustering.compat")
 local constants = require("kong.constants")
 local events = require("kong.clustering.events")
 local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local string = string
@@ -260,7 +261,7 @@ function _M:handle_cp_websocket(cert)
       labels = data.labels,
       cert_details = dp_cert_details,
       -- only update rpc_capabilities if dp_id is connected
-      rpc_capabilities = rpc_peers and rpc_peers[dp_id] or {},
+      rpc_capabilities = rpc_peers and rpc_peers[dp_id] or EMPTY,
     }, { ttl = purge_delay, no_broadcast_crud_event = true, })
     if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to update clustering data plane status: ", err, log_suffix)

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -8,6 +8,7 @@ local constants = require("kong.constants")
 local concurrency = require("kong.concurrency")
 local isempty = require("table.isempty")
 local events = require("kong.runloop.events")
+local EMPTY = require("kong.tools.table").EMPTY
 
 
 local insert_entity_for_txn = declarative.insert_entity_for_txn
@@ -94,7 +95,7 @@ function _M:init_cp(manager)
       cert_details = node_info.cert_details,  -- get from rpc call
       sync_status = CLUSTERING_SYNC_STATUS.NORMAL,
       config_hash = default_namespace_version,
-      rpc_capabilities = rpc_peers and rpc_peers[node_id] or {},
+      rpc_capabilities = rpc_peers and rpc_peers[node_id] or EMPTY,
     }, { ttl = purge_delay, no_broadcast_crud_event = true, })
     if not ok then
       ngx_log(ngx_ERR, "unable to update clustering data plane status: ", err)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6218

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
