### PR TITLE
[backport to release/3.4.x] chore(*): remove enterprise license notice

### DIFF
--- a/.github/workflows/license-notice-check.yml
+++ b/.github/workflows/license-notice-check.yml
@@ -1,0 +1,34 @@
+name: Check for Enterprise License Notice
+
+on:
+  pull_request:
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Find Enterprise License Notice
+        shell: bash
+        run: |
+          set -e
+
+          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise License Notice" .github/workflows/*.yml | head -n1)
+          echo "Detected workflow file: $workflow_file"
+
+          all_files=$(grep -r -F -l "This software is copyright Kong Inc. and its licensors." .)
+
+          # ignore this file
+          files=$(echo "$all_files" | grep -v "$workflow_file$" || true)
+
+
+          if [ -n "$files" ]; then
+            echo "Error: Enterprise license notice detected in the following files:"
+            echo "$files"
+            exit 1
+          else
+            echo "No enterprise license notice found."
+          fi
+

--- a/spec/02-integration/03-db/18-keys_spec.lua
+++ b/spec/02-integration/03-db/18-keys_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local merge = kong.table.merge

--- a/spec/02-integration/03-db/19-key-sets_spec.lua
+++ b/spec/02-integration/03-db/19-key-sets_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local merge = kong.table.merge
 local cjson = require "cjson"

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local merge = kong.table.merge

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local typedefs = require "kong.db.schema.typedefs"
 
 return {


### PR DESCRIPTION
KAG-6949

(cherry picked from commit 731e4e648ab9819e97cd6d1e378a092948277070)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
