### PR TITLE
fix(router): host matches should be case insensitive as per RFC 3986

### DIFF
--- a/changelog/unreleased/kong/fix-router-host-case-insensitive.yml
+++ b/changelog/unreleased/kong/fix-router-host-case-insensitive.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where the Host header was case-sensitive on route for matching, which should be case-insensitive as per RFC 3986."
+type: breaking_change
+scope: Core

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -17,6 +17,7 @@ local pairs = pairs
 local ipairs = ipairs
 local next = next
 local max = math.max
+local lower = string.lower
 
 
 local ngx           = ngx
@@ -444,7 +445,7 @@ function _M:exec(ctx)
   local fields = self.fields
 
   local req_uri = ctx and ctx.request_uri or var.request_uri
-  local req_host = get_header("host", ctx)
+  local req_host = lower(get_header("host", ctx))
 
   req_uri = strip_uri_args(req_uri)
 

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -355,8 +355,8 @@ local function marshall_route(r)
       else
         -- plain host matching
         has_host_plain = true
-        append(hosts_t, { value = host })
-        hosts_t[host] = host
+        append(hosts_t, { value = lower(host) })
+        hosts_t[lower(host)] = host
       end
     end
 
@@ -1648,7 +1648,7 @@ function _M.new(routes, cache, cache_neg)
       elseif match_wildcard_hosts then
         for i = 1, wildcard_hosts[0] do
           local host = wildcard_hosts[i]
-          local from, _, err = re_find(host_with_port, host.regex, "ajo")
+          local from, _, err = re_find(host_with_port, host.regex, "ajoi")
           if err then
             log(ERR, "could not match wildcard host: ", err)
             return
@@ -1755,7 +1755,7 @@ function _M.new(routes, cache, cache_neg)
     exec = function(ctx)
       local req_method = get_method()
       local req_uri = ctx and ctx.request_uri or var.request_uri
-      local req_host = get_header("host", ctx)
+      local req_host = lower(get_header("host", ctx))
       local req_scheme = ctx and ctx.scheme or var.scheme
       local sni = server_name()
 

--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -15,6 +15,7 @@ local ipairs = ipairs
 local tb_insert = table.insert
 local fmt = string.format
 local byte = string.byte
+local lower = string.lower
 local bor, band, lshift, rshift = bit.bor, bit.band, bit.lshift, bit.rshift
 
 
@@ -401,7 +402,7 @@ local function get_expression(route)
         host = host:sub(1, -2)
       end
 
-      local exp = "http.host ".. op .. [[ r#"]] .. host .. [["#]]
+      local exp = "http.host ".. op .. [[ r#"]] .. lower(host) .. [["#]]
       if port then
         exp = "(" .. exp .. LOGICAL_AND ..
               "net.dst.port ".. OP_EQUAL .. " " .. port .. ")"

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -163,7 +163,8 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
               id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
               hosts = {
                 "domain-1.org",
-                "domain-2.org"
+                "domain-2.org",
+                "Domain-3.org"
               },
             },
           },
@@ -379,6 +380,19 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         assert.same(use_case[1].route, match_t.route)
         if flavor == "traditional" then
           assert.same(use_case[1].route.hosts[1], match_t.matches.host)
+        end
+        assert.same(nil, match_t.matches.method)
+        assert.same(nil, match_t.matches.uri)
+        assert.same(nil, match_t.matches.uri_captures)
+      end)
+
+      it("[host] matches should be case insensitive", function()
+        -- host
+        local match_t = router:select("GET", "/", "domain-3.org")
+        assert.truthy(match_t)
+        assert.same(use_case[1].route, match_t.route)
+        if flavor == "traditional" then
+          assert.same(use_case[1].route.hosts[3], match_t.matches.host)
         end
         assert.same(nil, match_t.matches.method)
         assert.same(nil, match_t.matches.uri)


### PR DESCRIPTION
### Summary

fix(router) host matches should be case insensitive as per RFC 3986

[RFC3986 (section 3.2.2)](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) states that host header is case insensitive. 

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6158
