### PR TITLE
Revert "refactor(shorthand_fields): remove translate_backwards in favor of replaced_with (#13604)"

### DIFF
--- a/changelog/unreleased/kong/revert-translate-backwards.yml
+++ b/changelog/unreleased/kong/revert-translate-backwards.yml
@@ -1,0 +1,3 @@
+message: Reverted removal of `translate_backwards` from plugins' metaschema in order to maintain backward compatibility.
+type: bugfix
+scope: Core

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -716,6 +716,7 @@ local function make_shorthand_field_schema()
   shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
 
   insert(shorthand_field_schema, { func = { type = "function", required = true } })
+  insert(shorthand_field_schema, { translate_backwards = { type = "array", elements = { type = "string" }, required = false } })
   return shorthand_field_schema
 end
 

--- a/spec/02-integration/03-db/23-shorthand_fields_translate_backwards_spec.lua
+++ b/spec/02-integration/03-db/23-shorthand_fields_translate_backwards_spec.lua
@@ -1,0 +1,274 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local uuid = require("kong.tools.uuid").uuid
+
+
+describe("an old plugin: translate_backwards", function()
+  local bp, db, route, admin_client
+  local plugin_id = uuid()
+
+  lazy_setup(function()
+    helpers.test_conf.lua_package_path = helpers.test_conf.lua_package_path .. ";./spec-ee/fixtures/custom_plugins/?.lua"
+    bp, db = helpers.get_db_utils(nil, {
+      "plugins",
+    }, { 'translate-backwards-older-plugin' })
+
+    route = assert(bp.routes:insert {
+      hosts = { "redis.test" },
+    })
+
+    assert(helpers.start_kong({
+      plugins = "bundled,translate-backwards-older-plugin",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      lua_package_path  = "?./spec-ee/fixtures/custom_plugins/?.lua",
+    }))
+
+    admin_client = assert(helpers.admin_client())
+  end)
+
+  lazy_teardown(function()
+    if admin_client then
+      admin_client:close()
+    end
+
+    helpers.stop_kong()
+  end)
+
+  describe("when creating custom plugin", function()
+    after_each(function()
+      db:truncate("plugins")
+    end)
+
+    describe("when using the new field", function()
+      it("creates the custom plugin and fills in old field in response", function()
+        -- POST
+        local res = assert(admin_client:send {
+          method = "POST",
+          route = {
+            id = route.id
+          },
+          path = "/plugins",
+          headers = { ["Content-Type"] = "application/json" },
+          body = {
+            id = plugin_id,
+            name = "translate-backwards-older-plugin",
+            config = {
+              new_field = "ABC"
+            },
+          },
+        })
+
+        local json = cjson.decode(assert.res_status(201, res))
+        assert.same(json.config.new_field, "ABC")
+        assert.same(json.config.old_field, "ABC")
+
+        -- PATCH
+        res = assert(admin_client:send {
+          method = "PATCH",
+          path = "/plugins/" .. plugin_id,
+          headers = { ["Content-Type"] = "application/json" },
+          body = {
+            name = "translate-backwards-older-plugin",
+            config = {
+              new_field = "XYZ"
+            },
+          },
+        })
+
+        json = cjson.decode(assert.res_status(200, res))
+        assert.same(json.config.new_field, "XYZ")
+        assert.same(json.config.old_field, "XYZ")
+
+        -- GET
+        res = assert(admin_client:send {
+          method = "GET",
+          path = "/plugins/" .. plugin_id
+        })
+
+        json = cjson.decode(assert.res_status(200, res))
+        assert.same(json.config.new_field, "XYZ")
+        assert.same(json.config.old_field, "XYZ")
+      end)
+    end)
+
+    describe("when using the old field", function()
+      it("creates the custom plugin and fills in old field in response", function()
+        -- POST
+        local res = assert(admin_client:send {
+          method = "POST",
+          route = {
+            id = route.id
+          },
+          path = "/plugins",
+          headers = { ["Content-Type"] = "application/json" },
+          body = {
+            id = plugin_id,
+            name = "translate-backwards-older-plugin",
+            config = {
+              old_field = "ABC"
+            },
+          },
+        })
+
+        local json = cjson.decode(assert.res_status(201, res))
+        assert.same(json.config.new_field, "ABC")
+        assert.same(json.config.old_field, "ABC")
+
+        -- PATCH
+        res = assert(admin_client:send {
+          method = "PATCH",
+          path = "/plugins/" .. plugin_id,
+          headers = { ["Content-Type"] = "application/json" },
+          body = {
+            name = "translate-backwards-older-plugin",
+            config = {
+              old_field = "XYZ"
+            },
+          },
+        })
+
+        json = cjson.decode(assert.res_status(200, res))
+        assert.same(json.config.new_field, "XYZ")
+        assert.same(json.config.old_field, "XYZ")
+
+        -- GET
+        res = assert(admin_client:send {
+          method = "GET",
+          path = "/plugins/" .. plugin_id
+        })
+
+        json = cjson.decode(assert.res_status(200, res))
+        assert.same(json.config.new_field, "XYZ")
+        assert.same(json.config.old_field, "XYZ")
+      end)
+    end)
+
+    describe("when using the both new and old fields", function()
+      describe("when their values match", function()
+        it("creates the custom plugin and fills in old field in response", function()
+          -- POST
+          local res = assert(admin_client:send {
+            method = "POST",
+            route = {
+              id = route.id
+            },
+            path = "/plugins",
+            headers = { ["Content-Type"] = "application/json" },
+            body = {
+              id = plugin_id,
+              name = "translate-backwards-older-plugin",
+              config = {
+                new_field = "ABC",
+                old_field = "ABC"
+              },
+            },
+          })
+
+          local json = cjson.decode(assert.res_status(201, res))
+          assert.same(json.config.new_field, "ABC")
+          assert.same(json.config.old_field, "ABC")
+
+          -- PATCH
+          res = assert(admin_client:send {
+            method = "PATCH",
+            path = "/plugins/" .. plugin_id,
+            headers = { ["Content-Type"] = "application/json" },
+            body = {
+              name = "translate-backwards-older-plugin",
+              config = {
+                new_field = "XYZ",
+                old_field = "XYZ"
+              },
+            },
+          })
+
+          json = cjson.decode(assert.res_status(200, res))
+          assert.same(json.config.new_field, "XYZ")
+          assert.same(json.config.old_field, "XYZ")
+
+          -- GET
+          res = assert(admin_client:send {
+            method = "GET",
+            path = "/plugins/" .. plugin_id
+          })
+
+          json = cjson.decode(assert.res_status(200, res))
+          assert.same(json.config.new_field, "XYZ")
+          assert.same(json.config.old_field, "XYZ")
+        end)
+      end)
+
+      describe("when their values mismatch", function()
+        it("rejects such plugin", function()
+          -- POST --- with mismatched values
+          local res = assert(admin_client:send {
+            method = "POST",
+            route = {
+              id = route.id
+            },
+            path = "/plugins",
+            headers = { ["Content-Type"] = "application/json" },
+            body = {
+              id = plugin_id,
+              name = "translate-backwards-older-plugin",
+              config = {
+                new_field = "ABC",
+                old_field = "XYZ"
+              },
+            },
+          })
+
+          assert.res_status(400, res)
+
+          -- POST --- with correct values so that we can send PATCH below
+          res = assert(admin_client:send {
+            method = "POST",
+            route = {
+              id = route.id
+            },
+            path = "/plugins",
+            headers = { ["Content-Type"] = "application/json" },
+            body = {
+              id = plugin_id,
+              name = "translate-backwards-older-plugin",
+              config = {
+                new_field = "ABC",
+                old_field = "ABC"
+              },
+            },
+          })
+
+          local json = cjson.decode(assert.res_status(201, res))
+          assert.same(json.config.new_field, "ABC")
+          assert.same(json.config.old_field, "ABC")
+
+          -- PATCH
+          res = assert(admin_client:send {
+            method = "PATCH",
+            path = "/plugins/" .. plugin_id,
+            headers = { ["Content-Type"] = "application/json" },
+            body = {
+              name = "translate-backwards-older-plugin",
+              config = {
+                new_field = "EFG",
+                old_field = "XYZ"
+              },
+            },
+          })
+
+          assert.res_status(400, res)
+
+          -- GET
+          res = assert(admin_client:send {
+            method = "GET",
+            path = "/plugins/" .. plugin_id
+          })
+
+          json = cjson.decode(assert.res_status(200, res))
+          assert.same(json.config.new_field, "ABC")
+          assert.same(json.config.old_field, "ABC")
+        end)
+      end)
+    end)
+  end)
+end)

--- a/spec/fixtures/custom_plugins/kong/plugins/translate-backwards-older-plugin/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/translate-backwards-older-plugin/handler.lua
@@ -1,0 +1,12 @@
+local kong = kong
+
+local TranslateBackwardsOlderPlugin = {
+  PRIORITY = 1000,
+  VERSION = "0.1.0",
+}
+
+function TranslateBackwardsOlderPlugin:access(conf)
+    kong.log("access phase")
+end
+
+return TranslateBackwardsOlderPlugin

--- a/spec/fixtures/custom_plugins/kong/plugins/translate-backwards-older-plugin/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/translate-backwards-older-plugin/schema.lua
@@ -1,0 +1,25 @@
+return {
+  name = "translate-backwards-older-plugin",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+          { new_field = { type = "string", default = "new-value" } },
+        },
+        shorthand_fields = {
+          { old_field = {
+            type = "string",
+            translate_backwards = { 'new_field' },
+            deprecation = {
+              message = "translate-backwards-older-plugin: config.old_field is deprecated, please use config.new_field instead",
+              removal_in_version = "4.0", },
+            func = function(value)
+              return { new_field = value }
+            end
+          } },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This partially reverts commit 11405e5d4d2d88db746dd6ae0b700bc94f9fbe47. (not all changes were added back again)

`translate_backwards` was an udocumented experimental API that was created in order to generate API responses that were backwards compatible after plugin's schema field rename. It was later replaced by `deprecation.replaced_with` field in the schema. In the meantime it had been used by some custom plugins that rely on this field. Hence the reason why we need to bring it back - in order for those custom plugins to work.


### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

KAG-6947
