### PR TITLE
Enhance upstream_url schema with referenceable flag

### DIFF
--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -184,7 +184,9 @@ local model_options_schema = {
     { upstream_url = typedefs.url {
         description = "Manually specify or override the full URL to the AI operation endpoints, "
                    .. "when calling (self-)hosted models, or for running via a private endpoint.",
-        required = false }},
+        required = false,
+        referenceable = true,
+      }},
     { upstream_path = {
         description = "Manually specify or override the AI operation path, "
                    .. "used when e.g. using the 'preserve' route_type.",


### PR DESCRIPTION
Add referenceable attribute to upstream_url schema in order to load private endpoint from vault

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Allows to load AI Proxy upstream url for private endpoint generated with random caracteres, It allows us to load it from Vault instead of hard coding it in our configuration

### Checklist


- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)


