### PR TITLE
fix(router): include request protocol in cache keys

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -583,6 +583,17 @@ function _M:exec(ctx)
 
   CACHE_PARAMS:clear()
 
+  local scheme
+  if var.protocol == "UDP" then
+    scheme = "udp"
+
+  else
+    CACHE_PARAMS.sni = fields:get_value("tls.sni", CACHE_PARAMS)
+    scheme = CACHE_PARAMS.sni and "tls" or "tcp"
+  end
+
+  CACHE_PARAMS.scheme = scheme
+
   local cache_key = fields:get_cache_key(CACHE_PARAMS, ctx)
 
   -- cache lookup
@@ -596,16 +607,6 @@ function _M:exec(ctx)
       route_match_stat(ctx, "neg")
       return nil
     end
-
-    local scheme
-    if var.protocol == "UDP" then
-      scheme = "udp"
-
-    else
-      scheme = CACHE_PARAMS.sni and "tls" or "tcp"
-    end
-
-    CACHE_PARAMS.scheme = scheme
 
     local err
     match_t, err = self:matching(CACHE_PARAMS)

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -458,6 +458,7 @@ function _M:exec(ctx)
 
   CACHE_PARAMS.uri  = req_uri
   CACHE_PARAMS.host = req_host
+  CACHE_PARAMS.scheme = ctx and ctx.scheme or var.scheme
 
   local cache_key = fields:get_cache_key(CACHE_PARAMS)
 
@@ -469,8 +470,6 @@ function _M:exec(ctx)
       route_match_stat(ctx, "neg")
       return nil
     end
-
-    CACHE_PARAMS.scheme = ctx and ctx.scheme or var.scheme
 
     local err
     match_t, err = self:matching(CACHE_PARAMS)

--- a/kong/router/fields.lua
+++ b/kong/router/fields.lua
@@ -400,11 +400,6 @@ end -- is_http
 -- traversing these fields will always get a decided result (for one router instance)
 -- so we need not to add field's name in cache key now
 local function visit_for_cache_key(field, value, str_buf)
-  -- these fields were not in cache key
-  if field == "net.protocol" then
-    return true
-  end
-
   if type(value) == "table" then
     tb_sort(value)
     value = tb_concat(value, ",")

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5273,6 +5273,93 @@ do
       assert.same(use_case[2].route, match_t.route)
     end)
 
+    it("keeps stream protocol matches in separate cache entries", function()
+      local tcp_service = { name = "tcp-service", protocol = "tcp" }
+      local udp_service = { name = "udp-service", protocol = "udp" }
+      local use_case = {
+        {
+          service = tcp_service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8271",
+            protocols = { "tcp" },
+            expression = [[net.protocol == "tcp"]],
+            priority = 100,
+          },
+        },
+        {
+          service = udp_service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8272",
+            protocols = { "udp" },
+            expression = [[net.protocol == "udp"]],
+            priority = 100,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      local tcp_ctx = {}
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
+      local tcp_match = router:exec(tcp_ctx)
+      assert.same(use_case[1].route, tcp_match.route)
+      assert.falsy(tcp_ctx.route_match_cached)
+
+      local udp_ctx = {}
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
+      local udp_match = router:exec(udp_ctx)
+      assert.same(use_case[2].route, udp_match.route)
+      assert.falsy(udp_ctx.route_match_cached)
+    end)
+
+    it("keeps stream protocol misses in separate cache entries", function()
+      local udp_service = { name = "udp-service", protocol = "udp" }
+      local use_case = {
+        {
+          service = udp_service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8273",
+            protocols = { "udp" },
+            expression = [[net.protocol == "udp"]],
+            priority = 100,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
+      assert.falsy(router:exec({}))
+
+      local udp_ctx = {}
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
+      local udp_match = router:exec(udp_ctx)
+      assert.same(use_case[1].route, udp_match.route)
+      assert.falsy(udp_ctx.route_match_cached)
+    end)
+
+    it("derives TLS before building a protocol-only cache key", function()
+      local tls_service = { name = "tls-service", protocol = "tls" }
+      local use_case = {
+        {
+          service = tls_service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8274",
+            protocols = { "tls" },
+            expression = [[net.protocol == "tls"]],
+            priority = 100,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, {
+        protocol = "TCP",
+        ssl_preread_server_name = "example.test",
+      }))
+
+      local match_t = router:exec({})
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+    end)
+
   end)
 
   describe("Router (flavor = " .. flavor .. ") [http]", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5296,24 +5296,38 @@ do
           },
         },
       }
-      local router = assert(new_router(use_case))
+      local udp_first_router = assert(new_router(use_case))
 
       local udp_ctx = {}
-      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
-      local udp_match = router:exec(udp_ctx)
+      udp_first_router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
+      local udp_match = udp_first_router:exec(udp_ctx)
       assert.same(use_case[2].route, udp_match.route)
       assert.falsy(udp_ctx.route_match_cached)
 
       local tcp_ctx = {}
-      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
-      local tcp_match = router:exec(tcp_ctx)
+      udp_first_router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
+      local tcp_match = udp_first_router:exec(tcp_ctx)
       assert.same(use_case[1].route, tcp_match.route)
       assert.falsy(tcp_ctx.route_match_cached)
 
       local cached_tcp_ctx = {}
-      local cached_tcp_match = router:exec(cached_tcp_ctx)
+      local cached_tcp_match = udp_first_router:exec(cached_tcp_ctx)
       assert.same(use_case[1].route, cached_tcp_match.route)
       assert.same("pos", cached_tcp_ctx.route_match_cached)
+
+      local tcp_first_router = assert(new_router(use_case))
+
+      local fresh_tcp_ctx = {}
+      tcp_first_router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
+      local fresh_tcp_match = tcp_first_router:exec(fresh_tcp_ctx)
+      assert.same(use_case[1].route, fresh_tcp_match.route)
+      assert.falsy(fresh_tcp_ctx.route_match_cached)
+
+      local fresh_udp_ctx = {}
+      tcp_first_router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
+      local fresh_udp_match = tcp_first_router:exec(fresh_udp_ctx)
+      assert.same(use_case[2].route, fresh_udp_match.route)
+      assert.falsy(fresh_udp_ctx.route_match_cached)
     end)
 
     it("keeps stream protocol misses in separate cache entries", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5367,6 +5367,63 @@ do
 
     local use_case, router
 
+    it("keeps HTTP protocols in separate cache entries", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8275",
+            protocols = { "http" },
+            expression = [[net.protocol == "http"]],
+            priority = 100,
+          },
+        },
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8276",
+            protocols = { "https" },
+            expression = [[net.protocol == "https"]],
+            priority = 100,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      router._set_ngx(mock_ngx("GET", "/", nil, nil, { scheme = "http" }))
+      assert.same(use_case[1].route, router:exec({}).route)
+
+      local https_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil, nil, { scheme = "https" }))
+      assert.same(use_case[2].route, router:exec(https_ctx).route)
+      assert.falsy(https_ctx.route_match_cached)
+    end)
+
+    it("keeps HTTP protocol misses in separate cache entries", function()
+      local use_case = {
+        {
+          service = service,
+          route = {
+            id = "e8fb37f1-102d-461e-9c51-6608a6bb8277",
+            protocols = { "https" },
+            expression = [[net.protocol == "https"]],
+            priority = 100,
+          },
+        },
+      }
+      local router = assert(new_router(use_case))
+
+      router._set_ngx(mock_ngx("GET", "/", nil, nil, { scheme = "http" }))
+      assert.falsy(router:exec({}))
+
+      local https_ctx = {}
+      router._set_ngx(mock_ngx("GET", "/", nil, nil, { scheme = "https" }))
+      local match_t = router:exec(https_ctx)
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+      assert.falsy(https_ctx.route_match_cached)
+    end)
+
     lazy_setup(function()
       use_case = {
         -- query has one value

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -5298,17 +5298,22 @@ do
       }
       local router = assert(new_router(use_case))
 
+      local udp_ctx = {}
+      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
+      local udp_match = router:exec(udp_ctx)
+      assert.same(use_case[2].route, udp_match.route)
+      assert.falsy(udp_ctx.route_match_cached)
+
       local tcp_ctx = {}
       router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "TCP" }))
       local tcp_match = router:exec(tcp_ctx)
       assert.same(use_case[1].route, tcp_match.route)
       assert.falsy(tcp_ctx.route_match_cached)
 
-      local udp_ctx = {}
-      router._set_ngx(mock_ngx(nil, nil, nil, nil, { protocol = "UDP" }))
-      local udp_match = router:exec(udp_ctx)
-      assert.same(use_case[2].route, udp_match.route)
-      assert.falsy(udp_ctx.route_match_cached)
+      local cached_tcp_ctx = {}
+      local cached_tcp_match = router:exec(cached_tcp_ctx)
+      assert.same(use_case[1].route, cached_tcp_match.route)
+      assert.same("pos", cached_tcp_ctx.route_match_cached)
     end)
 
     it("keeps stream protocol misses in separate cache entries", function()


### PR DESCRIPTION
### Impact scenario

Routes can distinguish requests using `net.protocol`, but the protocol was omitted from the route cache key and populated only after cache lookup. Requests with otherwise identical routing fields could therefore reuse a positive or negative match across HTTP and HTTPS, or across TCP, UDP, and TLS. This can select the wrong Route, Service, or route-scoped plugin policy.

### Fix

- derive HTTP and stream protocols before cache-key construction
- include `net.protocol` in normal cache serialization
- preserve cache hits within the same protocol
- add positive and negative cache regressions for HTTP and stream protocols

### Testing

- `luacheck kong/router/fields.lua kong/router/atc.lua spec/01-unit/08-router_spec.lua`
- `ASDF_GOLANG_VERSION=1.26.1 bin/busted spec/01-unit`
- `3983 successes / 0 failures / 0 errors / 21 pending`