### PR TITLE
[backport to release/3.9.x] chore(ci): pin all github actions

### DIFF
--- a/.github/actions/build-wasm-test-filters/action.yml
+++ b/.github/actions/build-wasm-test-filters/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "CACHE_KEY=${CACHE_PREFIX}::${FILE_HASH}" >> $GITHUB_ENV
 
     - name: Restore Cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: restore-cache
       with:
         path: |
@@ -66,7 +66,7 @@ runs:
     - name: Save cache
       if: steps.restore-cache.outputs.cache-hit != 'true'
       id: save-cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/add-release-pongo.yml
+++ b/.github/workflows/add-release-pongo.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     - name: Checkout Pongo
       id: checkout_pongo
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         token: ${{ env.GITHUB_TOKEN }}
         repository: kong/kong-pongo

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -32,10 +32,10 @@ jobs:
           echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Checkout Kong source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Lookup build cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-deps
         with:
           path: ${{ env.INSTALL_ROOT }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Checkout kong-build-tools
         if: steps.cache-deps.outputs.cache-hit != 'true' || github.event.inputs.force_build == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           repository: Kong/kong-build-tools
           path: kong-build-tools
@@ -51,7 +51,7 @@ jobs:
 
       - name: Checkout go-pluginserver
         if: steps.cache-deps.outputs.cache-hit != 'true' || github.event.inputs.force_build == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           repository: Kong/go-pluginserver
           path: go-pluginserver
@@ -80,13 +80,13 @@ jobs:
           echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Checkout Kong source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           path: kong
           ref: ${{ github.event.inputs.source_branch }}
 
       - name: Checkout Kong Docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           repository: kong/docs.konghq.com
           path: docs.konghq.com
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ github.event.inputs.target_branch }}
 
       - name: Lookup build cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-deps
         with:
           path: ${{ env.INSTALL_ROOT }}

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Fetch mapping file
       id: fetch_mapping
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         ACCESS_TOKEN: ${{ secrets.PAT }}
       with:
@@ -25,7 +25,7 @@ jobs:
 
     - name: Generate Slack Payload
       id: generate-payload
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         SLACK_CHANNEL: gateway-notifications
         SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"

--- a/.github/workflows/backport-v2.yml
+++ b/.github/workflows/backport-v2.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - name: Create backport pull requests
         uses: korthout/backport-action@924c8170740fa1e3685f69014971f7f251633f53 # v2.4.1
         id: backport

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     # these aren't necessarily used by all tests, but building them here will
     # ensures that we have a warm cache when other tests _do_ need to build the
@@ -37,7 +37,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -73,7 +73,7 @@ jobs:
         luarocks config
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: failure()
       with:
         name: bazel-outputs

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,7 +46,7 @@ jobs:
       old-kong-version: ${{ steps.old-kong-version.outputs.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         fetch-depth: 0  # `git merge-base` requires the history
 
@@ -91,11 +91,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -139,7 +139,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Download runtimes file
       uses: Kong/gh-storage/download@b196a6b94032e56e414227c749e9f96a6afc2b91 # v1
@@ -158,7 +158,7 @@ jobs:
         static-mode: ${{ github.run_attempt > 1 }}
 
     - name: Upload schedule files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       continue-on-error: true
       with:
         name: schedule-test-files
@@ -232,11 +232,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     # used for plugin compatibility test
     - name: Checkout old version Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         path: kong-old
         # if the minor version is 0, `ref` will default to ''
@@ -245,7 +245,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -309,7 +309,7 @@ jobs:
         psql -hlocalhost -Ukong kong -tAc 'alter system set max_connections = 5000;'
 
     - name: Download test schedule file
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: schedule-test-files
 
@@ -326,13 +326,13 @@ jobs:
         pip install kong-pdk
 
     - name: Download test rerun information
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       continue-on-error: true
       with:
         name: test-rerun-info-${{ matrix.runner }}
 
     - name: Download test runtime statistics from previous runs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       continue-on-error: true
       with:
         name: test-runtime-statistics-${{ matrix.runner }}
@@ -362,7 +362,7 @@ jobs:
 
     - name: Upload error logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: busted-test-errlogs-${{ matrix.runner }}
         path: ${{ env.SPEC_ERRLOG_CACHE_DIR }}
@@ -370,7 +370,7 @@ jobs:
 
     - name: Upload test rerun information
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-rerun-info-${{ matrix.runner }}
         path: ${{ env.FAILED_TEST_FILES_FILE }}
@@ -378,14 +378,14 @@ jobs:
 
     - name: Upload test runtime statistics for offline scheduling
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-runtime-statistics-${{ matrix.runner }}
         path: ${{ env.TEST_FILE_RUNTIME_FILE }}
         retention-days: 7
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}-${{ matrix.runner }}
@@ -412,11 +412,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -449,14 +449,14 @@ jobs:
 
     - name: Upload error logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: PDK-test-errlogs
         path: ${{ env.SPEC_ERRLOG_CACHE_DIR }}
         retention-days: 1
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
@@ -477,7 +477,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Install requirements
       run: |
@@ -486,7 +486,7 @@ jobs:
         sudo luarocks install luafilesystem
 
     # Download all archived coverage stats files
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
     - name: Stats aggregation
       shell: bash

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -15,7 +15,7 @@ jobs:
     name: Requires changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Validate changelogs
         uses: Kong/gateway-changelog@bc389e6bcc015b3560c4d1024a3782331602a0f6

--- a/.github/workflows/cherry-picks-v2.yml
+++ b/.github/workflows/cherry-picks-v2.yml
@@ -26,7 +26,7 @@ jobs:
         startsWith(github.event.comment.body, '/cherry-pick')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
       - name: Create backport pull requests

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@a5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 14
           days-before-close: 7

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Find Enterprise Copyright
         shell: bash

--- a/.github/workflows/deck-integration.yml
+++ b/.github/workflows/deck-integration.yml
@@ -51,13 +51,13 @@ jobs:
         run: sudo apt update && sudo apt install -y libyaml-dev valgrind libprotobuf-dev libpam-dev postgresql-client jq
 
       - name: Checkout Kong source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           submodules: recursive
 
       - name: Lookup build cache
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ env.BUILD_ROOT }}
           key: ${{ needs.build.outputs.cache-key }}

--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - name: Label Community PR
         env:
           GH_TOKEN: ${{ secrets.COMMUNITY_PRS_TOKEN }}

--- a/.github/workflows/labeler-v2.yml
+++ b/.github/workflows/labeler-v2.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Generate cache key
       id: cache-key
@@ -42,7 +42,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -65,7 +65,7 @@ jobs:
         luarocks
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: failure()
       with:
         name: bazel-outputs
@@ -110,7 +110,7 @@ jobs:
         repo-token: ${{ secrets.PAT }}
 
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         # Fetch all history for all tags and branches
         fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
     - name: Load Cached Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build-packages.outputs.cache-key }}
@@ -251,7 +251,7 @@ jobs:
           inkscape --export-area-drawing --export-png="${i%.*}.png" --export-dpi=300 -b FFFFFF $i
         done
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.10'
         cache: 'pip'
@@ -267,7 +267,7 @@ jobs:
         done
 
     - name: Save results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       if: always()
       with:
         name: perf-results
@@ -278,7 +278,7 @@ jobs:
         retention-days: 31
 
     - name: Save error logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       if: always()
       with:
         name: error_logs

--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Read comment
       id: read_comment
@@ -43,7 +43,7 @@ jobs:
     - name: Validate input
       if: steps.read_comment.outputs.other_pr
       id: validate_url
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const url = `${{ steps.read_comment.outputs.other_pr }}`;
@@ -89,7 +89,7 @@ jobs:
         fi
 
     - name: Post result as comment in the PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       if: steps.run_extension.outputs.MESSAGE
       with:
         script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
     - name: Build Info
       id: build-info
       run: |
@@ -135,7 +135,7 @@ jobs:
     - name: Cache Git
       id: cache-git
       if: (matrix.package == 'rpm') && matrix.image != ''
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: /usr/local/git
         key: ${{ matrix.label }}-git-2.41.0
@@ -167,7 +167,7 @@ jobs:
         echo "/usr/local/git/bin" >> $GITHUB_PATH
 
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Swap git with https
       run: git config --global url."https://github".insteadOf git://github
@@ -184,7 +184,7 @@ jobs:
     - name: Cache Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
       with:
         path: bazel-bin/pkg
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -266,7 +266,7 @@ jobs:
         tail -n500 bazel-out/**/*/CMake.log || true
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ matrix.label }}-packages
         path: bazel-bin/pkg
@@ -283,16 +283,16 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-packages'] }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: ${{ matrix.label }}-packages
         path: bazel-bin/pkg
 
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
@@ -319,17 +319,17 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
 
     - name: Download artifact (alt)
       if: matrix.artifact-from-alt != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: ${{ matrix.artifact-from-alt }}-packages
         path: bazel-bin/pkg
@@ -420,10 +420,10 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
@@ -526,10 +526,10 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['release-packages'] }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
@@ -596,7 +596,7 @@ jobs:
         username: ${{ env.DOCKER_ORGANIZATION }}
         password: ${{ secrets.DOCKER_OAT_PUSH }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
     - name: Get latest commit SHA on master
       run: |

--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
         ref: master
 

--- a/.github/workflows/update-test-runtime-statistics.yml
+++ b/.github/workflows/update-test-runtime-statistics.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           token: ${{ secrets.PAT }}
 

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -40,14 +40,14 @@ jobs:
 
     steps:
       - name: Clone Source Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Lookup build cache
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ env.BUILD_ROOT }}
           key: ${{ needs.build.outputs.cache-key }}


### PR DESCRIPTION
KAG-9003
#14875 

(cherry picked from commit c00745344f1797e4b479d7a33fbfc56a5ab11b1d)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
