### PR TITLE
fix(rate-limiting): fix duplicate kong rate limit headers

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -19,6 +19,7 @@ local SYNC_RATE_REALTIME = -1
 
 local pdk_rl_store_response_header = pdk_private_rl.store_response_header
 local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
+local clear_header = kong.response.clear_header
 
 
 local EMPTY = require("kong.tools.table").EMPTY
@@ -122,6 +123,29 @@ local function increment(premature, conf, ...)
   policies[conf.policy].increment(conf, ...)
 end
 
+local function clear_response_headers()
+  clear_header(RATELIMIT_LIMIT)
+  clear_header(RATELIMIT_REMAINING)
+  clear_header(RATELIMIT_RESET)
+  clear_header(RETRY_AFTER)
+
+  for _, header in pairs(X_RATELIMIT_LIMIT) do
+    clear_header(header)
+  end
+
+  for _, header in pairs(X_RATELIMIT_REMAINING) do
+    clear_header(header)
+  end
+end
+
+function RateLimitingHandler:header_filter(conf)
+    clear_response_headers()
+    if not conf.hide_client_headers then
+        local ngx_ctx = ngx.ctx
+        pdk_rl_apply_response_headers(ngx_ctx)
+    end
+end
+
 
 function RateLimitingHandler:access(conf)
   local current_timestamp = time() * 1000
@@ -194,14 +218,9 @@ function RateLimitingHandler:access(conf)
     if stop then
       if not conf.hide_client_headers then
         pdk_rl_store_response_header(ngx_ctx, RETRY_AFTER, reset)
-        pdk_rl_apply_response_headers(ngx_ctx)
       end
 
       return kong.response.error(conf.error_code, conf.error_message)
-    end
-
-    if not conf.hide_client_headers then
-      pdk_rl_apply_response_headers(ngx_ctx)
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
When a service's upstream is another service with rate-limiting enabled, enabling a rate-limiting plugin on the service results in duplicate headers. This PR fixes the issue by removing Kong's rate-limiting headers from the upstream response and applying only the headers from the plugin.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14353
