### PR TITLE
fix(core): separate pluginserver runtime data from kong configuration

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
+++ b/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error"
+type: bugfix
+scope: Core


### PR DESCRIPTION
Backport https://github.com/Kong/kong/pull/14111 into 3.9 version

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/Kong/go-pdk/issues/226 and https://github.com/Kong/kong/issues/14260
