### PR TITLE
perf(llm): make parsing sse chunk 50% faster

### DIFF
--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -419,7 +419,7 @@ function _M.frame_to_events(frame, content_type)
     local start = 1
     while start <= #frame do
       local end_of_msg = str_find(frame, '\n', start, true)
-      if end_of_msg == nil then
+      if not end_of_msg then
         if kong then
           kong.ctx.plugin.truncated_frame = fmt("%s%s", (kong.ctx.plugin.truncated_frame or ""), frame)
         end
@@ -431,13 +431,13 @@ function _M.frame_to_events(frame, content_type)
       -- the returned s1 may be larger than the end of msg.
       local s1 = str_find(frame, ":", start, true)
       if s1 and s1 ~= 1 and s1 < end_of_msg then
-        local field = str_sub(frame, start, s1-1) -- returns "data" from data: hello world
-        local j = s1+1
+        local field = str_sub(frame, start, s1 - 1) -- returns "data" from data: hello world
+        local j = s1 + 1
         while j <= end_of_msg - 1 and str_byte(frame, j) == str_byte(" ") do
           -- consume spaces.
-          j = j+1
+          j = j + 1
         end
-        local value = str_sub(frame, j, end_of_msg-1) -- returns "hello world" from data: hello world
+        local value = str_sub(frame, j, end_of_msg - 1) -- returns "hello world" from data: hello world
 
         -- for now not checking if the value is already been set
         if     field == "event" then struct.event = value
@@ -446,7 +446,7 @@ function _M.frame_to_events(frame, content_type)
         end -- if
       end -- if
 
-      start = end_of_msg+1
+      start = end_of_msg + 1
       -- When start > #frame, str_byte returns nil, so we don't need to check out of bound here.
       if str_byte(frame, start) == str_byte('\n') then -- `\n\n`
         -- End of the SSE shunk. This is faster than calling str_find '\n' again.

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -800,8 +800,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
     it("transforms text/event-stream type", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/input.bin"))
-      local events = ai_shared.frame_to_events(input, "text/event-stream")  -- not "truncated json mode" like Gemini
-
+      events = ai_shared.frame_to_events(input, "text/event-stream")  -- not "truncated json mode" like Gemini
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/expected-output.json"))
       local expected_events = cjson.decode(expected)
 
@@ -875,7 +874,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
       package.loaded["kong.llm.drivers.gemini"] = nil
       gemini_driver = require("kong.llm.drivers.gemini")
     end)
-  
+
     teardown(function()
       _G._TEST = nil
     end)
@@ -940,7 +939,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
       package.loaded["kong.llm.drivers.bedrock"] = nil
       bedrock_driver = require("kong.llm.drivers.bedrock")
     end)
-  
+
     teardown(function()
       _G._TEST = nil
     end)

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -800,7 +800,7 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
     it("transforms text/event-stream type", function()
       local input = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/input.bin"))
-      events = ai_shared.frame_to_events(input, "text/event-stream")  -- not "truncated json mode" like Gemini
+      local events = ai_shared.frame_to_events(input, "text/event-stream")  -- not "truncated json mode" like Gemini
       local expected = pl_file.read(fmt("spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/expected-output.json"))
       local expected_events = cjson.decode(expected)
 

--- a/spec/fixtures/ai-proxy/unit/real-stream-frames/openai/llm-v1-chat.txt
+++ b/spec/fixtures/ai-proxy/unit/real-stream-frames/openai/llm-v1-chat.txt
@@ -1,1 +1,2 @@
 data: {"choices": [{"delta": {"content": "the answer"},"finish_reason": null,"index": 0,"logprobs": null}],"created": 1711938086,"id": "chatcmpl-991aYb1iD8OSD54gcxZxv8uazlTZy","model": "gpt-4-0613","object": "chat.completion.chunk","system_fingerprint": null}
+

--- a/spec/fixtures/ai-proxy/unit/real-stream-frames/openai/llm-v1-completions.txt
+++ b/spec/fixtures/ai-proxy/unit/real-stream-frames/openai/llm-v1-completions.txt
@@ -1,1 +1,2 @@
 data: {"choices": [{"finish_reason": null,"index": 0,"logprobs": null,"text": "the answer"}],"created": 1711938803,"id": "cmpl-991m7YSJWEnzrBqk41In8Xer9RIEB","model": "gpt-3.5-turbo-instruct","object": "text_completion"}
+

--- a/spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/expected-output.json
+++ b/spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/expected-output.json
@@ -7,5 +7,8 @@
   },
   {
     "data": "{    \"choices\": [        {            \"delta\": {},            \"finish_reason\": \"stop\",            \"index\": 0,            \"logprobs\": null        }    ],    \"created\": 1720136012,    \"id\": \"chatcmpl-9hQFArK1oMZcRwaIa86RGwrjVNmeY\",    \"model\": \"gpt-4-0613\",    \"object\": \"chat.completion.chunk\",    \"system_fingerprint\": null}"
+  },
+  {
+    "data": "[DONE]"
   }
 ] 

--- a/spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/input.bin
+++ b/spec/fixtures/ai-proxy/unit/streaming-chunk-formats/text-event-stream/input.bin
@@ -5,3 +5,4 @@ data: {    "choices": [        {            "delta": {                "content":
 data: {    "choices": [        {            "delta": {},            "finish_reason": "stop",            "index": 0,            "logprobs": null        }    ],    "created": 1720136012,    "id": "chatcmpl-9hQFArK1oMZcRwaIa86RGwrjVNmeY",    "model": "gpt-4-0613",    "object": "chat.completion.chunk",    "system_fingerprint": null}
 
 data: [DONE]
+


### PR DESCRIPTION
This implementation drops the usage of splitn.
Note that it assumes that each SSE chunk ends with `\n\n` which is expected (See https://github.com/Kong/kong/issues/14499). To satisfy this requirement, I also update some tests.
