### PR TITLE
 fix(llm): fix error when upstream_url missing trailing slash

### DIFF
--- a/changelog/unreleased/kong/fix-ai-upstream-url-trailing-empty.yml
+++ b/changelog/unreleased/kong/fix-ai-upstream-url-trailing-empty.yml
@@ -1,0 +1,4 @@
+message: |
+  **AI Plugins**: fix AI upstream URL trailing being empty
+type: bugfix
+scope: Plugin

--- a/changelog/unreleased/kong/fix-ai-upstream-url-trailing-empty.yml
+++ b/changelog/unreleased/kong/fix-ai-upstream-url-trailing-empty.yml
@@ -1,4 +1,4 @@
 message: |
-  **AI Plugins**: fix AI upstream URL trailing being empty
+  **AI Plugins**: Fixed AI upstream URL trailing being empty.
 type: bugfix
 scope: Plugin

--- a/kong/llm/drivers/anthropic.lua
+++ b/kong/llm/drivers/anthropic.lua
@@ -530,7 +530,7 @@ function _M.configure_request(conf)
   ai_shared.override_upstream_url(parsed_url, conf)
 
   -- if the path is read from a URL capture, ensure that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   kong.service.request.set_path(parsed_url.path)
   kong.service.request.set_scheme(parsed_url.scheme)

--- a/kong/llm/drivers/azure.lua
+++ b/kong/llm/drivers/azure.lua
@@ -121,7 +121,7 @@ function _M.configure_request(conf)
   ai_shared.override_upstream_url(parsed_url, conf)
 
   -- if the path is read from a URL capture, 3re that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   kong.service.request.set_path(parsed_url.path)
   kong.service.request.set_scheme(parsed_url.scheme)

--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -568,7 +568,7 @@ function _M.configure_request(conf, aws_sdk)
   end
 
   -- if the path is read from a URL capture, ensure that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   ai_shared.override_upstream_url(parsed_url, conf)
 

--- a/kong/llm/drivers/cohere.lua
+++ b/kong/llm/drivers/cohere.lua
@@ -509,7 +509,7 @@ function _M.configure_request(conf)
 
 
   -- if the path is read from a URL capture, ensure that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   kong.service.request.set_path(parsed_url.path)
   kong.service.request.set_scheme(parsed_url.scheme)

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -519,7 +519,7 @@ function _M.configure_request(conf, identity_interface)
 
 
   -- if the path is read from a URL capture, ensure that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   kong.service.request.set_path(parsed_url.path)
   kong.service.request.set_scheme(parsed_url.scheme)

--- a/kong/llm/drivers/openai.lua
+++ b/kong/llm/drivers/openai.lua
@@ -205,7 +205,7 @@ function _M.configure_request(conf)
   ai_shared.override_upstream_url(parsed_url, conf)
 
   -- if the path is read from a URL capture, ensure that it is valid
-  parsed_url.path = string_gsub(parsed_url.path, "^/*", "/")
+  parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
   kong.service.request.set_path(parsed_url.path)
   kong.service.request.set_scheme(parsed_url.scheme)


### PR DESCRIPTION
AG-203

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
