### PR TITLE
fix(ai-proxy): request identity encoding for translated streams

### DIFF
--- a/changelog/unreleased/kong/fix-ai-proxy-openai-stream-accept-encoding.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-openai-stream-accept-encoding.yml
@@ -1,0 +1,4 @@
+message: |
+  **ai-proxy**: Fixed an issue where translated streaming upstreams could return gzip-compressed SSE responses that Kong could not transform correctly.
+type: "bugfix"
+scope: "Plugin"

--- a/kong/llm/plugin/shared-filters/normalize-request.lua
+++ b/kong/llm/plugin/shared-filters/normalize-request.lua
@@ -157,6 +157,12 @@ local function validate_and_transform(conf)
     return bail(400, err)
   end
 
+  -- Compressed SSE is only safe when Kong can pass the stream through untouched.
+  -- If Kong needs to parse/translate streaming frames, ask upstream for raw SSE bytes.
+  if get_global_ctx("stream_mode") and not get_global_ctx("preserve_mode") then
+    kong.service.request.set_header("Accept-Encoding", "identity")
+  end
+
 
   -- if this is a 'native' request with adapter,
   -- we need to update all the request/inference parameters as appropriate.

--- a/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/09-streaming_integration_spec.lua
@@ -111,7 +111,9 @@ for _, strategy in helpers.all_strategies() do
               local body, err = ngx.req.get_body_data()
               body, err = json.decode(body)
 
-              local token = ngx.req.get_headers()["authorization"]
+              local headers = ngx.req.get_headers()
+              ngx.header["X-Upstream-Accept-Encoding"] = headers["accept-encoding"] or ""
+              local token = headers["authorization"]
               local token_query = ngx.req.get_uri_args()["apikey"]
 
               if token == "Bearer openai-key" or token_query == "openai-key" or body.apikey == "openai-key" then
@@ -159,7 +161,9 @@ for _, strategy in helpers.all_strategies() do
               local body, err = ngx.req.get_body_data()
               body, err = json.decode(body)
 
-              local token = ngx.req.get_headers()["authorization"]
+              local headers = ngx.req.get_headers()
+              ngx.header["X-Upstream-Accept-Encoding"] = headers["accept-encoding"] or ""
+              local token = headers["authorization"]
               local token_query = ngx.req.get_uri_args()["apikey"]
 
               if token == "Bearer openai-key" or token_query == "openai-key" or body.apikey == "openai-key" then
@@ -218,7 +222,9 @@ for _, strategy in helpers.all_strategies() do
               local body, err = ngx.req.get_body_data()
               body, err = json.decode(body)
 
-              local token = ngx.req.get_headers()["authorization"]
+              local headers = ngx.req.get_headers()
+              ngx.header["X-Upstream-Accept-Encoding"] = headers["accept-encoding"] or ""
+              local token = headers["authorization"]
               local token_query = ngx.req.get_uri_args()["apikey"]
 
               if token == "Bearer cohere-key" or token_query == "cohere-key" or body.apikey == "cohere-key" then
@@ -323,7 +329,9 @@ for _, strategy in helpers.all_strategies() do
               local body, err = ngx.req.get_body_data()
               body, err = json.decode(body)
 
-              local token = ngx.req.get_headers()["authorization"]
+              local headers = ngx.req.get_headers()
+              ngx.header["X-Upstream-Accept-Encoding"] = headers["accept-encoding"] or ""
+              local token = headers["authorization"]
               local token_query = ngx.req.get_uri_args()["apikey"]
 
               if token == "Bearer openai-key" or token_query == "openai-key" or body.apikey == "openai-key" then
@@ -387,6 +395,8 @@ for _, strategy in helpers.all_strategies() do
               local json = require("cjson.safe")
 
               ngx.req.read_body()
+              local headers = ngx.req.get_headers()
+              ngx.header["X-Upstream-Accept-Encoding"] = headers["accept-encoding"] or ""
 
               -- GOOD RESPONSE
               ngx.status = 200
@@ -867,6 +877,7 @@ for _, strategy in helpers.all_strategies() do
           end
         until not buffer
 
+        assert.equal("identity", res.headers["X-Upstream-Accept-Encoding"])
         assert.equal(#events, 8)
         assert.equal(buf:tostring(), "The answer to 1 + 1 is 2.")
         -- to verifiy not enable `kong.service.request.enable_buffering()`
@@ -1385,6 +1396,7 @@ for _, strategy in helpers.all_strategies() do
           end
         until not buffer
 
+        assert.equal("gzip, identity", res.headers["X-Upstream-Accept-Encoding"])
         assert.truthy(found_marker, "didn't find bedrock native response marker, is it being transformer?")
 
         -- to verify not enable `kong.service.request.enable_buffering()`


### PR DESCRIPTION
## Summary

Translated AI Proxy streaming paths can break when an upstream returns gzip-compressed SSE. This change requests `Accept-Encoding: identity` only when Kong is both:

- handling a streaming request, and
- not in preserve/pass-through mode.

Provider-specific `Accept-Encoding` behavior remains in place for non-streaming requests and preserve/pass-through streaming routes.

## Why

Compressed SSE is safe when Kong can pass bytes through untouched. It is unsafe when Kong must parse and transform streaming frames because the parser needs raw SSE frames incrementally.

A concrete failure mode reproduced locally with an OpenAI-compatible upstream:

- request is streaming
- upstream returns gzip-compressed SSE
- Kong must translate the upstream stream to the client format
- downstream response is `200` + `Content-Encoding: gzip` + empty/unusable body

Requesting identity encoding for translated streams avoids negotiating gzip for the path that Kong must parse/transform.

## Validation

Tested against a local `kong/kong-gateway:3.14` Docker repro using the base `ai-proxy` plugin with an OpenAI-compatible upstream URL.

Before patch:

- non-streaming request: `200`, JSON body
- streaming translated request: `200`, `Content-Type: text/event-stream`, `Content-Encoding: gzip`, 0-byte body

After patch, overlaying the central `normalize-request.lua` change into the same container/config:

- non-streaming request: `200`, JSON body
- streaming translated request: `200`, `Content-Type: text/event-stream`, no `Content-Encoding: gzip`, readable SSE body

Example downstream SSE after patch:

```text
event: message_start
data: {"type":"message_start",...}

event: content_block_delta
data: {"index":0,"delta":{"type":"text_delta","text":"Okay,"},...}
```

## Tests

Updated streaming integration coverage to assert:

- translated OpenAI streaming upstream receives `Accept-Encoding: identity`
- native/preserve Bedrock streaming upstream keeps provider-specific `Accept-Encoding: gzip, identity`

I could not run the upstream `bin/busted` target in this local checkout because the Kong dev runtime is not installed (`env: resty: No such file or directory`). I did run `git diff --check` and validated the behavior in Docker as described above.
