### PR TITLE
Restrict GITHUB_TOKEN permissions on GitHub Actions

### DIFF
--- a/.github/workflows/add-release-pongo.yml
+++ b/.github/workflows/add-release-pongo.yml
@@ -5,6 +5,8 @@ on:
     tags:
     - '[1-9]+.[0-9]+.[0-9]+'
 
+permissions: read-all
+
 jobs:
   set_vars:
     name: Set Vars

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -10,6 +10,8 @@ on:
       # globs for files that we want to check with ast-grep here
       - '**/*.lua'
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -16,6 +16,9 @@ on:
         description: "Ignore the build cache and build dependencies from scratch"
         type: boolean
         default: false
+
+permissions: read-all
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -4,6 +4,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: read-all
+
 jobs:
   check_comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
         description: 'Computed cache key, used for restoring cache in other workflows'
         value: ${{ jobs.build.outputs.cache-key }}
 
+permissions: read-all
+
 env:
   BUILD_ROOT: ${{ github.workspace }}/${{ inputs.relative-build-root }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,8 @@ on:
         type: boolean
         default: false
 
+permissions: read-all
+
 # cancel previous runs if new commits are pushed to the PR, but run for each commit on master
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -17,6 +17,8 @@ on:
     - master
     - release/*
 
+permissions: read-all
+
 jobs:
 
   autoformat:

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -9,6 +9,8 @@ on:
       - '.requirements'
       - 'changelog/**'
 
+permissions: read-all
+
 jobs:
   require-changelog:
     if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions: read-all
+
 jobs:
   validate-changelog:
     name: Validate changelog

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: read-all
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -3,6 +3,8 @@ name: Detect Unexpected EE Changes
 on:
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -2,6 +2,9 @@ name: Pull Request Label Checker
 on:
   pull_request:
     types: [opened, edited, synchronize, labeled, unlabeled]
+
+permissions: read-all
+
 jobs:
   check-labels:
     name: prevent merge labels

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -2,6 +2,9 @@ name: Pull Request Schema Labeler
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled]
+
+permissions: read-all
+
 jobs:
   schema-change-labels:
     if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"

--- a/.github/workflows/labeler-v2.yml
+++ b/.github/workflows/labeler-v2.yml
@@ -2,6 +2,8 @@ name: "Pull Request Labeler v2"
 on:
 - pull_request
 
+permissions: read-all
+
 jobs:
   labeler:
     if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -4,6 +4,8 @@ on:
     paths:
     - 'build/openresty/patches/**'
 
+permissions: read-all
+
 jobs:
   create-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,8 @@ on:
   # don't know the timezone but it's daily at least
   - cron:  '0 7 * * *'
 
+permissions: read-all
+
 env:
   terraform_version: '1.2.4'
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
 
+permissions: read-all
+
 # `commit-ly` is a flag that indicates whether the build should be run per commit.
 
 env:

--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -6,6 +6,8 @@ on:
   # run weekly
   - cron: '0 0 * * 0'
 
+permissions: read-all
+
 jobs:
   update:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-test-runtime-statistics.yml
+++ b/.github/workflows/update-test-runtime-statistics.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - feat/test-run-scheduler
 
+permissions: read-all
+
 jobs:
   process-statistics:
     name: Download statistics from GitHub and combine them

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -19,6 +19,9 @@ on:
     - release/*
     - test-please/*
   workflow_dispatch:
+
+permissions: read-all
+
 # cancel previous runs if new commits are pushed to the PR, but run for each commit on master
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

This PR restricts GITHUB_TOKEN permissions across all GitHub Actions workflows to follow the principle of least privilege, as recommended by GitHub and OpenSSF.

**Problem:** Currently, workflows use the default GITHUB_TOKEN permissions which are excessively permissive (read/write access to all issues, PRs, and repository contents). This token is available to all code and actions in a workflow, meaning malicious code in dependencies could steal the token and perform unauthorized actions.

**Solution:** 
- Added `permissions: read-all` as a top-level declaration to all 20 workflows that were missing it
- Workflows that require write access retain job-level permission overrides
- All 25 workflows now have explicit permissions defined

**Security Improvements:**
1. **Least Privilege**: All workflows default to read-only access
2. **Reduced Attack Surface**: Malicious code cannot steal tokens with excessive permissions
3. **Explicit Write Access**: Only jobs that specifically need write permissions have them
4. **Best Practices Compliance**: Follows [GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) and [OpenSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) recommendations

**Modified Workflows (20 files):**
- add-release-pongo.yml, ast-grep.yml, autodocs.yml, backport-fail-bot.yml, build.yml, build_and_test.yml, buildifier.yml, changelog-requirement.yml, changelog-validation.yml, community-stale.yml, copyright-check.yml, label-check.yml, label-schema.yml, labeler-v2.yml, openresty-patches-companion.yml, perf.yml, release.yml, update-ngx-wasm-module.yml, update-test-runtime-statistics.yml, upgrade-tests.yml

### Checklist

- [x] The Pull Request has tests (N/A - security hardening only, no functional changes)
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE (N/A - internal workflow security improvement)

### Issue reference

Fix #14778