### PR TITLE
[backport to release/3.9.x] chore(ci): enable dockerhub organization access token (OAT) (#14572)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   # official release repo
+  DOCKER_ORGANIZATION: kong
   DOCKER_REPOSITORY: kong/kong
   PRERELEASE_DOCKER_REPOSITORY: kong/kong-dev
   FULL_RELEASE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]'}}
@@ -335,8 +336,8 @@ jobs:
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
       uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
       with:
-        username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
-        password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+        username: ${{ env.DOCKER_ORGANIZATION }}
+        password: ${{ secrets.DOCKER_OAT_PUSH }}
 
     - name: Docker meta
       id: meta
@@ -464,8 +465,8 @@ jobs:
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN }}
       uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
       with:
-        username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
-        password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+        username: ${{ env.DOCKER_ORGANIZATION }}
+        password: ${{ secrets.DOCKER_OAT_PUSH }}
 
     # TODO: Refactor matrix file to support and parse platforms specific to distro
     # Workaround: Look for specific amd64 and arm64  hardcooded architectures
@@ -590,8 +591,8 @@ jobs:
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
       uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
       with:
-        username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
-        password: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUSH_TOKEN }}
+        username: ${{ env.DOCKER_ORGANIZATION }}
+        password: ${{ secrets.DOCKER_OAT_PUSH }}
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
#14572 

KAG-7040

(cherry picked from commit 36db98046b05cfe48b14d3ae00a3c5601bd105a8)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
