### PR TITLE
tests(clustering/wasm): enable rpc sync tests for wasm partially

### DIFF
--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -296,7 +296,10 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
     end)
   end)
 
-  describe("data planes with wasm disabled", function()
+  -- XXX TODO: currently sync v2 does not support configuration compatibility check
+  local only_sync_v1 = rpc_sync == "on" and pending or describe
+
+  only_sync_v1("data planes with wasm disabled", function()
     local node_id
 
     lazy_setup(function()
@@ -333,7 +336,7 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
     end)
   end)
 
-  describe("data planes missing one or more wasm filter", function()
+  only_sync_v1("data planes missing one or more wasm filter", function()
     local tmp_dir
     local node_id
 

--- a/spec/02-integration/20-wasm/06-clustering_spec.lua
+++ b/spec/02-integration/20-wasm/06-clustering_spec.lua
@@ -72,8 +72,9 @@ local function new_wasm_filter_directory()
 end
 
 
--- XXX TODO: enable rpc_sync = "on"
-for _, rpc_sync in ipairs { "off"  } do
+for _, v in ipairs({ {"off", "off"}, {"on", "off"}, {"on", "on"}, }) do
+  local rpc, rpc_sync = v[1], v[2]
+
 describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
   local cp_prefix = "cp"
   local cp_errlog = cp_prefix .. "/logs/error.log"
@@ -115,7 +116,8 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
       wasm_filters        = "user", -- don't enable bundled filters for this test
       wasm_filters_path   = cp_filter_path,
       nginx_main_worker_processes = 2,
-      cluster_rpc_sync = rpc_sync,
+      cluster_rpc         = rpc,
+      cluster_rpc_sync    = rpc_sync,
     }))
 
     assert.logfile(cp_errlog).has.line([[successfully loaded "response_transformer" module]], true, 10)
@@ -155,7 +157,8 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
         wasm_filters_path     = dp_filter_path,
         node_id               = node_id,
         nginx_main_worker_processes = 2,
-        cluster_rpc_sync = rpc_sync,
+        cluster_rpc           = rpc,
+        cluster_rpc_sync      = rpc_sync,
       }))
 
       assert.logfile(dp_errlog).has.line([[successfully loaded "response_transformer" module]], true, 10)
@@ -311,7 +314,8 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
         nginx_conf            = "spec/fixtures/custom_nginx.template",
         wasm                  = "off",
         node_id               = node_id,
-        cluster_rpc_sync = rpc_sync,
+        cluster_rpc           = rpc,
+        cluster_rpc_sync      = rpc_sync,
       }))
     end)
 
@@ -351,7 +355,8 @@ describe("#wasm - hybrid mode #postgres" .. " rpc_sync=" .. rpc_sync, function()
         wasm_filters          = "user", -- don't enable bundled filters for this test
         wasm_filters_path     = tmp_dir,
         node_id               = node_id,
-        cluster_rpc_sync = rpc_sync,
+        cluster_rpc           = rpc,
+        cluster_rpc_sync      = rpc_sync,
       }))
     end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5722

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
