### PR TITLE
feat: expose kong.request.get_raw_path in pluginsocket

### DIFF
--- a/changelog/unreleased/kong/pluginsocket-proto-get-raw-path.yml
+++ b/changelog/unreleased/kong/pluginsocket-proto-get-raw-path.yml
@@ -1,0 +1,2 @@
+message: |
+  Expose get_raw_query method in kong/include/kong/pluginsocket.proto

--- a/kong/include/kong/pluginsocket.proto
+++ b/kong/include/kong/pluginsocket.proto
@@ -305,6 +305,7 @@ service Kong {
     rpc Request_GetHttpVersion(google.protobuf.Empty) returns (Number);
     rpc Request_GetMethod(google.protobuf.Empty) returns (String);
     rpc Request_GetPath(google.protobuf.Empty) returns (String);
+    rpc Request_GetRawPath(google.protobuf.Empty) returns (String);
     rpc Request_GetPathWithQuery(google.protobuf.Empty) returns (String);
     rpc Request_GetRawQuery(google.protobuf.Empty) returns (String);
     rpc Request_GetQueryArg(String) returns (String);


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

