### PR TITLE
fix(router): keep stream preserve-host SNI request-local

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -7,6 +7,7 @@ local tb_new = require("table.new")
 local utils = require("kong.router.utils")
 local transform = require("kong.router.transform")
 local rat = require("kong.tools.request_aware_table")
+local shallow_copy = require("kong.tools.table").shallow_copy
 local yield = require("kong.tools.yield").yield
 
 
@@ -548,7 +549,7 @@ function _M:matching(params)
       port = service_port,
     },
     upstream_scheme = service_protocol,
-    upstream_host = matched_route.preserve_host and sni or nil,
+    upstream_host = nil,
   }
 end
 
@@ -621,8 +622,8 @@ function _M:exec(ctx)
     self.cache:set(cache_key, match_t)
   end
 
-  -- preserve_host logic, modify cache result
-  if match_t.route.preserve_host and match_t.upstream_host == nil then
+  if match_t.route.preserve_host then
+    match_t = shallow_copy(match_t)
     match_t.upstream_host = fields:get_value("tls.sni", CACHE_PARAMS)
   end
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5273,6 +5273,52 @@ do
       assert.same(use_case[2].route, match_t.route)
     end)
 
+    it("does not retain preserve_host SNI in a cached stream match", function()
+      local tls_service = { name = "tls-service", protocol = "tls" }
+      local use_case = {
+        {
+          service = tls_service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8281",
+            protocols = { "tls" },
+            expression = [[net.dst.port == 443]],
+            priority = 100,
+            preserve_host = true,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local first_ctx = { host_port = 443 }
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, {
+        protocol = "TCP",
+        server_port = "443",
+        ssl_preread_server_name = "tenant-a.example",
+      }))
+      local first = router:exec(first_ctx)
+      assert.equal("tenant-a.example", first.upstream_host)
+      assert.falsy(first_ctx.route_match_cached)
+
+      local second_ctx = { host_port = 443 }
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, {
+        protocol = "TCP",
+        server_port = "443",
+        ssl_preread_server_name = "tenant-b.example",
+      }))
+      local second = router:exec(second_ctx)
+      assert.equal("tenant-b.example", second.upstream_host)
+      assert.same("pos", second_ctx.route_match_cached)
+
+      local third_ctx = { host_port = 443 }
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, {
+        protocol = "TCP",
+        server_port = "443",
+      }))
+      local third = router:exec(third_ctx)
+      assert.is_nil(third.upstream_host)
+      assert.same("pos", third_ctx.route_match_cached)
+    end)
+
   end)
 
   describe("Router (flavor = " .. flavor .. ") [http]", function()


### PR DESCRIPTION
### Impact scenario

A stream Route with `preserve_host` can be cached without SNI as part of its route identity. The first connection then writes its SNI into the shared cached match, allowing later connections on the same cached Route to inherit the earlier upstream TLS name. Upstreams that use SNI for virtual hosts, certificates, tenants, or policy can consequently receive the wrong connection identity.

### Fix

- keep cached stream match results free of request-specific SNI
- shallow-copy preserve-host matches per request
- assign current SNI only to the request-local result
- retain the allocation-free cache path for other Routes

### Testing

- `luacheck kong/router/atc.lua spec/01-unit/08-router_spec.lua`
- `ASDF_GOLANG_VERSION=1.26.1 bin/busted spec/01-unit`
- `3979 successes / 0 failures / 0 errors / 21 pending`