### PR TITLE
chore(patches): backport revert override of ljlibd

### DIFF
--- a/build/openresty/patches/LuaJIT-2.1-20240815_03-revert-reflect-override-of-ljlibd.patch
+++ b/build/openresty/patches/LuaJIT-2.1-20240815_03-revert-reflect-override-of-ljlibd.patch
@@ -1,0 +1,52 @@
+diff --git a/bundle/LuaJIT-2.1-20240815/Makefile b/bundle/LuaJIT-2.1-20240815/Makefile
+index cac43c2..6ae2c49 100644
+--- a/bundle/LuaJIT-2.1-20240815/Makefile
++++ b/bundle/LuaJIT-2.1-20240815/Makefile
+@@ -41,7 +41,7 @@ INSTALL_SHARE= $(DPREFIX)/share
+ INSTALL_DEFINC= $(DPREFIX)/include/luajit-$(MMVERSION)
+ INSTALL_INC=   $(INSTALL_DEFINC)
+ 
+-export INSTALL_LJLIBD= $(INSTALL_SHARE)/luajit-$(MMVERSION)
++INSTALL_LJLIBD= $(INSTALL_SHARE)/luajit-$(MMVERSION)
+ INSTALL_JITLIB= $(INSTALL_LJLIBD)/jit
+ INSTALL_LMODD= $(INSTALL_SHARE)/lua
+ INSTALL_LMOD= $(INSTALL_LMODD)/$(ABIVER)
+diff --git a/bundle/LuaJIT-2.1-20240815/src/Makefile b/bundle/LuaJIT-2.1-20240815/src/Makefile
+index 134e7dd..f87762e 100644
+--- a/bundle/LuaJIT-2.1-20240815/src/Makefile
++++ b/bundle/LuaJIT-2.1-20240815/src/Makefile
+@@ -304,9 +304,6 @@ endif
+ ifneq (,$(LMULTILIB))
+   TARGET_XCFLAGS+= -DLUA_LMULTILIB=\"$(LMULTILIB)\"
+ endif
+-ifneq (,$(INSTALL_LJLIBD))
+-  TARGET_XCFLAGS+= -DLUA_LJDIR=\"$(INSTALL_LJLIBD)\"
+-endif
+ 
+ ##############################################################################
+ # Target system detection.
+diff --git a/bundle/LuaJIT-2.1-20240815/src/luaconf.h b/bundle/LuaJIT-2.1-20240815/src/luaconf.h
+index 0c97c2d..c311a97 100644
+--- a/bundle/LuaJIT-2.1-20240815/src/luaconf.h
++++ b/bundle/LuaJIT-2.1-20240815/src/luaconf.h
+@@ -37,6 +37,7 @@
+ #endif
+ #define LUA_LROOT	"/usr/local"
+ #define LUA_LUADIR	"/lua/5.1/"
++#define LUA_LJDIR	"/luajit-2.1/"
+ 
+ #ifdef LUA_ROOT
+ #define LUA_JROOT	LUA_ROOT
+@@ -50,11 +51,7 @@
+ #define LUA_RCPATH
+ #endif
+ 
+-#ifndef LUA_LJDIR
+-#define LUA_LJDIR	LUA_JROOT "/share/luajit-2.1"
+-#endif
+-
+-#define LUA_JPATH	";" LUA_LJDIR "/?.lua"
++#define LUA_JPATH	";" LUA_JROOT "/share" LUA_LJDIR "?.lua"
+ #define LUA_LLDIR	LUA_LROOT "/share" LUA_LUADIR
+ #define LUA_LCDIR	LUA_LROOT "/" LUA_LMULTILIB LUA_LUADIR
+ #define LUA_LLPATH	";" LUA_LLDIR "?.lua;" LUA_LLDIR "?/init.lua"


### PR DESCRIPTION
### Summary

This is a backport/cherry-pick of one LuaJIT revert commit patch that was already added to EE when bumping OpenResty to 1.27.1.1, as seen here: https://github.com/Kong/kong-ee/pull/11243

Thus no need to cherry-pick this to EE nor any changelog needed.