### PR TITLE
chore(lint): fix remaining helpers-outside-of-setup warnings

### DIFF
--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -8,9 +8,9 @@ local KEY_SET_NAME = "test"
 for _, strategy in helpers.all_strategies() do
   describe("Admin API - keys #" .. strategy, function()
     local pem_pub, pem_priv, jwk
-    helpers.setenv("SECRET_JWK", '{"alg": "RSA-OAEP", "kid": "test"}')
     local client
     lazy_setup(function()
+      helpers.setenv("SECRET_JWK", '{"alg": "RSA-OAEP", "kid": "test"}')
       helpers.get_db_utils(strategy, {
         "keys",
         "key_sets"})

--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -4,19 +4,24 @@ local helpers = require "spec.helpers"
 local https_server = helpers.https_server
 
 
-local test_port1 = helpers.get_available_port()
-local test_port2 = helpers.get_available_port()
-
-
--- create two servers, one double the delay of the other
-local server1 = https_server.new(test_port1, "127.0.0.1", "http", false, nil, 100)
-local server2 = https_server.new(test_port2, "127.0.0.1", "http", false, nil, 200)
-
 for _, strategy in helpers.each_strategy() do
   describe("Balancer: least-connections [#" .. strategy .. "]", function()
     local upstream1_id
 
+    local test_port1
+    local test_port2
+
+    local server1
+    local server2
+
     lazy_setup(function()
+      test_port1 = helpers.get_available_port()
+      test_port2 = helpers.get_available_port()
+
+      -- create two servers, one double the delay of the other
+      server1 = https_server.new(test_port1, "127.0.0.1", "http", false, nil, 100)
+      server2 = https_server.new(test_port2, "127.0.0.1", "http", false, nil, 200)
+
       local bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -214,13 +219,17 @@ for _, strategy in helpers.each_strategy() do
 
         local api_client = helpers.admin_client()
 
+        -- we never send a request to this upstream, so just pick a random
+        -- port number for testing
+        local test_port = math.random(1000, 9000)
+
         -- create a new target
         local res = assert(api_client:post("/upstreams/" .. an_upstream.id .. "/targets", {
           headers = {
             ["Content-Type"] = "application/json",
           },
           body = {
-            target = "127.0.0.1:" .. test_port1,
+            target = "127.0.0.1:" .. test_port,
             weight = 100
           },
         }))
@@ -239,7 +248,7 @@ for _, strategy in helpers.each_strategy() do
         api_client:close()
         local found = false
         for _, entry in ipairs(body.data) do
-          if entry.target == "127.0.0.1:" .. test_port1 and entry.weight == 100 then
+          if entry.target == "127.0.0.1:" .. test_port and entry.weight == 100 then
             found = true
             break
           end
@@ -250,7 +259,7 @@ for _, strategy in helpers.each_strategy() do
         api_client = helpers.admin_client()
         res, err = api_client:send({
           method = "DELETE",
-          path = "/upstreams/" .. an_upstream.id .. "/targets/127.0.0.1:" .. test_port1,
+          path = "/upstreams/" .. an_upstream.id .. "/targets/127.0.0.1:" .. test_port,
         })
         assert.is_nil(err)
         assert.same(204, res.status)
@@ -267,7 +276,7 @@ for _, strategy in helpers.each_strategy() do
         api_client:close()
         local found = false
         for _, entry in ipairs(body.data) do
-          if entry.target == "127.0.0.1:" .. test_port1 and entry.weight == 0 then
+          if entry.target == "127.0.0.1:" .. test_port and entry.weight == 0 then
             found = true
             break
           end

--- a/spec/02-integration/08-status_api/05-dns_client_spec.lua
+++ b/spec/02-integration/08-status_api/05-dns_client_spec.lua
@@ -1,13 +1,14 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-local tcp_status_port = helpers.get_available_port()
-
 for _, strategy in helpers.each_strategy() do
   describe("[#traditional] Status API - DNS client route with [#" .. strategy .. "]" , function()
     local client
+    local tcp_status_port
 
     lazy_setup(function()
+      tcp_status_port = helpers.get_available_port()
+
       local bp = helpers.get_db_utils(strategy, {
         "upstreams",
         "targets",
@@ -69,7 +70,11 @@ for _, strategy in helpers.each_strategy() do
   describe("[#traditional] Status API - DNS client route with [#" .. strategy .. "]" , function()
     local client
 
+    local tcp_status_port
+
     lazy_setup(function()
+      tcp_status_port = helpers.get_available_port()
+
       helpers.get_db_utils(strategy)
 
       assert(helpers.start_kong({
@@ -110,7 +115,11 @@ for _, strategy in helpers.each_strategy() do
   describe("[#hybrid] Status API - DNS client route with [#" .. strategy .. "]" , function()
     local client
 
+    local tcp_status_port
+
     lazy_setup(function()
+      tcp_status_port = helpers.get_available_port()
+
       helpers.get_db_utils(strategy) -- runs migrations
 
       assert(helpers.start_kong({

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -10,8 +10,6 @@ local REDIS_SSL_SNI     = helpers.redis_ssl_sni
 local REDIS_PASSWORD    = ""
 local REDIS_DATABASE    = 1
 local UPSTREAM_HOST     = "localhost"
-local UPSTREAM_PORT     = helpers.get_available_port()
-local UPSTREAM_URL      = string.format("http://%s:%d/always_200", UPSTREAM_HOST, UPSTREAM_PORT)
 
 local fmt               = string.format
 local proxy_client      = helpers.proxy_client
@@ -379,7 +377,13 @@ desc = fmt("Plugin: rate-limiting #db (access) [strategy: %s] [policy: %s] [limi
 describe(desc, function()
   local db, https_server, admin_client
 
+  local UPSTREAM_PORT
+  local UPSTREAM_URL
+
   lazy_setup(function()
+    UPSTREAM_PORT = helpers.get_available_port()
+    UPSTREAM_URL = string.format("http://%s:%d/always_200", UPSTREAM_HOST, UPSTREAM_PORT)
+
     _, db = helpers.get_db_utils(strategy, nil, { "rate-limiting", "key-auth" })
 
     if policy == "redis" then
@@ -1031,6 +1035,8 @@ describe(desc, function ()
   local db, https_server, admin_client
   local test_path = "/test"
   local service
+  local UPSTREAM_PORT
+  local UPSTREAM_URL
 
   local function start_kong()
     return helpers.start_kong({
@@ -1045,6 +1051,9 @@ describe(desc, function ()
   local stop_kong = helpers.stop_kong
 
   lazy_setup(function()
+    UPSTREAM_PORT = helpers.get_available_port()
+    UPSTREAM_URL = string.format("http://%s:%d/always_200", UPSTREAM_HOST, UPSTREAM_PORT)
+
     https_server = helpers.https_server.new(UPSTREAM_PORT)
     https_server:start()
   end)
@@ -1247,7 +1256,13 @@ desc = fmt("Plugin: rate-limiting with sync_rate #db (access) [strategy: %s]", s
 describe(desc, function ()
   local https_server, admin_client
 
+  local UPSTREAM_PORT
+  local UPSTREAM_URL
+
   lazy_setup(function()
+    UPSTREAM_PORT = helpers.get_available_port()
+    UPSTREAM_URL = string.format("http://%s:%d/always_200", UPSTREAM_HOST, UPSTREAM_PORT)
+
     helpers.get_db_utils(strategy, nil, {
       "rate-limiting",
     })
@@ -1356,7 +1371,13 @@ desc = fmt("Plugin: rate-limiting enable globally #db (access) [strategy: %s]", 
 describe(desc, function ()
   local https_server, admin_client
 
+  local UPSTREAM_PORT
+  local UPSTREAM_URL
+
   lazy_setup(function()
+    UPSTREAM_PORT = helpers.get_available_port()
+    UPSTREAM_URL = string.format("http://%s:%d/always_200", UPSTREAM_HOST, UPSTREAM_PORT)
+
     helpers.get_db_utils(strategy, nil, {
       "rate-limiting", "key-auth",
     })

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -1,9 +1,6 @@
 local helpers = require "spec.helpers"
 local shell = require "resty.shell"
 
-local tcp_service_port = helpers.get_available_port()
-local tcp_proxy_port = helpers.get_available_port()
-local tcp_status_port = helpers.get_available_port()
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
 describe("Plugin: prometheus (access via status API)", function()
@@ -11,6 +8,9 @@ describe("Plugin: prometheus (access via status API)", function()
   local status_client
   local proxy_client_grpc
   local proxy_client_grpcs
+  local tcp_service_port
+  local tcp_proxy_port
+  local tcp_status_port
 
   local function get_metrics()
     if not status_client then
@@ -25,6 +25,10 @@ describe("Plugin: prometheus (access via status API)", function()
   end
 
   setup(function()
+    tcp_service_port = helpers.get_available_port()
+    tcp_proxy_port = helpers.get_available_port()
+    tcp_status_port = helpers.get_available_port()
+
     local bp = helpers.get_db_utils()
 
     local upstream_hc_off = bp.upstreams:insert({
@@ -438,7 +442,11 @@ describe("Plugin: prometheus (access) granular metrics switch", function()
 
   local success_scrape = ""
 
+  local tcp_status_port
+
   setup(function()
+    tcp_status_port = helpers.get_available_port()
+
     local bp = helpers.get_db_utils()
 
     local service = bp.services:insert {
@@ -534,6 +542,8 @@ describe("CP/DP connectivity state #", function ()
   local status_client
   local cp_running
 
+  local tcp_status_port
+
   local function get_metrics()
     if not status_client then
       status_client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
@@ -547,6 +557,8 @@ describe("CP/DP connectivity state #", function ()
   end
 
   setup(function()
+    tcp_status_port = helpers.get_available_port()
+
     local bp = helpers.get_db_utils()
 
     bp.plugins:insert {


### PR DESCRIPTION
This is a follow-up to d1a8e41ab7923605510c8ca1ebc6692a65a90bd8 that fixes the remainder of the files with warnings.

```
$ ast-grep scan | wc -l
0
```