### PR TITLE
tests(utils): add coverage for parse_ngx_size edge cases

### DIFF
--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -236,6 +236,15 @@ describe("Utils", function()
       assert.equal(1024, parse_ngx_size("1k"))
       assert.equal(1024, parse_ngx_size("1K"))
       assert.equal(10, parse_ngx_size("10"))
+      -- multi-digit values
+      assert.equal(100 * 1024 * 1024, parse_ngx_size("100m"))
+      assert.equal(100 * 1024, parse_ngx_size("100k"))
+
+      -- decimal values
+      assert.equal(2.5 * 1024 * 1024, parse_ngx_size("2.5m"))
+
+      -- empty string falls back to 0
+      assert.equal(0, parse_ngx_size(""))
     end)
 
     describe("random_string()", function()


### PR DESCRIPTION
The existing unit test for `kong.tools.string.parse_ngx_size` only
covered single-digit whole number inputs (e.g. "1G", "1m", "10").

This adds test coverage for:
- multi-digit values ("100m", "100k")
- decimal values ("2.5m")
- empty string input, which falls back to 0

No behavior changes — test-only addition.