### PR TITLE
fix(clustering/rpc): warning log level for sync retry failing

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -27,6 +27,7 @@ local ipairs = ipairs
 local ngx_null = ngx.null
 local ngx_log = ngx.log
 local ngx_ERR = ngx.ERR
+local ngx_WARN = ngx.WARN
 local ngx_INFO = ngx.INFO
 local ngx_DEBUG = ngx.DEBUG
 
@@ -403,8 +404,8 @@ local function sync_once_impl(premature, retry_count)
   -- retry if the version is not updated
   retry_count = retry_count or 0
 
-  if retry_count > MAX_RETRY then
-    ngx_log(ngx_ERR, "sync_once retry count exceeded. retry_count: ", retry_count)
+  if retry_count >= MAX_RETRY then
+    ngx_log(ngx_WARN, "sync_once retry count exceeded. retry_count: ", retry_count)
     return
   end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -417,7 +417,7 @@ local function sync_once_impl(premature, retry_count)
   -- in some cases, the new spawned timer will be switched to immediately,
   -- preventing the coroutine who possesses the mutex to run
   -- to let other coroutines has a chance to run
-  local ok, err = kong.timer:at(0.1, sync_once_impl, retry_count or 0)
+  local ok, err = kong.timer:at(0.1, sync_once_impl, retry_count)
   -- this is a workaround for a timerng bug, where tail recursion causes failure
   -- ok could be a string so let's convert it to boolean
   if not ok then

--- a/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/09-notify_new_version_spec.lua
@@ -61,14 +61,16 @@ for _, strategy in helpers.each_strategy() do
           "no sync runs, version is " .. rep("0", 32), true, 10)
 
         assert.logfile(name).has.line(
-          "sync_once retry count exceeded. retry_count: 6", true, 10)
+          "sync_once retry count exceeded. retry_count: 5", true, 10)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
+        assert.logfile(name).has.no.line(
+          "[error]", true, 0)
 
         local name = nil
 
         -- cp logs
-        for i = 0, 6 do
+        for i = 0, 5 do
           assert.logfile(name).has.line(
             "kong.sync.v2.get_delta ok: " .. i, true, 10)
         end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6205
See: https://github.com/Kong/kong/pull/14174#discussion_r1919640857

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
