### PR TITLE
chore(lint): fix some helpers-outside-of-setup warnings

### DIFF
--- a/.ci/ast-grep/rules/helpers-outside-of-setup.yml
+++ b/.ci/ast-grep/rules/helpers-outside-of-setup.yml
@@ -69,6 +69,29 @@ utils:
         - pattern: before_each($$$)
         - pattern: after_each($$$)
 
+  in-upgrade-helper-setup:
+    pattern: $IDENT.setup($$$)
+    inside:
+      kind: chunk
+      stopBy: end
+      has:
+        any:
+          - pattern: $IDENT = require "spec.upgrade_helpers"
+          - pattern: $IDENT = require("spec.upgrade_helpers")
+        stopBy: end
+
+  in-function-scope:
+    any:
+      # local function my_setup()
+      #   helpers.get_available_port()
+      # end
+      - kind: function_declaration
+
+      # local my_setup = function()
+      #   helpers.get_available_port()
+      # end
+      - pattern: $IDENT = function($$$) $$$ end
+
   busted-describe:
     inside:
       kind: function_call
@@ -77,7 +100,8 @@ utils:
         any:
           - matches: busted-test-case
           - matches: busted-lifecycle
-          - kind: function_declaration
+          - matches: in-function-scope
+          - matches: in-upgrade-helper-setup
 
   non-setup-scope:
     any:

--- a/.ci/ast-grep/tests/__snapshots__/helpers-outside-of-setup-snapshot.yml
+++ b/.ci/ast-grep/tests/__snapshots__/helpers-outside-of-setup-snapshot.yml
@@ -1,6 +1,46 @@
 id: helpers-outside-of-setup
 snapshots:
   ? |
+    describe("my test", function()
+      for , strategy in helpers.each_strategy() do
+        local a = 123
+        local port = helpers.get_available_port()
+      end
+    end)
+  : labels:
+    - source: helpers.get_available_port()
+      style: primary
+      start: 113
+      end: 141
+    - source: |-
+        describe("my test", function()
+          for , strategy in helpers.each_strategy() do
+            local a = 123
+            local port = helpers.get_available_port()
+          end
+        end)
+      style: secondary
+      start: 0
+      end: 152
+  ? |
+    describe("my test", function()
+      local a = 123
+      local port = helpers.get_available_port()
+    end)
+  : labels:
+    - source: helpers.get_available_port()
+      style: primary
+      start: 62
+      end: 90
+    - source: |-
+        describe("my test", function()
+          local a = 123
+          local port = helpers.get_available_port()
+        end)
+      style: secondary
+      start: 0
+      end: 95
+  ? |
     describe(function()
       local a = 123
       local port = helpers.get_available_port()
@@ -18,6 +58,20 @@ snapshots:
       style: secondary
       start: 0
       end: 84
+  ? |
+    for , strategy in helpers.each_strategy() do
+      local a = 123
+      local port = helpers.get_available_port()
+
+      describe("my test", function()
+        -- ...
+      end)
+    end
+  : labels:
+    - source: helpers.get_available_port()
+      style: primary
+      start: 76
+      end: 104
   ? |
     for , strategy in helpers.each_strategy() do
       local a = 123

--- a/.ci/ast-grep/tests/helpers-outside-of-setup-test.yml
+++ b/.ci/ast-grep/tests/helpers-outside-of-setup-test.yml
@@ -22,6 +22,88 @@ valid:
       local port = helpers.get_available_port()
     end)
 
+  # inside a local function (declaration)
+  - |
+    describe("foo", function()
+      local port
+
+      local function my_setup()
+        port = helpers.get_available_port()
+      end
+
+      local function my_setup_with_opts(opts)
+        port = helpers.get_available_port()
+      end
+
+      lazy_setup(function()
+        my_setup()
+        my_setup_with_opts({})
+      end)
+    end)
+
+  # inside a local function (declaration + assignment)
+  - |
+    describe("foo", function()
+      local port
+
+      local my_setup = function()
+        port = helpers.get_available_port()
+      end
+
+      local my_setup_with_opts = function(opts)
+        port = helpers.get_available_port()
+      end
+
+      lazy_setup(function()
+        my_setup()
+        my_setup_with_opts({})
+      end)
+    end)
+
+  # inside a non-local function (declaration + assignment)
+  - |
+    local my_setup, my_setup_with_opts
+
+    describe("foo", function()
+      local port
+
+      my_setup = function()
+        port = helpers.get_available_port()
+      end
+
+      my_setup_with_opts = function(opts)
+        port = helpers.get_available_port()
+      end
+
+      lazy_setup(function()
+        my_setup()
+        my_setup_with_opts({})
+      end)
+    end)
+
+  # inside require"spec.upgrade_helpers".setup
+  - |
+    local uh = require "spec.upgrade_helpers"
+
+    describe("my test", function()
+      local port
+
+      uh.setup(function()
+        port = helpers.get_available_port()
+      end)
+    end)
+
+  # inside require("spec.upgrade_helpers").setup
+  - |
+    local uh = require("spec.upgrade_helpers")
+
+    describe("my test", function()
+      local port
+
+      uh.setup(function()
+        port = helpers.get_available_port()
+      end)
+    end)
 
 invalid:
   # at the outermost scope
@@ -34,12 +116,31 @@ invalid:
     for , strategy in helpers.each_strategy() do
       local a = 123
       local port = helpers.get_available_port()
+
+      describe("my test", function()
+        -- ...
+      end)
     end
 
-  # directly inside `describe()`
+  # inside describe() inside some iterator
+  - |
+    describe("my test", function()
+      for , strategy in helpers.each_strategy() do
+        local a = 123
+        local port = helpers.get_available_port()
+      end
+    end)
+
+  # directly inside `describe()` (no label)
   - |
     describe(function()
       local a = 123
       local port = helpers.get_available_port()
     end)
 
+  # directly inside `describe()` (with label)
+  - |
+    describe("my test", function()
+      local a = 123
+      local port = helpers.get_available_port()
+    end)

--- a/spec/02-integration/02-cmd/17-drain_spec.lua
+++ b/spec/02-integration/02-cmd/17-drain_spec.lua
@@ -1,7 +1,6 @@
 local helpers = require "spec.helpers"
 local http = require "resty.http"
 
-local cp_status_port = helpers.get_available_port()
 local dp_status_port = 8100
 
 local function get_status_no_ssl_verify()
@@ -157,17 +156,21 @@ end
 
 for _, strategy in helpers.each_strategy({"postgres"}) do
   describe("kong drain in hybrid mode #" .. strategy, function()
-    local bp = helpers.get_db_utils(strategy, {
-      "services",
-    })
-
-    -- insert some data to make sure the control plane is ready and send the configuration to dp
-    -- so that `current_hash` of dp wouldn't be DECLARATIVE_EMPTY_CONFIG_HASH, so that dp would be ready
-    assert(bp.services:insert {
-      name = "example",
-    })
+    local cp_status_port
 
     lazy_setup(function()
+      cp_status_port = helpers.get_available_port()
+
+      local bp = helpers.get_db_utils(strategy, {
+        "services",
+      })
+
+      -- insert some data to make sure the control plane is ready and send the configuration to dp
+      -- so that `current_hash` of dp wouldn't be DECLARATIVE_EMPTY_CONFIG_HASH, so that dp would be ready
+      assert(bp.services:insert {
+        name = "example",
+      })
+
       assert(helpers.start_kong({
         role = "data_plane",
         database = "off",

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -13,25 +13,7 @@ local function get_cert(server_name)
   return stdout
 end
 
-local mock_tls_server_port = helpers.get_available_port()
-
-local fixtures = {
-  http_mock = {
-    test_upstream_tls_server = fmt([[
-      server {
-          server_name example2.com;
-          listen %s ssl;
-
-          ssl_certificate        ../spec/fixtures/mtls_certs/example2.com.crt;
-          ssl_certificate_key    ../spec/fixtures/mtls_certs/example2.com.key;
-
-          location = / {
-              echo 'it works';
-          }
-      }
-    ]], mock_tls_server_port)
-  },
-}
+local fixtures = {}
 
 local function reload_router(flavor)
   helpers = require("spec.internal.module").reload_helpers(flavor)
@@ -59,6 +41,24 @@ for _, strategy in helpers.each_strategy() do
     reload_router(flavor)
 
     lazy_setup(function()
+      local mock_tls_server_port = helpers.get_available_port()
+
+      fixtures.http_mock = {
+        test_upstream_tls_server = fmt([[
+          server {
+              server_name example2.com;
+              listen %s ssl;
+
+              ssl_certificate        ../spec/fixtures/mtls_certs/example2.com.crt;
+              ssl_certificate_key    ../spec/fixtures/mtls_certs/example2.com.key;
+
+              location = / {
+                  echo 'it works';
+              }
+          }
+        ]], mock_tls_server_port)
+      }
+
       local bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -3,9 +3,9 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy() do
 describe("Proxy error handlers", function()
   local proxy_client
-  helpers.get_db_utils(strategy, {})
 
   lazy_setup(function()
+    helpers.get_db_utils(strategy, {})
     assert(helpers.start_kong {
       nginx_conf = "spec/fixtures/custom_nginx.template",
     })

--- a/spec/02-integration/05-proxy/24-buffered_spec.lua
+++ b/spec/02-integration/05-proxy/24-buffered_spec.lua
@@ -3,7 +3,6 @@ local cjson   = require "cjson"
 local http_mock = require "spec.helpers.http_mock"
 
 local md5 = ngx.md5
-local TCP_PORT = helpers.get_available_port()
 
 
 for _, client_protocol in ipairs({ "http", "https", "http2" }) do
@@ -14,9 +13,13 @@ for _, strategy in helpers.each_strategy() do
     -- ngx.location.capture that buffered proxying uses
 
     describe("[http]", function()
+      local TCP_PORT
       local proxy_client
       local proxy_ssl_client
+
       lazy_setup(function()
+        TCP_PORT = helpers.get_available_port()
+
         local bp = helpers.get_db_utils(strategy, {
           "routes",
           "services",

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -176,13 +176,16 @@ for _, strategy in helpers.each_strategy() do
   describe("#db Status API DB-mode [#" .. strategy .. "#] with DB down", function()
     local custom_prefix = helpers.test_conf.prefix.."2"
 
-    local status_api_port = helpers.get_available_port()
-    local stream_proxy_port = helpers.get_available_port()
+    local status_api_port
+    local stream_proxy_port
 
     local bp
     local status_client
 
     lazy_setup(function()
+      status_api_port = helpers.get_available_port()
+      stream_proxy_port = helpers.get_available_port()
+
       bp = helpers.get_db_utils(strategy, nil, {'prometheus'})
 
       local db_service = bp.services:insert{

--- a/spec/02-integration/09-hybrid_mode/11-status_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/11-status_spec.lua
@@ -1,17 +1,20 @@
 -- 09-hybrid_mode/11-status_ready.lua
 local helpers = require "spec.helpers"
 
-local cp_status_port = helpers.get_available_port()
-local dp_status_port = 8100
-
 for _, v in ipairs({ {"off", "off"}, {"on", "off"}, {"on", "on"}, }) do
   local rpc, rpc_sync = v[1], v[2]
 
 for _, strategy in helpers.each_strategy() do
 
   describe("Hybrid Mode - status ready #" .. strategy .. " rpc_sync=" .. rpc_sync, function()
+    local cp_status_port
+    local dp_status_port
 
-    helpers.get_db_utils(strategy, {})
+    lazy_setup(function()
+      cp_status_port = helpers.get_available_port()
+      dp_status_port = helpers.get_available_port()
+      helpers.get_db_utils(strategy, {})
+    end)
 
     local function start_kong_dp()
       return helpers.start_kong({

--- a/spec/02-integration/14-observability/03-tracer-pdk_spec.lua
+++ b/spec/02-integration/14-observability/03-tracer-pdk_spec.lua
@@ -3,7 +3,6 @@ local cjson   = require "cjson"
 local join    = require "pl.stringx".join
 
 
-local TCP_PORT = helpers.get_available_port()
 local tcp_trace_plugin_name = "tcp-trace-exporter"
 
 
@@ -19,6 +18,11 @@ for _, strategy in helpers.each_strategy() do
   local proxy_client
 
   describe("tracer pdk spec #" .. strategy, function()
+    local TCP_PORT
+
+    lazy_setup(function()
+      TCP_PORT = helpers.get_available_port()
+    end)
 
     local function setup_instrumentations(types, custom_spans, sampling_rate)
       local bp, _ = assert(helpers.get_db_utils(strategy, {

--- a/spec/02-integration/14-observability/06-telemetry-pdk_spec.lua
+++ b/spec/02-integration/14-observability/06-telemetry-pdk_spec.lua
@@ -1,13 +1,15 @@
 local helpers = require "spec.helpers"
 local pb = require "pb"
 
-local HTTP_SERVER_PORT_LOGS = helpers.get_available_port()
-
-
 for _, strategy in helpers.each_strategy() do
   describe("kong.pdk.telemetry #" .. strategy, function()
     local bp
     local plugin_instance_name = "my-pdk-logger-instance"
+    local HTTP_SERVER_PORT_LOGS
+
+    lazy_setup(function()
+      HTTP_SERVER_PORT_LOGS = helpers.get_available_port()
+    end)
 
     describe("log", function()
       describe("with OpenTelemetry", function()

--- a/spec/02-integration/16-queues/01-shutdown_spec.lua
+++ b/spec/02-integration/16-queues/01-shutdown_spec.lua
@@ -1,14 +1,14 @@
 local helpers    = require "spec.helpers"
 local http_mock = require "spec.helpers.http_mock"
 
-local HTTP_SERVER_PORT = helpers.get_available_port()
-
-
 for _, strategy in helpers.each_strategy() do
   describe("queue graceful shutdown [#" .. strategy .. "]", function()
     local proxy_client
+    local HTTP_SERVER_PORT
 
     lazy_setup(function()
+      HTTP_SERVER_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",

--- a/spec/02-integration/22-ai_plugins/01-reports_spec.lua
+++ b/spec/02-integration/22-ai_plugins/01-reports_spec.lua
@@ -4,7 +4,6 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.each_strategy() do
   local admin_client
@@ -12,6 +11,8 @@ for _, strategy in helpers.each_strategy() do
   local reports_server
 
   describe("anonymous reports for ai plugins #" .. strategy, function()
+    local MOCK_PORT
+
     local reports_send_ping = function(port)
       assert.eventually(function()
         admin_client = helpers.admin_client()
@@ -23,6 +24,8 @@ for _, strategy in helpers.each_strategy() do
     end
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       dns_hostsfile = assert(os.tmpname() .. ".hosts")
       local fd = assert(io.open(dns_hostsfile, "w"))
       assert(fd:write("127.0.0.1 " .. constants.REPORTS.ADDRESS))

--- a/spec/03-plugins/25-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/25-oauth2/01-schema_spec.lua
@@ -9,18 +9,24 @@ local fmt = string.format
 for _, strategy in helpers.each_strategy() do
 
   describe(fmt("Plugin: oauth2 [#%s] (schema)", strategy), function()
-    local bp, db = helpers.get_db_utils(strategy, {
-      "routes",
-      "services",
-      "consumers",
-      "plugins",
-      "oauth2_tokens",
-      "oauth2_authorization_codes",
-      "oauth2_credentials",
-    })
+    local bp, db
+    local oauth2_authorization_codes_schema
+    local oauth2_tokens_schema
 
-    local oauth2_authorization_codes_schema = db.oauth2_authorization_codes.schema
-    local oauth2_tokens_schema = db.oauth2_tokens.schema
+    lazy_setup(function()
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "oauth2_tokens",
+        "oauth2_authorization_codes",
+        "oauth2_credentials",
+      })
+
+      oauth2_authorization_codes_schema = db.oauth2_authorization_codes.schema
+      oauth2_tokens_schema = db.oauth2_tokens.schema
+    end)
 
     it("does not require `scopes` when `mandatory_scope` is false", function()
       local ok, errors = v({enable_authorization_code = true, mandatory_scope = false}, schema_def)

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -2,9 +2,6 @@ local helpers = require "spec.helpers"
 local shell = require "resty.shell"
 local pl_file = require "pl.file"
 
-local tcp_service_port = helpers.get_available_port()
-local tcp_proxy_port = helpers.get_available_port()
-local MOCK_PORT = helpers.get_available_port()
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
 describe("Plugin: prometheus (access)", function()
@@ -13,7 +10,13 @@ describe("Plugin: prometheus (access)", function()
   local proxy_client_grpc
   local proxy_client_grpcs
 
+  local tcp_service_port
+  local tcp_proxy_port
+
   setup(function()
+    tcp_service_port = helpers.get_available_port()
+    tcp_proxy_port = helpers.get_available_port()
+
     local bp = helpers.get_db_utils()
 
     local service = bp.services:insert {
@@ -618,8 +621,11 @@ describe("Plugin: prometheus (access) AI metrics", function()
   local proxy_client
   local admin_client
   local prometheus_plugin
+  local MOCK_PORT
 
   setup(function()
+    MOCK_PORT = helpers.get_available_port()
+
     local bp = helpers.get_db_utils()
 
     local fixtures = {

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -21,7 +21,6 @@ fixtures.dns_mock:A{
   address = "127.0.0.1"
 }
 
-local status_api_port = helpers.get_available_port()
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
 
@@ -30,8 +29,11 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local admin_ssl_client -- admin_ssl_client (lua-resty-http) does not support h2
     local proxy_ssl_client -- proxy_ssl_client (lua-resty-http) does not support h2
+    local status_api_port
 
     setup(function()
+      status_api_port = helpers.get_available_port()
+
       bp = helpers.get_db_utils(strategy, {"services", "routes", "plugins"})
 
       local mock_ssl_service = bp.services:insert{

--- a/spec/03-plugins/26-prometheus/06-hybrid-mode_metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/06-hybrid-mode_metrics_spec.lua
@@ -1,11 +1,13 @@
 local helpers = require "spec.helpers"
 
-local tcp_status_port = helpers.get_available_port()
 
 describe("Plugin: prometheus (Hybrid Mode)", function()
   local status_client
+  local tcp_status_port
 
   setup(function()
+    tcp_status_port = helpers.get_available_port()
+
     assert(helpers.start_kong {
       nginx_conf = "spec/fixtures/custom_nginx.template",
       plugins = "bundled",

--- a/spec/03-plugins/26-prometheus/07-optional_fields_spec.lua
+++ b/spec/03-plugins/26-prometheus/07-optional_fields_spec.lua
@@ -1,9 +1,6 @@
 local helpers = require "spec.helpers"
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
-local tcp_status_port = helpers.get_available_port()
-
-
 local function get_metrics(client)
   local res = assert(client:send {
     method = "GET",
@@ -36,6 +33,11 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: prometheus, on-demond export metrics #" .. strategy, function()
     local http_client, status_client
     local prometheus_id
+    local tcp_status_port
+
+    lazy_setup(function()
+      tcp_status_port = helpers.get_available_port()
+    end)
 
     -- restart the kong every time or the test would be flaky
     before_each(function()

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -16,21 +16,25 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: AWS Lambda (access) [#" .. strategy .. "]", function()
     local proxy_client
     local admin_client
-    local mock_http_server_port = helpers.get_available_port()
 
-    local mock = http_mock.new(mock_http_server_port, [[
-      ngx.print('hello world')
-    ]],  {
-      prefix = "mockserver",
-      log_opts = {
-        req = true,
-        req_body = true,
-        req_large_body = true,
-      },
-      tls = false,
-    })
+    local mock_http_server_port
+    local mock
 
     lazy_setup(function()
+      mock_http_server_port = helpers.get_available_port()
+
+      mock = http_mock.new(mock_http_server_port, [[
+        ngx.print('hello world')
+      ]],  {
+        prefix = "mockserver",
+        log_opts = {
+          req = true,
+          req_body = true,
+          req_large_body = true,
+        },
+        tls = false,
+      })
+
       local bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",

--- a/spec/03-plugins/29-acme/01-client_spec.lua
+++ b/spec/03-plugins/29-acme/01-client_spec.lua
@@ -99,9 +99,10 @@ for _, strategy in ipairs(strategies) do
   local KEY_ID = "123"
   local KEY_SET_NAME = "key_set_foo"
 
-  local pem_pub, pem_priv = helpers.generate_keys("PEM")
+  local pem_pub, pem_priv
 
   lazy_setup(function()
+    pem_pub, pem_priv = helpers.generate_keys("PEM")
     client = require("kong.plugins.acme.client")
     account_name = client._account_name(proper_config)
   end)

--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -10,43 +10,45 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: Azure Functions (access) [#" .. strategy .. "]", function()
     local mock
     local proxy_client
-    local mock_http_server_port = helpers.get_available_port()
-
-    mock = http_mock.new("127.0.0.1:" .. mock_http_server_port, {
-      ["/"] = {
-        access = [[
-          local json = require "cjson"
-          local method = ngx.req.get_method()
-          local uri = ngx.var.request_uri
-          local headers = ngx.req.get_headers(nil, true)
-          local query_args = ngx.req.get_uri_args()
-          ngx.req.read_body()
-          local body
-          -- collect body
-          body = ngx.req.get_body_data()
-          if not body then
-            local file = ngx.req.get_body_file()
-            if file then
-              local f = io.open(file, "r")
-              if f then
-                body = f:read("*a")
-                f:close()
-              end
-            end
-          end
-          ngx.say(json.encode({
-            query_args = query_args,
-            uri = uri,
-            method = method,
-            headers = headers,
-            body = body,
-            status = 200,
-          }))
-        ]]
-      },
-    })
+    local mock_http_server_port
 
     setup(function()
+      mock_http_server_port = helpers.get_available_port()
+
+      mock = http_mock.new("127.0.0.1:" .. mock_http_server_port, {
+        ["/"] = {
+          access = [[
+            local json = require "cjson"
+            local method = ngx.req.get_method()
+            local uri = ngx.var.request_uri
+            local headers = ngx.req.get_headers(nil, true)
+            local query_args = ngx.req.get_uri_args()
+            ngx.req.read_body()
+            local body
+            -- collect body
+            body = ngx.req.get_body_data()
+            if not body then
+              local file = ngx.req.get_body_file()
+              if file then
+                local f = io.open(file, "r")
+                if f then
+                  body = f:read("*a")
+                  f:close()
+                end
+              end
+            end
+            ngx.say(json.encode({
+              query_args = query_args,
+              uri = uri,
+              method = method,
+              headers = headers,
+              body = body,
+              status = 200,
+            }))
+          ]]
+        },
+      })
+
       local _, db = helpers.get_db_utils(strategy, {
         "routes",
         "services",

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -4,8 +4,6 @@ local cjson   = require "cjson"
 local pl_file = require "pl.file"
 local http_mock = require "spec.helpers.http_mock"
 
-local MOCK_PORT = helpers.get_available_port()
-
 local fmt = string.format
 
 
@@ -20,8 +18,11 @@ end
 for _, strategy in helpers.each_strategy() do
 describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
   local client, mock_server
+  local MOCK_PORT
 
   lazy_setup(function()
+    MOCK_PORT = helpers.get_available_port()
+
     local bp = helpers.get_db_utils(strategy, {
       "routes",
       "services",

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -26,8 +26,6 @@ local function sort_by_key(tbl)
   end)
 end
 
-local HTTP_SERVER_PORT_TRACES = helpers.get_available_port()
-local HTTP_SERVER_PORT_LOGS = helpers.get_available_port()
 local PROXY_PORT = 9000
 
 local post_function_access_body =
@@ -37,8 +35,13 @@ local post_function_access_body =
 for _, strategy in helpers.each_strategy() do
   describe("opentelemetry exporter #" .. strategy, function()
     local bp
+    local HTTP_SERVER_PORT_TRACES
+    local HTTP_SERVER_PORT_LOGS
 
     lazy_setup(function ()
+      HTTP_SERVER_PORT_TRACES = helpers.get_available_port()
+      HTTP_SERVER_PORT_LOGS = helpers.get_available_port()
+
       -- overwrite for testing
       pb.option("enum_as_value")
       pb.option("auto_default_values")

--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -8,8 +8,6 @@ local strip = require("kong.tools.string").strip
 
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
-
 
 local FILE_LOG_PATH_STATS_ONLY = os.tmpname()
 local FILE_LOG_PATH_NO_LOGS = os.tmpname()
@@ -65,8 +63,11 @@ local _EXPECTED_CHAT_STATS = {
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME, "ctx-checker-last", "ctx-checker" })
 
       -- set up openai mock fixtures

--- a/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/03-anthropic_integration_spec.lua
@@ -4,13 +4,15 @@ local pl_file = require "pl.file"
 local deepcompare  = require("pl.tablex").deepcompare
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up anthropic mock fixtures

--- a/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/04-cohere_integration_spec.lua
@@ -3,12 +3,14 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()    local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up cohere mock fixtures

--- a/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/05-azure_integration_spec.lua
@@ -3,13 +3,15 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up azure mock fixtures

--- a/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/06-mistral_integration_spec.lua
@@ -3,13 +3,15 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up mistral mock fixtures

--- a/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/07-llama2_integration_spec.lua
@@ -3,14 +3,15 @@ local cjson = require "cjson"
 local pl_file = require "pl.file"
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
-
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up mistral mock fixtures

--- a/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/08-encoding_integration_spec.lua
@@ -3,7 +3,6 @@ local cjson = require "cjson"
 local inflate_gzip = require("kong.tools.gzip").inflate_gzip
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 local openai_driver = require("kong.llm.drivers.openai")
 
@@ -113,8 +112,11 @@ local plugin_conf = {
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up openai mock fixtures

--- a/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
@@ -6,7 +6,6 @@ local strip = require("kong.tools.string").strip
 local http = require("resty.http")
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 local FILE_LOG_PATH_WITH_PAYLOADS = os.tmpname()
 
@@ -57,8 +56,11 @@ end
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy  .. "]", function()
     local client
+    local MOCK_PORT
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up openai mock fixtures

--- a/spec/03-plugins/38-ai-proxy/10-huggingface_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/10-huggingface_integration_spec.lua
@@ -3,14 +3,16 @@ local cjson = require("cjson")
 local pl_file = require("pl.file")
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 for _, strategy in helpers.all_strategies() do
   if strategy ~= "cassandra" then
     describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
       local client
+      local MOCK_PORT
 
       lazy_setup(function()
+        MOCK_PORT = helpers.get_available_port()
+
         local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
         -- set up huggingface mock fixtures

--- a/spec/03-plugins/38-ai-proxy/11-gemini_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/11-gemini_integration_spec.lua
@@ -4,7 +4,6 @@ local pl_file = require("pl.file")
 local strip = require("kong.tools.string").strip
 
 local PLUGIN_NAME = "ai-proxy"
-local MOCK_PORT = helpers.get_available_port()
 
 local FILE_LOG_PATH_WITH_PAYLOADS = os.tmpname()
 
@@ -56,8 +55,11 @@ for _, strategy in helpers.all_strategies() do
   if strategy ~= "cassandra" then
     describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
       local client
+      local MOCK_PORT
 
       lazy_setup(function()
+        MOCK_PORT = helpers.get_available_port()
+
         local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
         -- set up gemini mock fixtures

--- a/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/39-ai-request-transformer/02-integration_spec.lua
@@ -4,7 +4,6 @@ local pl_file = require "pl.file"
 
 local strip = require("kong.tools.string").strip
 
-local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-request-transformer"
 
 local FILE_LOG_PATH_STATS_ONLY = os.tmpname()
@@ -31,109 +30,6 @@ local function wait_for_json_log_entry(FILE_LOG_PATH)
 
   return json
 end
-
-local OPENAI_FLAT_RESPONSE = {
-  route_type = "llm/v1/chat",
-  logging = {
-    log_payloads = false,
-    log_statistics = true,
-  },
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/flat",
-      input_cost = 10.0,
-      output_cost = 10.0,
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local GEMINI_GOOD = {
-  route_type = "llm/v1/chat",
-  logging = {
-    log_payloads = false,
-    log_statistics = true,
-  },
-  model = {
-    name = "gemini-1.5-flash",
-    provider = "gemini",
-    options = {
-      max_tokens = 512,
-      temperature = 0.6,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/geminiflat",
-      input_cost = 20.0,
-      output_cost = 20.0,
-    },
-  },
-  auth = {
-    header_name = "x-goog-api-key",
-    header_value = "123",
-  },
-}
-
-local GEMINI_GOOD_FAILS_SAFETY = {
-  route_type = "llm/v1/chat",
-  logging = {
-    log_payloads = false,
-    log_statistics = true,
-  },
-  model = {
-    name = "gemini-1.5-flash",
-    provider = "gemini",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/failssafety",
-      input_cost = 10.0,
-      output_cost = 10.0,
-    },
-  },
-  auth = {
-    header_name = "x-goog-api-key",
-    header_value = "123",
-  },
-}
-
-local OPENAI_BAD_REQUEST = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badrequest"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local OPENAI_INTERNAL_SERVER_ERROR = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/internalservererror"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
 
 
 local REQUEST_BODY = [[
@@ -214,8 +110,118 @@ local client
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
+    local MOCK_PORT
+    local OPENAI_FLAT_RESPONSE
+    local GEMINI_GOOD
+    local GEMINI_GOOD_FAILS_SAFETY
+    local OPENAI_BAD_REQUEST
+    local OPENAI_INTERNAL_SERVER_ERROR
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+      OPENAI_FLAT_RESPONSE = {
+        route_type = "llm/v1/chat",
+        logging = {
+          log_payloads = false,
+          log_statistics = true,
+        },
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/flat",
+            input_cost = 10.0,
+            output_cost = 10.0,
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      GEMINI_GOOD = {
+        route_type = "llm/v1/chat",
+        logging = {
+          log_payloads = false,
+          log_statistics = true,
+        },
+        model = {
+          name = "gemini-1.5-flash",
+          provider = "gemini",
+          options = {
+            max_tokens = 512,
+            temperature = 0.6,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/geminiflat",
+            input_cost = 20.0,
+            output_cost = 20.0,
+          },
+        },
+        auth = {
+          header_name = "x-goog-api-key",
+          header_value = "123",
+        },
+      }
+
+      GEMINI_GOOD_FAILS_SAFETY = {
+        route_type = "llm/v1/chat",
+        logging = {
+          log_payloads = false,
+          log_statistics = true,
+        },
+        model = {
+          name = "gemini-1.5-flash",
+          provider = "gemini",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/failssafety",
+            input_cost = 10.0,
+            output_cost = 10.0,
+          },
+        },
+        auth = {
+          header_name = "x-goog-api-key",
+          header_value = "123",
+        },
+      }
+
+      OPENAI_BAD_REQUEST = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badrequest"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      OPENAI_INTERNAL_SERVER_ERROR = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/internalservererror"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up provider fixtures

--- a/spec/03-plugins/40-ai-response-transformer/01-transformer_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/01-transformer_spec.lua
@@ -4,27 +4,7 @@ local cjson = require "cjson"
 local http_mock = require "spec.helpers.http_mock"
 local pl_path = require "pl.path"
 
-local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-response-transformer"
-
-local OPENAI_INSTRUCTIONAL_RESPONSE = {
-  __key__ = "ai-response-transformer",
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://" .. helpers.mock_upstream_host .. ":" .. MOCK_PORT .. "/instructions"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
 local REQUEST_BODY = [[
   {
     "persons": [
@@ -68,7 +48,29 @@ describe(PLUGIN_NAME .. ": (unit)", function()
   local mock_response_file = pl_path.abspath(
     "spec/fixtures/ai-proxy/openai/request-transformer/response-with-instructions.json")
 
+  local MOCK_PORT
+  local OPENAI_INSTRUCTIONAL_RESPONSE
   lazy_setup(function()
+    MOCK_PORT = helpers.get_available_port()
+
+    OPENAI_INSTRUCTIONAL_RESPONSE = {
+      __key__ = "ai-response-transformer",
+      route_type = "llm/v1/chat",
+      model = {
+        name = "gpt-4",
+        provider = "openai",
+        options = {
+          max_tokens = 512,
+          temperature = 0.5,
+          upstream_url = "http://" .. helpers.mock_upstream_host .. ":" .. MOCK_PORT .. "/instructions"
+        },
+      },
+      auth = {
+        header_name = "Authorization",
+        header_value = "Bearer openai-key",
+      },
+    }
+
     mock = http_mock.new(tostring(MOCK_PORT), {
       ["/instructions"] = {
         content = string.format([[

--- a/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
+++ b/spec/03-plugins/40-ai-response-transformer/02-integration_spec.lua
@@ -4,7 +4,6 @@ local pl_file = require "pl.file"
 
 local strip = require("kong.tools.string").strip
 
-local MOCK_PORT = helpers.get_available_port()
 local PLUGIN_NAME = "ai-response-transformer"
 
 local FILE_LOG_PATH_STATS_ONLY = os.tmpname()
@@ -30,121 +29,6 @@ local function wait_for_json_log_entry(FILE_LOG_PATH)
 
   return json
 end
-
-local OPENAI_INSTRUCTIONAL_RESPONSE = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/instructions"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local OPENAI_FLAT_RESPONSE = {
-  route_type = "llm/v1/chat",
-  logging = {
-    log_payloads = false,
-    log_statistics = true,
-  },
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/flat",
-      input_cost = 10.0,
-      output_cost = 10.0,
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local GEMINI_GOOD = {
-  route_type = "llm/v1/chat",
-  logging = {
-    log_payloads = false,
-    log_statistics = true,
-  },
-  model = {
-    name = "gemini-1.5-flash",
-    provider = "gemini",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/failssafety",
-      input_cost = 10.0,
-      output_cost = 10.0,
-    },
-  },
-  auth = {
-    header_name = "x-goog-api-key",
-    header_value = "123",
-  },
-}
-
-local OPENAI_BAD_INSTRUCTIONS = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badinstructions"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local OPENAI_BAD_REQUEST = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badrequest"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
-local OPENAI_INTERNAL_SERVER_ERROR = {
-  route_type = "llm/v1/chat",
-  model = {
-    name = "gpt-4",
-    provider = "openai",
-    options = {
-      max_tokens = 512,
-      temperature = 0.5,
-      upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/internalservererror"
-    },
-  },
-  auth = {
-    header_name = "Authorization",
-    header_value = "Bearer openai-key",
-  },
-}
-
 
 local REQUEST_BODY = [[
   {
@@ -227,8 +111,131 @@ local client
 
 for _, strategy in helpers.all_strategies() do
   describe(PLUGIN_NAME .. ": (access) [#" .. strategy .. "]", function()
+    local MOCK_PORT
+    local OPENAI_INSTRUCTIONAL_RESPONSE
+    local OPENAI_FLAT_RESPONSE
+    local GEMINI_GOOD
+    local OPENAI_BAD_INSTRUCTIONS
+    local OPENAI_BAD_REQUEST
+    local OPENAI_INTERNAL_SERVER_ERROR
 
     lazy_setup(function()
+      MOCK_PORT = helpers.get_available_port()
+
+      OPENAI_INSTRUCTIONAL_RESPONSE = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/instructions"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      OPENAI_FLAT_RESPONSE = {
+        route_type = "llm/v1/chat",
+        logging = {
+          log_payloads = false,
+          log_statistics = true,
+        },
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/flat",
+            input_cost = 10.0,
+            output_cost = 10.0,
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      GEMINI_GOOD = {
+        route_type = "llm/v1/chat",
+        logging = {
+          log_payloads = false,
+          log_statistics = true,
+        },
+        model = {
+          name = "gemini-1.5-flash",
+          provider = "gemini",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/failssafety",
+            input_cost = 10.0,
+            output_cost = 10.0,
+          },
+        },
+        auth = {
+          header_name = "x-goog-api-key",
+          header_value = "123",
+        },
+      }
+
+      OPENAI_BAD_INSTRUCTIONS = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badinstructions"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      OPENAI_BAD_REQUEST = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/badrequest"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
+      OPENAI_INTERNAL_SERVER_ERROR = {
+        route_type = "llm/v1/chat",
+        model = {
+          name = "gpt-4",
+          provider = "openai",
+          options = {
+            max_tokens = 512,
+            temperature = 0.5,
+            upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/internalservererror"
+          },
+        },
+        auth = {
+          header_name = "Authorization",
+          header_value = "Bearer openai-key",
+        },
+      }
+
       local bp = helpers.get_db_utils(strategy == "off" and "postgres" or strategy, nil, { PLUGIN_NAME })
 
       -- set up provider fixtures


### PR DESCRIPTION
This reduces the number of warnings reported by the 'helpers-outside-of-setup' ast-grep lint rule.

## changes

### lint rule fixes

The lint rule itself had some false positives. I've updated it to remove those.

### file fixes

In order to keep the changes easy to review, I've limited fixes to cases that only require trivial edits--essentially just moving the offending function calls into a `setup()`/`lazy_setup()` scope.

There are several files that require a little more refactoring to fix, so I've left them alone for now. I'll address them in a follow-up PR, at which point this lint rule could be converted from a warning to an error.

```
spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
spec/02-integration/05-proxy/10-balancer/07-latency_spec.lua
spec/02-integration/05-proxy/10-balancer/07-latency_spec.lua
spec/02-integration/08-status_api/05-dns_client_spec.lua
spec/02-integration/09-hybrid_mode/01-sync_spec.lua
spec/03-plugins/23-rate-limiting/04-access_spec.lua
spec/03-plugins/26-prometheus/04-status_api_spec.lua
spec/03-plugins/26-prometheus/04-status_api_spec.lua
spec/03-plugins/26-prometheus/04-status_api_spec.lua
spec/03-plugins/39-ai-request-transformer/01-transformer_spec.lua
```

## before

```
$ ast-grep scan --filter helpers-outside-of-setup | grep -c '^warning'
60
```

## after

```
ast-grep scan --filter helpers-outside-of-setup | grep -c '^warning'
12
```

## motivation

It's not good practice to be doing setup-y things in the top-level (file/module) scope or directly within a `describe()` block because code in those scopes executes unconditionally even though the tests themselves might never run (i.e. `busted --exclude-tags=...` or `busted --list`). At best this causes slowdowns, and at worst it can create difficult-to-debug test failures.

Now, the majority of fixes here are for free listening port allocation (`helpers.get_available_port()`), which itself is pretty benign (though it currently invokes a shell and calls `netstat` + `grep`).

It's still good to identify patterns that we want to change though. For the most part we only ever _add_ new tests, so anything we can do to keep things as slim as possible helps stave off test exec time creep.