### PR TITLE
fix(router): disambiguate cache key values

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -7,7 +7,6 @@ local assert = assert
 local tonumber = tonumber
 local setmetatable = setmetatable
 local tb_sort = table.sort
-local tb_concat = table.concat
 
 
 local var           = ngx.var
@@ -399,19 +398,41 @@ end -- is_http
 -- the fields returned from atc-router have fixed order and name
 -- traversing these fields will always get a decided result (for one router instance)
 -- so we need not to add field's name in cache key now
+local function put_cache_scalar(value, str_buf)
+  local encoded = tostring(value)
+  str_buf:putf("%d:%s", #encoded, encoded)
+end
+
+
+local function put_cache_value(value, str_buf)
+  if value == nil then
+    str_buf:put("N|")
+    return
+  end
+
+  if type(value) == "table" then
+    tb_sort(value)
+    str_buf:putf("A%d:", #value)
+    for _, item in ipairs(value) do
+      put_cache_scalar(item, str_buf)
+    end
+    str_buf:put("|")
+    return
+  end
+
+  str_buf:put("S")
+  put_cache_scalar(value, str_buf)
+  str_buf:put("|")
+end
+
+
 local function visit_for_cache_key(field, value, str_buf)
   -- these fields were not in cache key
   if field == "net.protocol" then
     return true
   end
 
-  if type(value) == "table" then
-    tb_sort(value)
-    value = tb_concat(value, ",")
-  end
-
-  str_buf:putf("%s|", value or "")
-
+  put_cache_value(value, str_buf)
   return true
 end
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5072,6 +5072,210 @@ for _, flavor in ipairs({ "traditional_compatible", "expressions" }) do
   describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
 
+    it("does not reuse a scalar header match for repeated values", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8201",
+            headers = {
+              test = { "a,b" },
+            },
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = "a,b" }))
+      local match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(ctx.route_match_cached)
+
+      ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = { "a", "b" } }))
+      assert.falsy(router:exec(ctx))
+      assert.falsy(ctx.route_match_cached)
+    end)
+
+    it("does not reuse a repeated-header miss for a scalar value", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8202",
+            headers = {
+              test = { "a,b" },
+            },
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = { "a", "b" } }))
+      assert.falsy(router:exec(ctx))
+      assert.falsy(ctx.route_match_cached)
+
+      ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = "a,b" }))
+      local match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(ctx.route_match_cached)
+    end)
+
+    it("keeps missing and empty header values in distinct cache entries", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8203",
+            headers = {
+              test = { "" },
+            },
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local ctx = {}
+      router._set_ngx(mock_ngx("GET", "/"))
+      assert.falsy(router:exec(ctx))
+      assert.falsy(ctx.route_match_cached)
+
+      ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = "" }))
+      local match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(ctx.route_match_cached)
+    end)
+
+    it("frames header values containing cache delimiters", function()
+      for i, case in ipairs({
+        {
+          route_value = "a,b",
+          first = { "a,b", "c" },
+          second = { "a", "b,c" },
+        },
+        {
+          route_value = "a|b",
+          first = "a|b",
+          second = { "a|b" },
+        },
+      }) do
+        local use_case = {
+          {
+            service = service,
+            route = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb820" .. i + 3,
+              headers = {
+                test = { case.route_value },
+              },
+            },
+          },
+        }
+        local router = assert(new_router(use_case))
+
+        local ctx = {}
+        router._set_ngx(mock_ngx("GET", "/", { test = case.first }))
+        local match_t = router:exec(ctx)
+        assert.truthy(match_t)
+        assert.same(use_case[1].route, match_t.route)
+        assert.falsy(ctx.route_match_cached)
+
+        ctx = {}
+        router._set_ngx(mock_ngx("GET", "/", { test = case.second }))
+        match_t = router:exec(ctx)
+        if i == 1 then
+          assert.falsy(match_t)
+
+        else
+          assert.truthy(match_t)
+          assert.same(use_case[1].route, match_t.route)
+        end
+        assert.falsy(ctx.route_match_cached)
+      end
+    end)
+
+    it("shares a cache entry for reordered repeated header values", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8206",
+            headers = {
+              test = { "a" },
+            },
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = { "b", "a" } }))
+      local match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(ctx.route_match_cached)
+
+      ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", { test = { "a", "b" } }))
+      match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.same("pos", ctx.route_match_cached)
+    end)
+
+    it("keeps adjacent header field boundaries distinct", function()
+      local route_headers = {
+        alpha = { "alpha|" },
+        beta = { "beta|" },
+      }
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8207",
+            headers = route_headers,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+      local ordered_headers = {}
+      for _, field in ipairs(router.fields.fields) do
+        local header = field:match("^http%.headers%.(.+)$")
+        if header then
+          ordered_headers[#ordered_headers + 1] = header
+        end
+      end
+      assert.same(2, #ordered_headers)
+
+      local first_headers = {
+        alpha = route_headers.alpha[1],
+        beta = route_headers.beta[1],
+      }
+      local second_headers = deep_copy(first_headers)
+      local first_header = ordered_headers[1]
+      local second_header = ordered_headers[2]
+      second_headers[first_header] = first_headers[first_header]:sub(1, -2)
+      second_headers[second_header] = "|" .. first_headers[second_header]
+
+      local ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", first_headers))
+      local match_t = router:exec(ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(ctx.route_match_cached)
+
+      ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", second_headers))
+      assert.falsy(router:exec(ctx))
+      assert.falsy(ctx.route_match_cached)
+    end)
+
     it("[cache hit should be case sensitive]", function()
       local use_case = {
         {


### PR DESCRIPTION
### Potential authentication-policy impact

Kong does not cache authentication success in the router cache; authentication plugins still run for each request. However, plugin configuration can be scoped to a Route or Service. Consider two routes where a private route uses `key-auth` or `jwt`, while another route has no authentication plugin or uses a different policy. If requests with distinct routing-field representations receive the same cache key, a request that should select the private route can reuse the other route's cached match. Kong would then execute the plugin chain for the wrong route, so the authentication policy expected for the private route might not run.

This is conditional on a deployment having overlapping routes with different route- or service-scoped plugin policies. It is not reuse of a previously validated token; it is a consequence of selecting the wrong cached Route or Service.

### Summary

- encode router cache key values with explicit type and length framing
- distinguish missing, scalar, and repeated values without delimiter ambiguity
- add regression coverage for cache key value boundaries

### Problem

The router caches match results using request fields such as headers and query arguments. The previous cache key flattened these values with delimiters, so different request representations could share one cache entry.

Practical cases include:

- a header that is absent versus the same header present with an empty value, for example no `X-Route` field versus `X-Route:`
- a scalar header value containing a comma versus repeated field lines represented by OpenResty as an array
- field values that contain the same delimiters used by the cache key format

If one request populated the cache first, a later request could reuse its positive or negative route match even though its fields were different. This could select the wrong Service or apply the wrong route-specific plugin configuration.

### Fix

Cache key values are now framed with their type and length. Reordered repeated values retain the existing normalized cache behavior, while missing, scalar, repeated, empty, and delimiter-containing values remain distinct.

### Testing

- `ASDF_GOLANG_VERSION=1.26.1 bin/busted spec/01-unit`
- `3990 successes / 0 failures / 0 errors / 21 pending`