### PR TITLE
Add support for EKS IRSA authentication to the LLM Bedrock driver

### DIFF
--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -322,6 +322,12 @@ _M.cloud_identity_function = function(this_cache, plugin_config)
       }
 
       aws.config.credentials = creds
+    elseif aws_config.global.AWS_WEB_IDENTITY_TOKEN_FILE 
+      and aws_config.global.AWS_ROLE_ARN then
+      -- Support for EKS IRSA (IAM Roles for Service Accounts)
+      local creds = aws:TokenFileWebIdentityCredentials()
+
+      aws.config.credentials = creds
     end
 
     this_cache[plugin_config] = { interface = aws, error = nil }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Add support for EKS IRSA authentication to the LLM Bedrock driver without access key id and secret key

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
