### PR TITLE
ci(*): skip labeler on fork PRs

### DIFF
--- a/.github/workflows/labeler-v2.yml
+++ b/.github/workflows/labeler-v2.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### Summary

skip labeler on fork PRs

### Checklist

- [x] (no) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-6397](https://konghq.atlassian.net/browse/KAG-6397)


[KAG-6397]: https://konghq.atlassian.net/browse/KAG-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ