### PR TITLE
fix(balancer): remap grpc/grpcs health check types to http/https

### DIFF
--- a/changelog/unreleased/kong/fix-grpc-healthcheck-active-type.yml
+++ b/changelog/unreleased/kong/fix-grpc-healthcheck-active-type.yml
@@ -1,0 +1,7 @@
+message: >-
+  Fix crash when upstream healthchecks.active.type is set to "grpc" or "grpcs".
+  The lua-resty-healthcheck library only accepts "tcp", "http", or "https";
+  Kong now maps "grpc" to "http" and "grpcs" to "https" before passing the
+  checks configuration to the library.
+type: bugfix
+scope: Core

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -242,12 +242,34 @@ end
 function healthcheckers_M.create_healthchecker(balancer, upstream)
   -- Do not run active healthchecks in `stream` module
   local checks = upstream.healthchecks
+  local checks_copied = false
   if (ngx.config.subsystem == "stream" and checks.active.type ~= "tcp")
     or (ngx.config.subsystem == "http" and checks.active.type == "tcp")
   then
     checks = cycle_aware_deep_copy(checks)
+    checks_copied = true
     checks.active.healthy.interval = 0
     checks.active.unhealthy.interval = 0
+  end
+
+  -- lua-resty-healthcheck only accepts "tcp", "http", or "https" as check
+  -- types. gRPC runs over HTTP/2, so map grpc -> http and grpcs -> https.
+  if checks.active.type == "grpc" or checks.active.type == "grpcs"
+    or checks.passive.type == "grpc" or checks.passive.type == "grpcs"
+  then
+    if not checks_copied then
+      checks = cycle_aware_deep_copy(checks)
+    end
+    if checks.active.type == "grpc" then
+      checks.active.type = "http"
+    elseif checks.active.type == "grpcs" then
+      checks.active.type = "https"
+    end
+    if checks.passive.type == "grpc" then
+      checks.passive.type = "http"
+    elseif checks.passive.type == "grpcs" then
+      checks.passive.type = "https"
+    end
   end
 
   if not is_upstream_using_healthcheck(upstream) then

--- a/spec/01-unit/09-balancer/07-healthcheckers_spec.lua
+++ b/spec/01-unit/09-balancer/07-healthcheckers_spec.lua
@@ -1,0 +1,199 @@
+-- Tests for the grpc/grpcs -> http/https type remapping in create_healthchecker.
+-- All Kong infrastructure is stubbed so these tests run with plain busted.
+
+local captured_opts
+
+-- Stub transitive dependencies before requiring the module under test.
+package.preload["kong.runloop.balancer.balancers"] = function()
+  return { get_upstream = function() end }
+end
+package.preload["kong.runloop.balancer.upstreams"] = function()
+  return {
+    get_upstream_by_id = function() end,
+    get_all_upstreams = function() return {} end,
+  }
+end
+package.preload["kong.runloop.certificate"] = function()
+  return { get_certificate = function() return nil, "no-cert" end }
+end
+
+local healthcheckers = require "kong.runloop.balancer.healthcheckers"
+
+
+local function make_upstream(active_type, passive_type)
+  return {
+    ws_id              = "test-ws-id",
+    name               = "test-upstream",
+    client_certificate = nil,
+    host_header        = nil,
+    healthchecks = {
+      active = {
+        type        = active_type or "http",
+        http_path   = "/",
+        timeout     = 1,
+        concurrency = 10,
+        https_verify_certificate = true,
+        healthy   = { interval = 1, http_statuses = { 200 }, successes = 1 },
+        unhealthy = {
+          interval      = 1,
+          http_statuses = { 500 },
+          tcp_failures  = 1,
+          timeouts      = 1,
+          http_failures = 1,
+        },
+      },
+      passive = {
+        type    = passive_type or "http",
+        healthy = { http_statuses = { 200 }, successes = 0 },
+        unhealthy = {
+          http_statuses = { 429, 500 },
+          tcp_failures  = 1,
+          timeouts      = 1,
+          http_failures = 1,
+        },
+      },
+    },
+  }
+end
+
+
+local function make_balancer()
+  return {
+    eachAddress = function(self, fn) end,
+    setCallback = function() end,
+  }
+end
+
+
+describe("healthcheckers.create_healthchecker()", function()
+
+  before_each(function()
+    captured_opts = nil
+
+    package.loaded["resty.healthcheck"] = {
+      new = function(opts)
+        captured_opts = opts
+        return {
+          add_target        = function() return true end,
+          get_target_status = function() return nil end,
+          events            = { healthy = "healthy", unhealthy = "unhealthy" },
+          EVENT_SOURCE      = "hc-test",
+          stop              = function() end,
+          clear             = function() return true end,
+        }
+      end,
+    }
+
+    _G.ngx        = _G.ngx or {}
+    _G.ngx.log    = function() end
+    _G.ngx.ERR    = 4
+    _G.ngx.WARN   = 5
+    _G.ngx.config = { subsystem = "http" }
+
+    _G.kong = {
+      worker_events = {
+        register_weak = function() end,
+        unregister    = function() end,
+      },
+      configuration = { client_ssl = false },
+    }
+
+    healthcheckers.init()
+  end)
+
+  -- grpc type remapping -----------------------------------------------
+
+  it("remaps active.type grpc -> http before calling healthcheck.new", function()
+    local upstream = make_upstream("grpc", "http")
+    local ok, err = healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+    assert.is_not_nil(captured_opts)
+    assert.equals("http", captured_opts.checks.active.type)
+  end)
+
+  it("remaps active.type grpcs -> https before calling healthcheck.new", function()
+    local upstream = make_upstream("grpcs", "http")
+    local ok, err = healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+    assert.is_not_nil(captured_opts)
+    assert.equals("https", captured_opts.checks.active.type)
+  end)
+
+  it("remaps passive.type grpc -> http before calling healthcheck.new", function()
+    local upstream = make_upstream("http", "grpc")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("http", captured_opts.checks.passive.type)
+  end)
+
+  it("remaps passive.type grpcs -> https before calling healthcheck.new", function()
+    local upstream = make_upstream("http", "grpcs")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("https", captured_opts.checks.passive.type)
+  end)
+
+  -- Non-grpc types pass through unchanged -----------------------------
+
+  it("leaves active.type http unchanged", function()
+    local upstream = make_upstream("http", "http")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("http", captured_opts.checks.active.type)
+  end)
+
+  it("leaves active.type https unchanged", function()
+    local upstream = make_upstream("https", "http")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("https", captured_opts.checks.active.type)
+  end)
+
+  it("leaves active.type tcp unchanged", function()
+    local upstream = make_upstream("tcp", "http")
+    -- tcp in http subsystem zeros the active intervals; keep passive
+    -- thresholds non-zero so the healthchecker path is still taken.
+    upstream.healthchecks.passive.unhealthy.tcp_failures = 1
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("tcp", captured_opts.checks.active.type)
+  end)
+
+  -- Original upstream table must not be mutated ----------------------
+
+  it("does not mutate upstream.healthchecks when active.type is grpc", function()
+    local upstream = make_upstream("grpc", "http")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.equals("grpc", upstream.healthchecks.active.type)
+  end)
+
+  it("does not mutate upstream.healthchecks when passive.type is grpcs", function()
+    local upstream = make_upstream("http", "grpcs")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.equals("grpcs", upstream.healthchecks.passive.type)
+  end)
+
+  -- Stream-subsystem gating still correct for grpc -------------------
+
+  it("zeros active intervals and remaps grpc type in stream subsystem", function()
+    _G.ngx.config.subsystem = "stream"
+    local upstream = make_upstream("grpc", "http")
+    healthcheckers.create_healthchecker(make_balancer(), upstream)
+
+    assert.is_not_nil(captured_opts)
+    assert.equals("http", captured_opts.checks.active.type)
+    assert.equals(0, captured_opts.checks.active.healthy.interval)
+    assert.equals(0, captured_opts.checks.active.unhealthy.interval)
+  end)
+end)


### PR DESCRIPTION
## What does this PR do?

Fixes the crash that occurs when an upstream is configured with `healthchecks.active.type: grpc` or `grpcs`.

**Error (from `error.log`):**
```
checks.active.type can only be 'http', 'https' or 'tcp', got 'grpc'
```

This causes `declarative reconfigure failed` on every worker restart whenever a gRPC upstream has active health checks enabled.

## Root cause

`lua-resty-healthcheck` (v3.1.0, pinned in `kong-latest.rockspec`) validates `checks.active.type` and only accepts `"tcp"`, `"http"`, or `"https"`. Kong's upstream schema already allows `"grpc"` and `"grpcs"` as valid values, but `healthcheckers.lua` passes them verbatim to `healthcheck.new()` — no translation layer existed.

## Fix

In `healthcheckers_M.create_healthchecker`, after the existing subsystem-gating block, remap `grpc → http` and `grpcs → https` on a deep copy of the `checks` table before passing it to `healthcheck.new()`. gRPC runs over HTTP/2, so these are the correct protocol equivalents for health probing. The stored upstream entity is never mutated.

`passive.type` is remapped defensively for the same reason.

To avoid an unnecessary double deep-copy when the subsystem-gating block has already made one, a `checks_copied` flag tracks whether a copy exists.

## Changes

- `kong/runloop/balancer/healthcheckers.lua` — translate grpc/grpcs to http/https before calling the healthcheck library
- `spec/01-unit/09-balancer/07-healthcheckers_spec.lua` — 10 unit tests: type remapping (active + passive, grpc + grpcs), pass-through for tcp/http/https, no mutation of the original upstream entity, correct interaction with the stream-subsystem gating
- `changelog/unreleased/kong/fix-grpc-healthcheck-active-type.yml` — bugfix changelog YAML (`CHANGELOG.md` is not modified, per contributing guidelines)

## Pre-submit checklist

- [x] Commit history is clean and atomic
- [x] Rebased on top of `master`
- [ ] Static linting passes: `make lint` (requires Xcode/Bazel locally; blocked in this environment — please verify in CI)
- [ ] Tests pass: `make test` or `bin/busted -v spec/01-unit/09-balancer/07-healthcheckers_spec.lua`
- [x] `CHANGELOG.md` is **not** modified — a YAML file was added to `changelog/unreleased/kong/` instead

## How to test manually

1. Configure an upstream with `healthchecks.active.type: grpc`, `healthy.interval: 1`, and `healthy.successes: 1`
2. Start Kong in declarative (DB-less) or traditional mode
3. Confirm `error.log` does **not** contain `checks.active.type can only be`
4. Confirm the upstream health is queryable via Admin API: `GET /upstreams/<name>/health`

Fixes #13336