### PR TITLE
fix(clustering/rpc): added required field for mocked workspace to byass validation

### DIFF
--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -23,6 +23,10 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
         entity = {
           id = fake_uuid,
           name = "default",
+          -- It must contain feild "config" and "meta", otherwise the deltas
+          -- validation will fail with the error "required field missing".
+          config = {},
+          meta = {},
         },
         type = "workspaces",
         version = latest_version,


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The original constructed workspace lack required fields, this commit adds them to bypass DP's delta validation.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [KAG-5897](https://konghq.atlassian.net/browse/KAG-5897)


[KAG-5897]: https://konghq.atlassian.net/browse/KAG-5897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ