### PR TITLE
fix(ai-proxy): don't return empty response on invalid upstream JSON in preserve mode

### DIFF
--- a/changelog/unreleased/kong/fix-ai-proxy-preserve-invalid-json.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-preserve-invalid-json.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed a bug where, with `route_type = preserve` and statistics logging enabled, an invalid JSON response body from the upstream would raise an error in the analytics body filter and cause the client to receive an empty reply. The upstream body is now passed through unchanged."
+type: bugfix
+scope: Plugin

--- a/kong/llm/plugin/shared-filters/serialize-analytics.lua
+++ b/kong/llm/plugin/shared-filters/serialize-analytics.lua
@@ -1,4 +1,4 @@
-local cjson = require("cjson")
+local cjson = require("cjson.safe")
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local ai_plugin_o11y = require("kong.llm.plugin.observability")
 

--- a/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/02-openai_integration_spec.lua
@@ -223,6 +223,15 @@ for _, strategy in helpers.all_strategies() do
                 end
               }
             }
+
+            location = "/preserve/invalid_json" {
+              content_by_lua_block {
+                -- upstream advertises JSON but returns a truncated/invalid body
+                ngx.status = 200
+                ngx.header["Content-Type"] = "application/json"
+                ngx.print("{")
+              }
+            }
         }
       ]]
 
@@ -570,6 +579,36 @@ for _, strategy in helpers.all_strategies() do
         route = { id = preserve_good.id },
         config = {
           path = "/dev/stdout",
+        },
+      }
+      --
+
+      -- preserve mode, upstream returns invalid JSON while statistics logging is on
+      local preserve_invalid_json = assert(bp.routes:insert {
+        service = empty_service,
+        protocols = { "http", "https" },
+        paths = { "/preserve/invalid-json" },
+        snis = { "example.test" },
+      })
+      bp.plugins:insert {
+        name = PLUGIN_NAME,
+        route = { id = preserve_invalid_json.id },
+        config = {
+          route_type = "preserve",
+          logging = {
+            log_payloads = false,
+            log_statistics = true,
+          },
+          auth = {
+            header_name = "Authorization",
+            header_value = "Bearer openai-key",
+          },
+          model = {
+            provider = "openai",
+            options = {
+              upstream_url = "http://"..helpers.mock_upstream_host..":"..MOCK_PORT.."/preserve/invalid_json"
+            },
+          },
         },
       }
       --
@@ -1306,6 +1345,25 @@ for _, strategy in helpers.all_strategies() do
        assert.equals("text-embedding-3-large", json.model)
        assert.equals("openai/text-embedding-ada-002", r.headers["X-Kong-LLM-Model"])
     end)
+
+      it("proxies an invalid-json upstream body instead of returning an empty response", function()
+        local r = client:get("/preserve/invalid-json", {
+          headers = {
+            ["content-type"] = "application/json",
+            ["accept"] = "application/json",
+          },
+          body = cjson.encode({
+            messages = {
+              { role = "user", content = "hello" },
+            },
+          }),
+        })
+
+        -- the malformed body must be passed through, not swallowed into an
+        -- empty reply by an error in the analytics body_filter
+        local body = assert.res_status(200, r)
+        assert.equals("{", body)
+      end)
   end)
 
     describe("openai different auth methods", function()


### PR DESCRIPTION
### Summary

When the `ai-proxy` plugin is configured with `route_type = preserve` and statistics logging is enabled, an invalid JSON response body from the upstream crashes the analytics body filter and the client receives an empty response:

```
failed to run body_filter_by_lua*: .../serialize-analytics.lua: Expected object key string but found T_END at character 2
curl: (52) Empty reply from server
```

`serialize-analytics` decodes the upstream body with the throwing `cjson` decoder to read the response model name. In preserve mode the upstream body is arbitrary, so a malformed body (e.g. a truncated `{`) raises inside `body_filter_by_lua`, the request is torn down, and the client gets nothing instead of the upstream's actual response. Kong is a proxy — the upstream body should be passed through.

This PR switches that decode to the non-throwing `cjson.safe` decoder. A malformed body now simply leaves the response model unresolved (falling back to the request model), and the body is proxied through unchanged.

Added an integration test with a preserve-mode route whose upstream returns invalid JSON while statistics logging is on, asserting the client still receives the upstream body.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14903
