### PR TITLE
fix: escape path when using bedrock inference profiles

### DIFF
--- a/kong/llm/drivers/bedrock.lua
+++ b/kong/llm/drivers/bedrock.lua
@@ -570,6 +570,9 @@ function _M.configure_request(conf, aws_sdk)
   -- if the path is read from a URL capture, ensure that it is valid
   parsed_url.path = (parsed_url.path and string_gsub(parsed_url.path, "^/*", "/")) or "/"
 
+  -- escape the path in case it contains special characters
+  parsed_url.path = ngx.escape_uri(parsed_url.path)
+
   ai_shared.override_upstream_url(parsed_url, conf)
 
   kong.service.request.set_path(parsed_url.path)
@@ -583,7 +586,8 @@ function _M.configure_request(conf, aws_sdk)
   local r = {
     headers = {},
     method = ai_shared.operation_map[DRIVER_NAME][conf.route_type].method,
-    path = parsed_url.path,
+    -- the path is unescaped as the IAM auth required the unescaped value
+    path = ngx.unescape_uri(parsed_url.path),
     host = parsed_url.host,
     port = tonumber(parsed_url.port) or 443,
     body = kong.request.get_raw_body()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR attempts to fix issue #14309 by properly handling URL encoding in AWS SigV4 authentication. Specifically:  
- Escapes the `path` before setting the request.  
- Unescapes the `path` when computing the SigV4 signature.  

I still need to test this end-to-end with an AWS Bedrock inference profile.  

Please let me know if this approach is acceptable. If not, feel free to close this PR.  

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14309
