### PR TITLE
fix(vault): secret is temporarily empty after changed vault config

### DIFF
--- a/changelog/unreleased/kong/fix-vault-update.yml
+++ b/changelog/unreleased/kong/fix-vault-update.yml
@@ -1,0 +1,3 @@
+message: "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config"
+type: bugfix
+scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -950,7 +950,11 @@ local function new(self)
       self.log.warn("error updating secret reference ", reference, ": ", err)
     end
 
-    record[field] = value or ""
+    if value then
+      record[field] = value
+    elseif is_reference(record[field]) then
+      record[field] = ""
+    end
   end
 
 
@@ -1002,7 +1006,7 @@ local function new(self)
   -- are specified in a `$refs` field.
   --
   -- If a reference cannot be fetched from the cache, the corresponding field is
-  -- set to nil and an warning is logged.
+  -- not changed and an warning is logged.
   --
   -- @local
   -- @function update
@@ -1428,6 +1432,8 @@ local function new(self)
         end
       end
     end
+
+    LRU:flush_all()
 
     -- refresh all the secrets
     local _, err = self.timer:named_at("secret-rotation-on-crud-event", 0, rotate_secrets_timer)

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -950,7 +950,11 @@ local function new(self)
       self.log.warn("error updating secret reference ", reference, ": ", err)
     end
 
-    record[field] = value or ""
+    if value then
+      record[field] = value
+    elseif is_reference(record[field]) then
+      record[field] = ""
+    end
   end
 
 
@@ -1002,7 +1006,7 @@ local function new(self)
   -- are specified in a `$refs` field.
   --
   -- If a reference cannot be fetched from the cache, the corresponding field is
-  -- set to nil and an warning is logged.
+  -- not changed and an warning is logged.
   --
   -- @local
   -- @function update

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -950,11 +950,7 @@ local function new(self)
       self.log.warn("error updating secret reference ", reference, ": ", err)
     end
 
-    if value then
-      record[field] = value
-    elseif is_reference(record[field]) then
-      record[field] = ""
-    end
+    record[field] = value or ""
   end
 
 
@@ -1006,7 +1002,7 @@ local function new(self)
   -- are specified in a `$refs` field.
   --
   -- If a reference cannot be fetched from the cache, the corresponding field is
-  -- not changed and an warning is logged.
+  -- set to nil and an warning is logged.
   --
   -- @local
   -- @function update
@@ -1432,8 +1428,6 @@ local function new(self)
         end
       end
     end
-
-    LRU:flush_all()
 
     -- refresh all the secrets
     local _, err = self.timer:named_at("secret-rotation-on-crud-event", 0, rotate_secrets_timer)

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -948,12 +948,8 @@ local function new(self)
     local value, err = get(reference, true)
     if err then
       self.log.warn("error updating secret reference ", reference, ": ", err)
-    end
-
-    if value then
-      record[field] = value
-    elseif is_reference(record[field]) then
-      record[field] = ""
+    else
+      record[field] = value or ""
     end
   end
 

--- a/spec/01-unit/23-vaults_spec.lua
+++ b/spec/01-unit/23-vaults_spec.lua
@@ -303,7 +303,7 @@ describe("Vault PDK", function()
   end)
 
   describe("update function", function()
-    it("sets values to empty string on failure", function()
+    it("not change values on failure", function()
       finally(function()
         helpers.unsetenv("CREDENTIALS")
       end)
@@ -434,11 +434,11 @@ describe("Vault PDK", function()
 
       for _, cfg in ipairs({ config, config.sub }) do
         assert.equal("jane", cfg.str_found)
-        assert.equal("", cfg.str_not_found)
-        assert.equal("", cfg.str_not_found_2)
+        assert.equal("not found", cfg.str_not_found)
+        assert.equal("not found", cfg.str_not_found_2)
         assert.same({ "found", "jane", "qwerty", "jane", "found" }, cfg.arr_found)
-        assert.same({ "found", "jane", "", "jane", "found" }, cfg.arr_hole)
-        assert.same({ "found", "", "", "", "found" }, cfg.arr_not_found)
+        assert.same({ "found", "jane", "not found", "jane", "found" }, cfg.arr_hole)
+        assert.same({ "found", "not found", "not found", "not found", "found" }, cfg.arr_not_found)
         assert.same({
           nil,
           "found",
@@ -450,9 +450,9 @@ describe("Vault PDK", function()
         assert.same({
           nil,
           "found",
-          a = "",
-          b = "",
-          c = "",
+          a = "found",
+          b = "found",
+          c = "found",
           d = "found",
         }, cfg.map_not_found)
       end

--- a/spec/fixtures/custom_vaults/kong/vaults/test/schema.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/test/schema.lua
@@ -10,6 +10,9 @@ return {
         fields = {
           { default_value     = { type = "string", required = false } },
           { default_value_ttl = { type = "number", required = false } },
+          { latency = { type = "number", required = false } },
+          { raise_error = { type = "string", required = false } },
+          { return_error = { type = "string", required = false } },
           { ttl                 = typedefs.ttl },
           { neg_ttl             = typedefs.ttl },
           { resurrect_ttl       = typedefs.ttl },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
When vault config is changed, in the worker event we first flush the LRU cache, then start to update the secrets from vault provider. There’s a period of time in between that the cache is empty.
The `kong.vault.update()` function only lookups cache and will update the secret to an empty string when cache is empty. This can cause plugins to throw nil errors.
This commit changed `kong.vault.update()` function to not touch it if not found in the cache.
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5936
