### PR TITLE
[backport to release/3.9.x] chore(ci): fix the name of the workflow that checks for copyright (#14450)

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,21 +1,21 @@
-name: Check for Enterprise License Notice
+name: Check for Enterprise Copyright
 
 on:
   pull_request:
 
 jobs:
-  check-license:
+  check-copyright:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Find Enterprise License Notice
+      - name: Find Enterprise Copyright
         shell: bash
         run: |
           set -e
 
-          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise License Notice" .github/workflows/*.yml | head -n1)
+          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise Copyright" .github/workflows/*.yml | head -n1)
           echo "Detected workflow file: $workflow_file"
 
           all_files=$(grep -r -F -l "This software is copyright Kong Inc. and its licensors." .)
@@ -25,10 +25,10 @@ jobs:
 
 
           if [ -n "$files" ]; then
-            echo "Error: Enterprise license notice detected in the following files:"
+            echo "Error: Enterprise copyright detected in the following files:"
             echo "$files"
             exit 1
           else
-            echo "No enterprise license notice found."
+            echo "No enterprise copyright found."
           fi
 

--- a/.github/workflows/license-notice-check.yml
+++ b/.github/workflows/license-notice-check.yml
@@ -1,0 +1,34 @@
+name: Check for Enterprise License Notice
+
+on:
+  pull_request:
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Find Enterprise License Notice
+        shell: bash
+        run: |
+          set -e
+
+          workflow_file=$(grep -rnl "^name:[[:space:]]*Check for Enterprise License Notice" .github/workflows/*.yml | head -n1)
+          echo "Detected workflow file: $workflow_file"
+
+          all_files=$(grep -r -F -l "This software is copyright Kong Inc. and its licensors." .)
+
+          # ignore this file
+          files=$(echo "$all_files" | grep -v "$workflow_file$" || true)
+
+
+          if [ -n "$files" ]; then
+            echo "Error: Enterprise license notice detected in the following files:"
+            echo "$files"
+            exit 1
+          else
+            echo "No enterprise license notice found."
+          fi
+

--- a/kong/plugins/ai-prompt-decorator/filters/decorate-prompt.lua
+++ b/kong/plugins/ai-prompt-decorator/filters/decorate-prompt.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local new_tab = require("table.new")
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy

--- a/kong/plugins/ai-prompt-guard/filters/guard-prompt.lua
+++ b/kong/plugins/ai-prompt-guard/filters/guard-prompt.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local buffer = require("string.buffer")
 local ngx_re_find = ngx.re.find
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")

--- a/kong/plugins/ai-prompt-template/filters/render-prompt-template.lua
+++ b/kong/plugins/ai-prompt-template/filters/render-prompt-template.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local templater = require("kong.plugins.ai-prompt-template.templater")
 

--- a/kong/plugins/ai-request-transformer/filters/transform-request.lua
+++ b/kong/plugins/ai-request-transformer/filters/transform-request.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local fmt            = string.format
 local ai_plugin_ctx  = require("kong.llm.plugin.ctx")
 local ai_plugin_o11y = require("kong.llm.plugin.observability")

--- a/kong/plugins/ai-response-transformer/filters/transform-response.lua
+++ b/kong/plugins/ai-response-transformer/filters/transform-response.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local fmt            = string.format
 local http           = require("resty.http")
 local ai_plugin_ctx  = require("kong.llm.plugin.ctx")

--- a/kong/tls/plugins/certificate.lua
+++ b/kong/tls/plugins/certificate.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 --- Copyright 2019 Kong Inc.
 local ngx_ssl = require "ngx.ssl"
 local ssl_clt = require "ngx.ssl.clienthello"

--- a/kong/tls/plugins/sni_filter.lua
+++ b/kong/tls/plugins/sni_filter.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local constants    = require "kong.constants"
 local openssl_x509 = require "resty.openssl.x509"
 local chain_lib    = require "resty.openssl.x509.chain"

--- a/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
+++ b/spec/01-unit/01-db/11-declarative_lmdb_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers
 local buffer
 local kong_global

--- a/spec/03-plugins/03-http-log/05-old-plugin-compatibility_spec.lua
+++ b/spec/03-plugins/03-http-log/05-old-plugin-compatibility_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local helpers = require "spec.helpers"
 local fmt = string.format
 local plugin_name = "http-log"

--- a/spec/03-plugins/25-oauth2/05-kdf_spec.lua
+++ b/spec/03-plugins/25-oauth2/05-kdf_spec.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local secret_impl = require "kong.plugins.oauth2.secret"
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/handler.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local kong = kong
 
 local PreserveNullsHandler = {

--- a/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/preserve-nulls/schema.lua
@@ -1,10 +1,3 @@
--- This software is copyright Kong Inc. and its licensors.
--- Use of the software is subject to the agreement between your organization
--- and Kong Inc. If there is no such agreement, use is governed by and
--- subject to the terms of the Kong Master Software License Agreement found
--- at https://konghq.com/enterprisesoftwarelicense/.
--- [ END OF LICENSE 0867164ffc95e54f04670b5169c09574bdbd9bba ]
-
 local typedefs = require "kong.db.schema.typedefs"
 
 


### PR DESCRIPTION
KAG-6949
    
(cherry picked from commit 8ed78ce1c801064c9cbc6b997df16fe59b3aa16d)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
