### PR TITLE
chore(ci): lock go version to 1.21

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -331,6 +331,11 @@ jobs:
       with:
         name: test-runtime-statistics-${{ matrix.runner }}
 
+    - name: Lock Go version to 1.21
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
     - name: Run Tests
       env:
         KONG_TEST_PG_DATABASE: kong


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
failed ci job: https://github.com/Kong/kong/actions/runs/15670670375/job/44153359575#step:20:42
```
------- Running tests from spec/02-integration/10-external-plugins/99-reports_spec.lua :
        __________
         ERR spec/02-integration/10-external-plugins/99-reports_spec.lua:20: anonymous reports for go plugins #postgres lazy_setup
./spec/internal/cmd.lua:59: # command-line-arguments
link: github.com/ugorji/go/codec: invalid reference to runtime.typedmemclr
```

Currently, the default Go version on our self-hosted runners is 1.23, but after the busted tests, go version shows 1.24.

Based on some approaches in [ethereum/go-ethereum#30100](https://github.com/ethereum/go-ethereum/issues/30100), we first lock the Go version to 1.21 and will continue investigating the errors afterward. And I opened a new issue [ugorji/go/issues/422] to follow up.


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
