### PR TITLE
feat(pdk): revert response.get_header change to avoid behavior change

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -244,7 +244,7 @@ local function new(self, major_version)
       error("header name must be a string", 2)
     end
 
-    local header_value = ngx.header[name]
+    local header_value = _RESPONSE.get_headers()[name]
     if type(header_value) == "table" then
       return header_value[1]
     end

--- a/t/01-pdk/08-response/02-get_header.t
+++ b/t/01-pdk/08-response/02-get_header.t
@@ -116,7 +116,7 @@ X-Missing: nil
 
 
 
-=== TEST 4: response.get_header() returns existing header will not limited by get_headers() default max_headers configuration
+=== TEST 4: response.get_header() returns nil when response header does not fit in default max_headers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -145,7 +145,7 @@ X-Missing: nil
 --- request
 GET /t
 --- response_body chop
-accept header value: string
+accept header value: nil
 --- no_error_log
 [error]
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR is an amendment of https://github.com/Kong/kong/pull/13981.

### Context

I found that in openresty, they have special handling for some headers like "connection", "transfer-encoding" in `ngx.resp.get_headers` (see https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_headers.c#L521-L538).
However, `ngx.header.HEADER` doesn't include these special handling, which means fetching single header like "connection" may get `nil` but `get_headers()["connection"]` will get a not `nil` value.
So we need to revert the change in the `response.get_header` PDK to avoid this potential issue.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://konghq.atlassian.net/browse/KAG-5567
