### PR TITLE
fix(build): use default AR args for the Lua package on macOS

### DIFF
--- a/build/luarocks/lua/BUILD.lua.bazel
+++ b/build/luarocks/lua/BUILD.lua.bazel
@@ -11,13 +11,6 @@ filegroup(
 
 make(
     name = "lua",
-    args = select({
-        "@platforms//os:macos": [
-            "AR=/usr/bin/ar",
-        ],
-        "//conditions:default": [
-        ],
-    }),
     lib_source = ":all_srcs",
     out_binaries = [
         "lua",


### PR DESCRIPTION
Lua has a default `AR= ar rcu` in its makefile, overriding it with `AR=/usr/bin/ar` will cause the build fail on macOS due to missing required arguments

The `/usr/bin` is in the `PATH` by default on macOS, so it's okay to remove this override to fix the issue

JIRA: KM-1362

