### PR TITLE
fix(grpc-gateway): transcode single-value repeated query parameters

### DIFF
--- a/changelog/unreleased/kong/fix-grpc-gateway-repeated-single-value.yml
+++ b/changelog/unreleased/kong/fix-grpc-gateway-repeated-single-value.yml
@@ -1,0 +1,3 @@
+message: "**grpc-gateway**: Fixed a bug where a repeated request field supplied as a single query-parameter value (e.g. `?colors=RED`) failed to transcode with `400 failed to encode payload`. A single value is now wrapped into a one-element list, matching grpc-gateway query-parameter semantics."
+type: bugfix
+scope: Plugin

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -173,8 +173,14 @@ function deco.new(method, path, protofile)
 end
 
 local function get_field_type(typ, field)
-  local _, _, field_typ = pb.field(typ, field)
-  return field_typ
+  local _, _, field_typ, _, label = pb.field(typ, field)
+  return field_typ, label
+end
+
+-- proto3 marks repeated fields as either "repeated" (strings, messages, bytes)
+-- or "packed" (numeric/enum/bool that use packed encoding)
+local function is_repeated(label)
+  return label == "repeated" or label == "packed"
 end
 
 local function encode_fix(v, typ)
@@ -196,7 +202,8 @@ local function add_to_table( t, path, v, typ )
   local msg_typ = typ;
   for m in re_gmatch( path , "([^.]+)(\\.)?", "jo" ) do
     local key, dot = m[1], m[2]
-    msg_typ = get_field_type(msg_typ, key)
+    local label
+    msg_typ, label = get_field_type(msg_typ, key)
 
     -- not argument that we concern with
     if not msg_typ then
@@ -206,6 +213,11 @@ local function add_to_table( t, path, v, typ )
     if dot then
       tab[key] = tab[key] or {} -- create empty nested table if key does not exist
       tab = tab[key]
+    elseif is_repeated(label) and type(v) ~= "table" then
+      -- a repeated field passed as a single query-parameter value arrives as a
+      -- scalar (get_uri_args only returns a table for 2+ occurrences). Wrap it
+      -- so it encodes as a one-element list instead of failing to encode.
+      tab[key] = { encode_fix(v, msg_typ) }
     else
       tab[key] = encode_fix(v, msg_typ)
     end

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -166,6 +166,32 @@ for _, strategy in helpers.each_strategy() do
       assert.same({reply = "hello john_doe", boolean_test = false}, data)
     end)
 
+    describe("repeated query args", function ()
+      test("single value transcodes to a one-element list #14907", function()
+        local res, err = proxy_client:get("/v1/messages/john_doe?tags=a")
+
+        assert.equal(200, res.status)
+        assert.is_nil(err)
+
+        local body = res:read_body()
+        local data = cjson.decode(body)
+
+        assert.same({reply = "hello john_doe", boolean_test = false}, data)
+      end)
+
+      test("multiple values transcode as before", function()
+        local res, err = proxy_client:get("/v1/messages/john_doe?tags=a&tags=b")
+
+        assert.equal(200, res.status)
+        assert.is_nil(err)
+
+        local body = res:read_body()
+        local data = cjson.decode(body)
+
+        assert.same({reply = "hello john_doe", boolean_test = false}, data)
+      end)
+    end)
+
     describe("boolean behavior", function ()
       test("true", function()
         local res, err = proxy_client:get("/v1/messages/legacy/john_doe?boolean_test=true")

--- a/spec/fixtures/grpc/targetservice.proto
+++ b/spec/fixtures/grpc/targetservice.proto
@@ -57,6 +57,7 @@ service Bouncer {
 message HelloRequest {
   string greeting = 1;
   bool boolean_test = 2;
+  repeated string tags = 3;
 }
 
 message HelloResponse {


### PR DESCRIPTION
### Summary

The `grpc-gateway` plugin returns `HTTP 400 {"message":"failed to encode payload"}` when a **repeated** request field is supplied as a **single** query-parameter occurrence:

| Request | Before |
|---|---|
| `?colors=RED` (one occurrence) | **400 `failed to encode payload`** |
| `?colors=RED&colors=BLUE` (two occurrences) | `200` |
| scalar field `?name=bolt` | `200` |

`ngx.req.get_uri_args()` returns a bare string when a parameter occurs once and a Lua table only when it occurs two or more times. In `deco.lua`, `add_to_table` assigned that value directly, so a single occurrence handed `pb.encode` a scalar where a repeated field requires a list — hence the encode failure. Two-or-more occurrences already produced a table and worked. The single-value case is the common one (one selected filter).

This PR detects repeated fields from the protobuf field label (`repeated` for strings/messages/bytes, `packed` for numeric/enum/bool) and wraps a single scalar value into a one-element list before encoding, matching `grpc-ecosystem/grpc-gateway` query-parameter semantics. Multi-value requests are unchanged.

Added a `repeated string tags` field to the gRPC test fixture and integration tests covering the single-value and multi-value cases.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14907
