### PR TITLE
fix(dns): new DNS client did not correctly handle timeout option in resolv.conf

### DIFF
--- a/changelog/unreleased/kong/fix-new-dns-client-timeout.yml
+++ b/changelog/unreleased/kong/fix-new-dns-client-timeout.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where the new DNS client did not correctly handle the timeout option in resolv.conf.
+type: bugfix
+scope: Core

--- a/kong/dns/client.lua
+++ b/kong/dns/client.lua
@@ -186,7 +186,8 @@ function _M.new(opts)
 
   local r_opts = {
     retrans = opts.retrans or resolv.options.attempts or 5,
-    timeout = opts.timeout or resolv.options.timeout or 2000, -- ms
+    timeout = (opts.timeout and opts.timeout * 1000) or (resolv.options.timeout
+      and resolv.options.timeout * 1000) or 2000, -- ms
     no_random = no_random,
     nameservers = nameservers,
   }

--- a/kong/dns/client.lua
+++ b/kong/dns/client.lua
@@ -186,8 +186,7 @@ function _M.new(opts)
 
   local r_opts = {
     retrans = opts.retrans or resolv.options.attempts or 5,
-    timeout = (opts.timeout and opts.timeout * 1000) or (resolv.options.timeout
-      and resolv.options.timeout * 1000) or 2000, -- ms
+    timeout = opts.timeout or resolv.options.timeout or 2000, -- ms
     no_random = no_random,
     nameservers = nameservers,
   }

--- a/kong/dns/utils.lua
+++ b/kong/dns/utils.lua
@@ -142,10 +142,15 @@ local function parse_resolv_conf(path, enable_ipv6)
   resolv.search = resolv.search or (resolv.domain and { resolv.domain })
 
   -- check if timeout is 0s
-  if resolv.options.timeout and resolv.options.timeout <= 0 then
-    log(NOTICE, "A non-positive timeout of ", resolv.options.timeout,
-                "s is configured in resolv.conf. Setting it to 2000ms.")
-    resolv.options.timeout = 2000 -- 2000ms is lua-resty-dns default
+  if resolv.options.timeout then
+    if resolv.options.timeout <= 0 then
+      log(NOTICE, "A non-positive timeout of ", resolv.options.timeout,
+                  "s is configured in resolv.conf. Setting it to 2000ms.")
+      resolv.options.timeout = 2000 -- 2000ms is lua-resty-dns default
+
+    else
+      resolv.options.timeout = resolv.options.timeout * 1000
+    end
   end
 
   -- remove special domain like "."

--- a/kong/dns/utils.lua
+++ b/kong/dns/utils.lua
@@ -149,6 +149,7 @@ local function parse_resolv_conf(path, enable_ipv6)
       resolv.options.timeout = 2000 -- 2000ms is lua-resty-dns default
 
     else
+      -- convert resolv.conf timeout from seconds to milliseconds
       resolv.options.timeout = resolv.options.timeout * 1000
     end
   end

--- a/spec/01-unit/30-new-dns-client/01-utils_spec.lua
+++ b/spec/01-unit/30-new-dns-client/01-utils_spec.lua
@@ -348,7 +348,7 @@ options use-vc
       assert.is.equal("myservice.test", resolv.domain)
       assert.is.same({ "198.51.100.0", "2001:db8::1", "198.51.100.0:1234" }, resolv.nameserver)
       assert.is.same({ "list1", "list2" }, resolv.sortlist)
-      assert.is.same({ ndots = 2, timeout = 3, attempts = 4, debug = true, rotate = true,
+      assert.is.same({ ndots = 2, timeout = 3000, attempts = 4, debug = true, rotate = true,
           ["no-check-names"] = true, inet6 = true, ["ip6-bytestring"] = true,
           ["ip6-dotint"] = nil,  -- overridden by the next one, mutually exclusive
           ["no-ip6-dotint"] = true, edns0 = true, ["single-request"] = true,

--- a/spec/01-unit/30-new-dns-client/02-old_client_spec.lua
+++ b/spec/01-unit/30-new-dns-client/02-old_client_spec.lua
@@ -547,7 +547,7 @@ describe("[DNS client]", function()
         })
         local cli = assert(client_new())
         assert.same(cli.r_opts.retrans, attempts)
-        assert.same(cli.r_opts.timeout, timeout)
+        assert.same(cli.r_opts.timeout, timeout * 1000)
 
         local start_time = ngx.now()
         local answers = cli:resolve("timeout.test")

--- a/spec/01-unit/30-new-dns-client/02-old_client_spec.lua
+++ b/spec/01-unit/30-new-dns-client/02-old_client_spec.lua
@@ -521,7 +521,7 @@ describe("[DNS client]", function()
 
       local cli = assert(client_new())
       assert.same(cli.r_opts.retrans, 3)
-      assert.same(cli.r_opts.timeout, 1)
+      assert.same(cli.r_opts.timeout, 1000)
 
       local answers, err = cli:resolve("timeout.test")
       assert.is_nil(answers)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Original Kong dns client was treating resolv.conf timeout or RES_OPTIONS timeout as being in milliseconds when the reality per RFC is they are in seconds, so anyone using Kong who custom sets their DNS timeouts via those methods are getting 2ms of DNS time allowed vs 2000ms expected(2 second configured).

See references here:

https://github.com/Kong/kong/issues/14249#issuecomment-2658565525
and
https://github.com/Kong/kong/issues/14249#issuecomment-2658607207

This fix refers to original fix https://github.com/Kong/kong/pull/14313

Co-authored-by: @jeremyjpj0916

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6495
Fix https://github.com/Kong/kong/issues/14249
Fix https://github.com/Kong/kong/issues/14233
