### PR TITLE
fix(rate-limiting): fix duplicate kong rate limit headers

### DIFF
--- a/kong/pdk/private/rate_limiting.lua
+++ b/kong/pdk/private/rate_limiting.lua
@@ -4,7 +4,7 @@ local type         = type
 local pairs        = pairs
 local assert       = assert
 local tostring     = tostring
-local set_header   = kong.response.set_header
+local resp_header  = ngx.header
 
 -- determine the number of pre-allocated fields at runtime
 local max_fields_n = 4
@@ -103,7 +103,7 @@ function _M.apply_response_headers(ngx_ctx)
   local actual_fields_n = 0
 
   for k, v in pairs(rl_ctx) do
-    set_header(k, tostring(v))
+    resp_header[k] = tostring(v)
     actual_fields_n = actual_fields_n + 1
   end
 

--- a/kong/pdk/private/rate_limiting.lua
+++ b/kong/pdk/private/rate_limiting.lua
@@ -4,7 +4,7 @@ local type         = type
 local pairs        = pairs
 local assert       = assert
 local tostring     = tostring
-local resp_header  = ngx.header
+local set_header   = kong.response.set_header
 
 -- determine the number of pre-allocated fields at runtime
 local max_fields_n = 4
@@ -103,7 +103,7 @@ function _M.apply_response_headers(ngx_ctx)
   local actual_fields_n = 0
 
   for k, v in pairs(rl_ctx) do
-    resp_header[k] = tostring(v)
+    set_header(k, tostring(v))
     actual_fields_n = actual_fields_n + 1
   end
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -216,7 +216,9 @@ function RateLimitingHandler:access(conf)
 
     -- If limit is exceeded, terminate the request
     if stop then
-      pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
+      if not conf.hide_client_headers then
+        pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
+      end
 
       return kong.response.error(conf.error_code, conf.error_message)
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
When a service's upstream is another service with rate-limiting enabled, enabling a rate-limiting plugin on the service results in duplicate headers. This PR fixes the issue by removing Kong's rate-limiting headers from the upstream response and applying only the headers from the plugin.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14353
