### PR TITLE
refactor(clustering/rpc): wait 5 seconds for  rpc queue

### DIFF
--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -347,7 +347,7 @@ function _M:start()
     local batch_requests = {}
 
     while not exiting() do
-      -- 5 seconds for non-batching rpc calls
+      -- TODO: find the more proper timeout
       local payload, err = self.outgoing:pop(5)
       if err then
         return nil, err

--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -347,22 +347,21 @@ function _M:start()
     local batch_requests = {}
 
     while not exiting() do
-      -- 0.5 seconds for not waiting too long
-      local payload, err = self.outgoing:pop(0.5)
+      -- 5 seconds for non-batching rpc calls
+      local payload, err = self.outgoing:pop(5)
       if err then
         return nil, err
       end
 
       -- timeout
       if not payload then
-        local n = #batch_requests
-        if n > 0 then
+        if not isempty(batch_requests) then
           local bytes, err = self.wb:send_binary(compress_payload(batch_requests))
           if not bytes then
             return nil, err
           end
 
-          ngx_log(ngx_DEBUG, "[rpc] sent batch RPC call: ", n)
+          ngx_log(ngx_DEBUG, "[rpc] sent batch RPC call: ", #batch_requests)
 
           tb_clear(batch_requests)
         end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5934
In #14040 we changed the timeout from `5` to `0.5`, but that is not necessary and may cause checking queue frequently,
so this PR revert this small change.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
