### PR TITLE
Docs: change key-sets to Key Sets to match Konnect in entity description text

### DIFF
--- a/kong/db/schema/entities/key_sets.lua
+++ b/kong/db/schema/entities/key_sets.lua
@@ -15,7 +15,7 @@ return {
     {
       name = {
         type     = "string",
-        description = "The name to associate with the given key-set.",
+        description = "The name to associate with the given Key Set.",
         required = false,
         unique   = true,
       },

--- a/kong/db/schema/entities/keys.lua
+++ b/kong/db/schema/entities/keys.lua
@@ -18,7 +18,7 @@ return {
     {
       set = {
         type      = "foreign",
-        description = "The id of the key-set with which to associate the key.",
+        description = "The id of the Key Set with which to associate the key.",
         required  = false,
         reference = "key_sets",
         on_delete = "cascade",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

It's Key Sets in Konnect we should match that standard in description text to avoid confusion. 
https://github.com/Kong/developer.konghq.com/issues/258
### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
