### PR TITLE
Revert "fix(core): separate pluginserver runtime data from kong confi…

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
+++ b/changelog/unreleased/kong/fix-admin-api-route-path-response-error.yml
@@ -1,3 +1,0 @@
-message: "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error"
-type: bugfix
-scope: Core

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -10,7 +10,6 @@ local cjson_decode = cjson.decode
 local SIGTERM = 15
 
 
-local server_rt = {} -- store runtime of plugin server like proc
 local _M = {}
 
 
@@ -151,19 +150,16 @@ local function pluginserver_timer(premature, server_def)
     end
 
     kong.log.notice("[pluginserver] starting pluginserver process for ", server_def.name or "")
-    local proc = assert(ngx_pipe.spawn("exec " .. server_def.start_command, {
+    server_def.proc = assert(ngx_pipe.spawn("exec " .. server_def.start_command, {
       merge_stderr = true,
     }))
-    server_rt[server_def.name] = {
-      proc = proc,
-    }
     next_spawn = ngx.now() + 1
-    proc:set_timeouts(nil, nil, nil, 0)     -- block until something actually happens
-    kong.log.notice("[pluginserver] started, pid ", proc:pid())
+    server_def.proc:set_timeouts(nil, nil, nil, 0)     -- block until something actually happens
+    kong.log.notice("[pluginserver] started, pid ", server_def.proc:pid())
 
     while true do
-      grab_logs(proc, server_def.name)
-      local ok, reason, status = proc:wait()
+      grab_logs(server_def.proc, server_def.name)
+      local ok, reason, status = server_def.proc:wait()
 
       -- exited with a non 0 status
       if ok == false and reason == "exit" and status == 127 then
@@ -209,13 +205,12 @@ function _M.stop_pluginservers()
   -- only worker 0 manages plugin server processes
   if worker_id() == 0 then -- TODO move to privileged worker?
     for _, server_def in ipairs(kong_config.pluginservers) do
-      local server = server_rt[server_def.name]
-      if server and server.proc then
-        local ok, err = server.proc:kill(SIGTERM)
+      if server_def.proc then
+        local ok, err = server_def.proc:kill(SIGTERM)
         if not ok then
           kong.log.error("[pluginserver] failed to stop pluginserver '", server_def.name, ": ", err)
         end
-        kong.log.notice("[pluginserver] successfully stopped pluginserver '", server_def.name, "', pid ", server.proc:pid())
+        kong.log.notice("[pluginserver] successfully stopped pluginserver '", server_def.name, "', pid ", server_def.proc:pid())
       end
     end
   end


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This reverts the PR #14883.

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[KAG-8987]_


[KAG-8987]: https://konghq.atlassian.net/browse/KAG-8987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ