### PR TITLE
refactor(pdk): remove duplicate rate limiting context check

### DIFF
--- a/changelog/unreleased/kong/remove-duplicate-rl-ctx-check.yml
+++ b/changelog/unreleased/kong/remove-duplicate-rl-ctx-check.yml
@@ -1,0 +1,3 @@
+message: Remove duplicate rate limiting context check in PDK
+type: performance
+scope: PDK

--- a/kong/pdk/private/rate_limiting.lua
+++ b/kong/pdk/private/rate_limiting.lua
@@ -85,10 +85,6 @@ function _M.get_stored_response_header(ngx_ctx, key)
     return nil
   end
 
-  if not _has_rl_ctx(ngx_ctx) then
-    return nil
-  end
-
   local rl_ctx = _get_rl_ctx(ngx_ctx)
   return rl_ctx[key]
 end


### PR DESCRIPTION
### Summary

Removes a redundant `_has_rl_ctx(ngx_ctx)` check in `get_stored_response_header`. The check was performed twice in sequence.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong`
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com

### Issue reference