### PR TITLE
chore(tracing): log instead of throwing error

### DIFF
--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -280,7 +280,9 @@ function span_mt:finish(end_time_ns)
   end
 
   if end_time_ns and end_time_ns < self.start_time_ns then
-    error("invalid span duration", 2)
+    ngx_log(ngx_ERR, "invalid span duration: ",
+        end_time_ns - self.start_time_ns, " for span: ", self.name)
+    return
   end
 
   self.end_time_ns = end_time_ns or ffi_time_unix_nano()


### PR DESCRIPTION
### Summary

This module could throw errors if certain validations fail. While this is useful for type validation, it can be risky when the error logic depends on more complex conditions.

This commit removes the error thrown when a span's end time is earlier than its start time. Although this shouldn't happen under normal circumstances, the end time calculation depends on multiple factors, including values from Nginx, making it not trivial to ensure it is always valid. In such cases, logging an error is more appropriate than failing the request.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] (no) There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-6424