### PR TITLE
fix(tracing): omit http.route span attribute when route has no paths

### DIFF
--- a/changelog/unreleased/kong/fix-tracing-empty-http-route.yml
+++ b/changelog/unreleased/kong/fix-tracing-empty-http-route.yml
@@ -1,0 +1,6 @@
+message: >
+  **Tracing**: Fixed an issue where the `http.route` span attribute was set
+  to an empty string when the route had no paths, instead of being omitted
+  as required by the OpenTelemetry specification.
+type: bugfix
+scope: Core

--- a/kong/observability/tracing/instrumentation.lua
+++ b/kong/observability/tracing/instrumentation.lua
@@ -329,7 +329,10 @@ function _M.runloop_before_header_filter()
   if root_span then
     root_span:set_attribute("http.status_code", ngx.status)
     local r = ngx.ctx.route
-    root_span:set_attribute("http.route", r and r.paths and r.paths[1] or "")
+    local route_path = r and r.paths and r.paths[1]
+    if route_path then
+      root_span:set_attribute("http.route", route_path)
+    end
   end
 end
 

--- a/spec/02-integration/14-observability/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-observability/01-instrumentations_spec.lua
@@ -518,6 +518,51 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("#regression", function ()
+      describe("http.route attribute omitted when route has no paths", function ()
+        lazy_setup(function()
+          setup_instrumentations("all", false, function(bp)
+            local http_srv = bp.services:insert({
+              name = "host-only-service",
+              host = helpers.mock_upstream_host,
+              port = helpers.mock_upstream_port,
+            })
+
+            bp.routes:insert({
+              service = http_srv,
+              protocols = { "http" },
+              hosts = { "no-paths-route.test" },
+            })
+          end)
+        end)
+
+        lazy_teardown(function()
+          helpers.stop_kong()
+        end)
+
+        it("does not set http.route when route has no paths", function ()
+          local thread = helpers.tcp_server(TCP_PORT)
+          local r = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              host = "no-paths-route.test",
+            }
+          })
+          assert.res_status(200, r)
+
+          -- Getting back the TCP server input
+          local ok, res = thread:join()
+          assert.True(ok)
+          assert.is_string(res)
+
+          local spans = cjson.decode(res)
+          local kong_span = assert_has_spans("kong", spans, 1)[1]
+
+          -- http.route must not be set when route has no paths
+          assert.is_nil(kong_span.attributes["http.route"])
+        end)
+      end)
+
       describe("nil attribute for dns_query when fail to query", function ()
         lazy_setup(function()
           setup_instrumentations("dns_query", true, function(bp)


### PR DESCRIPTION
### Summary

Per the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-route), the `http.route` attribute must not be set on the span when the route is not known. Previously, Kong emitted an empty string as the value of `http.route` when the matched route had no paths defined (e.g., host-only routes), violating the specification.

This change makes `http.route` only be set when the route has an actual path value. When no path is available, the attribute is omitted entirely.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - N/A (internal behavioral fix to match existing OTel spec)

### Issue reference

Fix #14845