### PR TITLE
fix(build): use default AR args for the Lua package on macOS (#14648)

### DIFF
--- a/build/luarocks/lua/BUILD.lua.bazel
+++ b/build/luarocks/lua/BUILD.lua.bazel
@@ -11,13 +11,6 @@ filegroup(
 
 make(
     name = "lua",
-    args = select({
-        "@platforms//os:macos": [
-            "AR=/usr/bin/ar",
-        ],
-        "//conditions:default": [
-        ],
-    }),
     lib_source = ":all_srcs",
     out_binaries = [
         "lua",


### PR DESCRIPTION
Lua has a default `AR= ar rcu` in its makefile, overriding it with `AR=/usr/bin/ar` will cause the build fail on macOS due to missing required arguments

The `/usr/bin` is in the `PATH` by default on macOS, so it's okay to remove this override to fix the issue

JIRA: KM-1362
(cherry picked from commit 7c095c07ccd70ed21dcd6914ad5a61d9de002504)

#14648

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
