### PR TITLE
fix(clustering/rpc): set default value for sync entities

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -326,7 +326,7 @@ local function do_sync()
   end
   assert(type(kong.default_workspace) == "string")
 
-  -- validate deltas
+  -- validate deltas and set the default values
   local ok, err, err_t = validate_deltas(deltas, wipe)
   if not ok then
     notify_error(ns_delta.latest_version, err_t)

--- a/kong/clustering/services/sync/validate.lua
+++ b/kong/clustering/services/sync/validate.lua
@@ -86,10 +86,15 @@ local function validate_deltas(deltas, is_full_sync)
             errs_entities[delta_type] = {}
           end
           insert(errs_entities[delta_type], delta_entity)
-        end
-      end
-    end
-  end
+
+        else
+          -- we already set the correct default values for entity
+          copy.ws_id = delta_entity.ws_id
+          deltas.entity = copy
+        end -- if not ok
+      end -- if dao
+    end -- if delta_entity ~= nil and delta_entity ~= null
+  end -- for _, delta in ipairs(deltas)
 
   -- validate references
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6109

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
