### PR TITLE
fix(core): separate pluginserver runtime data from kong configuration…

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
+++ b/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
@@ -1,0 +1,3 @@
+message: "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error"
+type: bugfix
+scope: Core


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This is a manual backport of #14111.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-8987]_


[KAG-8987]: https://konghq.atlassian.net/browse/KAG-8987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ