### PR TITLE
fix(templates): allow specifying CSP header values

### DIFF
--- a/changelog/unreleased/kong/admin-gui-csp-header-value.yml
+++ b/changelog/unreleased/kong/admin-gui-csp-header-value.yml
@@ -1,0 +1,5 @@
+message: >-
+  Added a optional configuration parameter `admin_gui_csp_header_value` to Gateway that controls the
+  value of the Content-Security-Policy (CSP) header served with Admin GUI (Kong Manager).
+type: bugfix
+scope: Core

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -2039,10 +2039,25 @@
 
 #admin_gui_csp_header = off # Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager
                             #
-                            # This configuration controls the presence of the
-                            # `Content-Security-Policy` header while serving Kong Manager.
+                            # This configuration controls the presence of the CSP header when serving
+                            # Kong Manager. The default CSP header value will be used unless customized.
                             #
-                            # Setting this configuration to `on` to enable the CSP header.
+                            # To modify the value of the served CSP header, refer to the `admin_gui_csp_header_value`
+                            # configuration.
+                            #
+                            # Set this configuration to `on` to enable the CSP header.
+
+#admin_gui_csp_header_value = # The value of the `Content-Security-Policy` (CSP) header for Kong Manager.
+                              #
+                              # This configuration controls the value of the CSP header when serving
+                              # Kong Manager. If omitted or left empty, the default CSP header value
+                              # will be used.
+                              #
+                              # This is an advanced configuration intended for cases where the default
+                              # CSP header value does not meet your requirements. Use with caution.
+                              #
+                              # For more information on the CSP header, see:
+                              # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 #admin_gui_ssl_cert =   # The SSL certificate for `admin_gui_listen` values
                         # with SSL enabled.

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -570,6 +570,7 @@ local CONF_PARSERS = {
   admin_gui_path = { typ = "string" },
   admin_gui_api_url = { typ = "string" },
   admin_gui_csp_header = { typ = "boolean" },
+  admin_gui_csp_header_value = { typ = "string" },
 
   request_debug = { typ = "boolean" },
   request_debug_token = { typ = "string" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -212,6 +212,7 @@ admin_gui_url =
 admin_gui_path = /
 admin_gui_api_url = NONE
 admin_gui_csp_header = off
+admin_gui_csp_header_value =
 
 openresty_path =
 

--- a/kong/templates/nginx_kong_gui_include.lua
+++ b/kong/templates/nginx_kong_gui_include.lua
@@ -81,10 +81,8 @@ location ~* ^$(admin_gui_path_prefix)(?<path>/.*)?$ {
 
     add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
 
-> if admin_gui_csp_connect_src then
->   -- [CSP] 'wasm-unsafe-eval' in script-src is required for atc-router-wasm
->   -- [CSP] TODO: 'unsafe-inline' is still required for style-src because of monaco-editor. See: https://github.com/microsoft/monaco-editor/issues/271
-    add_header Content-Security-Policy "default-src 'self'; connect-src $(admin_gui_csp_connect_src); img-src 'self' data:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://buttons.github.io/buttons.js; style-src 'self' 'unsafe-inline';";
+> if _quoted_csp_header_value then -- <-- See`compile_kong_gui_include_conf` in kong/cmd/utils/prefix_handler.lua
+    add_header Content-Security-Policy $(_quoted_csp_header_value);
 > end
 
     add_header Referrer-Policy 'strict-origin-when-cross-origin';

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -61,6 +61,7 @@ describe("Configuration loader", function()
     assert.same({"0.0.0.0:8002", "0.0.0.0:8445 ssl"}, conf.admin_gui_listen)
     assert.equal("/", conf.admin_gui_path)
     assert.equal(false, conf.admin_gui_csp_header)
+    assert.equal(nil, conf.admin_gui_csp_header_value)
     assert.equal("logs/admin_gui_access.log", conf.admin_gui_access_log)
     assert.equal("logs/admin_gui_error.log", conf.admin_gui_error_log)
     assert.same({}, conf.ssl_cert) -- check placeholder value


### PR DESCRIPTION
### Summary

Add an optional configuration `admin_gui_csp_header_value` to allow specifying `Content-Security-Policy` header values for cases where the default CSP header value does not meet the requirements.

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-4283
