### PR TITLE
docs(DEVELOPER): fix a dead link in dev md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -273,7 +273,7 @@ Finally, all suites can be run at once by simply using:
 make test-all
 ```
 
-Consult the [run_tests.sh](.ci/run_tests.sh) script for more advanced example
+Consult the [test_suites.json](.ci/test_suites.json) json file for more advanced example
 usage of the test suites and the Makefile.
 
 Finally, a very useful tool in Lua development (as with many other dynamic


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This patch fix a dead link in DEVELOPER.md 

more: 

This test script drop in pr: #12180 and use est_suites.json instead.
but the dev doc seems not follow, the patch follow the change and 
fix the dead link. 


<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
