### PR TITLE
ci: remove unknown service redis-stack

### DIFF
--- a/scripts/dependency_services/common.sh
+++ b/scripts/dependency_services/common.sh
@@ -116,9 +116,6 @@ port_defs+=("PG_PORT:5432")
 services+=("redis")
 port_defs+=("REDIS_PORT:6379 REDIS_SSL_PORT:6380")
 
-services+=("redis-stack")
-port_defs+=("REDIS_STACK_PORT:6379")
-
 services+=("redis-auth")
 port_defs+=("REDIS_AUTH_PORT:6385")
 


### PR DESCRIPTION
This silents warning
```
service "redis-stack" is not running
Port REDIS_STACK_PORT for service redis-stack unknown
```

redis-stack service is introduced via syncing the EE change in 695e8ec8466.

It seems this service is not in the open source version.
