### PR TITLE
WIP: add w3c baggage extraction

### DIFF
--- a/kong/observability/tracing/propagation/extractors/_base.lua
+++ b/kong/observability/tracing/propagation/extractors/_base.lua
@@ -139,6 +139,9 @@ function _EXTRACTOR:extract(headers)
     ext_tracing_ctx.trace_id_original_size = #ext_tracing_ctx.trace_id
   end
 
+  if ext_tracing_ctx.baggage then
+    ext_tracing_ctx.baggage = ext_tracing_ctx.baggage
+  end
   -- convert IDs to internal format
   ext_tracing_ctx.trace_id  = to_kong_trace_id(ext_tracing_ctx.trace_id)
   ext_tracing_ctx.span_id   = to_kong_span_id(ext_tracing_ctx.span_id)

--- a/kong/observability/tracing/propagation/extractors/w3c.lua
+++ b/kong/observability/tracing/propagation/extractors/w3c.lua
@@ -7,6 +7,7 @@ local tonumber = tonumber
 local from_hex                 = propagation_utils.from_hex
 
 local W3C_TRACECONTEXT_PATTERN = "^(%x+)%-(%x+)%-(%x+)%-(%x+)$"
+local W3C_BAGGAGE_HEADER = "baggage"
 
 local W3C_EXTRACTOR            = _EXTRACTOR:new({
   headers_validate = {
@@ -14,6 +15,48 @@ local W3C_EXTRACTOR            = _EXTRACTOR:new({
   }
 })
 
+-- Will return the key, value & properties found in the baggage header
+-- example baggage : "key1=value1;prop1=val1;prop2, key2=value2;prop3=val3"
+-- will return:
+-- {
+--   { key = "key1", value = "value1", properties = { prop1 = "val1", prop2 = "val2" } },
+--   { key = "key2", value = "value2", properties = { prop3 = "val3" } },
+-- }
+local function parse_baggage_headers(headers)
+  local baggage_header = headers[W3C_BAGGAGE_HEADER]
+  if type(baggage_header) ~= "string" or baggage_header == "" then
+    return nil
+  end
+  local baggage = {}
+  --  Split list-member by comma
+  for pair in baggage_header:gmatch("([^,]+)") do
+    member = member:match("^%s*(.-)%s*$") -- trim whitespace
+
+    -- Split key-value; prop=val1; prop2
+    local key, rest = pair:match("^([^=]+)=(.*)$")
+    if key and rest then
+      key = key:match("^%s*(.-)%s*$") 
+      local value, props = rest:match("^([^;]+);?(.*)$")
+      value = ngx.unescape_uri(value:match("^%s*(.-)%s*$"))
+      local entry = { key, value, properties = {} }
+
+      -- Parse properties; prop1=val1; prop2
+      for prop in props:gmatch("([^;]+)") do
+        local pkey, pvalue = prop:match("^%s*([^=]+)=(.-)%s*$")
+        if pkey then
+          if pkey ~= "" then
+              entry.properties[pkey] = ngx.unescape_uri(pvalue)
+          else
+              entry.properties[pkey] = true
+          end
+        end
+      end
+
+      table.insert(baggage, entry)
+    end
+  end
+  return baggage
+end
 
 function W3C_EXTRACTOR:get_context(headers)
   local traceparent = headers["traceparent"]
@@ -68,7 +111,7 @@ function W3C_EXTRACTOR:get_context(headers)
     span_id       = parent_id,
     parent_id     = nil,
     should_sample = should_sample,
-    baggage       = nil,
+    baggage       = parse_baggage_headers(headers),
     w3c_flags     = flags_number,
   }
 end

--- a/kong/observability/tracing/propagation/init.lua
+++ b/kong/observability/tracing/propagation/init.lua
@@ -99,6 +99,7 @@ local function extract_tracing_context(conf)
     -- extract tracing context only from the first successful extractor
     if type(extracted_ctx) == "table" and next(extracted_ctx) ~= nil then
       kong.ctx.plugin.extracted_from = extractor_m
+      tracing_context.set_baggage(extracted_ctx.baggage)
       break
     end
   end

--- a/kong/observability/tracing/tracing_context.lua
+++ b/kong/observability/tracing/tracing_context.lua
@@ -16,6 +16,7 @@ local function init_tracing_context(ctx)
     -- yet available).
     unlinked_spans = table_new(0, 1),
     flags = nil,
+    baggage = nil,
   }
 
   return ctx.TRACING_CONTEXT
@@ -113,6 +114,15 @@ local function set_unlinked_span(name, span, ctx)
   tracing_context.unlinked_spans[name] = span
 end
 
+local function get_baggage(ctx)
+  local tracing_context = get_tracing_context(ctx)
+  return tracing_context.baggage
+end
+
+local function set_baggage(baggage, ctx)
+  local tracing_context = get_tracing_context(ctx)
+  tracing_context.baggage = baggage
+end
 
 
 return {
@@ -123,4 +133,5 @@ return {
   set_unlinked_span = set_unlinked_span,
   get_flags = get_flags,
   set_flags = set_flags,
+  get_baggage = get_baggage,
 }

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -633,6 +633,11 @@ local function new_tracer(name, options)
     return not not sampled
   end
 
+  function self:get_baggage()
+    local ctx = ngx.ctx
+    return tracing_context.get_baggage(ctx)
+  end
+
   tracer_memo[name] = setmetatable(self, tracer_mt)
   return tracer_memo[name]
 end

--- a/spec/01-unit/26-observability/02-propagation_strategies_spec.lua
+++ b/spec/01-unit/26-observability/02-propagation_strategies_spec.lua
@@ -285,6 +285,20 @@ local test_data = { {
       should_sample = false,
     },
     err = "w3c injector context is invalid: field span_id not found in context"
+  },{
+    description = "base baggage case",
+    inject = true,
+    headers = {
+      ["traceparent"] = fmt("00-%s-%s-01", trace_id_16, span_id_8_1),
+      ["baggage"] = "foo=bar,baz=qux",
+    },
+    ctx = {
+      trace_id = trace_id_16,
+      span_id = span_id_8_1,
+      parent_id = span_id_8_2,
+      should_sample = true,
+      baggage = { foo = "bar", baz = "qux"},
+    }
   } }
 }, {
   extractor = "b3",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Add W3C Baggage header extraction

Added a pdk function to get the baggage, works on adding new baggage key / properties needs to be done in the future.

### Checklist

- [ x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
