### PR TITLE
chore(ai-response-transformer): correct typo of STAGE

### DIFF
--- a/kong/plugins/ai-response-transformer/filters/transform-response.lua
+++ b/kong/plugins/ai-response-transformer/filters/transform-response.lua
@@ -15,7 +15,7 @@ local kong_utils     = require("kong.tools.gzip")
 
 local _M = {
   NAME = "ai-response-transformer-transform-response",
-  STAGE = "REQ_TRANSFORMATION",
+  STAGE = "RES_TRANSFORMATION",
   }
 
 local FILTER_OUTPUT_SCHEMA = {


### PR DESCRIPTION
Semantically the stage should be RES_TRANSFORMATION but functionality are not affected as body is already available.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
