### PR TITLE
docs(kong.conf) cluster_dp_labels: remove restriction for Konnect

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -374,11 +374,6 @@
                                  # Each label must be configured as a string in the
                                  # format `key:value`.
                                  #
-                                 # Labels are only compatible with hybrid mode
-                                 # deployments with Kong Konnect (SaaS).
-                                 # This configuration doesn't work with
-                                 # self-hosted deployments.
-                                 #
                                  # Keys and values follow the AIP standards:
                                  # https://kong-aip.netlify.app/aip/129/
                                  #


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Removing the Konnect-only limitation for cluster_dp_labels. 
This feature is not limited to Konnect as of Gateway 3.5, according to issue reporter.

Fixes https://konghq.atlassian.net/browse/DOCU-4213.

### Checklist

- [ N/A  ] The Pull Request has tests
- [ N/A ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ N/A ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - Not necessary, this is automated.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
