### PR TITLE
chore(ci): fix the name of the workflow that checks for copyright

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,21 +1,21 @@
-name: Check for Enterprise License Notice
+name: Check for Enterprise Copyright
 
 on:
   pull_request:
 
 jobs:
-  check-license:
+  check-copyright:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Find Enterprise License Notice
+      - name: Find Enterprise Copyright
         shell: bash
         run: |
           set -e
 
-          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise License Notice" .github/workflows/*.yml | head -n1)
+          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise Copyright" .github/workflows/*.yml | head -n1)
           echo "Detected workflow file: $workflow_file"
 
           all_files=$(grep -r -F -l "This software is copyright Kong Inc. and its licensors." .)
@@ -25,10 +25,10 @@ jobs:
 
 
           if [ -n "$files" ]; then
-            echo "Error: Enterprise license notice detected in the following files:"
+            echo "Error: Enterprise copyright detected in the following files:"
             echo "$files"
             exit 1
           else
-            echo "No enterprise license notice found."
+            echo "No enterprise copyright found."
           fi
 


### PR DESCRIPTION
KAG-6949

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
