### PR TITLE
fix(clustering/sync): insert default values to delta entities before validation

### DIFF
--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -36,13 +36,14 @@ local function validate_deltas(deltas, is_full_sync)
         -- unknown field.
         -- TODO: On the CP side, remove ws_id from the entity and set it only
         -- in the delta.
-        local ws_id = delta_entity.ws_id
-        delta_entity.ws_id = nil      -- clear ws_id
 
-        local ok, err_t = dao.schema:validate(delta_entity)
+        -- needs to insert default values into entity to align with the function
+        -- dc:validate(input), which will call process_auto_fields on its
+        -- entities of input.
+        local copy = dao.schema:process_auto_fields(delta_entity, "insert")
+        copy.ws_id = nil
 
-        delta_entity.ws_id = ws_id    -- restore ws_id
-
+        local ok, err_t = dao.schema:validate(copy)
         if not ok then
           errs[#errs + 1] = { [delta_type] = err_t }
         end

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -93,6 +93,31 @@ describe("[delta validations]",function()
     end
   end)
 
+  it("route has no required field", function()
+    local bp = setup_bp()
+
+    -- add entities
+    db_insert(bp, "workspaces", { name = "ws-001" })
+    local service = db_insert(bp, "services", { name = "service-001", })
+    db_insert(bp, "routes", {
+      name = "route-001",
+      paths = { "/mock" },
+      service = { id = service.id },
+    })
+
+    local deltas = declarative.export_config_sync()
+
+    for _, delta in ipairs(deltas) do
+      if delta.type == "routes" then
+        delta.entity.protocols = nil
+        break
+      end
+    end
+
+    local ok, err = validate_deltas(deltas)
+    assert.is_true(ok, "validate should not fail: " .. tostring(err))
+  end)
+
   it("route has unknown field", function()
     local bp = setup_bp()
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Try to align with sync v1 logic, v1 will ignore required fields error because

```
dc:validate(input)
....
  -> field_schema:process_auto_fields(value, "insert")
  -> route:validate
```

So when recursively calling the validate() function, it will call process_auto_fields before validating a specific entity inside for sync v1.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6249