### PR TITLE
feat(clustering/rpc): connection lost event

### DIFF
--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -634,6 +634,13 @@ function _M:connect(premature, node_id, host, path, cert, key)
   end
 
   ::err::
+  local worker_events = assert(kong.worker_events)
+
+  -- notify this worker
+  local ok, err = worker_events.post_local("clustering:jsonrpc", "connection_lost")
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, "unable to post rpc connection_lost event: ", err)
+  end
 
   if not exiting() then
     c:close()


### PR DESCRIPTION
### Summary

Emit an event when the connection is lost

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Precondition for KAG-6178
