### PR TITLE
fix(ai-proxy): OpenAI chat completion's tool_choice was not converted to Anthropic's

### DIFF
--- a/changelog/unreleased/kong/fix-ai-proxy-anthropic-tool-choice.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-anthropic-tool-choice.yml
@@ -1,0 +1,4 @@
+message: >
+  **ai-proxy**: Fixed an issue where OpenAI chat completion's tool_choice was not converted to Anthropic's.
+type: bugfix
+scope: Plugin

--- a/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_auto.json
+++ b/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_auto.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-4.1",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in Boston today?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "The city and state, e.g. San Francisco, CA"
+            },
+            "unit": {
+              "type": "string",
+              "enum": ["celsius", "fahrenheit"]
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}

--- a/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_none.json
+++ b/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_none.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4.1",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in Boston today?"
+    }
+  ],
+  "tool_choice": "none"
+}

--- a/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_object_function.json
+++ b/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_object_function.json
@@ -1,0 +1,28 @@
+{
+  "model": "gpt-4-0613",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are an AI assistant."
+    },
+    {
+      "role": "user",
+      "content": "Tell me a joke."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "my_function",
+        "parameters": {}
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "function": {
+      "name": "my_function"
+    }
+  }
+}

--- a/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_required.json
+++ b/spec/fixtures/ai-proxy/openai/llm-v1-chat/requests/tool_choice_required.json
@@ -1,0 +1,21 @@
+{
+  "model": "gpt-4-0613",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather today in Paris?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_current_weather",
+        "parameters": {
+          "location": "Paris"
+        }
+      }
+    }
+  ],
+  "tool_choice": "required"
+}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
