### PR TITLE
feat: kubernetes metrics binding

### DIFF
--- a/kong/observability/otlp/init.lua
+++ b/kong/observability/otlp/init.lua
@@ -150,11 +150,24 @@ local encode_traces, encode_logs, prepare_logs
 do
   local attributes_cache = setmetatable({}, { __mode = "k" })
   local function default_resource_attributes()
-    return {
+    local attributes =  {
       ["service.name"] = "kong",
       ["service.instance.id"] = kong and kong.node.get_id(),
       ["service.version"] = kong and kong.version,
     }
+    local pod_name = os.getenv("POD_NAME")
+    local pod_uid = os.getenv("POD_UID")
+    local pod_host = os.getenv("K8S_HOST")
+    local pod_namespace = os.getenv("K8S_NAMESPACE")
+    if pod_uid ~= "" and pod_name ~= "" then
+      attributes = table_merge(attributes, {
+          ["k8s.pod.name"] = pod_name,
+          ["k8s.pod.uid"] = pod_uid,
+          ["k8s.node.name"] = pod_host,
+          ["k8s.namespace.name"] = pod_namespace,
+      })
+    end
+    return attributes
   end
 
   local function render_resource_attributes(attributes)


### PR DESCRIPTION
### Summary
allow the APM node metrics to be binded to the pod workload by sending Kubernetes opentelemetry attributes
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)

