### PR TITLE
fix(core): transform CA certificates during DB import

### DIFF
--- a/changelog/unreleased/kong/fix-db-import-ca-cert-digest.yml
+++ b/changelog/unreleased/kong/fix-db-import-ca-cert-digest.yml
@@ -1,0 +1,5 @@
+message: |
+  Fixed `kong config db_import` to generate `cert_digest` for CA certificates
+  when declarative transformations are disabled.
+type: bugfix
+scope: Core

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -137,6 +137,7 @@ local function load_into_db(entities, meta)
   for i = 1, #sorted_schemas do
     local schema = sorted_schemas[i]
     local schema_name = schema.name
+    options.transform = meta._transform ~= false or schema_name == "ca_certificates"
 
     local primary_key, ok, err, err_t
     for _, entity in pairs(entities[schema_name]) do

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -26,6 +26,62 @@ routes:
     end)
   end)
 
+  describe("load_into_db", function()
+    local original_db
+
+    before_each(function()
+      original_db = kong.db
+    end)
+
+    after_each(function()
+      kong.db = original_db
+    end)
+
+    it("transforms CA certificates when declarative transformations are disabled", function()
+      local transform
+      local schema = {
+        name = "ca_certificates",
+        each_field = function()
+          return function() end
+        end,
+        extract_pk_values = function(_, entity)
+          return { id = entity.id }
+        end,
+      }
+
+      kong.db = {
+        workspaces = {
+          select_by_name = function()
+            return {
+              id = "00000000-0000-0000-0000-000000000000",
+              name = "default",
+            }
+          end,
+        },
+        ca_certificates = {
+          schema = schema,
+          upsert = function(_, _, _, options)
+            transform = options.transform
+            return true
+          end,
+        },
+      }
+
+      assert(declarative.load_into_db({
+        ca_certificates = {
+          certificate = {
+            id = "85a67812-678c-5fe5-9ff1-60af91f31b4b",
+            cert = "certificate",
+          },
+        },
+      }, {
+        _transform = false,
+      }))
+
+      assert.is_true(transform)
+    end)
+  end)
+
   it("ttl fields are accepted in DB-less schema validation", function()
     local dc = declarative.new_config(conf_loader())
     local entities, err = dc:parse_string([[


### PR DESCRIPTION
## Summary
- ensure `kong config db_import` runs the CA certificate transformation even when `_transform` is false
- generate the required `cert_digest` before the database upsert
- add a focused unit test covering the import behavior

Fixes #12110

## Test plan
- [x] Lua syntax validation for changed source and test files
- [x] `git diff --check`
- [ ] `bin/busted spec/01-unit/01-db/10-declarative_spec.lua` (local OpenResty `resty` executable is unavailable; CI should run this test)

Made with [Cursor](https://cursor.com)