### PR TITLE
[3.9] chore(ci): upgrade actions to node 24 runtime

### DIFF
--- a/.github/actions/build-wasm-test-filters/action.yml
+++ b/.github/actions/build-wasm-test-filters/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "CACHE_KEY=${CACHE_PREFIX}::${FILE_HASH}" >> $GITHUB_ENV
 
     - name: Restore Cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: restore-cache
       with:
         path: |
@@ -41,32 +41,27 @@ runs:
 
     - name: Install Rust Toolchain
       if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
+      uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # v1
       with:
-        profile: minimal
         toolchain: stable
-        override: true
         components: cargo
-        target: ${{ env.WASM_FILTER_TARGET }}
+        targets: ${{ env.WASM_FILTER_TARGET }}
 
-    - name: cargo build
+    - name: Build Test Filters
       if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-      with:
-        command: build
-        # building in release mode yields smaller library sizes, so it's
-        # better for our cacheability
-        args: >
-          --manifest-path "${{ env.WASM_FILTER_PATH }}/Cargo.toml"
-          --workspace
-          --lib
-          --target "${{ env.WASM_FILTER_TARGET }}"
+      shell: bash
+      run: |
+        cargo build \
+          --manifest-path "${WASM_FILTER_PATH:?}/Cargo.toml" \
+          --workspace \
+          --lib \
+          --target "${WASM_FILTER_TARGET:?}" \
           --release
 
     - name: Save cache
       if: steps.restore-cache.outputs.cache-hit != 'true'
       id: save-cache
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/add-release-pongo.yml
+++ b/.github/workflows/add-release-pongo.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     - name: Checkout Pongo
       id: checkout_pongo
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ env.GITHUB_TOKEN }}
         repository: kong/kong-pongo

--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -11,5 +11,4 @@ jobs:
       - name: assign-author
         # ignore the pull requests opened from PR because token is not correct
         if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-        uses: toshimaru/auto-author-assign@ebd30f10fb56e46eb0759a14951f36991426fed0
-
+        uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d #v3.0.2

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -32,10 +32,10 @@ jobs:
           echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Checkout Kong source code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lookup build cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-deps
         with:
           path: ${{ env.INSTALL_ROOT }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Checkout kong-build-tools
         if: steps.cache-deps.outputs.cache-hit != 'true' || github.event.inputs.force_build == 'true'
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Kong/kong-build-tools
           path: kong-build-tools
@@ -51,7 +51,7 @@ jobs:
 
       - name: Checkout go-pluginserver
         if: steps.cache-deps.outputs.cache-hit != 'true' || github.event.inputs.force_build == 'true'
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Kong/go-pluginserver
           path: go-pluginserver
@@ -80,13 +80,13 @@ jobs:
           echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Checkout Kong source code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: kong
           ref: ${{ github.event.inputs.source_branch }}
 
       - name: Checkout Kong Docs
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kong/docs.konghq.com
           path: docs.konghq.com
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ github.event.inputs.target_branch }}
 
       - name: Lookup build cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-deps
         with:
           path: ${{ env.INSTALL_ROOT }}
@@ -123,7 +123,7 @@ jobs:
           git checkout -b "autodocs-${{ steps.kong-branch.outputs.name }}"
 
       - name: Commit autodoc changes
-        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           repository: "./docs.konghq.com"
           commit_message: "Autodocs update"

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Fetch mapping file
       id: fetch_mapping
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         ACCESS_TOKEN: ${{ secrets.PAT }}
       with:
@@ -25,7 +25,7 @@ jobs:
 
     - name: Generate Slack Payload
       id: generate-payload
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         SLACK_CHANNEL: gateway-notifications
         SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"
@@ -44,8 +44,8 @@ jobs:
         result-encoding: string
 
     - name: Send Slack Message
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         payload: ${{ steps.generate-payload.outputs.result }}
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GATEWAY_NOTIFICATIONS_WEBHOOK }}
+        webhook: ${{ secrets.SLACK_GATEWAY_NOTIFICATIONS_WEBHOOK }}
+        webhook-type: incoming-webhook

--- a/.github/workflows/backport-v2.yml
+++ b/.github/workflows/backport-v2.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create backport pull requests
-        uses: korthout/backport-action@924c8170740fa1e3685f69014971f7f251633f53 # v2.4.1
+        uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
         id: backport
         with:
           github_token: ${{ secrets.PAT }}
@@ -37,6 +37,6 @@ jobs:
             }
       - name: add label
         if: steps.backport.outputs.was_successful == 'false'
-        uses: Kong/action-add-labels@81b0a07d6b2ec64d770be1ca94c31ec827418054
+        uses: Kong/action-add-labels@e9beb8480f1c0e4e1292df967adec60e388755fc
         with:
           labels: incomplete-backport

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # these aren't necessarily used by all tests, but building them here will
     # ensures that we have a warm cache when other tests _do_ need to build the
@@ -37,7 +37,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -73,7 +73,7 @@ jobs:
         luarocks config
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: failure()
       with:
         name: bazel-outputs

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,7 +46,7 @@ jobs:
       old-kong-version: ${{ steps.old-kong-version.outputs.ref }}
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0  # `git merge-base` requires the history
 
@@ -91,11 +91,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -139,17 +139,17 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download runtimes file
-      uses: Kong/gh-storage/download@b196a6b94032e56e414227c749e9f96a6afc2b91 # v1
+      uses: Kong/gh-storage/download@29d5de7b2b87c63016daae5680aefab30812a318 # main (node24)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         repo-path: Kong/gateway-action-storage/main/.ci/runtimes.json
 
     - name: Schedule tests
-      uses: Kong/gateway-test-scheduler/schedule@69f0c2a562ac44fc3650b8bfa62106b34094b5ce # v3
+      uses: Kong/gateway-test-scheduler/schedule@7f296716e385b5fce9573ebc5875f13c09504791 # main (node24)
       with:
         test-suites-file: .ci/test_suites.json
         test-file-runtime-file: .ci/runtimes.json
@@ -158,7 +158,7 @@ jobs:
         static-mode: ${{ github.run_attempt > 1 }}
 
     - name: Upload schedule files
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       continue-on-error: true
       with:
         name: schedule-test-files
@@ -232,11 +232,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # used for plugin compatibility test
     - name: Checkout old version Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: kong-old
         # if the minor version is 0, `ref` will default to ''
@@ -245,7 +245,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -309,7 +309,7 @@ jobs:
         psql -hlocalhost -Ukong kong -tAc 'alter system set max_connections = 5000;'
 
     - name: Download test schedule file
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: schedule-test-files
 
@@ -326,13 +326,13 @@ jobs:
         pip install kong-pdk
 
     - name: Download test rerun information
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       continue-on-error: true
       with:
         name: test-rerun-info-${{ matrix.runner }}
 
     - name: Download test runtime statistics from previous runs
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       continue-on-error: true
       with:
         name: test-runtime-statistics-${{ matrix.runner }}
@@ -353,16 +353,16 @@ jobs:
         DD_TRACE_GIT_METADATA_ENABLED: true
         DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         SPEC_ERRLOG_CACHE_DIR: ${{ env.SPEC_ERRLOG_CACHE_DIR }}
-      uses: Kong/gateway-test-scheduler/runner@69f0c2a562ac44fc3650b8bfa62106b34094b5ce # v3
+      uses: Kong/gateway-test-scheduler/runner@7f296716e385b5fce9573ebc5875f13c09504791 # main (node24)
       with:
         tests-to-run-file: test-chunk.${{ matrix.runner }}.json
         failed-test-files-file: ${{ env.FAILED_TEST_FILES_FILE }}
         test-file-runtime-file: ${{ env.TEST_FILE_RUNTIME_FILE }}
-        setup-venv-path: ${{ env.BUILD_ROOT }}
+        build-root: ${{ env.BUILD_ROOT }}
 
     - name: Upload error logs
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: busted-test-errlogs-${{ matrix.runner }}
         path: ${{ env.SPEC_ERRLOG_CACHE_DIR }}
@@ -370,7 +370,7 @@ jobs:
 
     - name: Upload test rerun information
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: test-rerun-info-${{ matrix.runner }}
         path: ${{ env.FAILED_TEST_FILES_FILE }}
@@ -378,14 +378,14 @@ jobs:
 
     - name: Upload test runtime statistics for offline scheduling
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: test-runtime-statistics-${{ matrix.runner }}
         path: ${{ env.TEST_FILE_RUNTIME_FILE }}
         retention-days: 7
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}-${{ matrix.runner }}
@@ -412,11 +412,11 @@ jobs:
           sudo echo "$(whoami) hard nofile 65536" | sudo tee -a /etc/security/limits.d/kong-ci.conf
 
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build.outputs.cache-key }}
@@ -449,14 +449,14 @@ jobs:
 
     - name: Upload error logs
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: PDK-test-errlogs
         path: ${{ env.SPEC_ERRLOG_CACHE_DIR }}
         retention-days: 1
 
     - name: Archive coverage stats file
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: ${{ always() && (inputs.coverage == true || github.event_name == 'schedule') }}
       with:
         name: luacov-stats-out-${{ github.job }}-${{ github.run_id }}
@@ -477,7 +477,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install requirements
       run: |
@@ -486,7 +486,7 @@ jobs:
         sudo luarocks install luafilesystem
 
     # Download all archived coverage stats files
-    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+    - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
 
     - name: Stats aggregation
       shell: bash

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -15,13 +15,13 @@ jobs:
     name: Requires changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: Find changelog files
         id: changelog-list
-        uses: kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311 # main (node24)
         with:
           files_yaml: |
             changelogs:

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -9,9 +9,9 @@ jobs:
     name: Validate changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate changelogs
-        uses: Kong/gateway-changelog@bc389e6bcc015b3560c4d1024a3782331602a0f6
+        uses: Kong/gateway-changelog@e163d5ce4d698c25d3e131fb2e3fcd7589d8299e # main (node24)
         with:
           files: changelog/unreleased/*/*.yml

--- a/.github/workflows/cherry-picks-v2.yml
+++ b/.github/workflows/cherry-picks-v2.yml
@@ -26,7 +26,7 @@ jobs:
         startsWith(github.event.comment.body, '/cherry-pick')
       )
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
       - name: Create backport pull requests
@@ -50,6 +50,6 @@ jobs:
             }
       - name: add label
         if: steps.cherry_pick.outputs.was_successful == 'false'
-        uses: Kong/action-add-labels@81b0a07d6b2ec64d770be1ca94c31ec827418054
+        uses: Kong/action-add-labels@e9beb8480f1c0e4e1292df967adec60e388755fc
         with:
           labels: incomplete-cherry-pick

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@a5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: 14
           days-before-close: 7

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Find Enterprise Copyright
         shell: bash

--- a/.github/workflows/deck-integration.yml
+++ b/.github/workflows/deck-integration.yml
@@ -51,13 +51,13 @@ jobs:
         run: sudo apt update && sudo apt install -y libyaml-dev valgrind libprotobuf-dev libpam-dev postgresql-client jq
 
       - name: Checkout Kong source code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
       - name: Lookup build cache
         id: cache-deps
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.BUILD_ROOT }}
           key: ${{ needs.build.outputs.cache-key }}

--- a/.github/workflows/label-community-pr.yml
+++ b/.github/workflows/label-community-pr.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Label Community PR
         env:
           GH_TOKEN: ${{ secrets.COMMUNITY_PRS_TOKEN }}

--- a/.github/workflows/labeler-v2.yml
+++ b/.github/workflows/labeler-v2.yml
@@ -4,9 +4,10 @@ on:
 
 jobs:
   labeler:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Dispatch the workflow
         if: ${{ github.repository_owner == 'Kong' }}
-        uses: benc-uk/workflow-dispatch@25b02cc069be46d637e8fe2f1e8484008e9e9609 # v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           workflow: create-pr.yml
           repo: kong/openresty-patches-review

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Generate cache key
       id: cache-key
@@ -42,7 +42,7 @@ jobs:
 
     - name: Lookup build cache
       id: cache-deps
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -65,7 +65,7 @@ jobs:
         luarocks
 
     - name: Bazel Outputs
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: failure()
       with:
         name: bazel-outputs
@@ -110,7 +110,7 @@ jobs:
         repo-token: ${{ secrets.PAT }}
 
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Fetch all history for all tags and branches
         fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
     - name: Load Cached Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.BUILD_ROOT }}
         key: ${{ needs.build-packages.outputs.cache-key }}
@@ -160,7 +160,7 @@ jobs:
         echo "suites=$suites" >> $GITHUB_OUTPUT
         echo "tags=$tags" >> $GITHUB_OUTPUT
 
-    - uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7 # v1.4.1
+    - uses: xt0rted/pull-request-comment-branch@e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1 # v3.0.0
       id: comment-branch
       if: github.event_name == 'issue_comment' && github.event.action == 'created'
 
@@ -251,7 +251,7 @@ jobs:
           inkscape --export-area-drawing --export-png="${i%.*}.png" --export-dpi=300 -b FFFFFF $i
         done
 
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.10'
         cache: 'pip'
@@ -267,7 +267,7 @@ jobs:
         done
 
     - name: Save results
-      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: always()
       with:
         name: perf-results
@@ -278,7 +278,7 @@ jobs:
         retention-days: 31
 
     - name: Save error logs
-      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: always()
       with:
         name: error_logs

--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Read comment
       id: read_comment
@@ -43,7 +43,7 @@ jobs:
     - name: Validate input
       if: steps.read_comment.outputs.other_pr
       id: validate_url
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const url = `${{ steps.read_comment.outputs.other_pr }}`;
@@ -89,7 +89,7 @@ jobs:
         fi
 
     - name: Post result as comment in the PR
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: steps.run_extension.outputs.MESSAGE
       with:
         script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build Info
       id: build-info
       run: |
@@ -135,7 +135,7 @@ jobs:
     - name: Cache Git
       id: cache-git
       if: (matrix.package == 'rpm') && matrix.image != ''
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /usr/local/git
         key: ${{ matrix.label }}-git-2.41.0
@@ -167,7 +167,7 @@ jobs:
         echo "/usr/local/git/bin" >> $GITHUB_PATH
 
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Swap git with https
       run: git config --global url."https://github".insteadOf git://github
@@ -184,7 +184,7 @@ jobs:
     - name: Cache Packages
       id: cache-deps
       if: env.GHA_CACHE == 'true'
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: bazel-bin/pkg
         key: ${{ steps.cache-key.outputs.cache-key }}
@@ -194,7 +194,7 @@ jobs:
         grep -v '^#' .requirements >> $GITHUB_ENV
 
     - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@e403ad507104847c3539436f64a9e9eecc73eeec #0.8.5
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 #0.9.10
       with:
         bazelisk-version: "1.20.0"
         # Avoid downloading Bazel every time.
@@ -266,7 +266,7 @@ jobs:
         tail -n500 bazel-out/**/*/CMake.log || true
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: ${{ matrix.label }}-packages
         path: bazel-bin/pkg
@@ -283,16 +283,16 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-packages'] }}"
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download artifact
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ matrix.label }}-packages
         path: bazel-bin/pkg
 
     - name: Install Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
@@ -319,31 +319,31 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download artifact
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
 
     - name: Download artifact (alt)
       if: matrix.artifact-from-alt != ''
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ matrix.artifact-from-alt }}-packages
         path: bazel-bin/pkg
 
     - name: Login to Docker Hub
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
-      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ env.DOCKER_ORGANIZATION }}
         password: ${{ secrets.DOCKER_OAT_PUSH }}
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       env:
         DOCKER_METADATA_PR_HEAD_SHA: true
       with:
@@ -354,10 +354,10 @@ jobs:
 
     - name: Set up QEMU
       if: matrix.docker-platforms != ''
-      uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Set platforms
       id: docker_platforms_arg
@@ -383,7 +383,7 @@ jobs:
         echo "rpm_platform=$rpm_platform" >> $GITHUB_OUTPUT
 
     - name: Build Docker Image
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         file: build/dockerfiles/${{ matrix.package }}.Dockerfile
         context: .
@@ -400,7 +400,7 @@ jobs:
 
     - name: Comment on commit
       if: github.event_name == 'push' && matrix.label == 'ubuntu'
-      uses: peter-evans/commit-comment@5a6f8285b8f2e8376e41fe1b563db48e6cf78c09 # v3.0.0
+      uses: peter-evans/commit-comment@f6d60c65d05bb59f750fa51ad3de1d443ba0eb52 # v4.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |
@@ -420,10 +420,10 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['build-images'] }}"
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
         cache: 'pip' # caching pip dependencies
@@ -461,11 +461,11 @@ jobs:
       IMAGE: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
     steps:
     - name: Install regctl
-      uses: regclient/actions/regctl-installer@ce5fd131e371ffcdd7508b478cb223b3511a9183
+      uses: regclient/actions/regctl-installer@f07124ffba4b0cbf96b2a666d481ed9d44b5e7e4
 
     - name: Login to Docker Hub
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN }}
-      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ env.DOCKER_ORGANIZATION }}
         password: ${{ secrets.DOCKER_OAT_PUSH }}
@@ -495,7 +495,7 @@ jobs:
     - name: Scan AMD64 Image digest
       id: sbom_action_amd64
       if: steps.image_manifest_metadata.outputs.amd64_sha != ''
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a5b1cfac7d55d8cf9390456a1e6799425e28840d # v4.0.1
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a92df3beb1e69e27d86be56346488f15fecaf0de # scan-docker-image@6.1.1
       with:
         asset_prefix: kong-${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}-linux-amd64
         image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
@@ -504,7 +504,7 @@ jobs:
     - name: Scan ARM64 Image digest
       if: steps.image_manifest_metadata.outputs.manifest_list_exists == 'true' && steps.image_manifest_metadata.outputs.arm64_sha != ''
       id: sbom_action_arm64
-      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a5b1cfac7d55d8cf9390456a1e6799425e28840d # v4.0.1
+      uses: Kong/public-shared-actions/security-actions/scan-docker-image@a92df3beb1e69e27d86be56346488f15fecaf0de # scan-docker-image@6.1.1
       with:
         asset_prefix: kong-${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}-linux-arm64
         image: ${{ needs.metadata.outputs.prerelease-docker-repository }}:${{ needs.metadata.outputs.commit-sha }}-${{ matrix.label }}
@@ -526,10 +526,10 @@ jobs:
         include: "${{ fromJSON(needs.metadata.outputs.matrix)['release-packages'] }}"
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download artifact
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: ${{ matrix.artifact-from }}-packages
         path: bazel-bin/pkg
@@ -591,12 +591,12 @@ jobs:
     steps:
     - name: Login to Docker Hub
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
-      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v2.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ env.DOCKER_ORGANIZATION }}
         password: ${{ secrets.DOCKER_OAT_PUSH }}
 
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get latest commit SHA on master
       run: |
@@ -604,7 +604,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ needs.metadata.outputs.docker-repository }}
         sep-tags: " "
@@ -628,7 +628,7 @@ jobs:
           suffix=-${{ matrix.label }}
 
     - name: Install regctl
-      uses: regclient/actions/regctl-installer@b6614f5f56245066b533343a85f4109bdc38c8cc
+      uses: regclient/actions/regctl-installer@f07124ffba4b0cbf96b2a666d481ed9d44b5e7e4
 
     - name: Push Images
       if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}

--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout Kong source code
-      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: master
 

--- a/.github/workflows/update-test-runtime-statistics.yml
+++ b/.github/workflows/update-test-runtime-statistics.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.PAT }}
 
       - name: Process statistics
-        uses: Kong/gateway-test-scheduler/analyze@69f0c2a562ac44fc3650b8bfa62106b34094b5ce # v3
+        uses: Kong/gateway-test-scheduler/analyze@7f296716e385b5fce9573ebc5875f13c09504791 # main (node24)
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
@@ -28,7 +28,7 @@ jobs:
           artifact-name-regexp: "^test-runtime-statistics-\\d+$"
 
       - name: Upload new runtimes file
-        uses: Kong/gh-storage/upload@b196a6b94032e56e414227c749e9f96a6afc2b91 # v1
+        uses: Kong/gh-storage/upload@29d5de7b2b87c63016daae5680aefab30812a318 # main (node24)
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -40,14 +40,14 @@ jobs:
 
     steps:
       - name: Clone Source Code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Lookup build cache
         id: cache-deps
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.BUILD_ROOT }}
           key: ${{ needs.build.outputs.cache-key }}


### PR DESCRIPTION
### Summary

GitHub Actions is deprecating Node.js 20 runners starting June 2nd, 2026. 
Upgrade all pinned action SHAs to versions that run on Node 24.

Related PR: https://github.com/Kong/kong/pull/14899

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix KAG-9086
