### PR TITLE
refactor(clustering/rpc): rename field `wipe` to `full_sync` and other code clean

### DIFF
--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -413,7 +413,7 @@ local function do_sync()
 
   local ok, err = t:commit()
   if not ok then
-    return nil, err
+    return nil, "failed to commit transaction: " .. err
   end
 
   if is_full_sync then
@@ -427,16 +427,12 @@ local function do_sync()
     -- Full sync could rebuild route, plugins and balancer route, so their
     -- hashes are nil.
     local reconfigure_data = { kong.default_workspace, nil, nil, nil, }
-    local ok, err = events.declarative_reconfigure_notify(reconfigure_data)
-    if not ok then
-      return nil, err
-    end
+    return events.declarative_reconfigure_notify(reconfigure_data)
+  end
 
-  else
-    for _, event in ipairs(crud_events) do
-      -- delta_type, crud_event_type, delta.entity, old_entity
-      db[event[1]]:post_crud_event(event[2], event[3], event[4])
-    end
+  for _, event in ipairs(crud_events) do
+    -- delta_type, crud_event_type, delta.entity, old_entity
+    db[event[1]]:post_crud_event(event[2], event[3], event[4])
   end
 
   return true

--- a/kong/clustering/services/sync/rpc.lua
+++ b/kong/clustering/services/sync/rpc.lua
@@ -355,7 +355,6 @@ local function do_sync()
 
   local db = kong.db
 
-  -- in case of no deltas, the version should not change
   local version = current_version
   local opts = {}
   local crud_events = {}

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-get-delta-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-get-delta-test/handler.lua
@@ -30,7 +30,7 @@ function RpcSyncV2GetDeltaTestHandler:init_worker()
 
     assert(type(res) == "table")
     assert(not isempty(res.default.deltas))
-    assert(res.default.wipe == true)
+    assert(res.default.full_sync == true)
     assert(not err)
 
     -- dp's version is greater than cp's version
@@ -39,7 +39,7 @@ function RpcSyncV2GetDeltaTestHandler:init_worker()
 
     assert(type(res) == "table")
     assert(not isempty(res.default.deltas))
-    assert(res.default.wipe == true)
+    assert(res.default.full_sync == true)
     assert(not err)
 
     -- dp's version is equal to cp's version
@@ -48,7 +48,7 @@ function RpcSyncV2GetDeltaTestHandler:init_worker()
 
     assert(type(res) == "table")
     assert(isempty(res.default.deltas))
-    assert(res.default.wipe == false)
+    assert(res.default.full_sync == false)
     assert(not err)
 
     ngx.log(ngx.DEBUG, "kong.sync.v2.get_delta ok")

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-notify-new-version-test/handler.lua
@@ -33,7 +33,7 @@ function RpcSyncV2NotifyNewVersioinTestHandler:init_worker()
     ngx.log(ngx.DEBUG, "kong.sync.v2.get_delta ok: ", counter)
     counter = counter + 1
 
-    return { default = { deltas = deltas, wipe = true, }, }
+    return { default = { deltas = deltas, full_sync = true, }, }
   end)
 
   -- test dp's sync.v2.notify_new_version on cp side

--- a/spec/fixtures/custom_plugins/kong/plugins/rpc-validation-test/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rpc-validation-test/handler.lua
@@ -41,7 +41,7 @@ function RpcSyncV2ValidationHandler:init_worker()
 
     ngx.log(ngx.DEBUG, "kong.sync.v2.get_delta ok")
 
-    return { default = { deltas = deltas, wipe = true, }, }
+    return { default = { deltas = deltas, full_sync = true, }, }
   end)
 
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-6504
Related PR: https://github.com/Kong/kong-ee/pull/11373
I think that this PR dose not need to cherry pick to EE.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
