### PR TITLE
perf(*): faster string splitting and an iterator

### DIFF
--- a/changelog/unreleased/kong/perf-string-splitting.yml
+++ b/changelog/unreleased/kong/perf-string-splitting.yml
@@ -1,0 +1,3 @@
+message: "Improved the performance of string splitting functions in Kong's core."
+type: performance
+scope: Core

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -17,7 +17,7 @@ local type         = type
 local fmt          = string.format
 local concat       = table.concat
 local re_match     = ngx.re.match
-local split        = require("kong.tools.string").split
+local splitn       = require("kong.tools.string").splitn
 local get_default_exit_body = require("kong.tools.http").get_default_exit_body
 
 
@@ -169,11 +169,11 @@ local function extract_options(db, args, schema, context)
       if re_match(tags, TAGS_AND_REGEX, 'jo') then
         -- 'a,b,c' or 'a'
         options.tags_cond = 'and'
-        options.tags = split(tags, ',')
+        options.tags = splitn(tags, ',')
       elseif re_match(tags, TAGS_OR_REGEX, 'jo') then
         -- 'a/b/c'
         options.tags_cond = 'or'
-        options.tags = split(tags, '/')
+        options.tags = splitn(tags, '/')
       else
         options.tags = tags
         -- not setting tags_cond since we can't determine the cond

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -8,7 +8,7 @@ local ipairs = ipairs
 local table_insert = table.insert
 local table_sort = table.sort
 local gsub = string.gsub
-local split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 local deflate_gzip = require("kong.tools.gzip").deflate_gzip
 local cjson_encode = cjson.encode
@@ -223,12 +223,11 @@ do
       return fields
     end
 
-    fields = split(name, ".")
-
-    for _, part in ipairs(fields) do
-      assert(part ~= "", "empty segment in field name: " .. tostring(name))
+    local count
+    fields, count = splitn(name, ".")
+    for i = 1, count do
+      assert(fields[i] ~= "", "empty segment in field name: " .. tostring(name))
     end
-
     cache[name] = fields
     return fields
   end

--- a/kong/clustering/compat/version.lua
+++ b/kong/clustering/compat/version.lua
@@ -1,6 +1,6 @@
 local type = type
 local tonumber = tonumber
-local split = require("kong.tools.string").split
+local isplitn = require("kong.tools.string").isplitn
 
 local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
 
@@ -32,12 +32,11 @@ end
 function _M.string_to_number(s)
   local base = 1000000000
   local num = 0
-  for _, v in ipairs(split(s, ".", 4)) do
+  for v in isplitn(s, ".", 4) do
     v = v:match("^(%d+)")
     num = num + base * (tonumber(v, 10) or 0)
     base = base / 1000
   end
-
   return num
 end
 

--- a/kong/clustering/rpc/manager.lua
+++ b/kong/clustering/rpc/manager.lua
@@ -15,7 +15,8 @@ local table_isempty = require("table.isempty")
 local table_clone = require("table.clone")
 local table_remove = table.remove
 local cjson = require("cjson.safe")
-local string_tools = require("kong.tools.string")
+local isplitn = require("kong.tools.string").isplitn
+local strip = require("kong.tools.string").strip
 
 
 local ipairs = ipairs
@@ -458,13 +459,11 @@ end
 function _M:handle_websocket()
   local rpc_protocol = ngx_var.http_sec_websocket_protocol
 
-  local meta_v1_supported
-  local protocols = string_tools.split(rpc_protocol, ",")
-
   -- choice a proper protocol
-  for _, v in ipairs(protocols) do
+  local meta_v1_supported
+  for v in isplitn(rpc_protocol, ",") do
     -- now we only support kong.meta.v1
-    if RPC_META_V1 == string_tools.strip(v) then
+    if RPC_META_V1 == strip(v) then
       meta_v1_supported = true
       break
     end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -28,7 +28,7 @@ local admin_gui_utils = require "kong.admin_gui.utils"
 
 
 local strip = require("kong.tools.string").strip
-local split = require("kong.tools.string").split
+local isplitn = require("kong.tools.string").isplitn
 local shallow_copy = require("kong.tools.table").shallow_copy
 
 
@@ -793,9 +793,8 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
   end
 
   local template_env = {}
-  nginx_conf_flags = nginx_conf_flags and split(nginx_conf_flags, ",") or {}
-  for _, flag in ipairs(nginx_conf_flags) do
-    template_env[flag] = true
+  for flag in isplitn(nginx_conf_flags, ",") do
+    template_env[strip(flag)] = true
   end
 
   local nginx_conf, err = compile_nginx_conf(kong_config, nginx_template)

--- a/kong/conf_loader/parse.lua
+++ b/kong/conf_loader/parse.lua
@@ -18,7 +18,7 @@ local normalize_ip = tools_ip.normalize_ip
 local is_valid_ip_or_cidr = tools_ip.is_valid_ip_or_cidr
 local try_decode_base64 = tools_string.try_decode_base64
 local strip = tools_string.strip
-local split = tools_string.split
+local isplitn = tools_string.isplitn
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 local is_valid_uuid = require("kong.tools.uuid").is_valid_uuid
 
@@ -28,7 +28,6 @@ local pairs = pairs
 local ipairs = ipairs
 local tostring = tostring
 local tonumber = tonumber
-local setmetatable = setmetatable
 local floor = math.floor
 local fmt = string.format
 local find = string.find
@@ -89,13 +88,13 @@ local function parse_value(value, typ)
     value = tonumber(value) -- catch ENV variables (strings) that are numbers
 
   elseif typ == "array" and type(value) == "string" then
-    -- must check type because pl will already convert comma
-    -- separated strings to tables (but not when the arr has
-    -- only one element)
-    value = setmetatable(split(value, ","), nil) -- remove List mt
-
-    for i = 1, #value do
-      value[i] = strip(value[i])
+    local s = value
+    value = {}
+    for v in isplitn(s, ",") do
+      v = strip(v)
+      if v ~= "" then
+        value[#value+1] = v
+      end
     end
   end
 

--- a/kong/observability/tracing/instrumentation.lua
+++ b/kong/observability/tracing/instrumentation.lua
@@ -5,7 +5,6 @@ local tablepool = require "tablepool"
 local tablex = require "pl.tablex"
 local base = require "resty.core.base"
 local cjson = require "cjson"
-local ngx_re = require "ngx.re"
 local tracing_context = require "kong.observability.tracing.tracing_context"
 
 local ngx = ngx
@@ -26,7 +25,7 @@ local tonumber = tonumber
 local setmetatable = setmetatable
 local cjson_encode = cjson.encode
 local _log_prefix = "[tracing] "
-local split = ngx_re.split
+local splitn = require("kong.tools.string").splitn
 local request_id_get = require "kong.observability.tracing.request_id".get
 
 local _M = {}
@@ -83,7 +82,7 @@ function _M.balancer(ctx)
   local span
   local balancer_tries = balancer_data.tries
   local try_count = balancer_data.try_count
-  local upstream_connect_time = split(var.upstream_connect_time, ", ", "jo")
+  local upstream_connect_time = splitn(var.upstream_connect_time, ", ")
 
   local last_try_balancer_span
   do

--- a/kong/observability/tracing/propagation/extractors/aws.lua
+++ b/kong/observability/tracing/propagation/extractors/aws.lua
@@ -1,12 +1,12 @@
 local _EXTRACTOR        = require "kong.observability.tracing.propagation.extractors._base"
 local propagation_utils = require "kong.observability.tracing.propagation.utils"
 
-local split = require "kong.tools.string".split
+local isplitn = require "kong.tools.string".isplitn
+local split_once = require "kong.tools.string".split_once
 local strip = require "kong.tools.string".strip
 
 local from_hex = propagation_utils.from_hex
-local match    = string.match
-local ipairs = ipairs
+local match = string.match
 local type = type
 
 local AWS_KV_PAIR_DELIM = ";"
@@ -45,10 +45,10 @@ function AWS_EXTRACTOR:get_context(headers)
   -- id can be deduced by concatenating the timestamp and uniqueid.
   --
   -- https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
-  for _, key_pair in ipairs(split(aws_header, AWS_KV_PAIR_DELIM)) do
-    local key_pair_list = split(key_pair, AWS_KV_DELIM)
-    local key = strip(key_pair_list[1])
-    local value = strip(key_pair_list[2])
+  for key_pair in isplitn(aws_header, AWS_KV_PAIR_DELIM) do
+    local key, value = split_once(key_pair, AWS_KV_DELIM)
+    key = strip(key)
+    value = strip(value)
 
     if key == AWS_TRACE_ID_KEY then
       local version, timestamp_subset, unique_id_subset = match(value, AWS_TRACE_ID_PATTERN)

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -12,7 +12,7 @@
 
 local buffer = require("string.buffer")
 local errlog = require("ngx.errlog")
-local ngx_re = require("ngx.re")
+local split = require("ngx.re").split
 local inspect = require("inspect")
 local phase_checker = require("kong.pdk.private.phases")
 local constants = require("kong.constants")
@@ -128,7 +128,7 @@ local _MODIFIERS = {
 
 
 local function parse_modifiers(format)
-  local buf, err = ngx_re.split(format, [==[(?<!%)(%[a-z_]+)]==], nil, nil, 0)
+  local buf, err = split(format, [==[(?<!%)(%[a-z_]+)]==], "jo")
   if not buf then
     return nil, "could not parse format: " .. err
   end

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -10,7 +10,7 @@ local get_request_id = require("kong.observability.tracing.request_id").get
 local EMPTY = {}
 
 local isempty = require "table.isempty"
-local split = require("kong.tools.string").split
+local split_once = require("kong.tools.string").split_once
 local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_get_http_version = ngx.req.http_version
@@ -219,7 +219,7 @@ local function aws_serializer(ctx, config)
     local protocol = http_version and 'HTTP/'..http_version or nil
     local httpMethod = var.request_method
     local domainName = var.host
-    local domainPrefix = split(domainName, ".")[1]
+    local domainPrefix = split_once(domainName, ".")
     local identity = {
       sourceIp = var.realip_remote_addr or var.remote_addr,
       userAgent = headers["user-agent"],

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -3,7 +3,7 @@ local openssl_mac = require "resty.openssl.mac"
 
 
 local sha256_base64 = require("kong.tools.sha256").sha256_base64
-local string_split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 
 
 local ngx = ngx
@@ -116,7 +116,7 @@ local function retrieve_hmac_fields(authorization_header)
     if m and #m >= 4 then
       hmac_params.username = m[1]
       hmac_params.algorithm = m[2]
-      hmac_params.hmac_headers = string_split(m[3], " ")
+      hmac_params.hmac_headers = splitn(m[3], " ")
       hmac_params.signature = m[4]
     end
   end

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -12,7 +12,7 @@ local type = type
 local next = next
 local table = table
 local error = error
-local split = require("kong.tools.string").split
+local split_once = require("kong.tools.string").split_once
 local strip = require("kong.tools.string").strip
 local string_find = string.find
 local string_gsub = string.gsub
@@ -453,9 +453,7 @@ local function retrieve_client_credentials(parameters, conf)
     if m and next(m) then
       local decoded_basic = ngx_decode_base64(m[1])
       if decoded_basic then
-        local basic_parts = split(decoded_basic, ":")
-        client_id = basic_parts[1]
-        client_secret = basic_parts[2]
+        client_id, client_secret = split_once(decoded_basic, ":")
       end
     end
 

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -3,7 +3,7 @@ local cache_key   = require "kong.plugins.proxy-cache.cache_key"
 local kong_meta   = require "kong.meta"
 local mime_type   = require "kong.tools.mime_type"
 local nkeys       = require "table.nkeys"
-local split       = require("kong.tools.string").split
+local splitn      = require("kong.tools.string").splitn
 
 
 local ngx              = ngx
@@ -196,12 +196,11 @@ function ProxyCacheHandler:init_worker()
   -- only need one worker to handle purges like this
   -- if/when we introduce inline LRU caching this needs to involve
   -- worker events as well
-  local unpack = unpack
-
   kong.cluster_events:subscribe("proxy-cache:purge", function(data)
     kong.log.err("handling purge of '", data, "'")
 
-    local plugin_id, cache_key = unpack(split(data, ":"))
+    local t = splitn(data, ":", 3)
+    local plugin_id, cache_key = t[1], t[2]
     local plugin, err = kong.db.plugins:select({ id = plugin_id })
     if err then
       kong.log.err("error in retrieving plugins: ", err)

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -12,7 +12,7 @@ local math_max = math.max
 
 
 local strip = kong_string.strip
-local split = kong_string.split
+local splitn = kong_string.splitn
 local pdk_rl_store_response_header = pdk_private_rl.store_response_header
 local pdk_rl_apply_response_headers = pdk_private_rl.apply_response_headers
 
@@ -29,15 +29,15 @@ local function parse_header(header_value, limits)
     if type(header_value) == "table" then
       parts = header_value
     else
-      parts = split(header_value, ",")
+      parts = splitn(header_value, ",")
     end
 
     for _, v in ipairs(parts) do
-      local increment_parts = split(v, "=")
-      if #increment_parts == 2 then
+      local increment_parts, count = splitn(v, "=", 3)
+      if count == 2 then
         local limit_name = strip(increment_parts[1])
         if limits[limit_name] then -- Only if the limit exists
-          increments[strip(increment_parts[1])] = tonumber(strip(increment_parts[2]))
+          increments[limit_name] = tonumber(strip(increment_parts[2]), 10)
         end
       end
     end

--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -1,16 +1,14 @@
 local isempty = require "table.isempty"
 local mime_type = require "kong.tools.mime_type"
-local ngx_re = require "ngx.re"
 
 
 local kong = kong
 local type = type
 local match = string.match
 local noop = function() end
-local ipairs = ipairs
 local parse_mime_type = mime_type.parse_mime_type
 local mime_type_includes = mime_type.includes
-local re_split = ngx_re.split
+local isplitn = require("kong.tools.string").isplitn
 local strip = require("kong.tools.string").strip
 
 
@@ -44,10 +42,9 @@ local function is_json_body(content_type)
   if not content_type then
     return false
   end
-  local content_types = re_split(content_type, ",")
   local expected_media_type = { type = "application", subtype = "json" }
-  for _, content_type in ipairs(content_types) do
-    local t, subtype = parse_mime_type(strip(content_type))
+  for ct in isplitn(content_type, ",") do
+    local t, subtype = parse_mime_type(strip(ct))
     if not t or not subtype then
       goto continue
     end

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -3,15 +3,14 @@ local new_span = require "kong.plugins.zipkin.span".new
 local propagation = require "kong.observability.tracing.propagation"
 local request_tags = require "kong.plugins.zipkin.request_tags"
 local kong_meta = require "kong.meta"
-local ngx_re = require "ngx.re"
 
 
 local ngx = ngx
 local ngx_var = ngx.var
-local split = ngx_re.split
 local subsystem = ngx.config.subsystem
 local fmt = string.format
 local rand_bytes = require("kong.tools.rand").get_rand_bytes
+local splitn = require("kong.tools.string").splitn
 local to_hex = require "resty.string".to_hex
 
 local ZipkinLogHandler = {
@@ -375,7 +374,7 @@ function ZipkinLogHandler:log(conf) -- luacheck: ignore 212
   local balancer_data = ngx_ctx.balancer_data
   if balancer_data then
     local balancer_tries = balancer_data.tries
-    local upstream_connect_time = split(ngx_var.upstream_connect_time, ", ", "jo")
+    local upstream_connect_time = splitn(ngx_var.upstream_connect_time, ", ")
     for i = 1, balancer_data.try_count do
       local try = balancer_tries[i]
       local name = fmt("%s (balancer try %d)", request_span.name, i)

--- a/kong/plugins/zipkin/request_tags.lua
+++ b/kong/plugins/zipkin/request_tags.lua
@@ -8,7 +8,7 @@
 -- Will add two tags to the request span in Zipkin
 
 
-local split = require "kong.tools.string".split
+local isplitn = require("kong.tools.string").isplitn
 
 local match = string.match
 
@@ -18,11 +18,7 @@ local request_tags = {}
 -- note that and errors is an output value; we do this instead of
 -- a return in order to be more efficient (allocate less tables)
 local function parse_tags(tags_string, dest, errors)
-  local items = split(tags_string, ";")
-  local item
-
-  for i = 1, #items do
-    item = items[i]
+  for item in isplitn(tags_string, ";") do
     if item ~= "" then
       local name, value = match(item, "^%s*(%S+)%s*=%s*(.*%S)%s*$")
       if name then

--- a/kong/runloop/events.lua
+++ b/kong/runloop/events.lua
@@ -6,11 +6,10 @@ local wasm         = require "kong.runloop.wasm"
 
 
 local kong         = kong
-local unpack       = unpack
 local ipairs       = ipairs
 local tonumber     = tonumber
 local fmt          = string.format
-local split        = require("kong.tools.string").split
+local splitn       = require("kong.tools.string").splitn
 
 
 local ngx   = ngx
@@ -113,7 +112,8 @@ end
 
 -- cluster event: "balancer:targets"
 local function cluster_balancer_targets_handler(data)
-  local operation, key = unpack(split(data, ":"))
+  local t = splitn(data, ":", 3)
+  local operation, key = t[1], t[2]
 
   local entity = "all"
   if key ~= "all" then
@@ -151,7 +151,8 @@ end
 
 
 local function cluster_balancer_upstreams_handler(data)
-  local operation, ws_id, id, name = unpack(split(data, ":"))
+  local t = splitn(data, ":", 5)
+  local operation, ws_id, id, name = t[1], t[2], t[3], t[4]
   local entity = {
     id = id,
     name = name,

--- a/kong/tools/emmy_debugger.lua
+++ b/kong/tools/emmy_debugger.lua
@@ -1,5 +1,5 @@
 local pl_path = require "pl.path"
-local split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 
 local env_config = {
   debugger = os.getenv("KONG_EMMY_DEBUGGER"),
@@ -64,7 +64,7 @@ local function init(config_)
   local multi_worker = env_config.multi_worker or env_config.multi_worker
 
   env_prefix = config.env_prefix or "KONG"
-  source_path = split(config.source_path or env_config.source_path or "", ":")
+  source_path = splitn(config.source_path or env_config.source_path or "", ":")
 
   if not debugger then
     return

--- a/kong/tools/ip.lua
+++ b/kong/tools/ip.lua
@@ -7,11 +7,11 @@ local ipairs   = ipairs
 local tonumber = tonumber
 local tostring = tostring
 local gsub     = string.gsub
-local sub      = string.sub
 local fmt      = string.format
 local lower    = string.lower
 local find     = string.find
-local split    = require("kong.tools.string").split
+local splitn   = require("kong.tools.string").splitn
+local split_once = require("kong.tools.string").split_once
 
 
 local _M = {}
@@ -30,12 +30,12 @@ end
 
 
 local function split_cidr(cidr, prefixes)
-  local p = find(cidr, "/", 3, true)
-  if not p then
+  local ip, prefix = split_once(cidr, "/")
+  if not ip then
     return
   end
 
-  return sub(cidr, 1, p - 1), prefixes[sub(cidr, p + 1)]
+  return ip, prefixes[prefix]
 end
 
 
@@ -240,9 +240,10 @@ function _M.check_hostname(address)
   -- notes:
   --   - punycode allows prefixed dash, if the characters before the dash are escaped
   --   - FQDN can end in dots
-  for index, segment in ipairs(split(name, ".")) do
+  local t, count = splitn(name, ".")
+  for index, segment in ipairs(t) do
     if segment:match("-$") or segment:match("^%.") or segment:match("%.$") or
-       (segment == "" and index ~= #split(name, ".")) then
+       (segment == "" and index ~= count) then
       return nil, "invalid hostname: " .. address
     end
   end

--- a/spec/01-unit/32-tools_string_spec.lua
+++ b/spec/01-unit/32-tools_string_spec.lua
@@ -1,0 +1,259 @@
+local splitn = require("kong.tools.string").splitn
+local isplitn = require("kong.tools.string").isplitn
+local split_once = require("kong.tools.string").split_once
+local inspect = require "inspect"
+
+
+local it = it
+local same = assert.same
+local equal = assert.equal
+local select = select
+local ipairs = ipairs
+local describe = describe
+
+
+local TEST_MATRIX = {
+  --inp-------pat---max--out------------------------
+  { nil,      nil,  nil, {                      } },
+  { nil,      nil,   -1, {                      } },
+  { nil,      nil,    0, {                      } },
+  { nil,      nil,    1, {                      } },
+  { nil,      nil,    2, {                      } },
+  { nil,      nil,    3, {                      } },
+  --
+  { "",       nil,  nil, { ""                   } },
+  { "",       nil,   -1, {                      } },
+  { "",       nil,    0, {                      } },
+  { "",       nil,    1, { ""                   } },
+  { "",       nil,    2, { ""                   } },
+  { "",       nil,    3, { ""                   } },
+  --
+  { nil,       "",  nil, {                      } },
+  { nil,       "",   -1, {                      } },
+  { nil,       "",    0, {                      } },
+  { nil,       "",    1, {                      } },
+  { nil,       "",    2, {                      } },
+  { nil,       "",    3, {                      } },
+  --
+  { "",        "",  nil, { "", ""               } },
+  { "",        "",   -1, {                      } },
+  { "",        "",    0, {                      } },
+  { "",        "",    1, { ""                   } },
+  { "",        "",    2, { "", ""               } },
+  { "",        "",    3, { "", ""               } },
+  --
+  { "a",      nil,  nil, { "a"                  } },
+  { "a",      nil,   -1, {                      } },
+  { "a",      nil,    0, {                      } },
+  { "a",      nil,    1, { "a"                  } },
+  { "a",      nil,    2, { "a"                  } },
+  { "a",      nil,    3, { "a"                  } },
+  --
+  { "a",       "",  nil, { "", "a", ""          } },
+  { "a",       "",   -1, {                      } },
+  { "a",       "",    0, {                      } },
+  { "a",       "",    1, { "a"                  } },
+  { "a",       "",    2, { "", "a"              } },
+  { "a",       "",    3, { "", "a", ""          } },
+  { "a",       "",    4, { "", "a", ""          } },
+  --
+  { nil,      "a",  nil, {                      } },
+  { nil,      "a",   -1, {                      } },
+  { nil,      "a",    0, {                      } },
+  { nil,      "a",    1, {                      } },
+  { nil,      "a",    2, {                      } },
+  { nil,      "a",    3, {                      } },
+  --
+  { "",       "a",  nil, { ""                   } },
+  { "",       "a",   -1, {                      } },
+  { "",       "a",    0, {                      } },
+  { "",       "a",    1, { ""                   } },
+  { "",       "a",    2, { ""                   } },
+  { "",       "a",    3, { ""                   } },
+  { "",       "a",    4, { ""                   } },
+  --
+  { "ab",     nil,  nil, { "ab"                 } },
+  { "ab",     nil,   -1, {                      } },
+  { "ab",     nil,    0, {                      } },
+  { "ab",     nil,    1, { "ab"                 } },
+  { "ab",     nil,    2, { "ab"                 } },
+  { "ab",     nil,    3, { "ab"                 } },
+  --
+  { "ab",      "", nil, { "", "a", "b", ""      } },
+  { "ab",      "",  -1, {                       } },
+  { "ab",      "",   0, {                       } },
+  { "ab",      "",   1, { "ab"                  } },
+  { "ab",      "",   2, { "", "ab"              } },
+  { "ab",      "",   3, { "", "a", "b"          } },
+  { "ab",      "",   4, { "", "a", "b", ""      } },
+  { "ab",      "",   5, { "", "a", "b", ""      } },
+  --
+  { "abc",    nil, nil, { "abc"                 } },
+  { "abc",    nil,  -1, {                       } },
+  { "abc",    nil,   0, {                       } },
+  { "abc",    nil,   1, { "abc"                 } },
+  { "abc",    nil,   2, { "abc"                 } },
+  { "abc",    nil,   3, { "abc"                 } },
+  --
+  { "abc",     "", nil, { "", "a", "b", "c", "" } },
+  { "abc",     "",  -1, {                       } },
+  { "abc",     "",   0, {                       } },
+  { "abc",     "",   1, { "abc"                 } },
+  { "abc",     "",   2, { "", "abc"             } },
+  { "abc",     "",   3, { "", "a", "bc"         } },
+  { "abc",     "",   4, { "", "a", "b", "c"     } },
+  { "abc",     "",   5, { "", "a", "b", "c", "" } },
+  { "abc",     "",   6, { "", "a", "b", "c", "" } },
+  --
+  { "a,b",    ",", nil, { "a", "b"              } },
+  { "a,b",    ",",  -1, {                       } },
+  { "a,b",    ",",   0, {                       } },
+  { "a,b",    ",",   1, { "a,b"                 } },
+  { "a,b",    ",",   2, { "a", "b"              } },
+  { "a,b",    ",",   3, { "a", "b"              } },
+  --
+  { "a,b,c",  ",", nil, { "a", "b", "c"         } },
+  { "a,b,c",  ",",  -1, {                       } },
+  { "a,b,c",  ",",   0, {                       } },
+  { "a,b,c",  ",",   1, { "a,b,c"               } },
+  { "a,b,c",  ",",   2, { "a", "b,c"            } },
+  { "a,b,c",  ",",   3, { "a", "b", "c"         } },
+  { "a,b,c",  ",",   4, { "a", "b", "c"         } },
+  --
+  { ",b,c",   ",", nil, { "", "b", "c"          } },
+  { ",b,c",   ",",  -1, {                       } },
+  { ",b,c",   ",",   0, {                       } },
+  { ",b,c",   ",",   1, { ",b,c"                } },
+  { ",b,c",   ",",   2, { "", "b,c"             } },
+  { ",b,c",   ",",   3, { "", "b", "c"          } },
+  { ",b,c",   ",",   4, { "", "b", "c"          } },
+  --
+  { "a,b,",   ",", nil, { "a", "b", ""          } },
+  { "a,b,",   ",",  -1, {                       } },
+  { "a,b,",   ",",   0, {                       } },
+  { "a,b,",   ",",   1, { "a,b,"                } },
+  { "a,b,",   ",",   2, { "a", "b,"             } },
+  { "a,b,",   ",",   3, { "a", "b", ""          } },
+  { "a,b,",   ",",   4, { "a", "b", ""          } },
+  --
+  { ",b,",    ",", nil, { "", "b", ""           } },
+  { ",b,",    ",",  -1, {                       } },
+  { ",b,",    ",",   0, {                       } },
+  { ",b,",    ",",   1, { ",b,"                 } },
+  { ",b,",    ",",   2, { "", "b,"              } },
+  { ",b,",    ",",   3, { "", "b", ""           } },
+  { ",b,",    ",",   4, { "", "b", ""           } },
+  --
+  { "////",  "//", nil, { "", "", ""            } },
+  { "////",  "//",  -1, {                       } },
+  { "////",  "//",   0, {                       } },
+  { "////",  "//",   1, { "////"                } },
+  { "////",  "//",   2, { "", "//"              } },
+  { "////",  "//",   3, { "", "", ""            } },
+  { "////",  "//",   4, { "", "", ""            } },
+}
+
+
+local function fn(f, ...)
+  local c = select("#", ...)
+  local m = f .. "("
+  for i = 1, c do
+    local v = inspect((select(i, ...)))
+    m = m .. (i > 1 and ", " .. v or v)
+  end
+  return m  .. ")"
+end
+
+
+describe("kong.tools.string:", function()
+  for _, t in ipairs(TEST_MATRIX) do
+    local test = fn("splitn", t[1], t[2], t[3])
+    it(test, function()
+      local r, c = splitn(t[1], t[2], t[3])
+      same(t[4], r, test)
+      equal(#t[4], c, test)
+    end)
+  end
+  it("splitn (long string special cases)", function()
+    local v = ("abcdefghij"):rep(10) .. "a" -- 101 chars in total
+    local r, c = splitn(v, nil, nil)
+    same({ v }, r)
+    equal(1, #r)
+    equal(1, c)
+    local r, c = splitn(v, "", nil)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("j",   r[101])
+    equal("a",   r[102])
+    equal("",    r[103])
+    equal(nil,   r[104])
+    equal(103,   c)
+    local r, c = splitn(v, "", 100)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("h",   r[99])
+    equal("ija", r[100])
+    equal(nil,   r[101])
+    equal(100,   c)
+    local r, c = splitn(v, "", 101)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("ja",  r[101])
+    equal(nil,   r[102])
+    equal(101,   c)
+    local r, c = splitn(v, "", 102)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("j",   r[101])
+    equal("a",   r[102])
+    equal(nil,   r[103])
+    equal(102,   c)
+    local r, c = splitn(v, "", 103)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("j",   r[101])
+    equal("a",   r[102])
+    equal("",    r[103])
+    equal(nil,   r[104])
+    equal(103,   c)
+    local r, c = splitn(v, "", 104)
+    equal(nil,   r[0])
+    equal("",    r[1])
+    equal("a",   r[2])
+    equal("j",   r[101])
+    equal("a",   r[102])
+    equal("",    r[103])
+    equal(nil,   r[104])
+    equal(103,   c)
+  end)
+  for _, t in ipairs(TEST_MATRIX) do
+    local r, c = splitn(t[1], t[2], t[3])
+    local test = fn("isplitn", t[1], t[2], t[3])
+    it(test, function()
+      local i = 0
+      for v in isplitn(t[1], t[2], t[3]) do
+        i =  i + 1
+        equal(r[i], v, test)
+      end
+      equal(c, i, test)
+    end)
+  end
+  for _, t in ipairs(TEST_MATRIX) do
+    if t[3] ~= 2 then
+      goto continue
+    end
+    local r = splitn(t[1], t[2], t[3])
+    local test = fn("split_once", t[1], t[2])
+    it(test, function()
+      local k, v = split_once(t[1], t[2])
+      equal(r[1], k, test)
+      equal(r[2], v, test)
+    end)
+::continue::
+  end
+end)

--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -1,8 +1,8 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local tablex = require "pl.tablex"
-local stringx = require "pl.stringx"
 local constants = require "kong.constants"
+local isplitn = require("kong.tools.string").isplitn
 local utils = require "spec.helpers.perf.utils"
 
 local NON_BUDLED_PLUGINS = {}
@@ -45,8 +45,7 @@ describe("Plugins conf property" , function()
       local bundled_plugins_list = json.plugins.available_on_server
       local rocks_installed_plugins, err = utils.execute([[luarocks show kong | grep -oP 'kong\.plugins\.\K([\w-]+)' | uniq]])
       assert.is_nil(err)
-      local rocks_installed_plugins_list = stringx.split(rocks_installed_plugins, "\n")
-      for _, plugin in ipairs(rocks_installed_plugins_list) do
+      for plugin in isplitn(rocks_installed_plugins, "\n") do
         if not NON_BUDLED_PLUGINS[plugin] then
           assert(bundled_plugins_list[plugin] ~= nil,
                  "Found installed plugin not in bundled list: " ..
@@ -202,4 +201,3 @@ describe("Plugins conf property" , function()
     end)
   end)
 end)
-

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -4,7 +4,7 @@ local cjson      = require "cjson"
 
 
 local strip = require("kong.tools.string").strip
-local split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 
 
 for _, strategy in helpers.each_strategy() do
@@ -210,10 +210,10 @@ for _, strategy in helpers.each_strategy() do
           local _, _, stdout = assert(helpers.execute("sudo find /var/log -type f -mmin -5 | grep syslog"))
           assert.True(#stdout > 0)
 
-          local files = split(stdout, "\n")
-          assert.True(#files > 0)
+          local files, count = splitn(stdout, "\n")
+          assert.True(count > 0)
 
-          if files[#files] == "" then
+          if files[count] == "" then
             table.remove(files)
           end
 

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
-local stringx = require "pl.stringx"
+local splitn = require("kong.tools.string").splitn
 
 
 describe("Plugin: datadog (log)", function()
@@ -544,8 +544,7 @@ describe("Plugin: datadog (log)", function()
 
         for _, g in ipairs(gauges) do
           -- tags start with `#`
-          local tmp = stringx.split(g, '#')
-          local tag_idx = #tmp
+          local tmp, tag_idx = splitn(g, '#')
           assert(tag_idx == 2, "Error: missing tags")
           local tags = tmp[tag_idx]
           assert(tags, "Error: missing tags")

--- a/spec/03-plugins/30-session/01-access_spec.lua
+++ b/spec/03-plugins/30-session/01-access_spec.lua
@@ -2,7 +2,7 @@ local constants = require "kong.constants"
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local lower = string.lower
-local split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 
 local REMEMBER_ROLLING_TIMEOUT = 3600
 
@@ -196,14 +196,14 @@ for _, strategy in helpers.each_strategy() do
         client:close()
 
         local cookie = assert.response(res).has.header("Set-Cookie")
-        local cookie_name = split(cookie, "=")[1]
+        local cookie_name = splitn(cookie, "=", 2)[1]
         assert.equal("session", cookie_name)
 
         -- e.g. ["Set-Cookie"] =
         --    "da_cookie=m1EL96jlDyQztslA4_6GI20eVuCmsfOtd6Y3lSo4BTY|15434724
         --    06|U5W4A6VXhvqvBSf4G_v0-Q|DFJMMSR1HbleOSko25kctHZ44oo; Path=/
         --    ; SameSite=Lax; Secure; HttpOnly"
-        local cookie_parts = split(cookie, "; ")
+        local cookie_parts = splitn(cookie, "; ")
         assert.equal("SameSite=Strict", cookie_parts[3])
         assert.equal("Secure", cookie_parts[4])
         assert.equal("HttpOnly", cookie_parts[5])
@@ -231,9 +231,9 @@ for _, strategy in helpers.each_strategy() do
         client:close()
 
         cookie = assert.response(res).has.header("Set-Cookie")
-        assert.equal("da_cookie", split(cookie, "=")[1])
+        assert.equal("da_cookie", splitn(cookie, "=", 2)[1])
 
-        local cookie_parts = split(cookie, "; ")
+        local cookie_parts = splitn(cookie, "; ")
         assert.equal("SameSite=Lax", cookie_parts[3])
         assert.equal(nil, cookie_parts[4])
         assert.equal(nil, cookie_parts[5])
@@ -261,14 +261,14 @@ for _, strategy in helpers.each_strategy() do
         client:close()
 
         local cookie = assert.response(res).has.header("Set-Cookie")
-        local cookie_name = split(cookie[1], "=")[1]
+        local cookie_name = splitn(cookie[1], "=", 2)[1]
         assert.equal("session", cookie_name)
 
         -- e.g. ["Set-Cookie"] =
         --    "session=m1EL96jlDyQztslA4_6GI20eVuCmsfOtd6Y3lSo4BTY|15434724
         --    06|U5W4A6VXhvqvBSf4G_v0-Q|DFJMMSR1HbleOSko25kctHZ44oo; Expires=Mon, 06 Jun 2022 08:30:27 GMT;
         --    Max-Age=3600; Path=/; SameSite=Lax; Secure; HttpOnly"
-        local cookie_parts = split(cookie[2], "; ")
+        local cookie_parts = splitn(cookie[2], "; ")
         print(cookie[2])
         assert.equal("Path=/", cookie_parts[2])
         assert.equal("SameSite=Strict", cookie_parts[3])

--- a/spec/04-perf/01-rps/01-simple_spec.lua
+++ b/spec/04-perf/01-rps/01-simple_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.use_defaults()
@@ -8,7 +8,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30

--- a/spec/04-perf/01-rps/02-balancer_spec.lua
+++ b/spec/04-perf/01-rps/02-balancer_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.use_defaults()
@@ -8,7 +8,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30

--- a/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.use_defaults()
@@ -8,7 +8,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30

--- a/spec/04-perf/01-rps/04-simple_hybrid_spec.lua
+++ b/spec/04-perf/01-rps/04-simple_hybrid_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.use_defaults()
@@ -8,7 +8,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 30

--- a/spec/04-perf/01-rps/05-prometheus.lua
+++ b/spec/04-perf/01-rps/05-prometheus.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.use_defaults()
@@ -8,7 +8,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 30

--- a/spec/04-perf/01-rps/06-core_entities_crud_spec.lua
+++ b/spec/04-perf/01-rps/06-core_entities_crud_spec.lua
@@ -1,5 +1,5 @@
 local perf = require "spec.helpers.perf"
-local split = require "ngx.re".split
+local splitn = require("kong.tools.string").splitn
 local utils = require "spec.helpers.perf.utils"
 local workspaces = require "kong.workspaces"
 local stringx = require "pl.stringx"
@@ -31,7 +31,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local REPEAT_PER_TEST = 0

--- a/spec/04-perf/01-rps/07-upstream_lock_regression_spec.lua
+++ b/spec/04-perf/01-rps/07-upstream_lock_regression_spec.lua
@@ -1,6 +1,6 @@
 local shell = require "resty.shell"
 local perf = require "spec.helpers.perf"
-local split = require "pl.stringx".split
+local splitn = require("kong.tools.string").splitn
 local utils = require "spec.helpers.perf.utils"
 local workspaces = require "kong.workspaces"
 local charts = require "spec.helpers.perf.charts"
@@ -19,7 +19,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 60

--- a/spec/04-perf/02-flamegraph/01-simple_spec.lua
+++ b/spec/04-perf/02-flamegraph/01-simple_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 local shell = require "resty.shell"
 
@@ -10,7 +10,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 180

--- a/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 
 perf.enable_charts(false) -- don't generate charts, we need flamegraphs only
@@ -9,7 +9,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 180

--- a/spec/04-perf/02-flamegraph/05-prometheus.lua
+++ b/spec/04-perf/02-flamegraph/05-prometheus.lua
@@ -1,5 +1,5 @@
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 local shell = require "resty.shell"
 
@@ -10,7 +10,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 180

--- a/spec/04-perf/02-flamegraph/07-upstream_lock_regression_spec.lua
+++ b/spec/04-perf/02-flamegraph/07-upstream_lock_regression_spec.lua
@@ -1,6 +1,6 @@
 local shell = require "resty.shell"
 local perf = require("spec.helpers.perf")
-local split = require("pl.stringx").split
+local splitn = require("kong.tools.string").splitn
 local utils = require("spec.helpers.perf.utils")
 local workspaces = require "kong.workspaces"
 local fmt = string.format
@@ -15,7 +15,7 @@ local versions = {}
 
 local env_versions = os.getenv("PERF_TEST_VERSIONS")
 if env_versions then
-  versions = split(env_versions, ",")
+  versions = splitn(env_versions, ",")
 end
 
 local LOAD_DURATION = 180

--- a/spec/fixtures/forward-proxy-server.lua
+++ b/spec/fixtures/forward-proxy-server.lua
@@ -1,6 +1,6 @@
 local _M = {}
 
-local split = require("kong.tools.string").split
+local splitn = require("kong.tools.string").splitn
 
 local header_mt = {
   __index = function(self, name)
@@ -28,12 +28,14 @@ function _M.connect(opts)
   local req_line = req_sock:receive()
   ngx.log(ngx.DEBUG, "request line: ", req_line)
 
-  local method, host_port = unpack(split(req_line, " "))
+  local t = splitn(req_line, " ", 3)
+  local method, host_port = t[1], t[2]
   if method ~= "CONNECT" then
     return ngx.exit(400)
   end
 
-  local upstream_host, upstream_port = unpack(split(host_port, ":"))
+  t = splitn(host_port, ":", 3)
+  local upstream_host, upstream_port = t[1], t[2]
 
   local headers = new_headers()
 


### PR DESCRIPTION
### Summary

On my testing the `splitn` implemented here is about 10x faster than the Penlight's `stringx.split`.

```
  splitn:  193 ms (new function)
 isplitn:  379 ms (iterator over splitn)
   split: 1638 ms (penlight and kong.tools.string.split as it is alias to penlight)
re.split: 1072 ms (ngx.re)
```

I also tested implementing `isplit` iterator without `splitn` and table allocation, but in my testing that didn't yield better performance.

Microbenchmark (yes, all of them are fast and they may do slightly different splits, but one is clearly the fastest):
```lua
local monotonic_msec = require("resty.core.time").monotonic_msec
local collectgarbage = collectgarbage
local update_time = ngx.update_time
local split1 = require("kong.tools.string").splitn
local split2 = require("kong.tools.string").split
local split3 = require("ngx.re").split
local sleep = ngx.sleep
local print = print

local TEST_SET = {
  "",
  ",",
  ",,",
  "a,,b",
  "a,b,c",
  "cat dog,fish bowl,qwerty,jack,,dog,mermaid,placeholderplaceholderplaceholderplaceholderplaceholderplaceholderplaceholder,wc",
  "cat dog,fish bowl,qwerty,jack,,dog,mermaid,placeholderplaceholderplaceholderplaceholderplaceholderplaceholderplaceholder,wc, 234",
}

local TEST_COUNT = #TEST_SET
local ITERATIONS = 1000000

local s, e
for _ = 1, 2 do
  collectgarbage()
  collectgarbage()
  collectgarbage()

  sleep(1)

  update_time()
  s = monotonic_msec()
  for _ = 1, ITERATIONS do
    for j = 1, TEST_COUNT do
      local _ = split1(TEST_SET[j], ",")
    end
  end
  update_time()
  e = monotonic_msec()
  print("  splitn: ", e - s, " ms")

  collectgarbage()
  collectgarbage()
  collectgarbage()

  sleep(1)

  update_time()
  s = monotonic_msec()
  for _ = 1, ITERATIONS do
    for j = 1, TEST_COUNT do
      local _ = split2(TEST_SET[j], ",")
    end
  end
  update_time()
  e = monotonic_msec()
  print("   split: ", e - s, " ms")

  collectgarbage()
  collectgarbage()
  collectgarbage()

  sleep(1)

  update_time()
  s = monotonic_msec()
  for _ = 1, ITERATIONS do
    for j = 1, TEST_COUNT do
      local _ = split3(TEST_SET[j], ",", "jo")
    end
  end
  update_time()
  e = monotonic_msec()
  print("re.split: ", e - s, " ms")
end
```

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-6825