### PR TITLE
fix: a parameters typo in llm huggingface

### DIFF
--- a/kong/llm/drivers/huggingface.lua
+++ b/kong/llm/drivers/huggingface.lua
@@ -94,9 +94,9 @@ local function set_default_parameters(request_table)
   end
   if parameters.max_tokens == nil then
     if request_table.messages then
-      -- conversational model use the max_lenght param
+      -- conversational model use the max_length param
       -- https://huggingface.co/docs/api-inference/en/detailed_parameters?code=curl#conversational-task
-      parameters.max_lenght = request_table.max_tokens
+      parameters.max_length = request_table.max_tokens
     else
       parameters.max_new_tokens = request_table.max_tokens
     end


### PR DESCRIPTION
Seems a typo for the parameters

ref: #13484


### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
