### PR TITLE
[backport -> master] fix(ai-prompt-decorator): increase max length for content field

### DIFF
--- a/changelog/unreleased/kong/fix_ai_prompt_decorator_content_length.yml
+++ b/changelog/unreleased/kong/fix_ai_prompt_decorator_content_length.yml
@@ -1,0 +1,4 @@
+message: |
+  Fixed an issue where the `ai-prompt-decorator` plugin prompt field was too short.
+type: feature
+scope: Plugin

--- a/kong/plugins/ai-prompt-decorator/schema.lua
+++ b/kong/plugins/ai-prompt-decorator/schema.lua
@@ -5,7 +5,7 @@ local prompt_record = {
   required = false,
   fields = {
     { role = { type = "string", required = true, one_of = { "system", "assistant", "user" }, default = "system" }},
-    { content = { type = "string", required = true, len_min = 1, len_max = 500 } },
+    { content = { type = "string", required = true, len_min = 1, len_max = 100000 } },
   }
 }
 


### PR DESCRIPTION
Automated backport to `master`, triggered manually..

## Original description

### Summary

Increase ai prompt message max length from 500 to 100000.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been added to `CHANGELOG/unreleased/kong` or adding `skip-changelog` label on PR if unnecessary. [README.md](https://github.com/Kong/kong/blob/master/CHANGELOG/README.md)
- [ ] The Pull Request has backports to all the versions it needs to cover
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [#14442](https://github.com/Kong/kong/issues/14442)
