### PR TITLE
fix(clustering/sync): fix delta not using absolute TTL

### DIFF
--- a/kong/clustering/services/sync/hooks.lua
+++ b/kong/clustering/services/sync/hooks.lua
@@ -77,11 +77,11 @@ end
 
 
 function _M:entity_delta_writer(entity, name, options, ws_id, is_delete)
-  if not is_delete and entity.ttl then
+  if not is_delete and entity and entity.ttl then
     -- Replace relative TTL value to absolute TTL value
     local exported_entity = self.strategy:export_entity(name, entity, options)
 
-    if exported_entity then
+    if exported_entity and exported_entity.ttl then
       ngx_log(ngx_DEBUG, "[kong.sync.v2] Update TTL from relative value to absolute value ", exported_entity.ttl, ".")
       entity.ttl = exported_entity.ttl
 

--- a/kong/clustering/services/sync/hooks.lua
+++ b/kong/clustering/services/sync/hooks.lua
@@ -83,7 +83,7 @@ function _M:entity_delta_writer(entity, name, options, ws_id, is_delete)
   if not is_delete and dao and entity and entity.ttl then
     -- Replace relative TTL value to absolute TTL value
     local export_options = kong_table.cycle_aware_deep_copy(options, true)
-    export_options["export"] = true
+    export_options.export = true
     local exported_entity = dao:select(entity, export_options)
 
     if exported_entity and exported_entity.ttl then

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -1,6 +1,7 @@
 local _M = {}
 local _MT = { __index = _M }
 
+local kong_table = require("kong.tools.table")
 
 local sub = string.sub
 local fmt = string.format
@@ -15,6 +16,7 @@ local VERSION_FMT = VER_PREFIX .. "%028x"
 
 function _M.new(db)
   local self = {
+    db = db,
     connector = db.connector,
   }
 
@@ -61,6 +63,13 @@ end
 
 function _M:is_valid_version(str)
   return sub(str, 1, VER_PREFIX_LEN) == VER_PREFIX
+end
+
+
+function _M:export_entity(name, entity, options)
+  local options = kong_table.cycle_aware_deep_copy(options, true)
+  options["export"] = true
+  return self.db[name]:select(entity, options)
 end
 
 

--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -1,7 +1,6 @@
 local _M = {}
 local _MT = { __index = _M }
 
-local kong_table = require("kong.tools.table")
 
 local sub = string.sub
 local fmt = string.format
@@ -16,7 +15,6 @@ local VERSION_FMT = VER_PREFIX .. "%028x"
 
 function _M.new(db)
   local self = {
-    db = db,
     connector = db.connector,
   }
 
@@ -63,13 +61,6 @@ end
 
 function _M:is_valid_version(str)
   return sub(str, 1, VER_PREFIX_LEN) == VER_PREFIX
-end
-
-
-function _M:export_entity(name, entity, options)
-  local options = kong_table.cycle_aware_deep_copy(options, true)
-  options["export"] = true
-  return self.db[name]:select(entity, options)
 end
 
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -3,7 +3,6 @@ local json          = require "pgmoon.json"
 local cjson_safe    = require "cjson.safe"
 local new_tab       = require "table.new"
 local clear_tab     = require "table.clear"
-local access = require("kong.plugins.session.access")
 
 
 local kong          = kong

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -3,6 +3,7 @@ local json          = require "pgmoon.json"
 local cjson_safe    = require "cjson.safe"
 local new_tab       = require "table.new"
 local clear_tab     = require "table.clear"
+local access = require("kong.plugins.session.access")
 
 
 local kong          = kong
@@ -1254,6 +1255,7 @@ function _M.new(connector, schema, errors)
     }
   })
 
+  -- Add statements for exporting database, avoiding exporting TTL in absolute value.
   add_statement_for_export("select", {
     operation = "read",
     expr = select_expressions,

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -59,6 +59,8 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 20)
     end)
 
     lazy_teardown(function()

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -61,7 +61,7 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
       }))
 
       if rpc_sync == "on" then
-        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 20)
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
       end
     end)
 

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -60,7 +60,9 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         cluster_rpc_sync = rpc_sync,
       }))
 
-      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 20)
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 20)
+      end
     end)
 
     lazy_teardown(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

The reason for not making SQL write statements returning absolute value is for the compatibility of other parts of code.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6296
