### PR TITLE
docs(pdk): tracing

### DIFF
--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -474,7 +474,7 @@ local function new_tracer(name, options)
   -- Returns the root span by default
   --
   -- @function kong.tracing.active_span
-  -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
+  -- @phases rewrite, access, header_filter, response, body_filter, log
   -- @treturn table span
   function self.active_span()
     if not VALID_TRACING_PHASES[ngx.get_phase()] then
@@ -487,7 +487,7 @@ local function new_tracer(name, options)
   --- Set the active span
   --
   -- @function kong.tracing.set_active_span
-  -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
+  -- @phases rewrite, access, header_filter, response, body_filter, log
   -- @tparam table span
   function self.set_active_span(span)
     if not VALID_TRACING_PHASES[ngx.get_phase()] then
@@ -504,7 +504,7 @@ local function new_tracer(name, options)
   --- Create a new Span
   --
   -- @function kong.tracing.start_span
-  -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
+  -- @phases rewrite, access, header_filter, response, body_filter, log
   -- @tparam string name span name
   -- @tparam table options
   -- @treturn table span


### PR DESCRIPTION
### Summary

update tracing pdk docs to remove the (currently not supported) admin_api phase.

### Checklist

- [x] (no) The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

[KAG-6485](https://konghq.atlassian.net/browse/KAG-6485)

closes https://github.com/Kong/kong/discussions/14288

[KAG-6485]: https://konghq.atlassian.net/browse/KAG-6485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ