### PR TITLE
chore(tests): stabilize flaky tests of response rate limiting plugin

### DIFF
--- a/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
+++ b/changelog/unreleased/kong/fix-response-ratelimiting-upstream-headers.yml
@@ -1,3 +1,3 @@
-message: "**response-ratelimiting**: fixed an issue in response rate limiting plugin where usage headers ought to be sent to upstream are lost."
+message: "**response-ratelimiting**: Fixed an issue in response rate limiting plugin where usage headers ought to be sent to upstream are lost."
 type: bugfix
 scope: Plugin

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -460,7 +460,7 @@ for _, strategy in helpers.each_strategy() do
             -- headers are indeed inserted.
           end)
 
-          it("blocks if exceeding limit #brian2", function()
+          it("blocks if exceeding limit", function()
             wait_server_sync({ Host = "test1.test" })
             test_limit("/response-headers", {["x-kong-limit"] = "video=1"}, "test1.test")
           end)
@@ -564,7 +564,7 @@ for _, strategy in helpers.each_strategy() do
           end)
         end)
 
-        describe("Upstream usage headers #brian", function()
+        describe("Upstream usage headers", function()
           it("should append the headers with multiple limits", function()
             wait_server_sync( { Host = "test8.test" })
             local res = proxy_client():get("/get", {

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -269,6 +269,7 @@ http {
                         ["/basic-auth/:user/:pass"]     = "Performs HTTP basic authentication with the given credentials",
                         ["/status/:code"]               = "Returns a response with the specified <status code>",
                         ["/stream/:num"]                = "Stream <num> chunks of JSON data via chunked Transfer Encoding",
+                        ["/timestamp"]                  = "Returns server timestamp in header",
                     },
                 })
             }
@@ -325,6 +326,14 @@ http {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.send_default_json_response({}, ngx.req.get_uri_args())
             }
+        }
+
+        location = /timestamp {
+            content_by_lua_block {
+                local ts = ngx.now()
+                ngx.header["Server-Time"] = ts
+                ngx.exit(200)
+            }           
         }
 
         location = /hop-by-hop {

--- a/spec/fixtures/template_inject/nginx_kong_test_custom_inject_http.lua
+++ b/spec/fixtures/template_inject/nginx_kong_test_custom_inject_http.lua
@@ -41,6 +41,7 @@ lua_shared_dict kong_mock_upstream_loggers  10m;
                         ["/basic-auth/:user/:pass"]     = "Performs HTTP basic authentication with the given credentials",
                         ["/status/:code"]               = "Returns a response with the specified <status code>",
                         ["/stream/:num"]                = "Stream <num> chunks of JSON data via chunked Transfer Encoding",
+                        ["/timestamp"]                  = "Returns server timestamp in header",
                     },
                 })
             }
@@ -97,6 +98,14 @@ lua_shared_dict kong_mock_upstream_loggers  10m;
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.send_default_json_response({}, ngx.req.get_uri_args(0))
             }
+        }
+
+        location = /timestamp {
+            content_by_lua_block {
+                local ts = ngx.now()
+                ngx.header["Server-Time"] = ts
+                ngx.exit(200)
+            }           
         }
 
         location = /hop-by-hop {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
The response rate limiting plugin's tests spec includes multiple flaky test cases, and it's not even enabled in CI(with the `#flaky` tag) which means some test cases are not correct but not been aware of.
The purpose of this PR is to make the flaky tests stable, and enable them in CI.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-5447
