### PR TITLE
fix(core): cherry-pick patch from Nginx to address CVEs

### DIFF
--- a/build/openresty/patches/nginx-1.27.1_12-CVE-2026-40701.patch
+++ b/build/openresty/patches/nginx-1.27.1_12-CVE-2026-40701.patch
@@ -1,0 +1,51 @@
+diff --git a/bundle/nginx-1.27.1/src/event/ngx_event_openssl_stapling.c b/bundle/nginx-1.27.1/src/event/ngx_event_openssl_stapling.c
+index e9bb835..35d3fb7 100644
+--- a/bundle/nginx-1.27.1/src/event/ngx_event_openssl_stapling.c
++++ b/bundle/nginx-1.27.1/src/event/ngx_event_openssl_stapling.c
+@@ -111,6 +111,7 @@ struct ngx_ssl_ocsp_ctx_s {
+ 
+     ngx_resolver_t              *resolver;
+     ngx_msec_t                   resolver_timeout;
++    ngx_resolver_ctx_t          *resolve;
+ 
+     ngx_msec_t                   timeout;
+ 
+@@ -1303,6 +1304,10 @@ ngx_ssl_ocsp_done(ngx_ssl_ocsp_ctx_t *ctx)
+     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, ctx->log, 0,
+                    "ssl ocsp done");
+ 
++    if (ctx->resolve) {
++        ngx_resolve_name_done(ctx->resolve);
++    }
++
+     if (ctx->peer.connection) {
+         ngx_close_connection(ctx->peer.connection);
+     }
+@@ -1395,7 +1400,10 @@ ngx_ssl_ocsp_request(ngx_ssl_ocsp_ctx_t *ctx)
+         resolve->data = ctx;
+         resolve->timeout = ctx->resolver_timeout;
+ 
++        ctx->resolve = resolve;
++
+         if (ngx_resolve_name(resolve) != NGX_OK) {
++            ctx->resolve = NULL;
+             ngx_ssl_ocsp_error(ctx);
+             return;
+         }
+@@ -1484,6 +1492,7 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
+     }
+ 
+     ngx_resolve_name_done(resolve);
++    ctx->resolve = NULL;
+ 
+     ngx_ssl_ocsp_connect(ctx);
+     return;
+@@ -1491,6 +1500,8 @@ ngx_ssl_ocsp_resolve_handler(ngx_resolver_ctx_t *resolve)
+ failed:
+ 
+     ngx_resolve_name_done(resolve);
++    ctx->resolve = NULL;
++
+     ngx_ssl_ocsp_error(ctx);
+ }
+ 

--- a/build/openresty/patches/nginx-1.27.1_13-CVE-2026-40460.patch
+++ b/build/openresty/patches/nginx-1.27.1_13-CVE-2026-40460.patch
@@ -1,0 +1,35 @@
+diff --git a/bundle/nginx-1.27.1/src/event/quic/ngx_event_quic_migration.c b/bundle/nginx-1.27.1/src/event/quic/ngx_event_quic_migration.c
+index 2d1467e..862d6de 100644
+--- a/bundle/nginx-1.27.1/src/event/quic/ngx_event_quic_migration.c
++++ b/bundle/nginx-1.27.1/src/event/quic/ngx_event_quic_migration.c
+@@ -193,6 +193,8 @@ valid:
+ 
+     path->validated = 1;
+ 
++    ngx_quic_set_connection_path(c, path);
++
+     if (path->mtu_unvalidated) {
+         path->mtu_unvalidated = 0;
+         return ngx_quic_validate_path(c, path);
+@@ -510,9 +512,10 @@ ngx_quic_handle_migration(ngx_connection_t *c, ngx_quic_header_t *pkt)
+     qc->path = next;
+     qc->path->tag = NGX_QUIC_PATH_ACTIVE;
+ 
+-    ngx_quic_set_connection_path(c, next);
++    if (next->validated) {
++        ngx_quic_set_connection_path(c, next);
+ 
+-    if (!next->validated && next->state != NGX_QUIC_PATH_VALIDATING) {
++    } else if (next->state != NGX_QUIC_PATH_VALIDATING) {
+         if (ngx_quic_validate_path(c, next) != NGX_OK) {
+             return NGX_ERROR;
+         }
+@@ -806,8 +809,6 @@ ngx_quic_expire_path_validation(ngx_connection_t *c, ngx_quic_path_t *path)
+         qc->path = bkp;
+         qc->path->tag = NGX_QUIC_PATH_ACTIVE;
+ 
+-        ngx_quic_set_connection_path(c, qc->path);
+-
+         ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                       "quic path seq:%uL addr:%V is restored from backup",
+                       qc->path->seqnum, &qc->path->addr_text);

--- a/build/openresty/patches/nginx-1.27.1_14-CVE-2026-42934.patch
+++ b/build/openresty/patches/nginx-1.27.1_14-CVE-2026-42934.patch
@@ -1,0 +1,54 @@
+diff --git a/bundle/nginx-1.27.1/src/http/modules/ngx_http_charset_filter_module.c b/bundle/nginx-1.27.1/src/http/modules/ngx_http_charset_filter_module.c
+index e52b96e..7a518e3 100644
+--- a/bundle/nginx-1.27.1/src/http/modules/ngx_http_charset_filter_module.c
++++ b/bundle/nginx-1.27.1/src/http/modules/ngx_http_charset_filter_module.c
+@@ -689,7 +689,6 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+     u_char        c, *p, *src, *dst, *saved, **table;
+     uint32_t      n;
+     ngx_buf_t    *b;
+-    ngx_uint_t    i;
+     ngx_chain_t  *out, *cl, **ll;
+ 
+     src = buf->pos;
+@@ -783,18 +782,12 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pool->log, 0,
+                    "http charset utf saved: %z", ctx->saved_len);
+ 
+-    p = src;
+-
+-    for (i = ctx->saved_len; i < NGX_UTF_LEN; i++) {
+-        ctx->saved[i] = *p++;
+-
+-        if (p == buf->last) {
+-            break;
+-        }
+-    }
++    len = ngx_min(NGX_UTF_LEN - ctx->saved_len, (size_t) (buf->last - src));
++    ngx_memcpy(&ctx->saved[ctx->saved_len], src, len);
++    len += ctx->saved_len;
+ 
+     saved = ctx->saved;
+-    n = ngx_utf8_decode(&saved, i);
++    n = ngx_utf8_decode(&saved, len);
+ 
+     c = '\0';
+ 
+@@ -810,7 +803,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+ 
+         /* incomplete UTF-8 symbol */
+ 
+-        if (i < NGX_UTF_LEN) {
++        if (len < NGX_UTF_LEN) {
+             out = ngx_http_charset_get_buf(pool, ctx);
+             if (out == NULL) {
+                 return NULL;
+@@ -823,8 +816,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
+             b->sync = 1;
+             b->shadow = buf;
+ 
+-            ngx_memcpy(&ctx->saved[ctx->saved_len], src, i);
+-            ctx->saved_len += i;
++            ctx->saved_len = len;
+ 
+             return out;
+         }

--- a/build/openresty/patches/nginx-1.27.1_15-CVE-2026-42946.patch
+++ b/build/openresty/patches/nginx-1.27.1_15-CVE-2026-42946.patch
@@ -1,0 +1,63 @@
+diff --git a/bundle/nginx-1.27.1/src/http/modules/ngx_http_proxy_module.c b/bundle/nginx-1.27.1/src/http/modules/ngx_http_proxy_module.c
+index c244ceb..e5883f9 100644
+--- a/bundle/nginx-1.27.1/src/http/modules/ngx_http_proxy_module.c
++++ b/bundle/nginx-1.27.1/src/http/modules/ngx_http_proxy_module.c
+@@ -1837,6 +1837,7 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
+     }
+ 
+     if (rc == NGX_ERROR) {
++        u->buffer.pos = ctx->status.line_start;
+ 
+ #if (NGX_HTTP_CACHE)
+ 
+diff --git a/bundle/nginx-1.27.1/src/http/modules/ngx_http_scgi_module.c b/bundle/nginx-1.27.1/src/http/modules/ngx_http_scgi_module.c
+index f818fc4..33ff6ca 100644
+--- a/bundle/nginx-1.27.1/src/http/modules/ngx_http_scgi_module.c
++++ b/bundle/nginx-1.27.1/src/http/modules/ngx_http_scgi_module.c
+@@ -1029,6 +1029,8 @@ ngx_http_scgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_scgi_process_header;
++        u->buffer.pos = status->line_start;
++        r->state = 0;
+         return ngx_http_scgi_process_header(r);
+     }
+ 
+diff --git a/bundle/nginx-1.27.1/src/http/modules/ngx_http_uwsgi_module.c b/bundle/nginx-1.27.1/src/http/modules/ngx_http_uwsgi_module.c
+index c965d4b..1c62f84 100644
+--- a/bundle/nginx-1.27.1/src/http/modules/ngx_http_uwsgi_module.c
++++ b/bundle/nginx-1.27.1/src/http/modules/ngx_http_uwsgi_module.c
+@@ -1257,6 +1257,8 @@ ngx_http_uwsgi_process_status_line(ngx_http_request_t *r)
+ 
+     if (rc == NGX_ERROR) {
+         u->process_header = ngx_http_uwsgi_process_header;
++        u->buffer.pos = status->line_start;
++        r->state = 0;
+         return ngx_http_uwsgi_process_header(r);
+     }
+ 
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http.h b/bundle/nginx-1.27.1/src/http/ngx_http.h
+index e06464e..a252fad 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http.h
++++ b/bundle/nginx-1.27.1/src/http/ngx_http.h
+@@ -72,6 +72,7 @@ typedef struct {
+     ngx_uint_t           http_version;
+     ngx_uint_t           code;
+     ngx_uint_t           count;
++    u_char              *line_start;
+     u_char              *start;
+     u_char              *end;
+ } ngx_http_status_t;
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_parse.c b/bundle/nginx-1.27.1/src/http/ngx_http_parse.c
+index f7e5038..6dd2206 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_parse.c
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_parse.c
+@@ -1648,6 +1648,8 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
+ 
+         /* "HTTP/" */
+         case sw_start:
++            status->line_start = p;
++
+             switch (ch) {
+             case 'H':
+                 state = sw_H;

--- a/build/openresty/patches/nginx-1.27.1_16-CVE-2026-42945.patch
+++ b/build/openresty/patches/nginx-1.27.1_16-CVE-2026-42945.patch
@@ -1,0 +1,12 @@
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_script.c b/bundle/nginx-1.27.1/src/http/ngx_http_script.c
+index a2b9f1b..2ea6113 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_script.c
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_script.c
+@@ -1202,6 +1202,7 @@ ngx_http_script_regex_end_code(ngx_http_script_engine_t *e)
+ 
+     r = e->request;
+ 
++    e->is_args = 0;
+     e->quote = 0;
+ 
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/build/openresty/patches/nginx-1.27.1_17-CVE-2026-9256.patch
+++ b/build/openresty/patches/nginx-1.27.1_17-CVE-2026-9256.patch
@@ -1,0 +1,163 @@
+diff --git a/bundle/nginx-1.27.1/src/http/modules/ngx_http_mp4_module.c b/bundle/nginx-1.27.1/src/http/modules/ngx_http_mp4_module.c
+index 041ad26..4507282 100644
+--- a/bundle/nginx-1.27.1/src/http/modules/ngx_http_mp4_module.c
++++ b/bundle/nginx-1.27.1/src/http/modules/ngx_http_mp4_module.c
+@@ -1060,7 +1060,9 @@ ngx_http_mp4_read(ngx_http_mp4_file_t *mp4, size_t size)
+ {
+     ssize_t  n;
+ 
+-    if (mp4->buffer_pos + size <= mp4->buffer_end) {
++    if (mp4->buffer_pos && mp4->buffer_end
++        && mp4->buffer_pos + size <= mp4->buffer_end)
++    {
+         return NGX_OK;
+     }
+ 
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_script.c b/bundle/nginx-1.27.1/src/http/ngx_http_script.c
+index 2ea6113..8f7b548 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_script.c
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_script.c
+@@ -1037,6 +1037,8 @@ ngx_http_script_start_args_code(ngx_http_script_engine_t *e)
+ void
+ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
+ {
++    int                           *cap;
++    u_char                        *p;
+     size_t                         len;
+     ngx_int_t                      rc;
+     ngx_uint_t                     n;
+@@ -1143,15 +1145,19 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
+     if (code->lengths == NULL) {
+         e->buf.len = code->size;
+ 
+-        if (code->uri) {
+-            if (r->ncaptures && (r->quoted_uri || r->plus_in_uri)) {
+-                e->buf.len += 2 * ngx_escape_uri(NULL, r->uri.data, r->uri.len,
+-                                                 NGX_ESCAPE_ARGS);
+-            }
+-        }
++        cap = r->captures;
++        p = r->captures_data;
+ 
+         for (n = 2; n < r->ncaptures; n += 2) {
+-            e->buf.len += r->captures[n + 1] - r->captures[n];
++            e->buf.len += cap[n + 1] - cap[n];
++
++            if (code->uri) {
++                if (r->quoted_uri || r->plus_in_uri) {
++                    e->buf.len += 2 * ngx_escape_uri(NULL, &p[cap[n]],
++                                                     cap[n + 1] - cap[n],
++                                                     NGX_ESCAPE_ARGS);
++                }
++            }
+         }
+ 
+     } else {
+@@ -1183,6 +1189,7 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
+         return;
+     }
+ 
++    e->is_args = 0;
+     e->quote = code->redirect;
+ 
+     e->pos = e->buf.data;
+@@ -1769,6 +1776,7 @@ ngx_http_script_complex_value_code(ngx_http_script_engine_t *e)
+     le.ip = code->lengths->elts;
+     le.line = e->line;
+     le.request = e->request;
++    le.is_args = e->is_args;
+     le.quote = e->quote;
+ 
+     for (len = 0; *(uintptr_t *) le.ip; len += lcode(&le)) {
+diff --git a/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c b/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
+index 2024395..bbe08ae 100644
+--- a/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
++++ b/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2_filter_module.c
+@@ -235,6 +235,14 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     }
+ 
+     if (r->headers_out.content_type.len) {
++
++        if (r->headers_out.content_type.len > NGX_HTTP_V2_MAX_FIELD) {
++            ngx_log_error(NGX_LOG_CRIT, fc->log, 0,
++                          "too long response header value: "
++                          "\"Content-Type: %V\"", &r->headers_out.content_type);
++            return NGX_ERROR;
++        }
++
+         len += 1 + NGX_HTTP_V2_INT_OCTETS + r->headers_out.content_type.len;
+ 
+         if (r->headers_out.content_type_len == r->headers_out.content_type.len
+@@ -258,6 +266,13 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+ 
+     if (r->headers_out.location && r->headers_out.location->value.len) {
+ 
++        if (r->headers_out.location->value.len > NGX_HTTP_V2_MAX_FIELD) {
++            ngx_log_error(NGX_LOG_CRIT, fc->log, 0,
++                          "too long response header value: \"Location: %V\"",
++                          &r->headers_out.location->value);
++            return NGX_ERROR;
++        }
++
+         if (r->headers_out.location->value.data[0] == '/'
+             && clcf->absolute_redirect)
+         {
+diff --git a/bundle/nginx-1.27.1/src/mail/ngx_mail_imap_handler.c b/bundle/nginx-1.27.1/src/mail/ngx_mail_imap_handler.c
+index 291e87a..dc8cbef 100644
+--- a/bundle/nginx-1.27.1/src/mail/ngx_mail_imap_handler.c
++++ b/bundle/nginx-1.27.1/src/mail/ngx_mail_imap_handler.c
+@@ -48,6 +48,7 @@ ngx_mail_imap_init_session(ngx_mail_session_t *s, ngx_connection_t *c)
+ 
+     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+         ngx_mail_close_connection(c);
++        return;
+     }
+ 
+     ngx_mail_send(c->write);
+diff --git a/bundle/nginx-1.27.1/src/mail/ngx_mail_pop3_handler.c b/bundle/nginx-1.27.1/src/mail/ngx_mail_pop3_handler.c
+index 226e741..6483528 100644
+--- a/bundle/nginx-1.27.1/src/mail/ngx_mail_pop3_handler.c
++++ b/bundle/nginx-1.27.1/src/mail/ngx_mail_pop3_handler.c
+@@ -69,6 +69,7 @@ ngx_mail_pop3_init_session(ngx_mail_session_t *s, ngx_connection_t *c)
+ 
+     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+         ngx_mail_close_connection(c);
++        return;
+     }
+ 
+     ngx_mail_send(c->write);
+diff --git a/bundle/nginx-1.27.1/src/mail/ngx_mail_proxy_module.c b/bundle/nginx-1.27.1/src/mail/ngx_mail_proxy_module.c
+index efed9ab..0decf95 100644
+--- a/bundle/nginx-1.27.1/src/mail/ngx_mail_proxy_module.c
++++ b/bundle/nginx-1.27.1/src/mail/ngx_mail_proxy_module.c
+@@ -882,6 +882,7 @@ ngx_mail_proxy_write_handler(ngx_event_t *wev)
+ 
+     if (ngx_handle_write_event(wev, 0) != NGX_OK) {
+         ngx_mail_proxy_internal_server_error(s);
++        return;
+     }
+ 
+     if (c->read->ready) {
+diff --git a/bundle/nginx-1.27.1/src/mail/ngx_mail_smtp_handler.c b/bundle/nginx-1.27.1/src/mail/ngx_mail_smtp_handler.c
+index e68ceed..8097d91 100644
+--- a/bundle/nginx-1.27.1/src/mail/ngx_mail_smtp_handler.c
++++ b/bundle/nginx-1.27.1/src/mail/ngx_mail_smtp_handler.c
+@@ -295,6 +295,7 @@ ngx_mail_smtp_greeting(ngx_mail_session_t *s, ngx_connection_t *c)
+ 
+     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+         ngx_mail_close_connection(c);
++        return;
+     }
+ 
+     if (c->read->ready) {
+@@ -302,8 +303,8 @@ ngx_mail_smtp_greeting(ngx_mail_session_t *s, ngx_connection_t *c)
+     }
+ 
+     if (sscf->greeting_delay) {
+-         c->read->handler = ngx_mail_smtp_invalid_pipelining;
+-         return;
++        c->read->handler = ngx_mail_smtp_invalid_pipelining;
++        return;
+     }
+ 
+     c->read->handler = ngx_mail_smtp_init_protocol;

--- a/changelog/unreleased/kong/fix-nginx-upstream-cves.yml
+++ b/changelog/unreleased/kong/fix-nginx-upstream-cves.yml
@@ -1,0 +1,5 @@
+message: >-
+  Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934,
+  CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.
+type: bugfix
+scope: Core


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

cherry-pick patch from Nginx to address CVEs

CVE-2026-40701
CVE-2026-40460
CVE-2026-42934
CVE-2026-42946
CVE-2026-42945
CVE-2026-9256

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-9064
https://github.com/Kong/kong/discussions/14867