### PR TITLE
perf(tools/string): a way faster strip function

### DIFF
--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -45,34 +45,26 @@ _M.strip = function(value)
     return ""
   end
 
-  local len = #value
   local s = 1 -- position of the leftmost non-whitespace char
-  for i = 1, len do
-    local b = byte(value, i)
-    if b == SPACE_BYTE or (b >= TAB_BYTE and b <= CR_BYTE) then
-      s = s + 1
-    else
-      break
-    end
-  end
-
-  if s > len then
+  ::spos::
+  local b = byte(value, s)
+  if not b then -- reached the end of the all whitespace string
     return ""
   end
-
-  local e = len -- position of the rightmost non-whitespace char
-  if s < e then
-    for i = e, 1, -1 do
-      local b = byte(value, i)
-      if b == SPACE_BYTE or (b >= TAB_BYTE and b <= CR_BYTE) then
-        e = e - 1
-      else
-        break
-      end
-    end
+  if b == SPACE_BYTE or (b >= TAB_BYTE and b <= CR_BYTE) then
+    s = s + 1
+    goto spos
   end
 
-  if s ~= 1 or e ~= len then
+  local e = -1 -- position of the rightmost non-whitespace char
+  ::epos::
+  b = byte(value, e)
+  if b == SPACE_BYTE or (b >= TAB_BYTE and b <= CR_BYTE) then
+    e = e - 1
+    goto epos
+  end
+
+  if s ~= 1 or e ~= -1 then
     value = sub(value, s, e)
   end
 


### PR DESCRIPTION
### Summary

In https://github.com/Kong/kong/pull/13168 I made this already faster, but this time I managed to make it a way faster, main reason being:
- not needing to count length of input
- not needing to use for loop :-)

Leading to potentially better JIT compilation results as well.

The code in my opinion is also easier to read and understand.

I get  `3492 ms` reduced to (with this PR) `149 ms` execution time in microbenchmark.

KAG-6354

### Checklist

- [ ] ~The Pull Request has tests~
- [ ] ~A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)~
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~