### PR TITLE
Fix grammar, formatting, and broken link in docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -47,7 +47,7 @@ You can find every supported distribution on the [official installation page](ht
 
 #### Kong Pongo
 
-[Pongo](https://github.com/Kong/kong-pongo) is a CLI tool that are
+[Pongo](https://github.com/Kong/kong-pongo) is a CLI tool that is
 specific for plugin development. It is docker-compose based and will
 create local test environments including all dependencies. Core features
 are running tests, integrated linter, config initialization, CI support,
@@ -146,7 +146,7 @@ using either one of the following ways:
 
 Then you have to make the Rust build system also authenticate with GitHub,
 there is nothing you need to do if you were authenticated using `gh` or `git credential helper`,
-otherwise, you can set the[`CARGO_NET_GIT_FETCH_WITH_CLI`](https://doc.rust-lang.org/cargo/reference/config.html)
+otherwise, you can set the [`CARGO_NET_GIT_FETCH_WITH_CLI`](https://doc.rust-lang.org/cargo/reference/config.html)
 environment variable to `true`.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ The Gateway is now available on the following ports on localhost:
 - `:8001` - configure Kong using Admin API or via [decK](https://github.com/kong/deck)
 - `:8002` - access Kong's management Web UI ([Kong Manager](https://github.com/Kong/kong-manager)) on [localhost:8002](http://localhost:8002)
 
-Next, follow the [quick start guide](https://docs.konghq.com/gateway-oss/latest/getting-started/configuring-a-service/
-) to tour the Gateway features.
+Next, follow the [quick start guide](https://docs.konghq.com/gateway-oss/latest/getting-started/configuring-a-service/) to tour the Gateway features.
 
 ### Getting started with AI Gateway for LLM and MCP
 


### PR DESCRIPTION
## Summary

- **DEVELOPER.md line 50**: Fix subject-verb agreement — `"is a CLI tool that are specific"` → `"that is specific"`
- **DEVELOPER.md line 149**: Add missing space before backtick — `"set the[\`CARGO_NET_GIT_FETCH_WITH_CLI\`]"` → `"set the [\`CARGO_NET_GIT_FETCH_WITH_CLI\`]"`
- **README.md line 49-50**: Fix broken Markdown link — closing `)` was on a new line, breaking the rendered link