### PR TITLE
fix(key-auth): change hide_credentials behaviour

### DIFF
--- a/changelog/unreleased/kong/fix-key-auth-remove-creds-in-all-locations.yml
+++ b/changelog/unreleased/kong/fix-key-auth-remove-creds-in-all-locations.yml
@@ -1,0 +1,4 @@
+message: Key-auth plugin "hide_credentials" parameter now removes credentials only in search locations
+type: bugfix
+scope: Plugin
+

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -143,8 +143,12 @@ local function do_authentication(conf)
       key = v
 
       if conf.hide_credentials then
-        kong.service.request.clear_query_arg(name)
-        kong.service.request.clear_header(name)
+        if conf.key_in_query then
+          kong.service.request.clear_query_arg(name)
+        end
+        if conf.key_in_header then
+          kong.service.request.clear_header(name)
+        end
 
         if conf.key_in_body then
           if not body then


### PR DESCRIPTION
### Summary

Change key-auth plugin "hide_credentials" parameter  behaviour.

Before proposed change, "hide_credentials" parameter of key-auth plugin makes "apikey" parameter removed from both headers and query_string regardless of search locations. This very simple fix allows to remove apikey from query and/or from headers accordingly to search locations.
This is required for me as I have some API backends that rely on a "apikey" value set as header, and the Kong gateway is set to find the "apikey" in query.
Fix:
* remove parameter in query only if configured to search in query
* remove parameter in headers only if configured to search in headers


### Checklist

Successfully tested.
Code change is obvious and does not require a full test spec.

### Issue reference
