### PR TITLE
docs(readme): display master latest commit's Build & Test workflow status

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ limitations under the License.
 [kong-benefits]: https://konghq.com/wp-content/uploads/2018/05/kong-benefits-github-readme.png
 [kong-master-builds]: https://hub.docker.com/r/kong/kong/tags
 [badge-action-url]: https://github.com/Kong/kong/actions
-[badge-action-image]: https://github.com/Kong/kong/workflows/Build%20&%20Test/badge.svg
+[badge-action-image]: https://github.com/Kong/kong/actions/workflows/build_and_test.yml/badge.svg?branch=master&event=push
 
 [busted]: https://github.com/Olivine-Labs/busted
 [luacheck]: https://github.com/mpeterv/luacheck


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Previous, the README.md Build & Test status will be red as long as the latest build fails no matter it's from our maintenance branch or a development branch (PR's branch), which is not a good way to show the repository's status. This PR changed it to show the latest commit's workflow run result from master.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
