### PR TITLE
tests(*): make nginx_worker_processes to take effect properly

### DIFF
--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -54,7 +54,7 @@ local function wait_until_healthy(prefix)
   if conf.admin_listen and conf.admin_listen ~= "off" then
     local port = assert(conf.admin_listen:match(":([0-9]+)"))
     assert
-      .with_timeout(5)
+      .with_timeout(10)
       .eventually(function()
         local client = helpers.admin_client(1000, port)
         local res, err = client:send({ path = "/status", method = "GET" })
@@ -413,7 +413,7 @@ describe("kong start/stop #" .. strategy, function()
         assert(helpers.start_kong({
           database = "off",
           declarative_config = yaml_file,
-          nginx_worker_processes = 100, -- stress test initialization
+          nginx_worker_processes = 50, -- stress test initialization
           nginx_conf = "spec/fixtures/custom_nginx.template",
         }))
 

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2542,7 +2542,7 @@ for _, strategy in helpers.each_strategy() do
 
         local workers_before = helpers.get_kong_workers()
         assert(helpers.signal_workers(nil, "-TERM"))
-        helpers.wait_until_no_common_workers(workers_before, 1) -- respawned
+        helpers.wait_until_no_common_workers(workers_before, 4) -- respawned
 
         proxy_client:close()
         proxy_client = helpers.proxy_client()

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -32,7 +32,7 @@ dedicated_config_processing = on
 dns_hostsfile = spec/fixtures/hosts
 resolver_hosts_file = spec/fixtures/hosts
 
-nginx_main_worker_processes = 1
+nginx_worker_processes = 1
 nginx_main_worker_rlimit_nofile = 4096
 nginx_events_worker_connections = 4096
 nginx_events_multi_accept = off


### PR DESCRIPTION
### Summary

`nginx_worker_processes` is the standard configuration in our template, and it has an alias `nginx_main_worker_processes`. So, no matter which one we configure, both will work. However, if we set these options at the same time, the one that takes effect will be `nginx_main_worker_processes`.

Since our test suite uses [`nginx_main_worker_processes`](https://github.com/Kong/kong/blob/7a505eaa6870a5b9e7da914a32464635691f1038/spec/kong_tests.conf#L35), that means using `nginx_worker_processes` in the test cases is not working. 

We have a bunch of test files that are using `nginx_worker_processes` instead of the `nginx_main_worker_processes` alias, and making one small change to the kong_test.conf file saves us the trouble of updating all of them (including EE).

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
