### PR TITLE
ci: restrict GITHUB_TOKEN permissions to read-only by default

### DIFF
--- a/.github/workflows/add-release-pongo.yml
+++ b/.github/workflows/add-release-pongo.yml
@@ -5,6 +5,8 @@ on:
     tags:
     - '[1-9]+.[0-9]+.[0-9]+'
 
+permissions: read-all
+
 jobs:
   set_vars:
     name: Set Vars

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -16,6 +16,8 @@ on:
         description: "Ignore the build cache and build dependencies from scratch"
         type: boolean
         default: false
+permissions: read-all
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -4,6 +4,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: read-all
+
 jobs:
   check_comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
 env:
   BUILD_ROOT: ${{ github.workspace }}/${{ inputs.relative-build-root }}
 
+permissions: read-all
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,8 @@ env:
   KONG_TEST_COVERAGE: ${{ inputs.coverage == true || github.event_name == 'schedule' }}
   RUNNER_COUNT: 7
 
+permissions: read-all
+
 jobs:
   metadata:
     name: Metadata

--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -17,6 +17,8 @@ on:
     - master
     - release/*
 
+permissions: read-all
+
 jobs:
 
   autoformat:

--- a/.github/workflows/changelog-requirement.yml
+++ b/.github/workflows/changelog-requirement.yml
@@ -9,6 +9,8 @@ on:
       - '.requirements'
       - 'changelog/**'
 
+permissions: read-all
+
 jobs:
   require-changelog:
     if: ${{ !contains(github.event.*.labels.*.name, 'skip-changelog') }}

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions: read-all
+
 jobs:
   validate-changelog:
     name: Validate changelog

--- a/.github/workflows/community-stale.yml
+++ b/.github/workflows/community-stale.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: read-all
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -7,6 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions: read-all
+
 jobs:
   check-copyright-and-ee-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -2,6 +2,8 @@ name: Pull Request Label Checker
 on:
   pull_request:
     types: [opened, edited, synchronize, labeled, unlabeled]
+permissions: read-all
+
 jobs:
   check-labels:
     name: prevent merge labels

--- a/.github/workflows/label-schema.yml
+++ b/.github/workflows/label-schema.yml
@@ -2,6 +2,8 @@ name: Pull Request Schema Labeler
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled]
+permissions: read-all
+
 jobs:
   schema-change-labels:
     if: "${{ contains(github.event.*.labels.*.name, 'schema-change-noteworthy') }}"

--- a/.github/workflows/labeler-v2.yml
+++ b/.github/workflows/labeler-v2.yml
@@ -2,6 +2,8 @@ name: "Pull Request Labeler v2"
 on:
 - pull_request
 
+permissions: read-all
+
 jobs:
   labeler:
     if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/openresty-patches-companion.yml
+++ b/.github/workflows/openresty-patches-companion.yml
@@ -4,6 +4,8 @@ on:
     paths:
     - 'build/openresty/patches/**'
 
+permissions: read-all
+
 jobs:
   create-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -14,6 +14,8 @@ env:
   # only for pr
   GHA_CACHE: ${{ github.event_name == 'pull_request' }}
 
+permissions: read-all
+
 jobs:
   build-packages:
     name: Build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ env:
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
 
+permissions: read-all
+
 jobs:
   metadata:
     name: Metadata

--- a/.github/workflows/update-ngx-wasm-module.yml
+++ b/.github/workflows/update-ngx-wasm-module.yml
@@ -6,6 +6,8 @@ on:
   # run weekly
   - cron: '0 0 * * 0'
 
+permissions: read-all
+
 jobs:
   update:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-test-runtime-statistics.yml
+++ b/.github/workflows/update-test-runtime-statistics.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - feat/test-run-scheduler
 
+permissions: read-all
+
 jobs:
   process-statistics:
     name: Download statistics from GitHub and combine them

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -27,6 +27,8 @@ env:
   GH_TOKEN: ${{ github.token }}
   BUILD_ROOT: ${{ github.workspace }}/bazel-bin/build
 
+permissions: read-all
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
## Summary

Restricts the default `GITHUB_TOKEN` permissions to read-only across all 20 GitHub Actions workflows that currently use the unrestricted default permissions.

## Problem

The default `GITHUB_TOKEN` permissions include read/write access to all issues, PRs, and repository contents. This token is available to all code and actions in a workflow, even if not explicitly passed. A compromised third-party action or malicious code in a workflow could steal the token and perform any action allowed by its permissions.

Both [GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) and the [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) recommend restricting `GITHUB_TOKEN` to the minimum permissions necessary.

## Changes

Added `permissions: read-all` at the top level of all 20 workflow files that lacked explicit permission restrictions:

- `add-release-pongo.yml`
- `ast-grep.yml`
- `autodocs.yml`
- `backport-fail-bot.yml`
- `build.yml`
- `buildifier.yml`
- `build_and_test.yml`
- `changelog-requirement.yml`
- `changelog-validation.yml`
- `community-stale.yml`
- `copyright-check.yml`
- `label-check.yml`
- `label-schema.yml`
- `labeler-v2.yml`
- `openresty-patches-companion.yml`
- `perf.yml`
- `release.yml`
- `update-ngx-wasm-module.yml`
- `update-test-runtime-statistics.yml`
- `upgrade-tests.yml`

## Why this is safe

- **Workflows with existing job-level permissions** (e.g. `community-stale.yml`, `labeler-v2.yml`, `update-ngx-wasm-module.yml`, `perf.yml`, `release.yml`) are unaffected because [job-level permissions override top-level permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).
- **Read-only workflows** (linters, validators, build/test) only need read access.
- **Workflows using `secrets.PAT`** for cross-repo operations are unaffected since PAT permissions are independent of `GITHUB_TOKEN`.

## Impact

- 20 files changed
- 40 insertions (2 lines per file: `permissions: read-all` + blank line)
- 0 deletions

Fixes #14778