### PR TITLE
chore(cd): amazonlinux-2 EOL

### DIFF
--- a/.github/matrix-full.yml
+++ b/.github/matrix-full.yml
@@ -54,12 +54,6 @@ build-packages:
   check-manifest-suite: el9-arm64
 
   # Amazon Linux
-- label: amazonlinux-2
-  package: rpm
-  package-type: aws2
-  check-manifest-suite: amazonlinux-2-amd64
-  # simdjson doesn't compile on gcc7.3.1 (needs 7.4)
-  bazel-args: --platforms=//:aws2-crossbuild-x86_64 --//:simdjson=False
 - label: amazonlinux-2023
   image: amazonlinux:2023
   package: rpm
@@ -176,12 +170,6 @@ release-packages:
   artifact: kong.el9.arm64.rpm
 
 # Amazon Linux
-- label: amazonlinux-2
-  package: rpm
-  artifact-from: amazonlinux-2
-  artifact-version: 2
-  artifact-type: amazonlinux
-  artifact: kong.aws2.amd64.rpm
 - label: amazonlinux-2023
   package: rpm
   artifact-from: amazonlinux-2023

--- a/build/cross_deps/README.md
+++ b/build/cross_deps/README.md
@@ -13,7 +13,6 @@ Note that the artifacts of those dependencies are only used during build time,
 they are not shipped together with our binary artifact (.deb, .rpm or docker image etc).
 
 We currently do cross compile on following platforms:
-- Amazonlinux 2
 - Amazonlinux 2023
 - Ubuntu 18.04 (Version 3.4.x.x only)
 - Ubuntu 22.04


### PR DESCRIPTION
### Summary

Amazon Linux 2 has reached end-of-life, so this removes all `amazonlinux-2` entries from the CD build matrices (`.github/matrix-full.yml` and `.github/matrix-debug.yml`). Only the `amazonlinux-2` package/image/release targets are dropped; `amazonlinux-2023` targets are left untouched.

### Issues resolved

KAG-9225 (https://konghq.atlassian.net/browse/KAG-9225)
