### PR TITLE
style: fix typo in comments

### DIFF
--- a/kong/plugins/prometheus/prometheus.lua
+++ b/kong/plugins/prometheus/prometheus.lua
@@ -213,7 +213,7 @@ local function full_metric_name(name, label_names, label_values)
       end
     end
 
-    -- add a comma to seperate k=v
+    -- add a comma to separate k=v
     if idx > 1 then
       buf:put(",")
     end

--- a/kong/runloop/balancer/consistent_hashing.lua
+++ b/kong/runloop/balancer/consistent_hashing.lua
@@ -180,7 +180,7 @@ function consistent_hashing:getPeer(cacheOnly, handle, valueToHash)
         ngx_log(ngx_DEBUG, "found address but it was unavailable. ",
                 " trying next one.")
       else
-        -- an unknown error occured
+        -- an unknown error occurred
         return nil, port
       end
 


### PR DESCRIPTION
Fixes two small typos in code comments:
- "occured" -> "occurred" in kong/runloop/balancer/consistent_hashing.lua
- "seperate" -> "separate" in kong/plugins/prometheus/prometheus.lua

No functional changes.