### PR TITLE
fix(plugins/ai-proxy): the request will panic if the model name with `/`

### DIFF
--- a/changelog/unreleased/kong/fix-ai-proxy-model-name-slash.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-model-name-slash.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed a panic triggered when handling models whose names contain `/`."
+type: "bugfix"
+scope: "Plugin"

--- a/changelog/unreleased/kong/fix-ai-proxy-model-name-slash.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-model-name-slash.yml
@@ -1,3 +1,3 @@
-message: "**ai-proxy**: Fixed a panic triggered when handling models whose names contain `/`."
+message: "**ai-proxy**: Fixed a panic triggered by a non-JSON response."
 type: "bugfix"
 scope: "Plugin"

--- a/kong/llm/plugin/shared-filters/serialize-analytics.lua
+++ b/kong/llm/plugin/shared-filters/serialize-analytics.lua
@@ -1,4 +1,4 @@
-local cjson = require("cjson")
+local cjson = require("cjson.safe")
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local ai_plugin_o11y = require("kong.llm.plugin.observability")
 
@@ -39,7 +39,10 @@ function _M:run(conf)
 
       else
         -- openai formats
-        local response_body_table = cjson.decode(response_body)
+        local response_body_table, err = cjson.decode(response_body)
+        if err then
+          kong.log.info("failed to decode response body: ", err)
+        end
         response_model = response_body_table and response_body_table.model
       end
     end


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

For Gemini/VertexAI, it concats the model name in the url, so it will return NOT FOUND error if the model name wrongly brings the provider prefix like `google/gemini-2.5-flash`. And it will raise an error while decoding the empty string with `cjson` instead of `cjson.safe`.


### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE
