### PR TITLE
fix(certificate): properly throw errors when parsing certificate from the vault

### DIFF
--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -261,7 +261,7 @@ local function get_certificate(pk, sni_name, ws_id)
                                                           pk, sni_name, ws_id)
 
   if certificate and hit_level ~= 3 and certificate["$refs"] then
-    certificate = parse_key_and_cert(kong.vault.update(certificate))
+    certificate, err = parse_key_and_cert(kong.vault.update(certificate))
   end
 
   return certificate, err


### PR DESCRIPTION

### Summary

`get_certificate` was not handling certificate parsing errors after a vault update. This fixes it.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-6392
