### PR TITLE
fix(oauth2):correct  header delimiter to use comma

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -827,9 +827,11 @@ local function retrieve_token(conf, access_token, realm)
           "plugin is configured without 'global_credentials'",
       },
       {
-        ["WWW-Authenticate"] = 'Bearer' .. realm .. ' error=' ..
-                                '"invalid_token" error_description=' ..
-                                '"The access token is invalid or has expired"'
+        ["WWW-Authenticate"] = 'Bearer' 
+          .. realm
+          .. (realm ~= "" and "," or "")
+          .. ' error="invalid_token", error_description='
+          .. '"The access token is invalid or has expired"',
       })
     end
 
@@ -977,9 +979,11 @@ local function do_authentication(conf)
         error_description = "The access token is invalid or has expired"
       },
       headers = {
-        ["WWW-Authenticate"] = 'Bearer' .. realm .. ' error=' ..
-                               '"invalid_token" error_description=' ..
-                               '"The access token is invalid or has expired"'
+        ["WWW-Authenticate"] = 'Bearer' 
+          .. realm
+          .. (realm ~= "" and "," or "")
+          .. ' error="invalid_token", error_description='
+          .. '"The access token is invalid or has expired"',
       }
     }
   end
@@ -995,9 +999,11 @@ local function do_authentication(conf)
         error_description = "The access token is invalid or has expired"
       },
       headers = {
-        ["WWW-Authenticate"] = 'Bearer' .. realm .. ' error=' ..
-                               '"invalid_token" error_description=' ..
-                               '"The access token is invalid or has expired"'
+        ["WWW-Authenticate"] = 'Bearer'
+          .. realm
+          .. (realm ~= "" and "," or "")
+          .. ' error="invalid_token", error_description='
+          .. '"The access token is invalid or has expired"'
       }
     }
   end
@@ -1013,9 +1019,11 @@ local function do_authentication(conf)
           error_description = "The access token is invalid or has expired"
         },
         headers = {
-          ["WWW-Authenticate"] = 'Bearer' .. realm .. ' error=' ..
-                                 '"invalid_token" error_description=' ..
-                                 '"The access token is invalid or has expired"'
+          ["WWW-Authenticate"] = 'Bearer'
+            .. realm
+            .. (realm ~= "" and "," or "")
+            .. ' error="invalid_token", error_description='
+            .. '"The access token is invalid or has expired"'
         }
       }
     end
@@ -1048,20 +1056,25 @@ local function do_authentication(conf)
 end
 
 local function invalid_oauth2_method(endpoint_name, realm)
+  local error_description = "The HTTP method "
+    .. kong.request.get_method()
+    .. " is invalid for the "
+    .. endpoint_name
+    .. " endpoint"
+
   return {
      status = 405,
      message = {
      [ERROR] = "invalid_method",
-       error_description = "The HTTP method " ..
-       kong.request.get_method() ..
-       " is invalid for the " .. endpoint_name .. " endpoint"
+       error_description = error_description
      },
      headers = {
-       ["WWW-Authenticate"] = 'Bearer' .. realm .. ' error=' ..
-                              '"invalid_method" error_description=' ..
-                              '"The HTTP method ' .. kong.request.get_method()
-                              .. ' is invalid for the ' ..
-                              endpoint_name .. ' endpoint"'
+       ["WWW-Authenticate"] = 'Bearer'
+        .. realm
+        .. (realm ~= "" and "," or "")
+        .. ' error="invalid_method", error_description="'
+        .. error_description
+        .. '"'
      }
    }
 end

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -1438,7 +1438,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           local json = cjson.decode(body)
           assert.same({ error_description = "The HTTP method GET is invalid for the token endpoint",
                         error = "invalid_method" }, json)
-          assert.are.equal('Bearer error="invalid_method" error_description="The HTTP method GET is invalid for the token endpoint"', res.headers["www-authenticate"])
+          assert.are.equal('Bearer error="invalid_method", error_description="The HTTP method GET is invalid for the token endpoint"', res.headers["www-authenticate"])
         end)
         it("returns an error when empty client_id and empty client_secret is sent regardless of method - with realm", function()
           local res = assert(proxy_ssl_client:send {
@@ -1454,7 +1454,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           local json = cjson.decode(body)
           assert.same({ error_description = "The HTTP method GET is invalid for the token endpoint",
                         error = "invalid_method" }, json)
-          assert.are.equal('Bearer realm="test-oauth2" error="invalid_method" error_description="The HTTP method GET is invalid for the token endpoint"', res.headers["www-authenticate"])
+          assert.are.equal('Bearer realm="test-oauth2", error="invalid_method", error_description="The HTTP method GET is invalid for the token endpoint"', res.headers["www-authenticate"])
         end)
         it("returns an error when grant_type is not sent", function()
           local res = assert(proxy_ssl_client:send {
@@ -3169,7 +3169,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal("Bearer error=\"invalid_token\" error_description=\"The access token is invalid or has expired\"", res.headers["www-authenticate"])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers["www-authenticate"])
       end)
       it("does not work when requesting a different API - with realm set", function()
         local token = provision_token()
@@ -3184,7 +3184,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal("Bearer error=\"invalid_token\" error_description=\"The access token is invalid or has expired\"", res.headers["www-authenticate"])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers["www-authenticate"])
       end)
       it("works when a correct access_token is being sent in a form body", function()
         local token = provision_token()
@@ -3452,7 +3452,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
             }
           })
           assert.res_status(401, res)
-          assert.are.equal("Bearer error=\"invalid_token\" error_description=\"The access token is invalid or has expired\"", res.headers["WWW-Authenticate"])
+          assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers["WWW-Authenticate"])
         end)
         it("does not access two different APIs that are not sharing global credentials 2", function()
           local token = provision_token("oauth2.test")
@@ -3466,7 +3466,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
             }
           })
           assert.res_status(401, res)
-          assert.are.equal('Bearer error="invalid_token" error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
+          assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
 
           local res = assert(proxy_ssl_client:send {
             method  = "POST",
@@ -3529,7 +3529,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal('Bearer error="invalid_token" error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
       end)
       it("returns 401 Unauthorized when an invalid access token is being sent via the Authorization header", function()
         local res = assert(proxy_ssl_client:send {
@@ -3543,7 +3543,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal('Bearer error="invalid_token" error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers['www-authenticate'])
       end)
       it("returns 401 Unauthorized when token has expired", function()
         local token = provision_token()
@@ -3568,7 +3568,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           return status == 401
         end, 7)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal('Bearer error="invalid_token" error_description="The access token is invalid or has expired"', headers['www-authenticate'])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', headers['www-authenticate'])
       end)
     end)
 
@@ -3740,7 +3740,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           return status == 401
         end, 7)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal("Bearer error=\"invalid_token\" error_description=\"The access token is invalid or has expired\"", res2.headers["WWW-Authenticate"])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res2.headers["WWW-Authenticate"])
 
         -- Refreshing the token
         local res = assert(proxy_ssl_client:send {
@@ -3811,7 +3811,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           return status == 401
         end, 7)
         assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
-        assert.are.equal('Bearer error="invalid_token" error_description="The access token is invalid or has expired"', headers['www-authenticate'])
+        assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', headers['www-authenticate'])
 
         local final_refreshed_token = refresh_token("oauth2_13.test", refreshed_token.refresh_token)
         local last_res = assert(proxy_client:send {
@@ -4412,7 +4412,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
                             "plugin is configured without 'global_credentials'",
         error = "invalid_token",
       }, json)
-      assert.are.equal("Bearer error=\"invalid_token\" error_description=\"The access token is invalid or has expired\"", res.headers["www-authenticate"])
+      assert.are.equal('Bearer error="invalid_token", error_description="The access token is invalid or has expired"', res.headers["www-authenticate"])
     end)
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix issue #14429 where authentication plugins were using spaces instead of commas to separate parameters in the `WWW-Authenticate` header. According to RFC 7235 (HTTP Authentication) ([Section 4.1](https://datatracker.ietf.org/doc/html/rfc7235#section-4.1)), the parameters should be comma-delimited.

### Related PRs:


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14429 
