### PR TITLE
fix: instrumentation http needs required attributes

### DIFF
--- a/kong/observability/tracing/instrumentation.lua
+++ b/kong/observability/tracing/instrumentation.lua
@@ -117,6 +117,9 @@ function _M.balancer(ctx)
 
       if balancer_data.hostname ~= nil then
         span:set_attribute("net.peer.name", balancer_data.hostname)
+        span:set_attribute("net.peer.port", balancer_data.port)
+        span:set_attribute("http.method", get_method())
+        span:set_attribute("http.url", balancer_data.scheme .. "://" .. balancer_data.hostname .. ctx.request_uri)
       end
 
       if try.balancer_latency_ns ~= nil then
@@ -139,6 +142,9 @@ function _M.balancer(ctx)
 
       if balancer_data.hostname ~= nil then
         span:set_attribute("net.peer.name", balancer_data.hostname)
+        span:set_attribute("net.peer.port", balancer_data.port)
+        span:set_attribute("http.method", get_method())
+        span:set_attribute("http.url", balancer_data.scheme .. "://" .. balancer_data.hostname .. ctx.request_uri)
       end
 
       local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT_NS


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
According to https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md

The Opentelemetry "http.method" attribute is required to match an HTTP span. This allows to resolve the dependencies tree in Elastic APM by completing the span.destination.service.name field.


### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
