### PR TITLE
docs(changelog): add a changelog for bumping libexpat

### DIFF
--- a/changelog/unreleased/kong/bump-libexpat-to-2_6_4.yml
+++ b/changelog/unreleased/kong/bump-libexpat-to-2_6_4.yml
@@ -1,0 +1,3 @@
+message: Bumped libexpat from 2.6.2 to 2.6.4
+type: dependency
+scope: Core


### PR DESCRIPTION
KAG-6222

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
