### PR TITLE
tests(clustering/rpc): wait dp full sync ends for rpc sync

### DIFF
--- a/spec/02-integration/07-sdk/03-cluster_spec.lua
+++ b/spec/02-integration/07-sdk/03-cluster_spec.lua
@@ -80,6 +80,10 @@ for _, strategy in helpers.each_strategy() do
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }, nil, nil, fixtures_dp))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     lazy_teardown(function()

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -48,6 +48,10 @@ describe("CP/DP communication #" .. strategy .. " rpc_sync=" .. rpc_sync, functi
       worker_state_update_frequency = 1,
     }))
 
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
+
     for _, plugin in ipairs(helpers.get_plugins_list()) do
       if plugin.name == "key-auth" then
         KEY_AUTH_PLUGIN = plugin
@@ -652,6 +656,10 @@ describe("CP/DP config sync #" .. strategy .. " rpc_sync=" .. rpc_sync, function
       cluster_rpc = rpc,
       worker_state_update_frequency = 1,
     }))
+
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
   end)
 
   lazy_teardown(function()
@@ -776,6 +784,10 @@ describe("CP/DP labels #" .. strategy, function()
       cluster_rpc = rpc,
       cluster_rpc_sync = rpc_sync,
     }))
+
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
   end)
 
   lazy_teardown(function()
@@ -840,6 +852,9 @@ describe("CP/DP cert details(cluster_mtls = shared) #" .. strategy, function()
       cluster_rpc = rpc,
       cluster_rpc_sync = rpc_sync,
     }))
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
   end)
 
   lazy_teardown(function()
@@ -905,6 +920,10 @@ describe("CP/DP cert details(cluster_mtls = pki) #" .. strategy, function()
       cluster_rpc = rpc,
       cluster_rpc_sync = rpc_sync,
     }))
+
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
   end)
 
   lazy_teardown(function()

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -49,6 +49,10 @@ describe("CP/DP PKI sync #" .. strategy .. " rpc_sync=" .. rpc_sync, function()
       cluster_rpc_sync = rpc_sync,
       worker_state_update_frequency = 1,
     }))
+
+    if rpc_sync == "on" then
+      assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+    end
   end)
 
   lazy_teardown(function()

--- a/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
@@ -65,6 +65,10 @@ describe("cluster_ocsp = on works #" .. strategy .. " rpc_sync=" .. rpc_sync, fu
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     lazy_teardown(function()
@@ -286,6 +290,10 @@ describe("cluster_ocsp = off works with #" .. strategy .. " rpc_sync=" .. rpc_sy
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     lazy_teardown(function()
@@ -434,6 +442,10 @@ describe("cluster_ocsp = optional works with #" .. strategy .. " rpc_sync=" .. r
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     lazy_teardown(function()

--- a/spec/02-integration/09-hybrid_mode/08-lazy_export_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/08-lazy_export_spec.lua
@@ -52,6 +52,10 @@ local function json_dp(rpc, rpc_sync)
     cluster_rpc = rpc,
     cluster_rpc_sync = rpc_sync,
   }))
+
+  if rpc_sync == "on" then
+    assert.logfile("dp1/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+  end
 end
 
 

--- a/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/10-forward-proxy_spec.lua
@@ -118,6 +118,10 @@ for _, strategy in helpers.each_strategy() do
           stream_listen = "0.0.0.0:5555",
         }, nil, nil, fixtures))
 
+        if rpc_sync == "on" then
+          assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+        end
+
       end)
 
       lazy_teardown(function()

--- a/spec/02-integration/09-hybrid_mode/13-deprecations_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/13-deprecations_spec.lua
@@ -63,6 +63,11 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile(dp_prefix .. "/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 20)
+      end
+
       dp_logfile = helpers.get_running_conf(dp_prefix).nginx_err_logs
       cp_logfile = helpers.get_running_conf(cp_prefix).nginx_err_logs
     end)

--- a/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
+++ b/spec/03-plugins/09-key-auth/04-hybrid_mode_spec.lua
@@ -59,6 +59,10 @@ for _, strategy in helpers.each_strategy({"postgres"}) do
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     lazy_teardown(function()

--- a/spec/03-plugins/11-correlation-id/02-schema_spec.lua
+++ b/spec/03-plugins/11-correlation-id/02-schema_spec.lua
@@ -162,6 +162,10 @@ describe("Plugin: correlation-id (schema) #a [#" .. strategy .."]", function()
         cluster_rpc = rpc,
         cluster_rpc_sync = rpc_sync,
       }))
+
+      if rpc_sync == "on" then
+        assert.logfile("servroot2/logs/error.log").has.line("[kong.sync.v2] full sync ends", true, 10)
+      end
     end)
 
     before_each(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Manually cherry-pick from https://github.com/Kong/kong-ee/pull/11388
Additionally, test from https://github.com/Kong/kong-ee/pull/11418 is cherry-picked as well.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [KAG-6393](https://konghq.atlassian.net/browse/KAG-6393)


[KAG-6393]: https://konghq.atlassian.net/browse/KAG-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ