### PR TITLE
fix(ai-proxy): preserve cachedContent in Gemini transformation

### DIFF
--- a/changelog/unreleased/kong/fix-ai-gemini-cached-content.yml
+++ b/changelog/unreleased/kong/fix-ai-gemini-cached-content.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed a bug where the Gemini driver dropped the `cachedContent` field during the OpenAI-to-Gemini request transformation, so Vertex AI context caches were never used. The cached token count is now also reported back as `usage.prompt_tokens_details.cached_tokens`."
+type: bugfix
+scope: Plugin

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -377,6 +377,13 @@ local function to_gemini_chat_openai(request_table, model_info, route_type)
     -- handle function calling translation from OpenAI format
     new_r.tools = request_table.tools and to_tools(request_table.tools)
     new_r.tool_config = request_table.tool_config
+
+    -- pass through a Vertex AI context cache reference if the caller set one.
+    -- Gemini expects the full resource name here, e.g.
+    -- "projects/123/locations/us-central1/cachedContents/456". We build new_r
+    -- from scratch above, so without this the field is silently dropped and the
+    -- cache never gets used.
+    new_r.cachedContent = request_table.cachedContent
   end
 
   return new_r, "application/json", nil
@@ -450,6 +457,14 @@ local function from_gemini_chat_openai(response, model_info, route_type)
         completion_tokens = response.usageMetadata.candidatesTokenCount,
         total_tokens = response.usageMetadata.totalTokenCount,
       }
+
+      -- when a context cache was used, report the cached portion the same way
+      -- OpenAI does so downstream analytics and clients can see it
+      if response.usageMetadata.cachedContentTokenCount then
+        messages.usage.prompt_tokens_details = {
+          cached_tokens = response.usageMetadata.cachedContentTokenCount,
+        }
+      end
     end
 
   else -- probably a server fault or other unexpected response

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -1280,6 +1280,104 @@ describe(PLUGIN_NAME .. ": (unit)", function()
     end)
   end)
 
+  describe("gemini context cache", function()
+    local gemini_driver
+
+    setup(function()
+      _G._TEST = true
+      package.loaded["kong.llm.drivers.gemini"] = nil
+      gemini_driver = require("kong.llm.drivers.gemini")
+    end)
+
+    teardown(function()
+      _G._TEST = nil
+    end)
+
+    it("passes cachedContent through to the gemini request", function()
+      local cache_name = "projects/123456789/locations/us-central1/cachedContents/987654321"
+      local request_table = {
+        messages = {
+          {
+            role = "user",
+            content = "What company are you an expert on?",
+          },
+        },
+        cachedContent = cache_name,
+      }
+
+      local gemini_request, _, err = gemini_driver._to_gemini_chat_openai(request_table)
+
+      assert.is_nil(err)
+      assert.not_nil(gemini_request)
+      assert.equal(cache_name, gemini_request.cachedContent)
+    end)
+
+    it("leaves cachedContent unset when the caller did not provide one", function()
+      local gemini_request, _, err = gemini_driver._to_gemini_chat_openai(SAMPLE_LLM_V1_CHAT)
+
+      assert.is_nil(err)
+      assert.not_nil(gemini_request)
+      assert.is_nil(gemini_request.cachedContent)
+    end)
+
+    it("reports cached prompt tokens from the gemini response", function()
+      local gemini_response = {
+        candidates = {
+          {
+            content = {
+              parts = {
+                { text = "I am an expert on Kong." },
+              },
+            },
+            finishReason = "STOP",
+          },
+        },
+        usageMetadata = {
+          promptTokenCount = 32776,
+          candidatesTokenCount = 8,
+          totalTokenCount = 32784,
+          cachedContentTokenCount = 32768,
+        },
+      }
+
+      local openai_response = gemini_driver._from_gemini_chat_openai(gemini_response, {}, "llm/v1/chat")
+
+      assert.not_nil(openai_response)
+
+      openai_response = cjson.decode(openai_response)
+      assert.equal(32776, openai_response.usage.prompt_tokens)
+      assert.same({ cached_tokens = 32768 }, openai_response.usage.prompt_tokens_details)
+    end)
+
+    it("omits prompt_tokens_details when no cache was used", function()
+      local gemini_response = {
+        candidates = {
+          {
+            content = {
+              parts = {
+                { text = "Two." },
+              },
+            },
+            finishReason = "STOP",
+          },
+        },
+        usageMetadata = {
+          promptTokenCount = 8,
+          candidatesTokenCount = 1,
+          totalTokenCount = 9,
+        },
+      }
+
+      local openai_response = gemini_driver._from_gemini_chat_openai(gemini_response, {}, "llm/v1/chat")
+
+      assert.not_nil(openai_response)
+
+      openai_response = cjson.decode(openai_response)
+      assert.is_nil(openai_response.usage.prompt_tokens_details)
+    end)
+  end)
+
+
   describe("bedrock tools", function()
     local bedrock_driver
 


### PR DESCRIPTION
### Summary

When using the OpenAI-compatible `llm/v1/chat` route with `provider: gemini`, the `cachedContent` field in the request body was silently dropped during the OpenAI-to-Gemini transformation. `to_gemini_chat_openai` builds a fresh request table and only copied `contents`, `systemInstruction`, `generationConfig` and `tools`, so any [Vertex AI context cache](https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-create) reference the caller passed (for example via `extra_body` in the OpenAI SDK) never reached the upstream. The request still succeeded, but the cache was ignored and the user paid full prompt-token cost.

This PR:

- Carries `cachedContent` through the transformation so the outgoing `generateContent` request references the cache.
- Surfaces the cached portion of the prompt back to clients as `usage.prompt_tokens_details.cached_tokens` (mapped from Gemini's `usageMetadata.cachedContentTokenCount`), matching the OpenAI usage schema. When no cache is used the field is omitted.

Added unit tests covering both the request pass-through and the response usage mapping (including the no-cache cases).

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14837
