### PR TITLE
docs(dns): fix typo and grammar in readme

### DIFF
--- a/kong/dns/README.md
+++ b/kong/dns/README.md
@@ -36,7 +36,7 @@ Performs a series of initialization operations:
 
 **Input parameters:**
 
-`@opts` It accepts a options table argument. The following options are supported:
+`@opts` It accepts an options table argument. The following options are supported:
 
 * TTL options:
   * `valid_ttl`: (default: `nil`)
@@ -109,7 +109,7 @@ Performs a DNS resolution.
   * specify the query type instead of `self.order` types.
 * `@cache_only`: (optional: `boolean`)
   * control whether to solely retrieve data from the internal cache without querying to the nameserver.
-* `@tries?`: see the above section `Return value and input paramter @tries?`.
+* `@tries?`: see the above section `Return value and input parameter @tries?`.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
### Summary

Fixes two small documentation issues in the DNS client README (`kong/dns/README.md`):

- `new`: "It accepts a options table argument" → "an options table argument".
- `resolve`: the reference to the "input parameter `@tries?`" section was spelled "paramter". This corrects the typo so it matches the section it points to ("Return value and input parameter `@tries?`").

Documentation-only change to an internal developer README; no behavior change.

### Checklist

- [ ] The Pull Request has tests — n/a, documentation only.
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary — changelog is unnecessary; requesting the `skip-changelog` label.
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com — n/a, this is an in-repo internal README, not the public docs site.

### Issue reference

None.
