### PR TITLE
feat(clustering/sync): flatten and report validation error

### DIFF
--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -156,7 +156,7 @@ function _M:process_rpc_msg(payload, collection)
     if not dispatch_cb then
       -- for RPC notify
       if not payload_id then
-        ngx_log(ngx_INFO, "[rpc] unable to find RPC notify call:", payload_method)
+        ngx_log(ngx_INFO, "[rpc] unable to find RPC notify call: ", payload_method)
         return true
       end
 

--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -35,6 +35,7 @@ local CLUSTERING_PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = CLUSTERING_PING_INTERVAL * 1.5
 local PING_TYPE = "PING"
 local PONG_TYPE = "PONG"
+local ngx_INFO = ngx.INFO
 local ngx_WARN = ngx.WARN
 local ngx_DEBUG = ngx.DEBUG
 
@@ -155,7 +156,8 @@ function _M:process_rpc_msg(payload, collection)
     if not dispatch_cb then
       -- for RPC notify
       if not payload_id then
-        return nil, "unable to find RPC notify callback for method: " .. payload_method
+        ngx_log(ngx_INFO, "[rpc] unable to find RPC notify call:", payload_method)
+        return true
       end
 
       -- for RPC call

--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -152,7 +152,13 @@ function _M:process_rpc_msg(payload, collection)
     ngx_log(ngx_DEBUG, "[rpc] got RPC call: ", payload_method, " (id: ", payload_id, ")")
 
     local dispatch_cb = self.manager.callbacks.callbacks[payload_method]
-    if not dispatch_cb and payload_id then
+    if not dispatch_cb then
+      -- for RPC notify
+      if not payload_id then
+        return nil, "unable to find RPC notify callback for method: " .. payload_method
+      end
+
+      -- for RPC call
       local res, err = self:push_response(new_error(payload_id, jsonrpc.METHOD_NOT_FOUND),
                                           "unable to send \"METHOD_NOT_FOUND\" error back to client: ",
                                           collection)

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -72,6 +72,8 @@ function _M:init_cp(manager)
   -- example: { version = <lastest version of deltas>, error = <flatten error>, }
   manager.callbacks:register("kong.sync.v2.notify_validation_error", function(node_id, msg)
     ngx_log(ngx_DEBUG, "[kong.sync.v2] received validation error")
+    -- TODO: We need a better error handling method, it might report this error
+    -- to Konnect or or log it locally.
     return true
   end)
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -181,7 +181,11 @@ end
 
 -- tell cp that the deltas validation failed
 local function notify_error(ver, err_t)
-  local msg = { version = ver, error = err_t, }
+  local msg = {
+    version = ver or "v02_deltas_have_no_latest_version_field",
+    error = err_t,
+  }
+
   local ok, err = kong.rpc:notify("control_plane",
                                   "kong.sync.v2.notify_validation_error",
                                   msg)
@@ -314,9 +318,7 @@ local function do_sync()
   -- validate deltas
   local ok, err, err_t = validate_deltas(deltas, wipe)
   if not ok then
-    notify_error(ns_delta.lastest_version or
-                 "v02_get_deltas_does_not_return_latest_version_field", err_t)
-
+    notify_error(ns_delta.lastest_version, err_t)
     return nil, err
   end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -329,7 +329,7 @@ local function do_sync()
   -- validate deltas
   local ok, err, err_t = validate_deltas(deltas, wipe)
   if not ok then
-    notify_error(ns_delta.lastest_version, err_t)
+    notify_error(ns_delta.latest_version, err_t)
     return nil, err
   end
 

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -69,7 +69,7 @@ function _M:init_cp(manager)
   -- CP
   -- Method: kong.sync.v2.notify_validation_error
   -- Params: msg: error message reported by DP
-  -- example: { version = <lastest version of deltas>, error = <flatten error>, }
+  -- example: { version = <latest version of deltas>, error = <flatten error>, }
   manager.callbacks:register("kong.sync.v2.notify_validation_error", function(node_id, msg)
     ngx_log(ngx_DEBUG, "[kong.sync.v2] received validation error")
     -- TODO: We need a better error handling method, it might report this error

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -68,7 +68,7 @@ function _M:init_cp(manager)
 
   -- CP
   -- Method: kong.sync.v2.notify_validation_error
-  -- Params: msg: list of current versions of the database
+  -- Params: msg: error message reported by DP
   -- example: { version = <lastest version of deltas>, error = <flatten error>, }
   manager.callbacks:register("kong.sync.v2.notify_validation_error", function(node_id, msg)
     ngx_log(ngx_DEBUG, "[kong.sync.v2] received validation error")

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -67,6 +67,15 @@ function _M:init_cp(manager)
   local purge_delay = manager.conf.cluster_data_plane_purge_delay
 
   -- CP
+  -- Method: kong.sync.v2.notify_validation_error
+  -- Params: msg: list of current versions of the database
+  -- example: { version = <lastest version of deltas>, error = <flatten error>, }
+  manager.callbacks:register("kong.sync.v2.notify_validation_error", function(node_id, msg)
+    ngx_log(ngx_DEBUG, "[kong.sync.v2] received validation error")
+    return true
+  end)
+
+  -- CP
   -- Method: kong.sync.v2.get_delta
   -- Params: versions: list of current versions of the database
   -- example: { default = { version = "1000", }, }

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -13,12 +13,14 @@ local function format_error(err_t)
   -- Declarative config parse errors will include all the input entities in
   -- the error table. Strip these out to keep the error payload size small.
   local errors = err_t.flattened_errors
-  if type(errors) == "table" then
-    for i = 1, #errors do
-      local err = errors[i]
-      if type(err) == "table" then
-        err.entity = nil
-      end
+  if type(errors) ~= "table" then
+    return
+  end
+
+  for i = 1, #errors do
+    local err = errors[i]
+    if type(err) == "table" then
+      err.entity = nil
     end
   end
 end

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -1,8 +1,11 @@
 local declarative = require("kong.db.declarative")
 local declarative_config = require("kong.db.schema.others.declarative_config")
+local db_errors = require("kong.db.errors")
+local ERRORS = require("kong.constants").CLUSTERING_DATA_PLANE_ERROR
 
 
 local null = ngx.null
+local insert = table.insert
 local pk_string = declarative_config.pk_string
 local validate_references_sync = declarative_config.validate_references_sync
 local pretty_print_error = declarative.pretty_print_error

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -231,6 +231,7 @@ local constants = {
   CLUSTERING_OCSP_TIMEOUT = 5000, -- 5 seconds
   CLUSTERING_DATA_PLANE_ERROR = {
     CONFIG_PARSE     = "declarative configuration parse failure",
+    DELTAS_PARSE     = "sync deltas parse failure",
     RELOAD           = "configuration reload failed",
     GENERIC          = "generic or unknown error",
   },

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -55,6 +55,8 @@ local ERRORS              = {
   INVALID_WORKSPACE       = 17, -- strategy reports a workspace error
   INVALID_UNIQUE_GLOBAL   = 18, -- unique field value is invalid for global query
   REFERENCED_BY_OTHERS    = 19, -- still referenced by other entities
+  INVALID_SEARCH_QUERY    = 20, -- ex. searched_field[unknown] = something -> 'unknown' is invalid (HTTP 400)
+  SYNC_DELTAS             = 21, -- error parsing sync deltas for sync.v2
 }
 
 
@@ -81,6 +83,8 @@ local ERRORS_NAMES                 = {
   [ERRORS.INVALID_WORKSPACE]       = "invalid workspace",
   [ERRORS.INVALID_UNIQUE_GLOBAL]   = "invalid global query",
   [ERRORS.REFERENCED_BY_OTHERS]    = "referenced by others",
+  [ERRORS.INVALID_SEARCH_QUERY]    = "invalid search query",
+  [ERRORS.SYNC_DELTAS]             = "invalid sync deltas",
 }
 
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -500,6 +500,17 @@ function _M:declarative_config(err_t)
 end
 
 
+function _M:sync_deltas(err_t)
+  if type(err_t) ~= "table" then
+    error("err_t must be a table", 2)
+  end
+
+  local message = fmt("sync deltas is invalid: %s", pl_pretty(err_t, ""))
+
+  return new_err_t(self, ERRORS.SYNC_DELTAS, message, err_t)
+end
+
+
 function _M:invalid_workspace(ws_id)
   if type(ws_id) ~= "string" then
     error("ws_id must be a string", 2)
@@ -1168,6 +1179,32 @@ function _M:declarative_config_flattened(err_t, input)
   err_t.flattened_errors = flattened
 
   return err_t
+end
+
+
+-- traverse schema validation errors and correlate them with objects/entities
+-- which does not pass delta validation for sync.v2
+--
+---@param  err_t table
+---@param  err_entities table
+---@return table
+function _M:sync_deltas_flattened(err_t, err_entities)
+  if type(err_t) ~= "table" then
+    error("err_t must be a table", 2)
+  end
+
+  if type(err_entities) ~= "table" then
+    error("err_entities is nil or not a table", 2)
+  end
+
+  local flattened = flatten_errors(err_entities, err_t)
+
+  err_t = self:sync_deltas(err_t)
+
+  err_t.flattened_errors = flattened
+
+  return err_t
+
 end
 
 

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -113,6 +113,8 @@ describe("[delta validations]",function()
     assert.same(err_t, dc_err_t)
 
     if expected_errs then
+      print("+++ ", require("inspect")(err_t))
+      print("+++ ", require("inspect")(expected_errs))
       assert.same(err_t, expected_errs)
     end
   end

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -405,5 +405,5 @@ describe("[delta validations]",function()
     assert_same_validation_error(deltas, config, errs)
   end)
 
-  -- TODO: add another test cases
+  -- TODO: add more test cases
 end)

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -236,10 +236,26 @@ describe("[delta validations]",function()
     })
 
     local deltas = declarative.export_config_sync()
-    local _, err = validate_deltas(deltas, false)
+    local _, err, err_t = validate_deltas(deltas, false)
+
     assert.matches(
       "entry 1 of 'services': could not find routes's foreign refrences services",
       err)
+
+    assert.same(err_t, {
+      code = 21,
+      fields = {
+        routes = {
+          services = {
+            "could not find routes's foreign refrences services ({\"id\":\"00000000-0000-0000-0000-000000000000\"})",
+          },
+        },
+      },
+      message = [[sync deltas is invalid: {routes={services={"could not find routes's foreign refrences services ({\"id\":\"00000000-0000-0000-0000-000000000000\"})"}}}]],
+      flattened_errors = {},
+      name = "sync deltas parse failure",
+      source = "kong.clustering.services.sync.validate.validate_deltas",
+    })
   end)
 
   it("100 routes -> 1 services: matched foreign keys", function()

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -113,8 +113,6 @@ describe("[delta validations]",function()
     assert.same(err_t, dc_err_t)
 
     if expected_errs then
-      print("+++ ", require("inspect")(err_t))
-      print("+++ ", require("inspect")(expected_errs))
       assert.same(err_t, expected_errs)
     end
   end
@@ -400,7 +398,7 @@ describe("[delta validations]",function()
               type = "field"
             }, {
               field = "protocol",
-              message = "expected one of: grpc, grpcs, http, https, tcp, tls, tls_passthrough, udp, ws, wss",
+              message = "expected one of: grpc, grpcs, http, https, tcp, tls, tls_passthrough, udp",
               type = "field"
             }, {
               field = "port",

--- a/spec/02-integration/18-hybrid_rpc/10-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/10-validate_deltas_spec.lua
@@ -73,13 +73,11 @@ for _, strategy in helpers.each_strategy() do
         -- cp logs
         assert.logfile(name).has.line(
           "kong.sync.v2.get_delta ok", true, 10)
-
-        -- cp error logs
         assert.logfile(name).has.line(
-          "unable to find RPC notify callback for method: kong.sync.v2.notify_validation_error",
+          "[rpc] unable to find RPC notify call: kong.sync.v2.notify_validation_error",
           true, 10)
-        assert.logfile(name).has.line(
-          "[error]", true, 10)
+        assert.logfile(name).has.no.line(
+          "[error]", true, 0)
       end)
     end)
   end)

--- a/spec/02-integration/18-hybrid_rpc/10-validate_deltas_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/10-validate_deltas_spec.lua
@@ -73,9 +73,13 @@ for _, strategy in helpers.each_strategy() do
         -- cp logs
         assert.logfile(name).has.line(
           "kong.sync.v2.get_delta ok", true, 10)
-        assert.logfile(name).has.no.line(
-          "[error]", true, 0)
 
+        -- cp error logs
+        assert.logfile(name).has.line(
+          "unable to find RPC notify callback for method: kong.sync.v2.notify_validation_error",
+          true, 10)
+        assert.logfile(name).has.line(
+          "[error]", true, 10)
       end)
     end)
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

1. flatten validation error for sync deltas
2. call RPC notify to API `kong.sync.v2.notify_validation_error` (spec: https://github.com/Kong/openrpc_specfiles/pull/18/)
3. fix bug that CP will crash if DP calls a non-existent RPC notify: KAG-6381

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6351 KAG-5898 KAG-6381
