### PR TITLE
fix(templates): add missing security headers for Admin GUI

### DIFF
--- a/changelog/unreleased/kong/admin-gui-csp-header.yml
+++ b/changelog/unreleased/kong/admin-gui-csp-header.yml
@@ -1,0 +1,6 @@
+message: >-
+  Added a new configuration parameter `admin_gui_csp_header` to Gateway that controls the Content-Security-Policy
+  (CSP) header served with Admin GUI (Kong Manager). This defaults to `"off"` and you can opt-in by
+  setting it to `"on"`.
+type: feature
+scope: Core

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2037,12 +2037,12 @@
                         # use the window protocol + host and append the
                         # resolved admin_listen HTTP/HTTPS port.
 
-#admin_gui_csp_header = off # Content-Security-Policy (CSP) header for Kong Manager
+#admin_gui_csp_header = off # Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager
                             #
-                            # This configuration parameter controls the presence of the
+                            # This configuration controls the presence of the
                             # `Content-Security-Policy` header while serving Kong Manager.
                             #
-                            # Setting this parameter to `on` to enable the CSP header.
+                            # Setting this configuration to `on` to enable the CSP header.
 
 #admin_gui_ssl_cert =   # The SSL certificate for `admin_gui_listen` values
                         # with SSL enabled.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2037,6 +2037,13 @@
                         # use the window protocol + host and append the
                         # resolved admin_listen HTTP/HTTPS port.
 
+#admin_gui_csp_header = off # Content-Security-Policy (CSP) header for Kong Manager
+                            #
+                            # This configuration parameter controls the presence of the
+                            # `Content-Security-Policy` header while serving Kong Manager.
+                            #
+                            # Setting this parameter to `on` to enable the CSP header.
+
 #admin_gui_ssl_cert =   # The SSL certificate for `admin_gui_listen` values
                         # with SSL enabled.
                         #

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -569,6 +569,7 @@ local CONF_PARSERS = {
   admin_gui_url = { typ = "array" },
   admin_gui_path = { typ = "string" },
   admin_gui_api_url = { typ = "string" },
+  admin_gui_csp_header = { typ = "boolean" },
 
   request_debug = { typ = "boolean" },
   request_debug_token = { typ = "string" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -211,6 +211,7 @@ untrusted_lua_sandbox_environment =
 admin_gui_url =
 admin_gui_path = /
 admin_gui_api_url = NONE
+admin_gui_csp_header = off
 
 openresty_path =
 

--- a/kong/templates/nginx_kong_gui_include.lua
+++ b/kong/templates/nginx_kong_gui_include.lua
@@ -80,6 +80,14 @@ location ~* ^$(admin_gui_path_prefix)(?<path>/.*)?$ {
     gzip_types text/plain text/css application/json application/javascript;
 
     add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+
+> if admin_gui_csp_connect_src then
+>   -- [CSP] 'wasm-unsafe-eval' in script-src is required for atc-router-wasm
+>   -- [CSP] TODO: 'unsafe-inline' is still required for style-src because of monaco-editor. See: https://github.com/microsoft/monaco-editor/issues/271
+    add_header Content-Security-Policy "default-src 'self'; connect-src $(admin_gui_csp_connect_src); img-src 'self' data:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://buttons.github.io/buttons.js; style-src 'self' 'unsafe-inline';";
+> end
+
+    add_header Referrer-Policy 'strict-origin-when-cross-origin';
     add_header X-Frame-Options 'sameorigin';
     add_header X-XSS-Protection '1; mode=block';
     add_header X-Content-Type-Options 'nosniff';

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -60,6 +60,7 @@ describe("Configuration loader", function()
     assert.same({"0.0.0.0:8000 reuseport backlog=16384", "0.0.0.0:8443 http2 ssl reuseport backlog=16384"}, conf.proxy_listen)
     assert.same({"0.0.0.0:8002", "0.0.0.0:8445 ssl"}, conf.admin_gui_listen)
     assert.equal("/", conf.admin_gui_path)
+    assert.equal(true, conf.admin_gui_csp_header)
     assert.equal("logs/admin_gui_access.log", conf.admin_gui_access_log)
     assert.equal("logs/admin_gui_error.log", conf.admin_gui_error_log)
     assert.same({}, conf.ssl_cert) -- check placeholder value

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -60,7 +60,7 @@ describe("Configuration loader", function()
     assert.same({"0.0.0.0:8000 reuseport backlog=16384", "0.0.0.0:8443 http2 ssl reuseport backlog=16384"}, conf.proxy_listen)
     assert.same({"0.0.0.0:8002", "0.0.0.0:8445 ssl"}, conf.admin_gui_listen)
     assert.equal("/", conf.admin_gui_path)
-    assert.equal(true, conf.admin_gui_csp_header)
+    assert.equal(false, conf.admin_gui_csp_header)
     assert.equal("logs/admin_gui_access.log", conf.admin_gui_access_log)
     assert.equal("logs/admin_gui_error.log", conf.admin_gui_error_log)
     assert.same({}, conf.ssl_cert) -- check placeholder value

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -1613,4 +1613,119 @@ describe("NGINX conf compiler", function()
       assert.matches("include 'nginx-kong-stream-inject.conf';", nginx_conf, nil, true)
     end)
   end)
+
+  describe("compile_kong_gui_include_conf()", function()
+    describe("Content-Security-Policy", function()
+      it("should not add header by default", function()
+        local conf = assert(conf_loader(helpers.test_conf_path))
+        local gui_include_conf = prefix_handler.compile_kong_gui_include_conf(conf)
+
+        assert.not_matches("add_header Content-Security-Policy", gui_include_conf, nil, true)
+      end)
+
+      it("should add header with default admin_listen", function()
+        local conf = assert(conf_loader(helpers.test_conf_path, {
+          admin_gui_csp_header = "on",
+        }))
+        local gui_include_conf = assert(prefix_handler.compile_kong_gui_include_conf(conf))
+        local found_connect_src = false
+
+        for line in gui_include_conf:gmatch("(.-)\n") do
+          if line:find("add_header Content-Security-Policy", 1, true) then
+            assert.matches("connect-src 'self' https://api.github.com/repos/kong/kong http://$host:9001;", line, nil,
+              true)
+            found_connect_src = true
+            break
+          end
+        end
+
+        assert.True(found_connect_src)
+      end)
+
+      it("should add header with one more secure admin_listen", function()
+        local conf = assert(conf_loader(helpers.test_conf_path, {
+          admin_gui_csp_header = "on",
+          admin_listen = "127.0.0.1:9001, 127.0.0.1:9444 ssl",
+        }))
+        local gui_include_conf = assert(prefix_handler.compile_kong_gui_include_conf(conf))
+        local found_connect_src = false
+
+        for line in gui_include_conf:gmatch("(.-)\n") do
+          if line:find("add_header Content-Security-Policy", 1, true) then
+            assert.matches(
+            "connect-src 'self' https://api.github.com/repos/kong/kong http://$host:9001 https://$host:9444;", line, nil,
+              true)
+            found_connect_src = true
+            break
+          end
+        end
+
+        assert.True(found_connect_src)
+      end)
+
+      it("should add header with only secure admin_listen", function()
+        local conf = assert(conf_loader(helpers.test_conf_path, {
+          admin_gui_csp_header = "on",
+          admin_listen = "127.0.0.1:9444 ssl"
+        }))
+        local gui_include_conf = assert(prefix_handler.compile_kong_gui_include_conf(conf))
+        local found_connect_src = false
+
+        for line in gui_include_conf:gmatch("(.-)\n") do
+          if line:find("add_header Content-Security-Policy", 1, true) then
+            assert.matches(
+            "connect-src 'self' https://api.github.com/repos/kong/kong https://$host:9444;", line, nil,
+              true)
+            found_connect_src = true
+            break
+          end
+        end
+
+        assert.True(found_connect_src)
+      end)
+
+      it("should add header without admin_listen", function()
+        -- Although kong_gui is not served when admin_listeners is off, we are test against the
+        -- compile function itself.
+        local conf = assert(conf_loader(helpers.test_conf_path, {
+          admin_gui_csp_header = "on",
+          admin_listen = "off"
+        }))
+        local gui_include_conf = assert(prefix_handler.compile_kong_gui_include_conf(conf))
+        local found_connect_src = false
+
+        for line in gui_include_conf:gmatch("(.-)\n") do
+          if line:find("add_header Content-Security-Policy", 1, true) then
+            assert.matches(
+            "connect-src 'self' https://api.github.com/repos/kong/kong;", line, nil, true)
+            found_connect_src = true
+            break
+          end
+        end
+
+        assert.True(found_connect_src)
+      end)
+
+      it("should add header with custom admin_gui_api_url", function()
+        local conf = assert(conf_loader(helpers.test_conf_path, {
+          admin_gui_csp_header = "on",
+          admin_gui_api_url = "http://admin-api.kong.local:18001"
+        }))
+        local gui_include_conf = assert(prefix_handler.compile_kong_gui_include_conf(conf))
+        local found_connect_src = false
+
+        for line in gui_include_conf:gmatch("(.-)\n") do
+          if line:find("add_header Content-Security-Policy", 1, true) then
+            assert.matches(
+            "connect-src 'self' https://api.github.com/repos/kong/kong http://admin-api.kong.local:18001;", line, nil,
+              true)
+            found_connect_src = true
+            break
+          end
+        end
+
+        assert.True(found_connect_src)
+      end)
+    end)
+  end)
 end)


### PR DESCRIPTION
### Summary

This pull request adds `Content-Security-Policy` and `Referrer-Policy` headers while serving Admin GUI requests.

Cherry-picking PR in EE was created manually. Please refer to the linked PR.

Since the `Content-Security-Policy` has caused some issues with the Kong Manager before, we introduce a new configuration parameter `admin_gui_csp_header` which defaults to `"off"` to control the availability of this header. Users can opt in manually.

As for the `Referrer-Policy` header, we will serve `'strict-origin-when-cross-origin'` which seems to be the default value today:

> Note: This is the default policy if no policy is specified, or if the provided value is invalid (see spec revision [November 2020](https://github.com/whatwg/fetch/pull/1066)). Previously the default was no-referrer-when-downgrade.
>
> [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#strict-origin-when-cross-origin_2)


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-4283
