### PR TITLE
[cherry-pick -> master] fix(proxy): upstream connection pooling with long pool names

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.28_03-fix-invalid-hostname.patch
+++ b/build/openresty/patches/ngx_lua-0.10.28_03-fix-invalid-hostname.patch
@@ -1,0 +1,22 @@
+diff --git a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
+index ae0f138..aa26a4a 100644
+--- a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
++++ b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
+@@ -702,7 +702,7 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+                     item->host.len = host->len;
+ 
+                 } else {
+-                    item->host.data = ngx_pstrdup(c->pool, bp->addr_text);
++                    item->host.data = ngx_pstrdup(c->pool, host);
+                     if (item->host.data == NULL) {
+                         ngx_http_lua_balancer_close(c);
+ 
+@@ -713,7 +713,7 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+                         return;
+                     }
+ 
+-                    item->host.len = bp->addr_text->len;
++                    item->host.len = host->len;
+                 }
+ 
+             } else {

--- a/changelog/unreleased/kong/fix-invalid-hostname.yml
+++ b/changelog/unreleased/kong/fix-invalid-hostname.yml
@@ -1,0 +1,5 @@
+message: >
+  Fixed an issue where upstream connection pooling failed when pool names exceeded 32 characters 
+  by applying a patch from upstream OpenResty.
+type: "bugfix"
+scope: "Core"


### PR DESCRIPTION
### Summary

Adds a patch from upstream OpenResty:
https://github.com/openresty/lua-nginx-module/commit/18ce5fbd58171a5faec966a5f7099ce930c812c2

A cherry-pick from: https://github.com/Kong/kong-ee/pull/12287

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

https://konghq.atlassian.net/browse/KAG-6951
