### PR TITLE
fix(plugins): add old_default to redis shorthand fields to prevent spurious deprecation warnings

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -115,7 +115,8 @@ return {
             deprecation = {
               replaced_with = { { path = { 'redis', 'port' } } },
               message = "rate-limiting: config.redis_port is deprecated, please use config.redis.port instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 6379, },
             func = function(value)
               return { redis = { port = value } }
             end
@@ -146,7 +147,8 @@ return {
             deprecation = {
               replaced_with = { { path = { 'redis', 'ssl' } } },
               message = "rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = false, },
             func = function(value)
               return { redis = { ssl = value } }
             end
@@ -156,7 +158,8 @@ return {
             deprecation = {
               replaced_with = { { path = { 'redis', 'ssl_verify' } } },
               message = "rate-limiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = false, },
             func = function(value)
               return { redis = { ssl_verify = value } }
             end
@@ -176,7 +179,8 @@ return {
             deprecation = {
               replaced_with = { { path = { 'redis', 'timeout' } } },
               message = "rate-limiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 2000, },
             func = function(value)
               return { redis = { timeout = value } }
             end
@@ -186,7 +190,8 @@ return {
             deprecation = {
               replaced_with = { { path = { 'redis', 'database' } } },
               message = "rate-limiting: config.redis_database is deprecated, please use config.redis.database instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 0, },
             func = function(value)
               return { redis = { database = value } }
             end

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -154,7 +154,8 @@ return {
             deprecation = {
               replaced_with = { { path = {'redis', 'port'} } },
               message = "response-ratelimiting: config.redis_port is deprecated, please use config.redis.port instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 6379, },
             func = function(value)
               return { redis = { port = value } }
             end
@@ -185,7 +186,8 @@ return {
             deprecation = {
               replaced_with = { { path = {'redis', 'ssl'} } },
               message = "response-ratelimiting: config.redis_ssl is deprecated, please use config.redis.ssl instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = false, },
             func = function(value)
               return { redis = { ssl = value } }
             end
@@ -195,7 +197,8 @@ return {
             deprecation = {
               replaced_with = { { path = {'redis', 'ssl_verify'} } },
               message = "response-ratelimiting: config.redis_ssl_verify is deprecated, please use config.redis.ssl_verify instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = false, },
             func = function(value)
               return { redis = { ssl_verify = value } }
             end
@@ -215,7 +218,8 @@ return {
             deprecation = {
               replaced_with = { { path = {'redis', 'timeout'} } },
               message = "response-ratelimiting: config.redis_timeout is deprecated, please use config.redis.timeout instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 2000, },
             func = function(value)
               return { redis = { timeout = value } }
             end
@@ -225,7 +229,8 @@ return {
             deprecation = {
               replaced_with = { { path = {'redis', 'database'} } },
               message = "response-ratelimiting: config.redis_database is deprecated, please use config.redis.database instead",
-              removal_in_version = "4.0", },
+              removal_in_version = "4.0",
+              old_default = 0, },
             func = function(value)
               return { redis = { database = value } }
             end


### PR DESCRIPTION
## Summary

This PR fixes an issue where `rate-limiting` and `response-ratelimiting` plugins were generating excessive deprecation warnings even when users never configured any redis-related parameters.

**Root Cause Analysis:**

1. When reading plugin configuration, Kong reverse-maps the new `redis.*` field values back to deprecated `redis_*` shorthand fields (for backwards compatibility)
2. The `redis.*` fields have default values (e.g., `ssl=false`, `port=6379`, `timeout=2000`, `database=0`)
3. These default values get reverse-mapped to `redis_*` fields on every config read
4. Since the `redis_*` shorthand field definitions lacked `old_default` values, **every value (including defaults) triggered deprecation warnings**
5. According to `kong/db/schema/metaschema.lua`:
   - If `old_default` is **not set**, the warning is **always** printed
   - If `old_default` is **set**, the warning is only printed when the value differs from `old_default`

**The Fix:**

Added `old_default` values to shorthand fields that have corresponding defaults in `redis.*`:

| Field | old_default |
|-------|-------------|
| `redis_port` | `6379` |
| `redis_ssl` | `false` |
| `redis_ssl_verify` | `false` |
| `redis_timeout` | `2000` |
| `redis_database` | `0` |

Fields without defaults (`redis_host`, `redis_password`, `redis_username`, `redis_server_name`) don't need `old_default` as `nil` values don't trigger the reverse mapping.

**Before this fix:**
```
[kong] init.lua:904 rate-limiting: config.redis_ssl is deprecated, please use config.redis.ssl instead
```
(Logged on **every request**, even when user never configured redis)

**After this fix:**
- No deprecation warnings when using default values
- Warnings still appear when users explicitly use deprecated `redis_*` config with non-default values

## Related Issue

Fixes https://github.com/Kong/kong/issues/14418

## Test Plan

- [x] Existing integration tests in `spec/03-plugins/23-rate-limiting/05-integration_spec.lua` and `spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua` verify:
  - Using new `redis.*` config format → **no deprecation warnings**
  - Using legacy `redis_*` config with non-default values → **deprecation warnings appear**
- [x] Manual verification: Create rate-limiting plugin without any redis config, confirm no deprecation warnings in logs