### PR TITLE
fix(db): support non-id primary keys for foreign entities in cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1210,7 +1210,7 @@ affects payloads from all logging plugins that use the log serializer:
  [#12607](https://github.com/Kong/kong/issues/12607)
 ##### Default
 
-- Fixed a bug where, if the the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
+- Fixed a bug where, if the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
  [#12606](https://github.com/Kong/kong/issues/12606)
 
 - Fix an issue where external plugins using the protobuf-based protocol would fail to call the `kong.Service.SetUpstream` method with an error `bad argument #2 to 'encode' (table expected, got boolean)`.

--- a/changelog/3.7.0/3.7.0.md
+++ b/changelog/3.7.0/3.7.0.md
@@ -360,7 +360,7 @@ affects payloads from all logging plugins that use the log serializer:
  [KAG-3699](https://konghq.atlassian.net/browse/KAG-3699)
 #### Default
 
-- Fixed a bug where, if the the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
+- Fixed a bug where, if the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
  [#12606](https://github.com/Kong/kong/issues/12606)
  [KAG-3779](https://konghq.atlassian.net/browse/KAG-3779) [FTI-5780](https://konghq.atlassian.net/browse/FTI-5780)
 

--- a/changelog/3.7.0/kong/decrease-cocurrency-limit-of-timer-ng.yml
+++ b/changelog/3.7.0/kong/decrease-cocurrency-limit-of-timer-ng.yml
@@ -1,3 +1,3 @@
 message: |
-    Fixed a bug where, if the the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
+    Fixed a bug where, if the ulimit setting (open files) was low, Kong would fail to start as the `lua-resty-timer-ng` exhausted the available `worker_connections`. Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 2048]` to `[256, 1024]` to fix this bug.
 type: bugfix

--- a/changelog/unreleased/kong/fix-dao-cache-pk.yml
+++ b/changelog/unreleased/kong/fix-dao-cache-pk.yml
@@ -1,0 +1,3 @@
+message: |
+  Fixed an issue in DAO and Declarative Config where foreign key primary keys were hardcoded to 'id'. Addresses several FIXME comments in the codebase.
+type: bugfix

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -1527,7 +1527,8 @@ local function get_cache_key_value(name, key, fields)
   end
 
   if type(value) == "table" and fields[name].type == "foreign" then
-    value = value.id -- FIXME extract foreign key, do not assume `id`
+    local foreign_pk = fields[name].schema.primary_key
+    value = value[foreign_pk[1]]
     if value == null or value == nil then
       return
     end

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -591,8 +591,10 @@ local function build_cache_key(entity, item, schema, parent_fk, child_key)
 
     elseif item[k] == nil then
       if k == child_key then
-        if parent_fk.id and next(parent_fk, "id") == nil then
-          insert(ck, parent_fk.id)
+        local foreign_schema = schema.fields[k].schema
+        local pk_name = foreign_schema.primary_key[1]
+        if parent_fk[pk_name] and next(parent_fk, pk_name) == nil then
+          insert(ck, parent_fk[pk_name])
         else
           -- FIXME support building cache_keys with fk's whose pk is not id
           return nil


### PR DESCRIPTION
Resolved a couple of lingering FIXMEs in the DAO and Declarative Config code paths where foreign keys were incorrectly assumed to always use the `id` field. The changes now handle foreign key references more consistently across different schemas.

Also cleaned up a few minor typos in changelog entries while working in the area.

### Summary

This PR removes assumptions that foreign key relationships always reference an `id` field in the DAO and Declarative Config implementations. This improves compatibility with entities that use alternative primary key fields and addresses existing FIXME comments in the codebase.

Additionally, a few small typo fixes were made in changelog files.

### Checklist

* [ ] The Pull Request has tests
* [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [[README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)](https://github.com/Kong/gateway-changelog/blob/main/README.md)
* [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

