### PR TITLE
test(clustering/sync): validate unloaded plugin

### DIFF
--- a/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
+++ b/spec/01-unit/19-hybrid/04-validate_deltas_spec.lua
@@ -466,5 +466,35 @@ describe("[delta validations]",function()
     assert_same_validation_error(deltas, config, errs)
   end)
 
+  it("unloaded plugin", function()
+    local bp = setup_bp()
+
+    -- add entities
+    db_insert(bp, "workspaces", { name = "ws-001" })
+
+    -- add the unloaded plugin which will trigger a validation error
+    db_insert(bp, "plugins", { name = "unloaded-plugin", })
+
+    local deltas = declarative.export_config_sync()
+
+    local config = declarative.export_config()
+
+    local errs = {
+      fields = {},
+      flattened_errors = {{
+        entity_id = config.plugins[1].id,
+        entity_name = "unloaded-plugin",
+        entity_type = "plugin",
+        errors = {{
+          field = "name",
+          message = "plugin 'unloaded-plugin' not enabled; add it to the 'plugins' configuration property",
+          type = "field",
+        }},
+      }},
+    }
+
+    assert_same_validation_error(deltas, config, errs)
+  end)
+
   -- TODO: add more test cases
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
