### PR TITLE
fix(clustering/rpc): rpc concentrator may not work with sync v1

### DIFF
--- a/spec/02-integration/18-hybrid_rpc/04-concentrator_spec.lua
+++ b/spec/02-integration/18-hybrid_rpc/04-concentrator_spec.lua
@@ -13,7 +13,8 @@ local function start_cp(strategy, prefix,
     admin_listen = "127.0.0.1:" .. admin_listen_port,
     nginx_conf = "spec/fixtures/custom_nginx.template",
 
-    nginx_worker_processes = 1,
+    -- it should be multiple workers for concentrator test
+    nginx_worker_processes = 4,
     log_level = "debug",
     cluster_rpc = "on",
     plugins = "bundled,rpc-concentrator-test",
@@ -94,9 +95,9 @@ for _, strategy in helpers.each_strategy() do
       local cp_logfile = "cp2/logs/error.log"
 
       assert.logfile(cp_logfile).has.line(
-        "[kong.test.concentrator] node_id: ", true, 5)
+        "\\[kong.test.concentrator\\] node_id: .{36}")
       assert.logfile(cp_logfile).has.line(
-        "via concentrator", true, 5)
+        "calling kong.test.concentrator\\(node_id: .{36}\\) via concentrator")
       assert.logfile(cp_logfile).has.line(
         "[rpc] kong.test.concentrator succeeded", true, 5)
       assert.logfile(cp_logfile).has.no.line(


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

KAG-7005

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
