### PR TITLE
chore(scripts): update the version_bump script's commit message

### DIFF
--- a/scripts/make-release
+++ b/scripts/make-release
@@ -156,7 +156,7 @@ case "$step" in
 
       git add "$rockspec"
 
-      git commit --allow-empty -m "release: $version"
+      git commit --allow-empty -m "chore(release): bump version to $version"
       git log -n 1
 
       SUCCESS "Version bump for the release is now committed locally." \


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

Update the `scripts/make-release version_bump` script's commit message.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
KAG-7109
