### PR TITLE
fix(observability): omit http.route when no route matched

### DIFF
--- a/changelog/unreleased/kong/fix-http-route-empty-string.yml
+++ b/changelog/unreleased/kong/fix-http-route-empty-string.yml
@@ -1,0 +1,3 @@
+message: "**observability**: The `http.route` span attribute is now omitted when a request does not match any route, instead of being set to an empty string, to comply with the OpenTelemetry semantic conventions."
+type: bugfix
+scope: Core

--- a/kong/observability/tracing/instrumentation.lua
+++ b/kong/observability/tracing/instrumentation.lua
@@ -329,7 +329,13 @@ function _M.runloop_before_header_filter()
   if root_span then
     root_span:set_attribute("http.status_code", ngx.status)
     local r = ngx.ctx.route
-    root_span:set_attribute("http.route", r and r.paths and r.paths[1] or "")
+    -- Only set http.route when we actually matched a route with a path.
+    -- The OpenTelemetry semantic conventions say the attribute must be omitted
+    -- when the route is not known, rather than reported as an empty string.
+    local http_route = r and r.paths and r.paths[1]
+    if http_route then
+      root_span:set_attribute("http.route", http_route)
+    end
   end
 end
 

--- a/spec/02-integration/14-observability/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-observability/01-instrumentations_spec.lua
@@ -41,6 +41,11 @@ local function assert_has_attributes(span, attributes)
   end
 end
 
+local function assert_has_no_attribute(span, key)
+  assert.is_nil(span.attributes[key], fmt(
+        "Expected span not to have attribute %s, but got %s\n", key, pretty.write(span.attributes)))
+end
+
 local TCP_PORT = 35001
 local tcp_trace_plugin_name = "tcp-trace-exporter"
 for _, strategy in helpers.each_strategy() do
@@ -569,6 +574,79 @@ for _, strategy in helpers.each_strategy() do
           -- has error reported
           assert.is_not_nil(upstream_dns.events)
         end)
+      end)
+    end)
+
+    describe("http.route", function ()
+      lazy_setup(function()
+        local bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { tcp_trace_plugin_name }))
+
+        local http_srv = assert(bp.services:insert {
+          name = "mock-service",
+          host = helpers.mock_upstream_host,
+          port = helpers.mock_upstream_port,
+        })
+
+        -- host-restricted route so a request to another host matches no route
+        bp.routes:insert({
+          service = http_srv,
+          protocols = { "http" },
+          paths = { "/" },
+          hosts = { "known-host" },
+        })
+
+        bp.plugins:insert({
+          name = tcp_trace_plugin_name,
+          config = {
+            host = "127.0.0.1",
+            port = TCP_PORT,
+            custom_spans = false,
+          }
+        })
+
+        assert(helpers.start_kong {
+          database = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          plugins = "bundled, tcp-trace-exporter",
+          tracing_instrumentations = "request",
+          tracing_sampling_rate = 1,
+        })
+
+        proxy_client = helpers.proxy_client()
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("is not set on the root span when no route matched", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/nope",
+          headers = {
+            host = "unknown-host",
+          }
+        })
+        assert.res_status(404, r)
+
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        local spans = cjson.decode(res)
+        local kong_span = assert_has_spans("kong", spans, 1)[1]
+
+        assert_has_attributes(kong_span, {
+          ["http.method"]      = "GET",
+          ["http.status_code"] = "404",
+        })
+        -- http.route must be omitted (not an empty string) when unknown
+        assert_has_no_attribute(kong_span, "http.route")
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

In the header_filter instrumentation, the `http.route` span attribute was set with an empty string as the fallback when the request did not match any route:

```lua
root_span:set_attribute("http.route", r and r.paths and r.paths[1] or "")
```

Per the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-route), `http.route` must be omitted when the matched route is not known, rather than reported as an empty string. Emitting `""` produces misleading spans and can break downstream consumers that expect a valid route template when the attribute is present.

This PR only sets `http.route` when a route with a path actually matched, and adds an integration test asserting the attribute is absent on the root span for an unmatched (404) request.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14845
