### PR TITLE
fix(ai-proxy): use provider total token counts

### DIFF
--- a/changelog/unreleased/kong/fix-ai-total-token-metrics.yml
+++ b/changelog/unreleased/kong/fix-ai-total-token-metrics.yml
@@ -1,0 +1,3 @@
+message: "Fixed AI Proxy metrics to use provider-reported total token counts when available."
+type: bugfix
+scope: Plugin

--- a/kong/llm/adapters/bedrock.lua
+++ b/kong/llm/adapters/bedrock.lua
@@ -51,6 +51,7 @@ function _BedrockAdapter:extract_metadata(response_body)
       return {
         prompt_tokens = response_body.usage.inputTokens or 0,
         completion_tokens = response_body.usage.outputTokens or 0,
+        total_tokens = response_body.usage.totalTokens,
       }
     end
 

--- a/kong/llm/adapters/gemini.lua
+++ b/kong/llm/adapters/gemini.lua
@@ -50,6 +50,7 @@ function _GeminiAdapter:extract_metadata(response_body)
       return {
         prompt_tokens = response_body.usageMetadata.promptTokenCount or 0,
         completion_tokens = response_body.usageMetadata.candidatesTokenCount or 0,
+        total_tokens = response_body.usageMetadata.totalTokenCount,
       }
     end
 

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -847,6 +847,9 @@ function _M.post_request(conf, response_object)
 
     ai_plugin_o11y.metrics_set("llm_prompt_tokens_count", response_object.usage.prompt_tokens)
     ai_plugin_o11y.metrics_set("llm_completion_tokens_count", response_object.usage.completion_tokens)
+    if response_object.usage.total_tokens then
+      ai_plugin_o11y.metrics_set("llm_total_tokens_count", response_object.usage.total_tokens)
+    end
 
     if response_object.usage.prompt_tokens and response_object.usage.completion_tokens and
        conf.model.options and conf.model.options.input_cost and conf.model.options.output_cost then

--- a/kong/llm/plugin/shared-filters/normalize-json-response.lua
+++ b/kong/llm/plugin/shared-filters/normalize-json-response.lua
@@ -58,6 +58,10 @@ local function transform_body(conf)
     if t and t.usage and t.usage.completion_tokens then
       ai_plugin_o11y.metrics_set("llm_completion_tokens_count", t.usage.completion_tokens)
     end
+
+    if t and t.usage and t.usage.total_tokens then
+      ai_plugin_o11y.metrics_set("llm_total_tokens_count", t.usage.total_tokens)
+    end
   end
 
   set_global_ctx("response_body", response_body) -- to be sent out later or consumed by other plugins

--- a/kong/llm/plugin/shared-filters/normalize-sse-chunk.lua
+++ b/kong/llm/plugin/shared-filters/normalize-sse-chunk.lua
@@ -117,9 +117,15 @@ local function handle_streaming_frame(conf, chunk, finished)
       if conf.model.provider == "gemini" then
         ai_plugin_o11y.metrics_set("llm_prompt_tokens_count", metadata.prompt_tokens or 0)
         ai_plugin_o11y.metrics_set("llm_completion_tokens_count", metadata.completion_tokens or 0)
+        if metadata.total_tokens then
+          ai_plugin_o11y.metrics_set("llm_total_tokens_count", metadata.total_tokens)
+        end
       else
         ai_plugin_o11y.metrics_add("llm_prompt_tokens_count", metadata.prompt_tokens or 0)
         ai_plugin_o11y.metrics_add("llm_completion_tokens_count", metadata.completion_tokens or 0)
+        if metadata.total_tokens then
+          ai_plugin_o11y.metrics_set("llm_total_tokens_count", metadata.total_tokens)
+        end
       end
     end
   end

--- a/kong/llm/plugin/shared-filters/parse-json-response.lua
+++ b/kong/llm/plugin/shared-filters/parse-json-response.lua
@@ -39,6 +39,9 @@ function _M:run(_)
       else
         ai_plugin_o11y.metrics_set("llm_prompt_tokens_count", metadata.prompt_tokens)
         ai_plugin_o11y.metrics_set("llm_completion_tokens_count", metadata.completion_tokens)
+        if metadata.total_tokens then
+          ai_plugin_o11y.metrics_set("llm_total_tokens_count", metadata.total_tokens)
+        end
       end
 
     else
@@ -54,6 +57,10 @@ function _M:run(_)
 
       if t and t.usage and t.usage.completion_tokens then
         ai_plugin_o11y.metrics_set("llm_completion_tokens_count", t.usage.completion_tokens)
+      end
+
+      if t and t.usage and t.usage.total_tokens then
+        ai_plugin_o11y.metrics_set("llm_total_tokens_count", t.usage.total_tokens)
       end
     end
   end

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -664,7 +664,11 @@ describe("Plugin: prometheus (access) AI metrics", function()
                   ngx.print(pl_file.read("spec/fixtures/ai-proxy/openai/llm-v1-chat/responses/bad_request.json"))
                 else
                   ngx.status = 200
-                  ngx.print(pl_file.read("spec/fixtures/ai-proxy/openai/llm-v1-chat/responses/good.json"))
+                  local response = json.decode(pl_file.read(
+                    "spec/fixtures/ai-proxy/openai/llm-v1-chat/responses/good.json"
+                  ))
+                  response.usage.total_tokens = 298
+                  ngx.print(json.encode(response))
                 end
               else
                 ngx.status = 401
@@ -844,7 +848,7 @@ describe("Plugin: prometheus (access) AI metrics", function()
 
     assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="completion_tokens",workspace="default"} 12', body, nil, true)
     assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="prompt_tokens",workspace="default"} 25', body, nil, true)
-    assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="total_tokens",workspace="default"} 37', body, nil, true)
+    assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="total_tokens",workspace="default"} 298', body, nil, true)
   end)
 
   it("increments the count for proxied AI requests", function()
@@ -883,7 +887,7 @@ describe("Plugin: prometheus (access) AI metrics", function()
 
     assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="completion_tokens",workspace="default"} 24', body, nil, true)
     assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="prompt_tokens",workspace="default"} 50', body, nil, true)
-    assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="total_tokens",workspace="default"} 74', body, nil, true)
+    assert.matches('ai_llm_tokens_total{ai_provider="openai",ai_model="gpt-3.5-turbo",cache_status="",vector_db="",embeddings_provider="",embeddings_model="",token_type="total_tokens",workspace="default"} 596', body, nil, true)
   end)
 
   it("behave correctly if AI metrics are not found", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

AI metrics currently derive `llm_total_tokens_count` from prompt and completion token counts when providers include an explicit total. Some providers can report additional billed tokens in `usage.total_tokens` or equivalent native metadata, so this underreports `ai_llm_tokens_total` for `token_type="total_tokens"`.

This change records provider-reported total token counts when available across the AI response parsing paths, while keeping the existing prompt-plus-completion fallback for providers that omit a total. The Prometheus AI metrics regression now returns a provider total that differs from `prompt_tokens + completion_tokens` and asserts the exported total uses the explicit value.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [x] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - N/A, no user-facing docs change

### Issue reference

Fix #14816

### Validation

- `git diff --check`
- Checked for committed focused-test markers with `rg -n -w '#only|#o' spec` and `rg -n -- '---\s+ONLY' t`
- Syntax-checked touched Lua files and the Prometheus spec with the repo-built LuaJIT
- Ran a focused observability check for `llm_total_tokens_count` fallback and explicit override behavior
- Attempted `make test-custom test_spec=spec/03-plugins/26-prometheus/02-access_spec.lua`; the local dev venv build failed before tests because LuaRocks could not build `lyaml` without `libyaml-dev`, and passwordless sudo is unavailable in this environment
