### PR TITLE
fix(grpc-gateway): transcode a repeated field passed as a single query param

### DIFF
--- a/changelog/unreleased/kong/fix-grpc-gateway-repeated-single-query-param.yml
+++ b/changelog/unreleased/kong/fix-grpc-gateway-repeated-single-query-param.yml
@@ -1,0 +1,7 @@
+message: |
+  **grpc-gateway**: Fixed an issue where a `repeated` request field supplied as a
+  single query parameter (e.g. `?colors=RED`) failed to transcode and returned
+  `HTTP 400 "failed to encode payload"`. A single value is now normalized to a
+  one-element list, matching grpc-gateway query parameter semantics.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -173,11 +173,32 @@ function deco.new(method, path, protofile)
 end
 
 local function get_field_type(typ, field)
-  local _, _, field_typ = pb.field(typ, field)
-  return field_typ
+  local _, _, field_typ, _, label = pb.field(typ, field)
+  return field_typ, label
 end
 
-local function encode_fix(v, typ)
+-- pb.field reports a repeated field's label as "repeated" (non-packed, e.g.
+-- repeated string) or "packed" (proto3-packed scalars and enums, e.g.
+-- repeated int32 / repeated SomeEnum).
+local REPEATED_LABELS = {
+  repeated = true,
+  packed = true,
+}
+
+local function encode_fix(v, typ, label)
+  if REPEATED_LABELS[label] then
+    -- ngx.req.get_uri_args returns a string for a single-occurrence key and a
+    -- table for multiple occurrences. A repeated field must encode to a list,
+    -- so normalize a single value to a one-element array before encoding.
+    if type(v) ~= "table" then
+      v = { v }
+    end
+    for i = 1, #v do
+      v[i] = encode_fix(v[i], typ)
+    end
+    return v
+  end
+
   if typ == "bool" then
     -- special case for URI parameters
     return v and v ~= "0" and v ~= "false"
@@ -196,7 +217,8 @@ local function add_to_table( t, path, v, typ )
   local msg_typ = typ;
   for m in re_gmatch( path , "([^.]+)(\\.)?", "jo" ) do
     local key, dot = m[1], m[2]
-    msg_typ = get_field_type(msg_typ, key)
+    local label
+    msg_typ, label = get_field_type(msg_typ, key)
 
     -- not argument that we concern with
     if not msg_typ then
@@ -207,7 +229,7 @@ local function add_to_table( t, path, v, typ )
       tab[key] = tab[key] or {} -- create empty nested table if key does not exist
       tab = tab[key]
     else
-      tab[key] = encode_fix(v, msg_typ)
+      tab[key] = encode_fix(v, msg_typ, label)
     end
   end
 

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -268,6 +268,25 @@ for _, strategy in helpers.each_strategy() do
       }, cjson.decode(body))
     end)
 
+    describe("repeated field as query parameter", function()
+      -- single occurrence used to fail with 400 "failed to encode payload"
+      -- because ngx.req.get_uri_args returns a string (not a table) and the
+      -- repeated field could not be encoded. See issue #14907.
+      test("single value transcodes to a one-element list", function()
+        local res, _ = proxy_client:get("/v1/echo?array=a")
+        assert.equal(200, res.status)
+        local data = cjson.decode((res:read_body()))
+        assert.same({ "a" }, data.array)
+      end)
+
+      test("multiple values transcode to a list", function()
+        local res, _ = proxy_client:get("/v1/echo?array=a&array=b")
+        assert.equal(200, res.status)
+        local data = cjson.decode((res:read_body()))
+        assert.same({ "a", "b" }, data.array)
+      end)
+    end)
+
     test("null in json", function()
       local res, _ = proxy_client:post("/bounce", {
         headers = { ["Content-Type"] = "application/json" },

--- a/spec/fixtures/grpc/targetservice.proto
+++ b/spec/fixtures/grpc/targetservice.proto
@@ -49,6 +49,11 @@ service Bouncer {
     option (google.api.http) = {
       post: "/v1/echo"
       body: "*"
+      // GET binding exercises repeated fields supplied as query parameters,
+      // e.g. `?array=a` (single) and `?array=a&array=b` (multiple).
+      additional_bindings {
+        get: "/v1/echo"
+      }
     };
   }
 }


### PR DESCRIPTION
### Summary

The `grpc-gateway` plugin returns `HTTP 400 {"message":"failed to encode payload"}` when a **repeated** request field is supplied as a **single** query-parameter occurrence (e.g. `?colors=RED`). The same field with two or more occurrences (`?colors=RED&colors=BLUE`) transcodes fine, so a repeated field is only usable when the client happens to pass multiple values — the single-value case (one selected filter) is the common one and fails deterministically.

**Root cause.** `ngx.req.get_uri_args()` returns a string for a single-occurrence key and a table for multiple occurrences. In `kong/plugins/grpc-gateway/deco.lua`, `add_to_table` / `encode_fix` assigned that value to the leaf field with no awareness of the field's cardinality. For a `repeated` field, `pb.encode` then rejected the bare string because the field must encode to a list (`table expected at field '...', got string`). With two occurrences the value is already a table, which is why single- vs. multiple-value behaved differently.

**Fix.** `encode_fix` now inspects the field's label from `pb.field` — reported as `repeated` for non-packed fields (e.g. `repeated string`) and `packed` for proto3-packed scalars and enums (e.g. `repeated int32`, `repeated SomeEnum`) — and normalizes a single value to a one-element array before encoding, mapping each element through `encode_fix`. This matches `grpc-ecosystem/grpc-gateway` query-parameter semantics, where `?colors=RED` → `colors = [RED]`.

**Test.** A `GET /v1/echo` binding was added to the existing `Echo` RPC in the `targetservice.proto` fixture (whose `repeated string array` field is echoed back), so the repeated-query behavior is covered without rebuilding the gRPC target server. New cases assert both the single-value (`?array=a`) and multiple-value (`?array=a&array=b`) paths.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong`
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com — not required; this restores documented grpc-gateway behavior

### Issue reference

Fix #14907
