### PR TITLE
fix(ci): fix upgrade-test failure caused by renamed rockspec file

### DIFF
--- a/scripts/upgrade-tests/test-upgrade-path.sh
+++ b/scripts/upgrade-tests/test-upgrade-path.sh
@@ -94,6 +94,19 @@ function build_containers() {
     $COMPOSE up --wait
     prepare_container $OLD_CONTAINER
     docker exec -w /kong $OLD_CONTAINER make $old_make_target CRYPTO_DIR=/usr/local/kong
+
+    if [ -f kong-latest.rockspec ]; then
+        version=$(grep -E '^\s*(major|minor|patch)\s*=' kong/meta.lua \
+            | sed -E 's/[^0-9]*([0-9]+).*/\1/' \
+            | paste -sd. -)
+    
+        tmpfile=$(mktemp kong-rockspec.XXXX)
+        sed "s/^version *= *\".*\"/version = \"$version-0\"/" kong-latest.rockspec > "$tmpfile"
+        mv "$tmpfile" kong-latest.rockspec
+    
+        mv kong-latest.rockspec kong-$version-0.rockspec
+    fi
+
     make dev-legacy CRYPTO_DIR=/usr/local/kong
 }
 


### PR DESCRIPTION
KAG-7370

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
