### PR TITLE
fix(plugins/key-auth): only clear key from enabled sources

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -143,8 +143,12 @@ local function do_authentication(conf)
       key = v
 
       if conf.hide_credentials then
-        kong.service.request.clear_query_arg(name)
-        kong.service.request.clear_header(name)
+        if conf.key_in_query then
+          kong.service.request.clear_query_arg(name)
+        end
+        if conf.key_in_header then
+          kong.service.request.clear_header(name)
+        end
 
         if conf.key_in_body then
           if not body then


### PR DESCRIPTION
### Summary

Even if config.key_in_query is set to false, the query is still modified by the cleanup code. i.e. "%20" will be replaced by "+" for any query parameter. This maybe surprising to the user, as the config option was explicitly disabled.
For key_in_body this is already handled differently. I.e. body is only modified if key_in_body is true.
To make the cleanup code behave more consistent and expectable this PR makes the cleanup also conditional for query and header.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

