### PR TITLE
fix(router): normalize valueless query arrays

### DIFF
--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -406,6 +406,12 @@ local function visit_for_cache_key(field, value, str_buf)
   end
 
   if type(value) == "table" then
+    for i, item in ipairs(value) do
+      if type(item) == "boolean" then
+        value[i] = ""
+      end
+    end
+
     tb_sort(value)
     value = tb_concat(value, ",")
   end
@@ -422,6 +428,10 @@ local function visit_for_context(field, value, ctx)
   -- multiple values for a single header/query parameter, like /?foo=bar&foo=baz
   if v_type == "table" then
     for _, v in ipairs(value) do
+      if type(v) == "boolean" then
+        v = ""
+      end
+
       local res, err = ctx:add_value(field, v)
       if not res then
         return nil, err

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5072,6 +5072,54 @@ for _, flavor in ipairs({ "traditional_compatible", "expressions" }) do
   describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
 
+    it("normalizes repeated valueless query arguments", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8260",
+            expression = [[any(http.queries.test) == ""]],
+            priority = 100,
+          },
+        },
+      }
+
+      local router = assert(new_router(use_case))
+
+      local repeated_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil,
+                               { test = { true, true } }))
+      local repeated_match = router:exec(repeated_ctx)
+      assert.truthy(repeated_match)
+      assert.same(use_case[1].route, repeated_match.route)
+      assert.falsy(repeated_ctx.route_match_cached)
+
+      local explicit_empty_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil,
+                               { test = { "", "" } }))
+      local explicit_empty_match = router:exec(explicit_empty_ctx)
+      assert.truthy(explicit_empty_match)
+      assert.same(use_case[1].route, explicit_empty_match.route)
+      assert.same("pos", explicit_empty_ctx.route_match_cached)
+
+      router = assert(new_router(use_case))
+      local mixed_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil,
+                               { test = { true, "value" } }))
+      local mixed_match = router:exec(mixed_ctx)
+      assert.truthy(mixed_match)
+      assert.same(use_case[1].route, mixed_match.route)
+      assert.falsy(mixed_ctx.route_match_cached)
+
+      local reordered_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil,
+                               { test = { "value", true } }))
+      local reordered_match = router:exec(reordered_ctx)
+      assert.truthy(reordered_match)
+      assert.same(use_case[1].route, reordered_match.route)
+      assert.same("pos", reordered_ctx.route_match_cached)
+    end)
+
     it("[cache hit should be case sensitive]", function()
       local use_case = {
         {


### PR DESCRIPTION
### Trigger condition and impact

This issue occurs when the same query parameter appears more than once and at least one occurrence is valueless. OpenResty then returns an array containing boolean `true`, for example:

- `?test&test` becomes `{ true, true }`
- `?test&test=value` becomes `{ true, "value" }`
- `?test=value&test` becomes `{ "value", true }`

The router assumed that repeated query values were strings. Sorting an array containing booleans, or inserting those booleans into the routing context, could fail instead of evaluating the route. A valid request could consequently miss its intended Route or return an error. Repeated requests can also generate avoidable router error logs and create an availability concern.

Single values and repeated string-only values are not affected: `?test`, `?test=`, `?test=value`, `?test=a&test=b`, and `?test=&test=` already follow the existing supported paths.

### Summary

- normalize repeated valueless query arguments before sorting and context insertion
- preserve existing scalar and empty-value behavior
- add regression coverage for repeated valueless query arguments

### Problem

OpenResty represents a valueless query argument as boolean `true`. A scalar `true` was already normalized to an empty string, but the same normalization was missing for values inside arrays.

For example, a route expression such as `any(http.queries.test) == ""` should handle `?test&test` consistently with explicit empty values. The boolean array previously prevented normal matching.

### Fix

Valueless entries inside repeated-value arrays are normalized from `true` to an empty string before sorting and context insertion. This preserves valueless-argument semantics and allows equivalent reordered arrays to use the same cache entry.

### Testing

- `ASDF_GOLANG_VERSION=1.26.1 bin/busted spec/01-unit`
- `3980 successes / 0 failures / 0 errors / 21 pending`