### PR TITLE
fix(ai-proxy): use provider total_tokens for llm_total_tokens_count metric

### DIFF
--- a/changelog/unreleased/kong/fix-ai-llm-total-tokens-metric.yml
+++ b/changelog/unreleased/kong/fix-ai-llm-total-tokens-metric.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed the `llm_total_tokens_count` metric to use the provider's reported `total_tokens` when available, instead of always summing prompt and completion tokens. Models that use reasoning/hidden tokens report a total greater than the sum, which was previously under-counted."
+type: bugfix
+scope: Plugin

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -848,6 +848,13 @@ function _M.post_request(conf, response_object)
     ai_plugin_o11y.metrics_set("llm_prompt_tokens_count", response_object.usage.prompt_tokens)
     ai_plugin_o11y.metrics_set("llm_completion_tokens_count", response_object.usage.completion_tokens)
 
+    -- Prefer the provider's reported total. For models with reasoning/hidden
+    -- tokens the total is more than prompt + completion, so falling back to the
+    -- sum (see observability.metrics_get) would under-report usage.
+    if response_object.usage.total_tokens then
+      ai_plugin_o11y.metrics_set("llm_total_tokens_count", response_object.usage.total_tokens)
+    end
+
     if response_object.usage.prompt_tokens and response_object.usage.completion_tokens and
        conf.model.options and conf.model.options.input_cost and conf.model.options.output_cost then
         local cost = (response_object.usage.prompt_tokens * conf.model.options.input_cost +

--- a/spec/01-unit/26-observability/07-llm-metrics_spec.lua
+++ b/spec/01-unit/26-observability/07-llm-metrics_spec.lua
@@ -1,0 +1,31 @@
+local function reload_module(name)
+  package.loaded[name] = nil
+  return require(name)
+end
+
+
+describe("kong.llm.plugin.observability metrics", function()
+  local o11y
+
+  before_each(function()
+    _G.ngx.ctx = {}
+    o11y = reload_module("kong.llm.plugin.observability")
+  end)
+
+  it("falls back to prompt + completion when total is not set", function()
+    o11y.metrics_set("llm_prompt_tokens_count", 3)
+    o11y.metrics_set("llm_completion_tokens_count", 7)
+
+    assert.equal(10, o11y.metrics_get("llm_total_tokens_count"))
+  end)
+
+  it("uses the provider's total when set, even if it differs from the sum", function()
+    -- models with reasoning/hidden tokens report a total that is greater than
+    -- prompt + completion; the reported total must win
+    o11y.metrics_set("llm_prompt_tokens_count", 3)
+    o11y.metrics_set("llm_completion_tokens_count", 7)
+    o11y.metrics_set("llm_total_tokens_count", 298)
+
+    assert.equal(298, o11y.metrics_get("llm_total_tokens_count"))
+  end)
+end)


### PR DESCRIPTION
### Summary

The AI Proxy plugin never records `llm_total_tokens_count` explicitly. In `kong/llm/plugin/observability.lua`, `metrics_get("llm_total_tokens_count")` therefore always falls back to computing `prompt_tokens + completion_tokens`:

```lua
elseif key == "llm_total_tokens_count" then
  return _M.metrics_get("llm_prompt_tokens_count") + _M.metrics_get("llm_completion_tokens_count")
```

For models that use reasoning / hidden tokens, the provider's reported `total_tokens` is larger than `prompt + completion` (e.g. `prompt=3, completion=7, total=298`). The Prometheus metric `ai_llm_total_tokens_count` then reports `10` instead of `298`, under-counting real (billed) usage.

This PR sets `llm_total_tokens_count` from `response_object.usage.total_tokens` in `kong/llm/drivers/shared.lua` when the provider reports it, keeping the prompt+completion sum only as a fallback for providers that don't return a total.

Added a unit test for the observability metrics covering both the explicit-total and fallback cases.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14816
