### PR TITLE
docs(cors): Clarify behavior with no origins specified

### DIFF
--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -31,7 +31,7 @@ return {
     { config = {
         type = "record",
         fields = {
-          { origins = { description = "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.", type = "array",
+          { origins = { description = "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes. NOTE: If you don't specify any allowed domains, all origins are allowed.", type = "array",
               elements = {
                 type = "string",
                 custom_validator = validate_asterisk_or_regex,


### PR DESCRIPTION
### Summary

Added a note to clarify the behavior of the cors plugin when the origins element is absent or empty, as requested [here](https://github.com/Kong/docs.konghq.com/issues/7875).

### Checklist

- [N/A] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/Kong/docs.konghq.com/issues/7875
