### PR TITLE
fix(clustering/rpc): validate version string more strictly

### DIFF
--- a/kong/clustering/services/sync/strategies/postgres.lua
+++ b/kong/clustering/services/sync/strategies/postgres.lua
@@ -2,6 +2,7 @@ local _M = {}
 local _MT = { __index = _M }
 
 
+local type = type
 local sub = string.sub
 local fmt = string.format
 local ngx_null = ngx.null
@@ -10,7 +11,9 @@ local ngx_null = ngx.null
 -- version string should look like: "v02_0000"
 local VER_PREFIX = "v02_"
 local VER_PREFIX_LEN = #VER_PREFIX
-local VERSION_FMT = VER_PREFIX .. "%028x"
+local VER_DIGITS = 28
+-- equivalent to "v02_" .. "%028x"
+local VERSION_FMT = VER_PREFIX .. "%0" .. VER_DIGITS .. "x"
 
 
 function _M.new(db)
@@ -60,7 +63,29 @@ end
 
 
 function _M:is_valid_version(str)
-  return sub(str, 1, VER_PREFIX_LEN) == VER_PREFIX
+  if type(str) ~= "string" then
+    return false
+  end
+
+  if #str ~= VER_PREFIX_LEN + VER_DIGITS then
+    return false
+  end
+
+  -- | v02_xxxxxxxxxxxxxxxxxxxxxxxxxx |
+  --   |--|
+  -- Is starts with "v02_"?
+  if sub(str, 1, VER_PREFIX_LEN) ~= VER_PREFIX then
+    return false
+  end
+
+  -- | v02_xxxxxxxxxxxxxxxxxxxxxxxxxx |
+  --       |------------------------|
+  -- Is the rest a valid hex number?
+  if not tonumber(sub(str, VER_PREFIX_LEN + 1), 16) then
+    return false
+  end
+
+  return true
 end
 
 

--- a/spec/01-unit/19-hybrid/05-validate-versions_spec.lua
+++ b/spec/01-unit/19-hybrid/05-validate-versions_spec.lua
@@ -1,0 +1,38 @@
+local is_valid_version = require("kong.clustering.services.sync.strategies.postgres").is_valid_version
+local VER_PREFIX = "v02_"
+local str_rep = string.rep
+
+describe("is_valid_version", function()
+    it("accept valid version", function()
+        -- all zero version
+        local ver = VER_PREFIX .. str_rep("0", 28)
+        assert.True(is_valid_version(nil, ver))
+
+        -- non-hexidecimal
+        ver = VER_PREFIX .. str_rep("9", 28)
+        assert.True(is_valid_version(nil, ver))
+
+        -- hexidecimal
+        ver = VER_PREFIX .. str_rep("f", 28)
+        assert.True(is_valid_version(nil, ver))
+    end)
+
+    it("reject invalid version", function()
+        -- invalid prefix
+        local ver = "v01_" .. str_rep("0", 28)
+        assert.False(is_valid_version(nil, ver))
+
+        -- invalid length
+        ver = VER_PREFIX .. str_rep("0", 27)
+        assert.False(is_valid_version(nil, ver))
+
+        -- invalid non-hexidecimal
+        ver = VER_PREFIX .. str_rep("-", 28)
+        assert.False(is_valid_version(nil, ver))
+
+        -- invalid hexidecimal
+        ver = VER_PREFIX .. str_rep("g", 28)
+        assert.False(is_valid_version(nil, ver))
+    end)
+end)
+


### PR DESCRIPTION
### Summary

Currently, the `is_valid_version` accepts invalid versions like `v02_xxxxxxxx`, which not only isn't a valid hex number but also has an unexpected string length.

We should validate the version string more strictly.

### Checklist

- [X] The Pull Request has tests
- [N/A] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

_[KAG-6452]_


[KAG-6452]: https://konghq.atlassian.net/browse/KAG-6452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ