### PR TITLE
fix(core): downgrade log level for routes rebuilding (#12340)

### DIFF
--- a/changelog/unreleased/kong/fix-downgrade-routes-plugins-rebuilding-log-level.yml
+++ b/changelog/unreleased/kong/fix-downgrade-routes-plugins-rebuilding-log-level.yml
@@ -1,0 +1,3 @@
+message: Fixed an issue where the error logs generated during router rebuilding might be excessively noisy.
+type: bugfix
+scope: Core

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -388,7 +388,8 @@ local function new_router(version)
         end
 
         if new_version ~= version then
-          return nil, "router was changed while rebuilding it"
+          log(INFO, "could not build router: router was changed while rebuilding it")
+          return nil, nil
         end
       end
       counter = counter + 1
@@ -496,7 +497,7 @@ end
 local function get_updated_router()
   if kong.db.strategy ~= "off" and kong.configuration.worker_consistency == "strict" then
     local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
-    if not ok then
+    if not ok and err then
       -- If an error happens while updating, log it and return non-updated
       -- version.
       log(ERR, "could not rebuild router: ", err, " (stale router will be used)")
@@ -1032,7 +1033,7 @@ return {
           -- If the semaphore is locked, that means that the rebuild is
           -- already ongoing.
           local ok, err = rebuild_router(router_async_opts)
-          if not ok then
+          if not ok and err then
             log(ERR, "could not rebuild router via timer: ", err)
           end
         end


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-6944
