### PR TITLE
feat(anonymous_reports): report the state of new_dns_client

### DIFF
--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -449,6 +449,7 @@ local function configure_ping(kong_conf)
   add_immutable_value("_admin_gui", #kong_conf.admin_gui_listeners > 0 and 1 or 0)
   add_immutable_value("_proxy", #kong_conf.proxy_listeners > 0 and 1 or 0)
   add_immutable_value("_stream", #kong_conf.stream_listeners > 0 and 1 or 0)
+  add_immutable_value("new_dns_client", kong_conf.new_dns_client)
 end
 
 

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -347,6 +347,25 @@ describe("reports", function()
            "_stream=0"
         })
     end)
+
+    it("sends 'new_dns_client'", function()
+      local conf = assert(conf_loader())
+      conf.new_dns_client = true
+      send_reports_and_check_result(
+        reports,
+        conf,
+        port,
+        {"new_dns_client=true"}
+      )
+
+      conf.new_dns_client = false
+      send_reports_and_check_result(
+        reports,
+        conf,
+        port,
+        {"new_dns_client=false"}
+      )
+    end)
   end)
 
   describe("retrieve_redis_version()", function()


### PR DESCRIPTION
### Summary

Report the state of new_dns_client in anonymous reports.

### Checklist

- [X] The Pull Request has tests

### Issue reference

[KAG-7019]


[KAG-7019]: https://konghq.atlassian.net/browse/KAG-7019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ