### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/kong/llm/drivers/astraflow.lua
+++ b/kong/llm/drivers/astraflow.lua
@@ -1,0 +1,9 @@
+-- Astraflow (by UCloud) is an OpenAI-compatible AI model aggregation platform
+-- supporting 200+ models. Because its API is fully OpenAI-compatible, this driver
+-- simply delegates all request/response handling to the OpenAI driver.
+--
+-- Global endpoint : https://api-us-ca.umodelverse.ai/v1  (env: ASTRAFLOW_API_KEY)
+-- China endpoint  : https://api.modelverse.cn/v1         (env: ASTRAFLOW_CN_API_KEY)
+-- Website         : https://astraflow.ucloud-global.com  (global)
+--                   https://astraflow.ucloud.cn          (China)
+return require("kong.llm.drivers.openai")

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -101,6 +101,7 @@ _M.upstream_url_format = {
   bedrock       = "https://bedrock-runtime.%s.amazonaws.com",
   mistral       = "https://api.mistral.ai:443",
   huggingface   = "https://api-inference.huggingface.co/models/%s",
+  astraflow     = "https://api-us-ca.umodelverse.ai",
 }
 
 _M.operation_map = {
@@ -171,6 +172,16 @@ _M.operation_map = {
       method = "POST",
     },
   },
+  astraflow = {
+    ["llm/v1/completions"] = {
+      path = "/v1/completions",
+      method = "POST",
+    },
+    ["llm/v1/chat"] = {
+      path = "/v1/chat/completions",
+      method = "POST",
+    },
+  },
   bedrock = {
     ["llm/v1/chat"] = {
       path = "/model/%s/%s",
@@ -196,6 +207,9 @@ _M.clear_response_headers = {
     "Set-Cookie",
   },
   bedrock = {
+    "Set-Cookie",
+  },
+  astraflow = {
     "Set-Cookie",
   },
 }

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -209,7 +209,7 @@ local model_schema = {
         type = "string", description = "AI provider request format - Kong translates "
                                     .. "requests to and from the specified backend compatible formats.",
         required = true,
-        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini", "bedrock", "huggingface" }}},
+        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini", "bedrock", "huggingface", "astraflow" }}},
     { name = {
         type = "string",
         description = "Model name to execute.",


### PR DESCRIPTION
### Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) (by UCloud / 优刻得) as a supported LLM provider in Kong's AI plugins.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because its API is fully wire-compatible with the OpenAI API, the integration requires only minimal changes — no new SDK, no new subpackage.

**Changes:**

| File | Change |
|---|---|
| `kong/llm/schemas/init.lua` | Added `"astraflow"` to the `model.provider` `one_of` enum |
| `kong/llm/drivers/shared.lua` | Added `astraflow` entry to `upstream_url_format`, `operation_map`, and `clear_response_headers` |
| `kong/llm/drivers/astraflow.lua` | New driver file — delegates entirely to the OpenAI driver (OpenAI-compatible) |

**Provider details:**

| | Global | China |
|---|---|---|
| **Base URL** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| **Website** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |

**Usage example:**

```yaml
plugins:
  - name: ai-proxy
    config:
      route_type: llm/v1/chat
      auth:
        header_name: Authorization
        header_value: Bearer <ASTRAFLOW_API_KEY>
      model:
        provider: astraflow
        name: gpt-4o
        options:
          upstream_url: https://api-us-ca.umodelverse.ai/v1/chat/completions
```

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #_[issue number]_