### PR TITLE
escape dots in logging plugins custom_fields_by_lua

### DIFF
--- a/changelog/unreleased/kong/fix-escape-dots-in-logging-plugins.yml
+++ b/changelog/unreleased/kong/fix-escape-dots-in-logging-plugins.yml
@@ -1,0 +1,3 @@
+message: "Users can now use a backslash to escape dots in logging plugins' `custom_fields_by_lua`  key strings, preventing dots from creating nested tables."
+type: bugfix
+scope: PDK

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -185,6 +185,9 @@ for _, strategy in helpers.each_strategy() do
           port   = TCP_PORT,
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           }
         },
@@ -262,6 +265,9 @@ for _, strategy in helpers.each_strategy() do
 
         -- Since it's over HTTP, let's make sure there are no TLS information
         assert.same(123, log_message.new_field)
+        assert.same(456, log_message.nested.keys)
+        assert.same(789, log_message["escape.dots"])
+        assert.same(135, log_message.nested["escape.dots"])
       end)
 
       it("unsets existing log values", function()

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -42,6 +42,9 @@ for _, strategy in helpers.each_strategy() do
           port   = UDP_PORT,
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           },
         },
@@ -160,6 +163,9 @@ for _, strategy in helpers.each_strategy() do
         -- Making sure it's alright
         local log_message = cjson.decode(res)
         assert.same(123, log_message.new_field)
+        assert.same(456, log_message.nested.keys)
+        assert.same(789, log_message["escape.dots"])
+        assert.same(135, log_message.nested["escape.dots"])
       end)
 
       it("unsets existing log values", function()

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -307,6 +307,9 @@ for _, strategy in helpers.each_strategy() do
                                     .. "/post_log/custom_http",
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           },
         }
@@ -452,6 +455,9 @@ for _, strategy in helpers.each_strategy() do
         local entries = get_log("custom_http", 1)
         assert.same("127.0.0.1", entries[1].client_ip)
         assert.same(123, entries[1].new_field)
+        assert.same(456, entries[1].nested.keys)
+        assert.same(789, entries[1]["escape.dots"])
+        assert.same(135, entries[1].nested["escape.dots"])
       end)
     end)
 

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -177,6 +177,9 @@ for _, strategy in helpers.each_strategy() do
           reopen = true,
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           },
         },
@@ -272,6 +275,9 @@ for _, strategy in helpers.each_strategy() do
           reopen = true,
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           },
         },
@@ -344,6 +350,9 @@ for _, strategy in helpers.each_strategy() do
         assert.is_number(log_message.request.size)
         assert.is_number(log_message.response.size)
         assert.same(123, log_message.new_field)
+        assert.same(456, log_message.nested.keys)
+        assert.same(789, log_message["escape.dots"])
+        assert.same(135, log_message.nested["escape.dots"])
       end)
 
       it("unsets existing log values", function()

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -94,6 +94,9 @@ for _, strategy in helpers.each_strategy() do
           key  = "123456789",
           custom_fields_by_lua = {
             new_field = "return 123",
+            ["nested.keys"] = "return 456",
+            ["escape\\.dots"] = "return 789",
+            ["nested.escape\\.dots"] = "return 135",
             route = "return nil", -- unset route field
           }
         }
@@ -339,6 +342,9 @@ for _, strategy in helpers.each_strategy() do
         }, 500)
         assert.equal("14", pri)
         assert.equal(123, message.new_field)
+        assert.same(456, message.nested.keys)
+        assert.same(789, message["escape.dots"])
+        assert.same(135, message.nested["escape.dots"])
       end)
       it("unsets existing log values", function()
         local pri, message = run({

--- a/t/01-pdk/02-log/05-set_serialize_value.t
+++ b/t/01-pdk/02-log/05-set_serialize_value.t
@@ -3,7 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 do "./t/Util.pm";
 
-plan tests => 49;
+plan tests => 51;
 
 run_tests();
 
@@ -186,6 +186,14 @@ add existing value does not set it true
             pdk.log.set_serialize_value("foo.bar.baz", 3, { mode = "add" })
             local s = pdk.log.serialize({ kong = pdk })
             pdk.log.info("add existing deep leaf does not change it", s.foo.bar.baz == 2)
+
+            pdk.log.set_serialize_value("foo4\\.bar\\.baz", 4, { mode = "add" })
+            local s = pdk.log.serialize({ kong = pdk })
+            pdk.log.info("add new branch with dots escaped creates it ", s["foo4.bar.baz"] == 4)
+
+            pdk.log.set_serialize_value("foo4.bar\\.baz", 4, { mode = "add" })
+            local s = pdk.log.serialize({ kong = pdk })
+            pdk.log.info("add new branch with nested and dots escaped creates it ", s.foo4["bar.baz"] == 4)
         }
     }
 
@@ -202,6 +210,8 @@ replace existing deep leaf changes it true
 add new deep leaf to root adds it true
 add new branch creates it true
 add existing deep leaf does not change it
+add new branch with dots escaped creates it true
+add new branch with nested and dots escaped creates it true
 --- no_error_log
 [error]
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Users can now use a backslash to escape dots in logging plugins' `custom_fields_by_lua`  key strings, preventing dots from creating nested tables.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[[11582](https://github.com/Kong/kong/issues/11582)]_
[KAG-2601](https://konghq.atlassian.net/browse/KAG-2601)

[KAG-2601]: https://konghq.atlassian.net/browse/KAG-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ