### PR TITLE
perf(router): adjust the sequence of predicate generated inside a traditional compatible route expression

### DIFF
--- a/kong/router/transform.lua
+++ b/kong/router/transform.lua
@@ -377,9 +377,37 @@ local function get_expression(route)
 
   -- http expression, protocol = http/https/grpc/grpcs
 
-  gen = gen_for_field("http.method", OP_EQUAL, route.methods)
+  gen = gen_for_field("http.path", path_op_transform, route.paths, path_val_transform)
   if gen then
     expression_append(expr_buf, LOGICAL_AND, gen)
+  end
+
+  local headers = route.headers
+  if not is_empty_field(headers) then
+    headers_buf:reset()
+
+    for h, v in pairs(headers) do
+      single_header_buf:reset():put("(")
+
+      for i, value in ipairs(v) do
+        local name = "any(lower(http.headers." .. replace_dashes_lower(h) .. "))"
+        local op = OP_EQUAL
+
+        -- value starts with "~*"
+        if byte(value, 1) == TILDE and byte(value, 2) == ASTERISK then
+          value = value:sub(3)
+          op = OP_REGEX
+        end
+
+        expression_append(single_header_buf, LOGICAL_OR,
+                          name .. " " .. op .. " " .. escape_str(value:lower()), i)
+      end
+
+      expression_append(headers_buf, LOGICAL_AND,
+                        single_header_buf:put(")"):get())
+    end
+
+    expression_append(expr_buf, LOGICAL_AND, headers_buf:get())
   end
 
   local hosts = route.hosts
@@ -412,37 +440,9 @@ local function get_expression(route)
     expression_append(expr_buf, LOGICAL_AND, hosts_buf:put(")"):get())
   end
 
-  gen = gen_for_field("http.path", path_op_transform, route.paths, path_val_transform)
+  gen = gen_for_field("http.method", OP_EQUAL, route.methods)
   if gen then
     expression_append(expr_buf, LOGICAL_AND, gen)
-  end
-
-  local headers = route.headers
-  if not is_empty_field(headers) then
-    headers_buf:reset()
-
-    for h, v in pairs(headers) do
-      single_header_buf:reset():put("(")
-
-      for i, value in ipairs(v) do
-        local name = "any(lower(http.headers." .. replace_dashes_lower(h) .. "))"
-        local op = OP_EQUAL
-
-        -- value starts with "~*"
-        if byte(value, 1) == TILDE and byte(value, 2) == ASTERISK then
-          value = value:sub(3)
-          op = OP_REGEX
-        end
-
-        expression_append(single_header_buf, LOGICAL_OR,
-                          name .. " " .. op .. " " .. escape_str(value:lower()), i)
-      end
-
-      expression_append(headers_buf, LOGICAL_AND,
-                        single_header_buf:put(")"):get())
-    end
-
-    expression_append(expr_buf, LOGICAL_AND, headers_buf:get())
   end
 
   local str = expr_buf:get()


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR adjusts the sequence of HTTP fields and their predicates generated inside a traditional compatible route expression, expecting to improve routing matching performance in general situations.

Before this PR, the sequence is src_ip -> src_port -> dst_ip -> dst_port -> methods -> hosts -> paths -> headers
After this PR it becomes src_ip -> src_port -> dst_ip -> dst_port ->  paths -> headers -> hosts -> methods.

The reason for this change is that the expression is evaluated from left to right in the atc-router, so a field that is most unlikely to be matched should be put into the very left of the expression as a short circuit, otherwise, there will be lots of unnecessary predicates executed and CPU cycles wasted.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

This was discovered as part of the issue in FTI-6456.
