### PR TITLE
fix(admin): fix error caused by duplicate Content-Type

### DIFF
--- a/changelog/unreleased/kong/fix-duplicate-content-type.yml
+++ b/changelog/unreleased/kong/fix-duplicate-content-type.yml
@@ -1,0 +1,4 @@
+message: |
+  Fixed error caused by duplicate `Content-Type`.
+type: bugfix
+scope: Admin API

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -257,6 +257,9 @@ function _M.before_filter(self)
       end
     end
 
+  elseif type(content_type) == "table" then
+    return kong.response.exit(400, "Multiple Content-Type headers not allowed")
+
   elseif sub(content_type, 1, 16) == "application/json"
       or sub(content_type, 1, 19) == "multipart/form-data"
       or sub(content_type, 1, 33) == "application/x-www-form-urlencoded"


### PR DESCRIPTION
### Summary

This is the bug reported in issue #14187.

If we send a request like this:
```
POST / HTTP/1.1
Accept: */*
Host: 127.0.0.0
Content-Type: application/x-www-form-urlencoded
Content-Type: application/x-www-form-urlencoded
```
then the `content_type` variable will be a table, whereas if the request is like this:
```
POST / HTTP/1.1
Accept: */*
Host: 127.0.0.0
Content-Type: application/x-www-form-urlencoded; application/json
```
the `content_type` will be a string `application/x-www-form-urlencoded; application/json`.


As described by RFC 7230: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2
> A sender MUST NOT generate multiple header fields with the same field
   name in a message unless either the entire field value for that
   header field is defined as a comma-separated list [i.e., #(values)]
   or the header field is a well-known exception (as noted below).

So, I think there should be a check for the case where the `content_type` variable is of table type and return a 400 response.


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-6498
