### PR TITLE
feat(upstream): add keepalive max lifetime

### DIFF
--- a/build/openresty/patches/lua-resty-core-0.1.30_01-enable-keepalive-max-lifetime.patch
+++ b/build/openresty/patches/lua-resty-core-0.1.30_01-enable-keepalive-max-lifetime.patch
@@ -1,0 +1,49 @@
+diff --git a/bundle/lua-resty-core-0.1.30/lib/ngx/balancer.lua b/bundle/lua-resty-core-0.1.30/lib/ngx/balancer.lua
+--- a/bundle/lua-resty-core-0.1.30/lib/ngx/balancer.lua
++++ b/bundle/lua-resty-core-0.1.30/lib/ngx/balancer.lua
+@@ -39,7 +39,8 @@ if subsystem == 'http' then
+         char **err);
+ 
+     int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+-        unsigned long timeout, unsigned int max_requests, char **err);
++        unsigned long timeout, unsigned int max_requests,
++        unsigned long max_lifetime, char **err);
+ 
+     int ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+         int count, char **err);
+@@ -201,7 +202,7 @@ if subsystem == "http" then
+ end
+ 
+ if subsystem == "http" then
+-    function _M.enable_keepalive(idle_timeout, max_requests)
++    function _M.enable_keepalive(idle_timeout, max_requests, max_lifetime)
+         local r = get_request()
+         if not r then
+             error("no request found")
+@@ -230,10 +231,25 @@ if subsystem == "http" then
+ 
+         elseif max_requests < 0 then
+             error("bad argument #2 to 'enable_keepalive' (expected >= 0)", 2)
++        end
++
++        if not max_lifetime then
++            max_lifetime = 0
++
++        elseif type(max_lifetime) ~= "number" then
++            error("bad argument #3 to 'enable_keepalive' " ..
++                  "(number expected, got " .. type(max_lifetime) .. ")", 2)
++
++        elseif max_lifetime < 0 then
++            error("bad argument #3 to 'enable_keepalive' (expected >= 0)", 2)
++
++        else
++            max_lifetime = max_lifetime * 1000
+         end
+ 
+         local rc = ngx_lua_ffi_balancer_enable_keepalive(r, idle_timeout,
+-                                                         max_requests, errmsg)
++                                                         max_requests,
++                                                         max_lifetime, errmsg)
+         if rc == FFI_OK then
+             return true
+         end

--- a/build/openresty/patches/ngx_lua-0.10.28_04-enable-keepalive-max-lifetime.patch
+++ b/build/openresty/patches/ngx_lua-0.10.28_04-enable-keepalive-max-lifetime.patch
@@ -1,0 +1,87 @@
+diff --git a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
+--- a/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
++++ b/bundle/ngx_lua-0.10.28/src/ngx_http_lua_balancer.c
+@@ -34,6 +34,7 @@ typedef struct {
+ struct ngx_http_lua_balancer_peer_data_s {
+     ngx_uint_t                          keepalive_requests;
+     ngx_msec_t                          keepalive_timeout;
++    ngx_msec_t                          keepalive_max_lifetime;
+ 
+     void                               *data;
+ 
+@@ -430,6 +431,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+     bp->more_tries = 0;
+     bp->keepalive_requests = 0;
+     bp->keepalive_timeout = 0;
++    bp->keepalive_max_lifetime = 0;
+     bp->keepalive = 0;
+     bp->total_tries++;
+ 
+@@ -616,7 +618,22 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+             {
+                 goto invalid;
+             }
++
++            if (bp->keepalive_max_lifetime) {
++                ngx_msec_t now = ngx_current_msec;
+ 
++                if (now - c->start_time >= bp->keepalive_max_lifetime) {
++                    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                                   "lua balancer: keepalive not saving expired "
++                                   "connection %p, cpool: %p, age: %M, "
++                                   "max_lifetime: %M",
++                                   c, lscf, now - c->start_time,
++                                   bp->keepalive_max_lifetime);
++
++                    goto invalid;
++                }
++            }
++
+             if (!u->keepalive) {
+                 goto invalid;
+             }
+@@ -1019,7 +1036,8 @@ ngx_http_lua_ffi_balancer_bind_to_local_addr(ngx_http_request_t *r,
+ 
+ int
+ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+-    unsigned long timeout, unsigned int max_requests, char **err)
++    unsigned long timeout, unsigned int max_requests,
++    unsigned long max_lifetime, char **err)
+ {
+     ngx_http_upstream_t                     *u;
+     ngx_http_lua_ctx_t                      *ctx;
+@@ -1057,6 +1075,7 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+ 
+     bp->keepalive_timeout = (ngx_msec_t) timeout;
+     bp->keepalive_requests = (ngx_uint_t) max_requests;
++    bp->keepalive_max_lifetime = (ngx_msec_t) max_lifetime;
+     bp->keepalive = 1;
+ 
+     return NGX_OK;
+@@ -1486,6 +1505,26 @@ ngx_http_lua_balancer_get_cached_item(ngx_http_lua_srv_conf_t *lscf,
+                                 socklen, local->socklen) == 0))
+         {
+             c = item->connection;
++
++            if (bp->keepalive_max_lifetime) {
++                ngx_msec_t now = ngx_current_msec;
++
++                if (now - c->start_time >= bp->keepalive_max_lifetime) {
++                    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                                   "lua balancer: keepalive closing expired "
++                                   "connection %p, cpool: %p, age: %M, "
++                                   "max_lifetime: %M",
++                                   c, lscf, now - c->start_time,
++                                   bp->keepalive_max_lifetime);
++
++                    ngx_queue_remove(q);
++                    ngx_queue_remove(&item->queue);
++                    ngx_queue_insert_head(&lscf->balancer.free, &item->queue);
++                    ngx_http_lua_balancer_close(c);
++                    continue;
++                }
++            }
++
+             ngx_queue_remove(q);
+             ngx_queue_remove(&item->queue);
+             ngx_queue_insert_head(&lscf->balancer.free, &item->queue);

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1014,6 +1014,15 @@
                                         # connection may be kept open
                                         # indefinitely.
 
+#upstream_keepalive_max_lifetime = 0    # Sets the default maximum lifetime (in
+                                        # seconds) of an upstream keepalive
+                                        # connection. After the maximum lifetime
+                                        # is exceeded, the connection will be
+                                        # closed.
+                                        # A value of `0` will disable this
+                                        # behavior, and a keepalive connection
+                                        # may be kept open indefinitely.
+
 #allow_debug_header = off               # Enable the `Kong-Debug` header function.
                                         # If it is `on`, Kong will add
                                         # `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`,

--- a/kong/conf_loader/constants.lua
+++ b/kong/conf_loader/constants.lua
@@ -316,6 +316,7 @@ local CONF_PARSERS = {
   upstream_keepalive_pool_size = { typ = "number" },
   upstream_keepalive_max_requests = { typ = "number" },
   upstream_keepalive_idle_timeout = { typ = "number" },
+  upstream_keepalive_max_lifetime = { typ = "number" },
   allow_debug_header = { typ = "boolean" },
 
   headers = { typ = "array" },

--- a/kong/conf_loader/parse.lua
+++ b/kong/conf_loader/parse.lua
@@ -815,6 +815,10 @@ local function check_and_parse(conf, opts)
     errors[#errors + 1] = "upstream_keepalive_idle_timeout must be 0 or greater"
   end
 
+  if conf.upstream_keepalive_max_lifetime < 0 then
+    errors[#errors + 1] = "upstream_keepalive_max_lifetime must be 0 or greater"
+  end
+
   if conf.tracing_instrumentations and #conf.tracing_instrumentations > 0 then
     local instrumentation = require "kong.observability.tracing.instrumentation"
     local available_types_map = cycle_aware_deep_copy(instrumentation.available_types)

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -149,6 +149,7 @@ local CTX_NREC = 50 -- normally Kong has ~32 keys in ctx
 local UPSTREAM_KEEPALIVE_POOL_SIZE
 local UPSTREAM_KEEPALIVE_IDLE_TIMEOUT
 local UPSTREAM_KEEPALIVE_MAX_REQUESTS
+local UPSTREAM_KEEPALIVE_MAX_LIFETIME
 
 
 local declarative_entities
@@ -650,6 +651,7 @@ function Kong.init()
   UPSTREAM_KEEPALIVE_POOL_SIZE = config.upstream_keepalive_pool_size
   UPSTREAM_KEEPALIVE_IDLE_TIMEOUT = config.upstream_keepalive_idle_timeout
   UPSTREAM_KEEPALIVE_MAX_REQUESTS = config.upstream_keepalive_max_requests
+  UPSTREAM_KEEPALIVE_MAX_LIFETIME = config.upstream_keepalive_max_lifetime
 
   -- The dns client has been initialized in conf_loader, so we set it directly.
   -- Other modules should use 'kong.dns' to avoid reinitialization.
@@ -1439,7 +1441,9 @@ function Kong.balancer()
   end
 
   if pool then
-    ok, err = enable_keepalive(UPSTREAM_KEEPALIVE_IDLE_TIMEOUT, UPSTREAM_KEEPALIVE_MAX_REQUESTS)
+    ok, err = enable_keepalive(UPSTREAM_KEEPALIVE_IDLE_TIMEOUT,
+                               UPSTREAM_KEEPALIVE_MAX_REQUESTS,
+                               UPSTREAM_KEEPALIVE_MAX_LIFETIME)
     if not ok then
       ngx_log(ngx_ERR, "could not enable connection keepalive: ", err)
     end
@@ -1447,7 +1451,8 @@ function Kong.balancer()
     ngx_log(ngx_DEBUG, "enabled connection keepalive (pool=", pool,
                        ", pool_size=", UPSTREAM_KEEPALIVE_POOL_SIZE,
                        ", idle_timeout=", UPSTREAM_KEEPALIVE_IDLE_TIMEOUT,
-                       ", max_requests=", UPSTREAM_KEEPALIVE_MAX_REQUESTS, ")")
+                       ", max_requests=", UPSTREAM_KEEPALIVE_MAX_REQUESTS,
+                       ", max_lifetime=", UPSTREAM_KEEPALIVE_MAX_LIFETIME, ")")
   end
 
   -- record overall latency

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -75,6 +75,7 @@ error_default_type = text/plain
 upstream_keepalive_pool_size = 512
 upstream_keepalive_max_requests = 10000
 upstream_keepalive_idle_timeout = 60
+upstream_keepalive_max_lifetime = 0
 allow_debug_header = off
 
 nginx_user = kong kong

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1984,10 +1984,12 @@ describe("Configuration loader", function()
         upstream_keepalive_pool_size = 10,
         upstream_keepalive_max_requests = 20,
         upstream_keepalive_idle_timeout = 30,
+        upstream_keepalive_max_lifetime = 40,
       }))
       assert.equal(10, conf.upstream_keepalive_pool_size)
       assert.equal(20, conf.upstream_keepalive_max_requests)
       assert.equal(30, conf.upstream_keepalive_idle_timeout)
+      assert.equal(40, conf.upstream_keepalive_max_lifetime)
     end)
 
     it("accepts upstream_keepalive_pool_size = 0", function()
@@ -2011,6 +2013,13 @@ describe("Configuration loader", function()
       assert.equal(0, conf.upstream_keepalive_idle_timeout)
     end)
 
+    it("accepts upstream_keepalive_max_lifetime = 0", function()
+      local conf = assert(conf_loader(nil, {
+        upstream_keepalive_max_lifetime = 0,
+      }))
+      assert.equal(0, conf.upstream_keepalive_max_lifetime)
+    end)
+
     it("rejects negative values", function()
       local conf, err = conf_loader(nil, {
         upstream_keepalive_pool_size = -1,
@@ -2029,6 +2038,12 @@ describe("Configuration loader", function()
       })
       assert.is_nil(conf)
       assert.equal("upstream_keepalive_idle_timeout must be 0 or greater", err)
+
+      local conf, err = conf_loader(nil, {
+        upstream_keepalive_max_lifetime = -1,
+      })
+      assert.is_nil(conf)
+      assert.equal("upstream_keepalive_max_lifetime must be 0 or greater", err)
     end)
   end)
 

--- a/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
+++ b/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
@@ -348,6 +348,67 @@ describe("#postgres upstream keepalive", function()
   end)
 
 
+  it("keeps stable upstream keepalive pool names when max lifetime is enabled", function()
+    start_kong({
+      upstream_keepalive_max_lifetime = 3600,
+    })
+
+    local res = assert(proxy_client:send {
+      method = "GET",
+      path = "/echo_sni",
+      headers = {
+        Host = "one.test",
+      }
+    })
+    local body = assert.res_status(200, res)
+    assert.equal("SNI=one.test", body)
+
+    assert.errlog()
+          .has
+          .line([[enabled connection keepalive \(pool=[A-F0-9.:]+\|\d+\|one.test, pool_size=]])
+    assert.errlog()
+          .has.line([[keepalive get pool, name: [A-F0-9.:]+\|\d+\|one.test, cpool: 0+]])
+    assert.errlog()
+          .not_has.line([[enabled connection keepalive \(pool=[A-F0-9.:]+\|\d+\|one.test\|gen_]], true)
+  end)
+
+
+  it("closes expired upstream keepalive connections when max lifetime is exceeded", function()
+    start_kong({
+      upstream_keepalive_max_lifetime = 1,
+    })
+
+    local res = assert(proxy_client:send {
+      method = "GET",
+      path = "/echo_sni",
+      headers = {
+        Host = "one.test",
+      }
+    })
+    local body = assert.res_status(200, res)
+    assert.equal("SNI=one.test", body)
+
+    ngx.sleep(1.1)
+
+    local res = assert(proxy_client:send {
+      method = "GET",
+      path = "/echo_sni",
+      headers = {
+        Host = "one.test",
+      }
+    })
+    local body = assert.res_status(200, res)
+    assert.equal("SNI=one.test", body)
+
+    assert.errlog()
+          .has.line([[keepalive closing expired connection [A-F0-9]+, cpool: [A-F0-9]+, age: \d+, max_lifetime: 1000]])
+    assert.errlog()
+          .has.line([[enabled connection keepalive \(pool=[A-F0-9.:]+\|\d+\|one.test, pool_size=]])
+    assert.errlog()
+          .not_has.line([[enabled connection keepalive \(pool=[A-F0-9.:]+\|\d+\|one.test\|gen_]], true)
+  end)
+
+
   it("free upstream keepalive pool", function()
     start_kong({ upstream_keepalive_max_requests = 1, })
 


### PR DESCRIPTION
## Summary
- add upstream_keepalive_max_lifetime to Kong config parsing, defaults, docs, and balancer keepalive logging
- extend the OpenResty keepalive FFI and balancer implementation to expire cached upstream connections once their configured lifetime is exceeded
- add unit and integration coverage for config validation, stable keepalive pool names, and expired connection recycling

## Verification
- git diff --check
- patch --dry-run against upstream lua-resty-core 0.1.30 and ngx_lua 0.10.28 source files
- local bin/busted execution is still blocked in this environment because resty is not installed on the host yet
