### PR TITLE
fix(core): Via header is not RFC7230 compliant

### DIFF
--- a/changelog/unreleased/kong/fix-via.yml
+++ b/changelog/unreleased/kong/fix-via.yml
@@ -1,0 +1,4 @@
+message: >
+  Fixed an issue where Via header was not RFC7230 compliant. Previously, the Via header was likely `<protocol> kong/<version>`. Now, it is set to `<protocol> kong (kong/<version>)`.
+type: bugfix
+scope: Core

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -234,7 +234,7 @@ function AWSLambdaHandler:access(conf)
   headers = kong.table.merge(headers) -- create a copy of headers
 
   if kong.configuration.enabled_headers[VIA_HEADER] then
-    local outbound_via = (ngx_var.http2 and "2 " or "1.1 ") .. server_tokens
+    local outbound_via = (ngx_var.http2 and "2 " or "1.1 ") .. fmt("kong (%s)", server_tokens)
     headers[VIA_HEADER] = headers[VIA_HEADER] and headers[VIA_HEADER] .. ", " .. outbound_via
                           or outbound_via
   end

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -79,7 +79,7 @@ function azure:access(conf)
   end
 
   if kong.configuration.enabled_headers[VIA_HEADER] then
-    local outbound_via = (var.http2 and "2 " or "1.1 ") .. server_tokens
+    local outbound_via = (var.http2 and "2 " or "1.1 ") .. fmt("kong (%s)", server_tokens)
     response_headers[VIA_HEADER] = response_headers[VIA_HEADER] and response_headers[VIA_HEADER] .. ", " .. outbound_via
                                    or outbound_via
  end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1382,8 +1382,9 @@ return {
 
       do
         local req_via = get_header(constants.HEADERS.VIA, ctx)
-        local kong_inbound_via = protocol_version and protocol_version .. " " .. SERVER_HEADER
-                                 or SERVER_HEADER
+        local received_by_and_comment = fmt("kong (%s)", SERVER_HEADER)
+        local kong_inbound_via = protocol_version and protocol_version .. " " .. received_by_and_comment
+                                 or received_by_and_comment
         var.upstream_via = req_via and req_via .. ", " .. kong_inbound_via
                            or kong_inbound_via
       end
@@ -1593,7 +1594,7 @@ return {
                                  DEFAULT_PROXY_HTTP_VERSION
           end
 
-          local kong_outbound_via = proxy_http_version .. " " .. SERVER_HEADER
+          local kong_outbound_via = proxy_http_version .. " " .. fmt("kong (%s)", SERVER_HEADER)
           local resp_via = var["upstream_http_" .. headers.VIA]
           header[headers.VIA] = resp_via and resp_via .. ", " .. kong_outbound_via
                                 or kong_outbound_via

--- a/spec/02-integration/05-proxy/14-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/14-server_tokens_spec.lua
@@ -6,7 +6,7 @@ local uuid   = require("kong.tools.uuid").uuid
 
 
 local default_server_header = meta._SERVER_TOKENS
-local default_via_value =  "1.1 " .. default_server_header
+local default_via_value =  "1.1 " .. string.format("kong (%s)", default_server_header)
 
 for _, strategy in helpers.each_strategy() do
 describe("headers [#" .. strategy .. "]", function()

--- a/spec/02-integration/05-proxy/35-via_spec.lua
+++ b/spec/02-integration/05-proxy/35-via_spec.lua
@@ -8,6 +8,7 @@ local re_match  = ngx.re.match
 local str_fmt   = string.format
 
 local SERVER_TOKENS = meta._SERVER_TOKENS
+local RECEIVED_BY_AND_COMMENT = str_fmt("kong (%s)", meta._SERVER_TOKENS)
 
 for _, strategy in helpers.all_strategies() do
   describe("append Kong Gateway info to the 'Via' header [#" .. strategy .. "]", function()
@@ -146,8 +147,8 @@ for _, strategy in helpers.all_strategies() do
 
       local body = assert.res_status(200, res)
       local json_body = cjson.decode(body)
-      assert.are_same({ via = "1.1 dev, 1.1 " .. SERVER_TOKENS }, json_body)
-      assert.are_same("2 nginx, HTTP/1.1 http_mock, 1.1 " .. SERVER_TOKENS, res.headers["Via"])
+      assert.are_same({ via = "1.1 dev, 1.1 " .. RECEIVED_BY_AND_COMMENT }, json_body)
+      assert.are_same("2 nginx, HTTP/1.1 http_mock, 1.1 " .. RECEIVED_BY_AND_COMMENT, res.headers["Via"])
       assert.are_same("http-mock", res.headers["Server"])
 
       if proxy_client then
@@ -170,8 +171,8 @@ for _, strategy in helpers.all_strategies() do
 
       assert.are_equal(200, tonumber(headers:get(":status")))
       local json_body = cjson.decode(body)
-      assert.are_same({ via = "1.1 dev, 2 " .. SERVER_TOKENS }, json_body)
-      assert.are_same("2 nginx, HTTP/1.1 http_mock, 1.1 " .. SERVER_TOKENS, headers:get("Via"))
+      assert.are_same({ via = "1.1 dev, 2 " .. RECEIVED_BY_AND_COMMENT }, json_body)
+      assert.are_same("2 nginx, HTTP/1.1 http_mock, 1.1 " .. RECEIVED_BY_AND_COMMENT, headers:get("Via"))
       assert.are_same("http-mock", headers:get("Server"))
     end)
 
@@ -193,7 +194,7 @@ for _, strategy in helpers.all_strategies() do
       local server = re_match(resp, [=[Response headers received\:[\s\S]*\nserver\:\s(.*?)\n]=], "jo")
       assert.are_equal(SERVER_TOKENS, server[1])
       local via = re_match(resp, [=[Response headers received\:[\s\S]*\nvia\:\s(.*?)\n]=], "jo")
-      assert.are_equal("2 " .. SERVER_TOKENS, via[1])
+      assert.are_equal("2 " .. RECEIVED_BY_AND_COMMENT, via[1])
       local body = re_match(resp, [=[Response contents\:([\s\S]+?)\nResponse trailers received]=], "jo")
       local json_body = cjson.decode(body[1])
       assert.are_equal("hello world!", json_body.reply)
@@ -217,7 +218,7 @@ for _, strategy in helpers.all_strategies() do
       local server = re_match(resp, [=[Response headers received\:[\s\S]*\nserver\:\s(.*?)\n]=], "jo")
       assert.are_equal(SERVER_TOKENS, server[1])
       local via = re_match(resp, [=[Response headers received\:[\s\S]*\nvia\:\s(.*?)\n]=], "jo")
-      assert.are_equal("2 " .. SERVER_TOKENS, via[1])
+      assert.are_equal("2 " .. RECEIVED_BY_AND_COMMENT, via[1])
       local body = re_match(resp, [=[Response contents\:([\s\S]+?)\nResponse trailers received]=], "jo")
       local json_body = cjson.decode(body[1])
       assert.are_equal("hello world!", json_body.reply)

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -7,6 +7,7 @@ local http_mock = require "spec.helpers.http_mock"
 
 local TEST_CONF = helpers.test_conf
 local server_tokens = meta._SERVER_TOKENS
+local via_header_suffix = string.format("kong (%s)", server_tokens)
 local null = ngx.null
 local fmt = string.format
 
@@ -971,7 +972,7 @@ for _, strategy in helpers.each_strategy() do
         })
 
         if server_tokens then
-          assert.equal("2 " .. server_tokens, res.headers["Via"])
+          assert.equal("2 " .. via_header_suffix, res.headers["Via"])
         end
       end)
 

--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -4,6 +4,7 @@ local meta = require "kong.meta"
 local http_mock = require "spec.helpers.http_mock"
 
 local server_tokens = meta._SERVER_TOKENS
+local via_header_suffix = string.format("kong (%s)", server_tokens)
 
 
 for _, strategy in helpers.each_strategy() do
@@ -259,7 +260,7 @@ for _, strategy in helpers.each_strategy() do
         }
       })
 
-      assert.equal("2 " .. server_tokens, res.headers["Via"])
+      assert.equal("2 " .. via_header_suffix, res.headers["Via"])
     end)
 
     it("returns Content-Length header", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14700

