### PR TITLE
fix(pdk): make kong.service.request.clear_query_arg encode spaces as %20 instead of +

### DIFF
--- a/changelog/unreleased/kong/fix-pdk-clear-query-arg-space-encoding.yml
+++ b/changelog/unreleased/kong/fix-pdk-clear-query-arg-space-encoding.yml
@@ -1,0 +1,6 @@
+message: |
+   **kong.service.request.clear_query_arg**: Changed the encoding of spaces in query arguments from `+`
+   to `%20` as a short-term solution to an issue that some users are reporting. While the `+` is correct
+   encoding of space in querystrings, Kong uses `%20` in many other APIs (inherited from Nginx / OpenResty)
+type: breaking_change
+scope: Plugin

--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -16,6 +16,7 @@ local table_concat = table.concat
 local type = type
 local string_find = string.find
 local string_sub = string.sub
+local string_gsub = string.gsub
 local string_byte = string.byte
 local string_lower = string.lower
 local normalize_multi_header = checks.normalize_multi_header
@@ -295,7 +296,11 @@ local function new(self)
 
     local args = ngx_var.args
     if args and args ~= "" then
-      ngx_var.args = search_remove(args, name)
+      args = search_remove(args, name)
+      if string_find(args, "+", nil, true) then
+        args = string_gsub(args, "+", "%%20")
+      end
+      ngx_var.args = args
     end
   end
 


### PR DESCRIPTION
### Summary

The `+` encoding is more correct (in query strings), but it seems to cause some problems with some users. As a short-term solution I propose that we just convert `+` to `%20`. This is more in-lines what Nginx and OpenResty seems to be doing as well.

KAG-6324

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] ~There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE~

### Issue reference

Fix FTI-6475
