### PR TITLE
Enhance dependabot config with docker ecosystem and security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,27 @@
-# Set update schedule for GitHub Actions
-
 version: 2
 updates:
-
+  # GitHub Actions ecosystem for workflow dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: daily
+    rebase-strategy: auto
+    # Disable Dependabot version updates
+    # We are only interested in security updates
+    open-pull-requests-limit: 0
+    groups:
+      all-security:
+        applies-to: security-updates
+
+  # Docker ecosystem for container dependencies
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: daily
+    rebase-strategy: auto
+    # Disable Dependabot version updates
+    # We are only interested in security updates
+    open-pull-requests-limit: 0
+    groups:
+      all-security:
+        applies-to: security-updates


### PR DESCRIPTION
## Summary

This PR enhances the Dependabot configuration to provide comprehensive security update coverage and aligns with organization-wide security-only update strategy.

### Changes Made:

1. **Added Docker ecosystem**: Monitors .devcontainer/Dockerfile dependencies for security updates
2. **Enhanced GitHub Actions configuration**: Switch from weekly to daily monitoring with security-only focus
3. **Implemented security-only updates**: Added open-pull-requests-limit: 0 to focus solely on security updates
4. **Added grouped security updates**: Both ecosystems now use grouped security updates for better organization
5. **Maintained automated rebase strategy**: Preserves existing automation approach

### Coverage Areas:

- **GitHub Actions**: Workflow dependencies in .github/workflows/ (enhanced to security-only)
- **Docker**: Container dependencies in .devcontainer/Dockerfile (new)

### Note on Bazel Support:

Bazel/LuaRocks ecosystems are not currently supported by GitHub Dependabot, so we focus on the ecosystems that can be monitored effectively.

### Test Plan:

- [ ] Verify Dependabot configuration syntax is valid
- [ ] Confirm GitHub Actions security updates are detected daily (vs previous weekly)
- [ ] Confirm Docker base image security updates are detected for .devcontainer
- [ ] Ensure security-only configuration prevents non-security version updates
- [ ] Verify grouped security updates work correctly