### PR TITLE
Update @return values of basic-auth.access:retrieve_credentials

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -26,8 +26,8 @@ local _M = {}
 --
 -- @param request ngx request object
 -- @param {table} conf Plugin config
--- @return {string} public_key
--- @return {string} private_key
+-- @return {string} username
+-- @return {string} password
 local function retrieve_credentials(header_name, conf, header)
   local username, password
   local authorization_header = header or kong.request.get_header(header_name)


### PR DESCRIPTION
Update the docblock of basic-auth.access:retrieve_credentials to reflect the username and password values returned.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
