### PR TITLE
fix(targets): targets can't be removed from dns query queue

### DIFF
--- a/changelog/unreleased/kong/fix-target-deletion.yml
+++ b/changelog/unreleased/kong/fix-target-deletion.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where targets can't be removed from dns query if they were deleted or updated via admin API.
+scope: Core
+type: bugfix


### PR DESCRIPTION
### Summary

For the deployment that multiple kong instances in traditional mode share the same database, when there are updates in targets via admin API happening on one of the instances, the related targets can not be removed from the DNS query queue via cluster events notification broadcasted by the initial instance.

This issue is that the payload in the cluster event broadcasted from other instances only contains the upstream ID attached to the target. However, the handler that is eventually supposed to consume the payload expects a target entity.
The issue is not caused by an incorrect payload in the cluster event, because the payload of a cluster event is transmitted via the database. Therefore, passing a smaller and simpler payload is a wise choice, whereas a complete target entity obviously has a more complex data structure.

In this PR, a list of all the related targets is retrieved from cached with the upstream id, and they are all removed from the queue. This is an acceptable approach as the related balancer entity will be reconstructed right away, meanwhile, all dns queries for the valid targets will be rescheduled as well.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-6469
