### PR TITLE
fix(core): applied upstream nginx security patches for limiting the n…

### DIFF
--- a/build/openresty/patches/nginx-1.27.1_18-CVE-2026-49975.patch
+++ b/build/openresty/patches/nginx-1.27.1_18-CVE-2026-49975.patch
@@ -1,0 +1,120 @@
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_core_module.c b/bundle/nginx-1.27.1/src/http/ngx_http_core_module.c
+index 937ffe2..d1948a7 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_core_module.c
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_core_module.c
+@@ -254,6 +254,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
+       offsetof(ngx_http_core_srv_conf_t, large_client_header_buffers),
+       NULL },
+ 
++    { ngx_string("max_headers"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_num_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_core_srv_conf_t, max_headers),
++      NULL },
++
+     { ngx_string("ignore_invalid_headers"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+       ngx_conf_set_flag_slot,
+@@ -3470,6 +3477,7 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
+     cscf->request_pool_size = NGX_CONF_UNSET_SIZE;
+     cscf->client_header_timeout = NGX_CONF_UNSET_MSEC;
+     cscf->client_header_buffer_size = NGX_CONF_UNSET_SIZE;
++    cscf->max_headers = NGX_CONF_UNSET_UINT;
+     cscf->ignore_invalid_headers = NGX_CONF_UNSET;
+     cscf->merge_slashes = NGX_CONF_UNSET;
+     cscf->underscores_in_headers = NGX_CONF_UNSET;
+@@ -3511,6 +3519,8 @@ ngx_http_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+         return NGX_CONF_ERROR;
+     }
+ 
++    ngx_conf_merge_uint_value(conf->max_headers, prev->max_headers, 1000);
++
+     ngx_conf_merge_value(conf->ignore_invalid_headers,
+                               prev->ignore_invalid_headers, 1);
+ 
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_core_module.h b/bundle/nginx-1.27.1/src/http/ngx_http_core_module.h
+index 765e7ff..5af748e 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_core_module.h
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_core_module.h
+@@ -198,6 +198,8 @@ typedef struct {
+ 
+     ngx_msec_t                  client_header_timeout;
+ 
++    ngx_uint_t                  max_headers;
++
+     ngx_flag_t                  ignore_invalid_headers;
+     ngx_flag_t                  merge_slashes;
+     ngx_flag_t                  underscores_in_headers;
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_request.c b/bundle/nginx-1.27.1/src/http/ngx_http_request.c
+index 9593b7f..97ed5a3 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_request.c
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_request.c
+@@ -1489,6 +1489,15 @@ ngx_http_process_request_headers(ngx_event_t *rev)
+ 
+             /* a header line has been parsed successfully */
+ 
++            if (r->headers_in.count++ >= cscf->max_headers) {
++                r->lingering_close = 1;
++                ngx_log_error(NGX_LOG_INFO, c->log, 0,
++                              "client sent too many header lines");
++                ngx_http_finalize_request(r,
++                                          NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
++                break;
++            }
++
+             h = ngx_list_push(&r->headers_in.headers);
+             if (h == NULL) {
+                 ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+diff --git a/bundle/nginx-1.27.1/src/http/ngx_http_request.h b/bundle/nginx-1.27.1/src/http/ngx_http_request.h
+index 65c8333..2245280 100644
+--- a/bundle/nginx-1.27.1/src/http/ngx_http_request.h
++++ b/bundle/nginx-1.27.1/src/http/ngx_http_request.h
+@@ -182,6 +182,7 @@ typedef struct {
+ 
+ typedef struct {
+     ngx_list_t                        headers;
++    ngx_uint_t                        count;
+ 
+     ngx_table_elt_t                  *host;
+     ngx_table_elt_t                  *connection;
+diff --git a/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2.c b/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2.c
+index 91a28b2..c428242 100644
+--- a/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2.c
++++ b/bundle/nginx-1.27.1/src/http/v2/ngx_http_v2.c
+@@ -1822,6 +1822,15 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+         }
+ 
+     } else {
++        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
++
++        if (r->headers_in.count++ >= cscf->max_headers) {
++            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
++                          "client sent too many header lines");
++            ngx_http_finalize_request(r, NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
++            goto error;
++        }
++
+         h = ngx_list_push(&r->headers_in.headers);
+         if (h == NULL) {
+             return ngx_http_v2_connection_error(h2c,
+diff --git a/bundle/nginx-1.27.1/src/http/v3/ngx_http_v3_request.c b/bundle/nginx-1.27.1/src/http/v3/ngx_http_v3_request.c
+index e41ad50..e457d88 100644
+--- a/bundle/nginx-1.27.1/src/http/v3/ngx_http_v3_request.c
++++ b/bundle/nginx-1.27.1/src/http/v3/ngx_http_v3_request.c
+@@ -665,6 +665,15 @@ ngx_http_v3_process_header(ngx_http_request_t *r, ngx_str_t *name,
+         }
+ 
+     } else {
++        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
++
++        if (r->headers_in.count++ >= cscf->max_headers) {
++            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
++                          "client sent too many header lines");
++            ngx_http_finalize_request(r, NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
++            return NGX_ERROR;
++        }
++
+         h = ngx_list_push(&r->headers_in.headers);
+         if (h == NULL) {
+             ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);

--- a/build/openresty/patches/ngx_lua-0.10.28_03-missing-lightud.patch
+++ b/build/openresty/patches/ngx_lua-0.10.28_03-missing-lightud.patch
@@ -1,10 +1,10 @@
 diff --git a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
-index 43ab8209..a83cc2de 100644
+index d18fd05..b5ace90 100644
 --- a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
 +++ b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_log.c
-@@ -253,10 +253,12 @@ log_wrapper(ngx_log_t *log, const char *ident, ngx_uint_t level,
+@@ -257,10 +257,12 @@ log_wrapper(ngx_log_t *log, const char *ident, ngx_uint_t level,
                  break;
-
+ 
              case LUA_TLIGHTUSERDATA:
 -                *p++ = 'n';
 -                *p++ = 'u';
@@ -16,6 +16,6 @@ index 43ab8209..a83cc2de 100644
 +                    *p++ = 'l';
 +                    *p++ = 'l';
 +                }
-
+ 
                  break;
-
+ 

--- a/changelog/unreleased/kong/fix-nginx-cve-2026-49975.yml
+++ b/changelog/unreleased/kong/fix-nginx-cve-2026-49975.yml
@@ -1,0 +1,4 @@
+message: >-
+  Applied upstream nginx security patches for limiting the number of maximum headers (CVE-2026-49975).
+type: bugfix
+scope: Core


### PR DESCRIPTION
…umber of maximum headers

See: CVE-2026-49975

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference


Fix KAG-9189

https://github.com/Kong/kong/discussions/14892