### PR TITLE
perf(tracing): improving performance of trace ID size lookup

### DIFF
--- a/changelog/unreleased/kong/perf-trace-ID-size-lookup.yml
+++ b/changelog/unreleased/kong/perf-trace-ID-size-lookup.yml
@@ -1,0 +1,3 @@
+message: "improving performance of trace ID size lookup."
+type: performance
+scope: Core

--- a/kong/observability/tracing/propagation/injectors/_base.lua
+++ b/kong/observability/tracing/propagation/injectors/_base.lua
@@ -154,7 +154,7 @@ function _INJECTOR:inject(inj_tracing_ctx)
   local allowed = self.trace_id_allowed_sizes
   local lookup = self.trace_id_allowed_sizes_lookup
 
-  local new_trace_id_size = (orig_size ~= nil and lookup[orig_size]) and orig_size or allowed[1]
+  local new_trace_id_size = lookup[orig_size] and orig_size or allowed[1]
 
   inj_tracing_ctx.trace_id  = to_id_size(inj_tracing_ctx.trace_id, new_trace_id_size)
   inj_tracing_ctx.span_id   = to_id_size(inj_tracing_ctx.span_id, self.span_id_size_bytes)

--- a/kong/observability/tracing/propagation/injectors/_base.lua
+++ b/kong/observability/tracing/propagation/injectors/_base.lua
@@ -2,7 +2,6 @@ local propagation_utils = require "kong.observability.tracing.propagation.utils"
 
 local to_id_size  = propagation_utils.to_id_size
 local set_header  = kong.service.request.set_header
-local contains    = require("kong.tools.table").table_contains
 local type = type
 local ipairs = ipairs
 
@@ -72,6 +71,11 @@ function _INJECTOR:new(e)
          inst.span_id_size_bytes > 0,
          err .. "invalid span_id_size_bytes variable")
 
+  local allowed_lookup = {}
+  for _, size in ipairs(inst.trace_id_allowed_sizes) do
+    allowed_lookup[size] = true
+  end
+  inst.trace_id_allowed_sizes_lookup = allowed_lookup
   return inst
 end
 
@@ -148,8 +152,9 @@ function _INJECTOR:inject(inj_tracing_ctx)
   -- Extractors automatically set `trace_id_original_size` during extraction.
   local orig_size = inj_tracing_ctx.trace_id_original_size
   local allowed = self.trace_id_allowed_sizes
-  local new_trace_id_size = contains(allowed, orig_size) and orig_size
-      or allowed[1]
+  local lookup = self.trace_id_allowed_sizes_lookup
+
+  local new_trace_id_size = (orig_size ~= nil and lookup[orig_size]) and orig_size or allowed[1]
 
   inj_tracing_ctx.trace_id  = to_id_size(inj_tracing_ctx.trace_id, new_trace_id_size)
   inj_tracing_ctx.span_id   = to_id_size(inj_tracing_ctx.span_id, self.span_id_size_bytes)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Replace table_contains with a more efficient lookup table for trace ID sizes, improving performance of trace ID size lookup.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
