### PR TITLE
fix(clustering/sync): prioritize using entity ws_id during validation

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -516,7 +516,7 @@ function DeclarativeConfig.validate_references_sync(deltas, deltas_map, is_full_
   for _, delta in ipairs(deltas) do
     local item_type = delta.type
     local item = delta.entity
-    local ws_id = delta.ws_id or kong.default_workspace
+    local ws_id = item.ws_id or delta.ws_id or kong.default_workspace
 
     local foreign_refs = foreign_references[item_type]
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6429
