### PR TITLE
fix(clustering/rpc): add random for timer‘s name

### DIFF
--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -178,9 +178,9 @@ function _M:process_rpc_msg(payload, collection)
 
       -- collection is nil, it means it is a single call
       -- we should call async function
-      -- for notification we will give it a negative fake id as timer's name
-      local name = string_format("JSON-RPC callback for node_id: %s, id: %d, method: %s",
-                                 self.node_id, payload_id or -math.random(10^5), payload_method)
+      -- random is for avoiding timer's name confliction
+      local name = string_format("JSON-RPC callback for node_id: %s, id: %d, rand: %d, method: %s",
+                                 self.node_id, payload_id or 0, math.random(10^5), payload_method)
       res, err = kong.timer:named_at(name, 0, _M._dispatch, self, dispatch_cb, payload)
 
       if not res and payload_id then

--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -178,8 +178,9 @@ function _M:process_rpc_msg(payload, collection)
 
       -- collection is nil, it means it is a single call
       -- we should call async function
+      -- for notification we will give it a negative fake id as timer's name
       local name = string_format("JSON-RPC callback for node_id: %s, id: %d, method: %s",
-                                 self.node_id, payload_id or 0, payload_method)
+                                 self.node_id, payload_id or -math.random(10^5), payload_method)
       res, err = kong.timer:named_at(name, 0, _M._dispatch, self, dispatch_cb, payload)
 
       if not res and payload_id then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6336

Currently it is a temporary solution, we may work on it later.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
