### PR TITLE
refactor(clustering/rpc): rpc sync should start without delay

### DIFF
--- a/kong/clustering/services/sync/init.lua
+++ b/kong/clustering/services/sync/init.lua
@@ -8,7 +8,6 @@ local strategy = require("kong.clustering.services.sync.strategies.postgres")
 local rpc = require("kong.clustering.services.sync.rpc")
 
 
-local FIRST_SYNC_DELAY = 0.2  -- seconds
 local EACH_SYNC_DELAY  = constants.CLUSTERING_PING_INTERVAL   -- 30 seconds
 
 
@@ -81,7 +80,7 @@ function _M:init_worker()
     end
 
     -- sync to CP ASAP
-    assert(self.rpc:sync_once(FIRST_SYNC_DELAY))
+    assert(self.rpc:sync_once())
 
     assert(self.rpc:sync_every(EACH_SYNC_DELAY))
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-5891

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
