### PR TITLE
ci: add pgvector folder to CI labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -266,7 +266,7 @@ schema-change-noteworthy:
 - changed-files:
   - any-glob-to-any-file: [
       'kong/db/schema/**/*.lua', 'kong/**/schema.lua', 'kong/plugins/**/daos.lua', 'plugins-ee/**/daos.lua', 'plugins-ee/**/schema.lua', 'kong/db/dao/*.lua', 'kong/enterprise_edition/redis/init.lua',
-      'kong/llm/init.lua', 'kong/llm/schemas/*.lua',
+      'kong/llm/init.lua', 'kong/llm/schemas/*.lua', 'kong/llm/vectordb/strategies/pgvector/init.lua',
     ]
 
 build/bazel:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
