### PR TITLE
chore(docs): fix contact link to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: Kong Gateway Open Source Community Pledge
     url: https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
   - name: Feature Request
-    url: https://github.com/Kong/kong/discussions/categories/ideas
+    url: https://github.com/Kong/kong/discussions/categories/ideas-and-feature-requests
     about: Propose your cool ideas and feature requests at the Kong discussion forum
   - name: Question
     url: https://github.com/Kong/kong/discussions/categories/help


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Fix broken link.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference