### PR TITLE
fix(openresty): skip the non-null light userdata while `ngx.log`

### DIFF
--- a/build/openresty/patches/ngx_lua-0.10.28_04-missing-lightud.patch
+++ b/build/openresty/patches/ngx_lua-0.10.28_04-missing-lightud.patch
@@ -1,0 +1,21 @@
+diff --git a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
+index 43ab8209..a83cc2de 100644
+--- a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
++++ b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
+@@ -253,10 +253,12 @@ log_wrapper(ngx_log_t *log, const char *ident, ngx_uint_t level,
+                 break;
+
+             case LUA_TLIGHTUSERDATA:
+-                *p++ = 'n';
+-                *p++ = 'u';
+-                *p++ = 'l';
+-                *p++ = 'l';
++                if (lua_touserdata(L, i) == NULL) {
++                    *p++ = 'n';
++                    *p++ = 'u';
++                    *p++ = 'l';
++                    *p++ = 'l';
++                }
+
+                 break;
+


### PR DESCRIPTION
### Summary

This PR fixes incorrect log lines.

### Checklist

- [X] The Pull Request has tests

### Issue reference

_[KAG-4942]_


[KAG-4942]: https://konghq.atlassian.net/browse/KAG-4942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ