### PR TITLE
Fix volume path for PostgreSQL in docker-compose

### DIFF
--- a/scripts/dependency_services/docker-compose-test-services.yml
+++ b/scripts/dependency_services/docker-compose-test-services.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 127.0.0.1::5432
     volumes:
-      - postgres-data:/var/lib/posgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./00-create-pg-db.sh:/docker-entrypoint-initdb.d/00-create-pg-db.sh
     environment:
       POSTGRES_DBS: kong,kong_tests


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary
Changes the mount path for postgres to work with postgres:18
Ref: https://github.com/docker-library/postgres/pull/1259
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
