### PR TITLE
Relax insert_final_newline rule in .editorconfig to avoid unwanted diffs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,10 @@
-root                     = true
+root = true
 
 [*]
 end_of_line              = lf
-insert_final_newline     = true
+# We relax this rule because many files don't end with a newline,
+# and it causes unwanted diffs in compliant editors.
+insert_final_newline     = unset
 trim_trailing_whitespace = true
 charset                  = utf-8
 


### PR DESCRIPTION
### What this PR does

This PR relaxes the `insert_final_newline` rule in `.editorconfig` by unsetting it. This helps avoid unnecessary diffs when using editors that automatically insert a final newline, especially in files that previously did not end with one.

### Why it's needed

Currently, `.editorconfig` enforces `insert_final_newline = true`, but many Lua and other project files don’t follow this rule. Editors that respect `.editorconfig` add a newline automatically, creating unwanted diffs.

Relaxing this rule and optionally enforcing it using a linter like [`editorconfig-checker`](https://github.com/editorconfig-checker/editorconfig-checker) in CI would ensure better consistency and avoid accidental formatting changes during contributions.

### Additional context

Related to the discussion started by [@spacewander](https://github.com/Kong/kong/pull/14640#issuecomment-XXXXXXX).

Happy to make further adjustments if needed.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
