### PR TITLE
feat(clustering/rpc): correct rpc disconnected event on dp side

### DIFF
--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -578,7 +578,7 @@ function _M:connect(premature, node_id, host, path, cert, key)
                        " to connect control plane")
   end
 
-  -- a flag to enuse connection is established
+  -- a flag to ensure connection is established
   local connection_established
 
   local ok, err = c:connect(uri, opts)

--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -53,7 +53,7 @@ local function post_rpc_event(ev, params)
   -- notify this worker
   local ok, err = worker_events.post_local("clustering:jsonrpc", ev, params)
   if not ok then
-    ngx_log(ngx_ERR, _log_prefix, "unable to post rpc ", ev, "event: ", err)
+    ngx_log(ngx_ERR, _log_prefix, "unable to post rpc ", ev, " event: ", err)
   end
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5891

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

Precondition for [KAG-6178](https://konghq.atlassian.net/browse/KAG-6178)


[KAG-6178]: https://konghq.atlassian.net/browse/KAG-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ