### PR TITLE
tests(clustering/rpc): check not existed method for notification

### DIFF
--- a/kong/clustering/rpc/socket.lua
+++ b/kong/clustering/rpc/socket.lua
@@ -191,7 +191,13 @@ function _M:process_rpc_msg(payload, collection)
                                  self.node_id, payload_id or 0, math.random(10^5), payload_method)
       res, err = kong.timer:named_at(name, 0, _M._dispatch, self, dispatch_cb, payload)
 
-      if not res and payload_id then
+      if not res then
+        -- for RPC notify
+        if not payload_id then
+          return nil, "unable to dispatch JSON-RPC notify call: " .. err
+        end
+
+        -- for RPC call
         local reso, erro = self:push_response(new_error(payload_id, jsonrpc.INTERNAL_ERROR),
                                               "unable to send \"INTERNAL_ERROR\" error back to client: ",
                                               collection)

--- a/spec/02-integration/18-hybrid_rpc/07-notification_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/07-notification_spec.lua
@@ -55,6 +55,8 @@ for _, strategy in helpers.each_strategy() do
           "[rpc] notifying kong.test.notification(node_id:", true, 10)
         assert.logfile(name).has.line(
           "[rpc] notification has no response", true, 10)
+        assert.logfile(name).has.line(
+          "[rpc] unable to find RPC notify call: kong.test.not_exists_in_cp", true, 10)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
 
@@ -67,6 +69,8 @@ for _, strategy in helpers.each_strategy() do
           "notification is world", true, 10)
         assert.logfile(name).has.line(
           "[rpc] notification has no response", true, 10)
+        assert.logfile(name).has.line(
+          "[rpc] unable to find RPC notify call: kong.test.not_exists_in_dp", true, 10)
         assert.logfile(name).has.no.line(
           "assertion failed", true, 0)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notification-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notification-test/handler.lua
@@ -15,6 +15,10 @@ function RpcNotificationTestHandler:init_worker()
       local res, err = kong.rpc:notify(node_id, "kong.test.notification", "world")
       assert(res == true)
       assert(err == nil)
+
+      local res, err = kong.rpc:notify(node_id, "kong.test.not_exists_in_dp")
+      assert(res == true)
+      assert(err == nil)
     end
 
     -- perr should not get this by notification
@@ -30,6 +34,11 @@ function RpcNotificationTestHandler:init_worker()
 
     assert(res == true)
     assert(err == nil)
+
+    local res, err = kong.rpc:notify("control_plane", "kong.test.not_exists_in_cp")
+    assert(res == true)
+    assert(err == nil)
+
   end, "clustering:jsonrpc", "connected")
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6157

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
