### PR TITLE
ci: restrict GITHUB_TOKEN to read-only in core CI workflows

### DIFF
--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -10,6 +10,9 @@ on:
       # globs for files that we want to check with ast-grep here
       - '**/*.lua'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
         description: 'Computed cache key, used for restoring cache in other workflows'
         value: ${{ jobs.build.outputs.cache-key }}
 
+permissions:
+  contents: read
+
 env:
   BUILD_ROOT: ${{ github.workspace }}/${{ inputs.relative-build-root }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 # cancel previous runs if new commits are pushed to the PR, but run for each commit on master
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -17,6 +17,9 @@ on:
     - master
     - release/*
 
+permissions:
+  contents: read
+
 jobs:
 
   autoformat:

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -9,6 +9,9 @@ on:
       - '.requirements'
       - 'changelog/**'
 
+permissions:
+  contents: read
+
 jobs:
   require-changelog:
     if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   validate-changelog:
     name: Validate changelog

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -3,6 +3,9 @@ name: Detect Unexpected EE Changes
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary
- add explicit top-level workflow permissions:
  - `permissions: { contents: read }`
- apply to core read-only CI workflows:
  - `.github/workflows/build.yml`
  - `.github/workflows/build_and_test.yml`
  - `.github/workflows/buildifier.yml`
  - `.github/workflows/ast-grep.yml`
  - `.github/workflows/changelog-requirement.yml`
  - `.github/workflows/changelog-validation.yml`
  - `.github/workflows/copyright-check.yml`

## Why
These workflows currently rely on repository-default `GITHUB_TOKEN` scope. Explicit read-only defaults reduce blast radius from compromised workflow code/actions and move toward least-privilege guidance.

Relates to #14778.

## Notes
- This PR intentionally targets core CI/lint/read-only workflows first.
- Release/automation workflows with write needs are left unchanged in this patch.
