### PR TITLE
Update docblocks' return types in client.lua

### DIFF
--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -43,7 +43,7 @@ local function new(self)
   --
   -- @function kong.client.get_ip
   -- @phases certificate, rewrite, access, header_filter, response, body_filter, log
-  -- @treturn string The remote IP address of the client making the request.
+  -- @return string The remote IP address of the client making the request.
   -- @usage
   -- -- Given a client with IP 127.0.0.1 making connection through
   -- -- a load balancer with IP 10.0.0.1 to Kong answering the request for
@@ -76,7 +76,7 @@ local function new(self)
   --
   -- @function kong.client.get_forwarded_ip
   -- @phases certificate, rewrite, access, header_filter, response, body_filter, log
-  -- @treturn string The remote IP address of the client making the request,
+  -- @return string The remote IP address of the client making the request,
   -- considering forwarded addresses.
   --
   -- @usage
@@ -103,7 +103,7 @@ local function new(self)
   -- returns the load balancer's port, and **not** that of the downstream client.
   -- @function kong.client.get_port
   -- @phases certificate, rewrite, access, header_filter, response, body_filter, log
-  -- @treturn number The remote client port.
+  -- @return number The remote client port.
   -- @usage
   -- -- [client]:40000 <-> 80:[balancer]:30000 <-> 80:[kong]:20000 <-> 80:[service]
   -- kong.client.get_port() -- 30000
@@ -132,7 +132,7 @@ local function new(self)
   -- * [real\_ip\_recursive](https://docs.konghq.com/gateway/latest/reference/configuration/#real_ip_recursive)
   -- @function kong.client.get_forwarded_port
   -- @phases certificate, rewrite, access, header_filter, response, body_filter, log
-  -- @treturn number The remote client port, considering forwarded ports.
+  -- @return number The remote client port, considering forwarded ports.
   -- @usage
   -- -- [client]:40000 <-> 80:[balancer]:30000 <-> 80:[kong]:20000 <-> 80:[service]
   -- kong.client.get_forwarded_port() -- 40000
@@ -152,7 +152,7 @@ local function new(self)
   -- If not set yet, it returns `nil`.
   -- @function kong.client.get_credential
   -- @phases access, header_filter, response, body_filter, log
-  -- @treturn string The authenticated credential.
+  -- @treturn table|nil The authenticated credential (consumer_id, id, and username) or `nil`.
   -- @usage
   -- local credential = kong.client.get_credential()
   -- if credential then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

I found it confusing that the [kong.client](https://docs.konghq.com/gateway/3.10.x/plugin-development/pdk/kong.client/) documentation said `kong.client.get_credential()` returns a string, but the `@treturn` and example usage indicate that in fact a table is returned.  While I was in there, I saw other places where return values seem to have been mis-documented the other way around - where `@treturn` was indicated, but the return values were actually string.

I am not sure of all of the table items returned from get_credential(), but from what I can tell it is just id, consumer_id, and username. I need someone to confirm if that is all.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - (N/A - this PR handles the auto-generated PDK docs)
- [ ] Somebody besides @steveoliver confirms the items returned from `ngx.ctx.authenticated_credential`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
