### PR TITLE
balancer: fix 'occured' -> 'occurred' in consistent_hashing comment

### DIFF
--- a/kong/runloop/balancer/consistent_hashing.lua
+++ b/kong/runloop/balancer/consistent_hashing.lua
@@ -180,7 +180,7 @@ function consistent_hashing:getPeer(cacheOnly, handle, valueToHash)
         ngx_log(ngx_DEBUG, "found address but it was unavailable. ",
                 " trying next one.")
       else
-        -- an unknown error occured
+        -- an unknown error occurred
         return nil, port
       end
 


### PR DESCRIPTION
Comment in `kong/runloop/balancer/consistent_hashing.lua` line 183 reads `an unknown error occured`. Fixed to `occurred`. Comment-only change.