### PR TITLE
fix(): Fix loading proto3 files with optional label

### DIFF
--- a/spec/fixtures/grpc/targetservice.proto
+++ b/spec/fixtures/grpc/targetservice.proto
@@ -14,6 +14,7 @@ service Bouncer {
       // HTTP | gRPC
       // -----|-----
       // `GET /v1/messages/123456`  | `HelloRequest(greeting: "123456")`
+      // comment to test CI build
       get: "/v1/messages/{greeting}"
       additional_bindings {
         get: "/v1/messages/legacy/{greeting=**}"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix [Issue 14421](https://github.com/Kong/kong/issues/14421)
grpc-gateway fails to load proto file with message "proto3 disallow 'optional' label"

### Checklist

- [x] The Pull Request has tests
- [ x A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[14421]_
