### PR TITLE
fix(jwt):correct  header delimiter to use comma

### DIFF
--- a/changelog/unreleased/kong/fix-jwt-www-authenticate-header-delimiter.yml
+++ b/changelog/unreleased/kong/fix-jwt-www-authenticate-header-delimiter.yml
@@ -1,0 +1,3 @@
+message: "**jwt**: correct `WWW-Authenticate` header delimiter to use comma according to RFC 7235."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -157,11 +157,14 @@ local function do_authentication(conf)
     return error(err)
   end
 
-  local realm = conf.realm and fmt(' realm="%s"', conf.realm) or ""
-  local www_authenticate_base = "Bearer" .. realm
-  local www_authenticate_with_error = www_authenticate_base
-    .. (realm ~= "" and "," or "")
-    .. ' error="invalid_token"'
+  local www_authenticate_base, www_authenticate_with_error
+  if conf.realm then
+    www_authenticate_base = fmt('Bearer realm="%s"', conf.realm)
+    www_authenticate_with_error = www_authenticate_base .. ', error="invalid_token"'
+  else
+    www_authenticate_base = "Bearer"
+    www_authenticate_with_error = 'Bearer error="invalid_token"'
+  end
 
   local token_type = type(token)
   if token_type ~= "string" then

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -157,8 +157,12 @@ local function do_authentication(conf)
     return error(err)
   end
 
-  local www_authenticate_base = conf.realm and fmt('Bearer realm="%s"', conf.realm) or 'Bearer'
-  local www_authenticate_with_error = www_authenticate_base .. ' error="invalid_token"'
+  local realm = conf.realm and fmt(' realm="%s"', conf.realm) or ""
+  local www_authenticate_base = "Bearer" .. realm
+  local www_authenticate_with_error = www_authenticate_base
+    .. (realm ~= "" and "," or "")
+    .. ' error="invalid_token"'
+
   local token_type = type(token)
   if token_type ~= "string" then
     if token_type == "nil" then

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -608,7 +608,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "No credentials found for given 'iss'" }, json)
-        assert.equal('Bearer realm="test-jwt" error="invalid_token"', res.headers["WWW-Authenticate"])
+        assert.equal('Bearer realm="test-jwt", error="invalid_token"', res.headers["WWW-Authenticate"])
       end)
       it("returns a 401 if the JWT in the cookie is corrupted", function()
         PAYLOAD.iss = jwt_secret.key
@@ -623,7 +623,7 @@ for _, strategy in helpers.each_strategy() do
         })
         local body = assert.res_status(401, res)
         assert.equal([[{"message":"Bad token; invalid JSON"}]], body)
-        assert.equal('Bearer realm="test-jwt" error="invalid_token"', res.headers["WWW-Authenticate"])
+        assert.equal('Bearer realm="test-jwt", error="invalid_token"', res.headers["WWW-Authenticate"])
       end)
       it("reports a 200 without cookies but with a JWT token in the Authorization header", function()
         PAYLOAD.iss = jwt_secret.key


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Fix issue https://github.com/Kong/kong/issues/14429 where authentication plugins were using spaces instead of commas to separate parameters in the WWW-Authenticate header. According to RFC 7235 (HTTP Authentication) ([Section 4.1](https://datatracker.ietf.org/doc/html/rfc7235#section-4.1)), the parameters should be comma-delimited.

### Related PR

-  #14436 

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14429 
