### PR TITLE
chore(ci): skip build_and_test and release workflows for PRs updating COPYRIGHT and LICENSE files (#14821)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,6 +4,8 @@ on:
     paths-ignore:
     # ignore markdown files (CHANGELOG.md, README.md, etc.)
     - '**/*.md'
+    - 'COPYRIGHT'
+    - 'LICENSE'
     - '.github/workflows/release.yml'
     - 'changelog/**'
     - 'kong.conf.default'
@@ -13,6 +15,7 @@ on:
     - '**/*.md'
     # ignore PRs for the generated COPYRIGHT file
     - 'COPYRIGHT'
+    - 'LICENSE'
     branches:
     - master
     - release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     paths-ignore:
     - '**/*.md'
+    - 'COPYRIGHT'
+    - 'LICENSE'
     - '.github/workflows/build_and_test.yml'
     - 'changelog/**'
     - 'kong.conf.default'


### PR DESCRIPTION
Skip build_and_test and release workflows for PRs that only update the COPYRIGHT or LICENSE file.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

manual cherry-pick of #14821

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
