### PR TITLE
chore: add pr created at time in the schema change message

### DIFF
--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -7,10 +7,17 @@ jobs:
     if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"
     runs-on: ubuntu-latest
     steps:
+    - name: PR Created Time
+      id: get-pr-created-time
+      run: |
+        PR_CREATED_AT=$(jq -r '.pull_request.created_at' $GITHUB_EVENT_PATH)
+        echo "pr_created_at=$PR_CREATED_AT" >> "$GITHUB_OUTPUT"
     - name: Schema change label found
       uses: Kong/action-slack-notify@bd750854aaf93c5c6f69799bf813c40e7786368a # v2_node20
       continue-on-error: true
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SCHEMA_CHANGE }}
-        SLACK_MESSAGE: ${{ github.event.pull_request.title }}
+        SLACK_MESSAGE: |
+          ${{ github.event.pull_request.title }}
+          PR Created at: ${{ env.pr_created_at }}
         SLACK_FOOTER: "<${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}>"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Add PR creation time to the schema Slack notification message for gateway schema changes. This allows us to track when the PR was created, helping identify how long ago the first schema change event occurred.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
