### PR TITLE
refactor(clustering/rpc): clean default_workspace logic

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -274,6 +274,32 @@ local function lmdb_delete(db, t, delta, opts, is_full_sync)
 end
 
 
+local function precheck_deltas(deltas)
+  local default_ws_changed
+
+  for _, delta in ipairs(deltas) do
+    local delta_type = delta.type
+    local delta_entity = delta.entity
+
+    -- Update default workspace if delta is for workspace update
+    if delta_type == "workspaces" and
+      delta_entity ~= nil and
+      delta_entity ~= ngx_null and
+      delta_entity.name == "default" and
+      kong.default_workspace ~= delta_entity.id
+    then
+      kong.default_workspace = delta_entity.id
+      default_ws_changed = true
+      break
+    end
+  end -- for _, delta
+
+  assert(type(kong.default_workspace) == "string")
+
+  return default_ws_changed
+end
+
+
 local function do_sync()
   if not is_rpc_ready() then
     return nil, "rpc is not ready"
@@ -309,22 +335,7 @@ local function do_sync()
 
   -- we should find the correct default workspace
   -- and replace the old one with it
-  local default_ws_changed
-  for _, delta in ipairs(deltas) do
-    local delta_entity = delta.entity
-    -- Update default workspace if delta is for workspace update
-    if delta.type == "workspaces" and
-      delta_entity ~= nil and
-      delta_entity ~= ngx_null and
-      delta_entity.name == "default" and
-      kong.default_workspace ~= delta_entity.id
-    then
-      kong.default_workspace = delta_entity.id
-      default_ws_changed = true
-      break
-    end
-  end
-  assert(type(kong.default_workspace) == "string")
+  local default_ws_changed = precheck_deltas(deltas)
 
   -- validate deltas and set the default values
   local ok, err, err_t = validate_deltas(deltas, wipe)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
