### PR TITLE
feat(clustering/sync): add strict validation for delta workspace id

### DIFF
--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -44,6 +44,16 @@ local function validate_deltas(deltas, is_full_sync)
     local delta_entity = delta.entity
 
     if delta_entity ~= nil and delta_entity ~= null then
+
+      -- validate workspace id
+      local ws_id = delta_entity.ws_id or delta.ws_id
+      if not ws_id or ws_id == null then
+        if not errs[delta_type] then
+          errs[delta_type] = {}
+        end
+        insert(errs[delta_type], { ["ws_id"] = "required field missing", })
+      end
+
       -- table: primary key string -> entity
       local schema = db[delta_type].schema
       local pk = schema:extract_pk_values(delta_entity)

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -51,7 +51,7 @@ local function validate_deltas(deltas, is_full_sync)
         if not errs[delta_type] then
           errs[delta_type] = {}
         end
-        insert(errs[delta_type], { ["ws_id"] = "required field missing", })
+        insert(errs[delta_type], "workspace id not found")
       end
 
       -- table: primary key string -> entity

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -154,15 +154,11 @@ describe("[delta validations]",function()
     assert.same(err_t, {
       code = 21,
       fields = {
-        routes = {{
-          ws_id = "required field missing",
-        }},
-        services = {{
-          ws_id = "required field missing",
-        }}
+        routes = { "workspace id not found" },
+        services = { "workspace id not found" },
       },
       flattened_errors = { },
-      message = 'sync deltas is invalid: {routes={{ws_id="required field missing"}},services={{ws_id="required field missing"}}}',
+      message = 'sync deltas is invalid: {routes={"workspace id not found"},services={"workspace id not found"}}',
       name = "sync deltas parse failure",
       source = "kong.clustering.services.sync.validate.validate_deltas",
     })

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -141,6 +141,12 @@ describe("[delta validations]",function()
         delta.entity.ws_id = nil
         delta.ws_id = nil
       end
+
+      if delta.type == "services" then
+        assert(delta.entity.ws_id)
+        delta.entity.ws_id = ngx.null
+        delta.ws_id = ngx.null
+      end
     end
 
     local ok, err, err_t = validate_deltas(deltas)
@@ -148,13 +154,15 @@ describe("[delta validations]",function()
     assert.same(err_t, {
       code = 21,
       fields = {
-        routes = { {
-          ws_id = "required field missing"
-        } }
+        routes = {{
+          ws_id = "required field missing",
+        }},
+        services = {{
+          ws_id = "required field missing",
+        }}
       },
-      flattened_errors = {
-      },
-      message = 'sync deltas is invalid: {routes={{ws_id="required field missing"}}}',
+      flattened_errors = { },
+      message = 'sync deltas is invalid: {routes={{ws_id="required field missing"}},services={{ws_id="required field missing"}}}',
       name = "sync deltas parse failure",
       source = "kong.clustering.services.sync.validate.validate_deltas",
     })

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -131,21 +131,21 @@ describe("[delta validations]",function()
 
     local deltas = declarative.export_config_sync()
 
-    ngx.log(ngx.ERR, "xxxxxx ", require("inspect")(deltas))
-
     for _, delta in ipairs(deltas) do
       local ws_id = delta.ws_id
       assert(ws_id and ws_id ~= ngx.null)
 
+      -- XXX EE: kong-ce entities exported from export_config_sync() do not
+      --         contain ws_id field, while kong-ee enntities does.
+      -- assert(delta.entity.ws_id)
+
       -- mannually remove routes ws_id, and then validation will report error
       if delta.type == "routes" then
-        assert(delta.entity.ws_id)
         delta.entity.ws_id = nil
         delta.ws_id = nil
       end
 
       if delta.type == "services" then
-        assert(delta.entity.ws_id)
         delta.entity.ws_id = ngx.null
         delta.ws_id = ngx.null
       end

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -131,6 +131,8 @@ describe("[delta validations]",function()
 
     local deltas = declarative.export_config_sync()
 
+    ngx.log(ngx.ERR, "xxxxxx ", require("inspect")(deltas))
+
     for _, delta in ipairs(deltas) do
       local ws_id = delta.ws_id
       assert(ws_id and ws_id ~= ngx.null)

--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -149,7 +149,7 @@ describe("[delta validations]",function()
       end
     end
 
-    local ok, err, err_t = validate_deltas(deltas)
+    local _, _, err_t = validate_deltas(deltas)
 
     assert.same(err_t, {
       code = 21,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Add support to strict ws_id validation to sync.v2.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-5760