### PR TITLE
fix(ci): fix script injection from `Github` context (FTI-7084)

### DIFF
--- a/.github/workflows/add-release-pongo.yml
+++ b/.github/workflows/add-release-pongo.yml
@@ -9,6 +9,9 @@ jobs:
   set_vars:
     name: Set Vars
     runs-on: ubuntu-latest-kong
+    env:
+      REF_NAME: ${{ github.ref_name }}
+      RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
     outputs:
       code_base: ${{ steps.define_vars.outputs.CODE_BASE }}
       tag_version: ${{ steps.define_vars.outputs.TAG_VERSION }}
@@ -25,9 +28,9 @@ jobs:
         echo "CODE_BASE=$CODE_BASE" >> "$GITHUB_OUTPUT"
 
         if [[ "${{ github.event_name }}" == "push" ]] ; then
-          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="$REF_NAME"
         elif [[ "${{ github.event_name }}" == "release" ]] ; then
-          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="$RELEASE_TAG_NAME"
         fi
         echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_OUTPUT"
   add_release_to_pongo:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -135,9 +135,11 @@ jobs:
 
     - name: Choose perf suites
       id: choose_perf
+      env:
+        COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        suites="$(printf '%s' "${{ github.event.comment.body }}" | awk '{print $1}')"
-        tags="$(printf '%s' "${{ github.event.comment.body }}" | awk '{print $2}')"
+        suites="$(printf '%s' "$COMMENT_BODY" | awk '{print $1}')"
+        tags="$(printf '%s' "$COMMENT_BODY" | awk '{print $2}')"
 
         if [[ $suite == "/flamegraph" ]]; then
           suites="02-flamegraph"
@@ -166,15 +168,18 @@ jobs:
 
     - name: Find compared versions
       id: compare_versions
+      env:
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        pr_ref=$(echo "${{ github.event.pull_request.base.ref }}")
-        custom_vers="$(printf '%s' "${{ github.event.comment.body }}" | awk '{print $3}')"
+        pr_ref=$(echo "$PR_BASE_REF")
+        custom_vers="$(printf '%s' "$COMMENT_BODY" | awk '{print $3}')"
 
         if [[ ! -z "${pr_ref}" ]]; then
           vers="git:${{ github.head_ref }},git:${pr_ref}"
         elif [[ ! -z "${custom_vers}" ]]; then
           vers="${custom_vers}"
-        elif [[ ! -z "${{ github.event.comment.body }}" ]]; then
+        elif [[ ! -z "$COMMENT_BODY" ]]; then
           vers="git:${{ steps.comment-branch.outputs.head_ref}},git:${{ steps.comment-branch.outputs.base_ref}}"
         else # is cron job/on master
           vers="git:master,git:origin/master~10,git:origin/master~50"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-7084
