### PR TITLE
fix(balancer): do not abort target events when the target cache is empty

### DIFF
--- a/changelog/unreleased/kong/fix-target-event-empty-cache.yml
+++ b/changelog/unreleased/kong/fix-target-event-empty-cache.yml
@@ -1,0 +1,3 @@
+message: Fixed an error in balancer target event handling that aborted the balancer rebuild when the worker-local target cache was empty and the event carried a partial target entity.
+scope: Core
+type: bugfix

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -190,13 +190,17 @@ function targets_M.on_target_event(operation, target)
 
   if operation ~= "create" then
     local ok, err
-    ok = cancel_dns_renewal(target)
+    ok, err = cancel_dns_renewal(target)
     if not ok then
-      for _, t in ipairs(targets_list) do
+      -- targets_list may be nil: it is cleared above and only populated lazily
+      for _, t in ipairs(targets_list or EMPTY) do
         ok, err = cancel_dns_renewal(t)
         if not ok then
           log(ERR, "could not stop DNS renewal for target removed from ", upstream_id, ": ", err)
         end
+      end
+      if not targets_list then
+        log(ERR, "could not stop DNS renewal for target removed from ", upstream_id, ": ", err)
       end
     end
   end

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -199,9 +199,6 @@ function targets_M.on_target_event(operation, target)
           log(ERR, "could not stop DNS renewal for target removed from ", upstream_id, ": ", err)
         end
       end
-      if not targets_list then
-        log(ERR, "could not stop DNS renewal for target removed from ", upstream_id, ": ", err)
-      end
     end
   end
 

--- a/spec/01-unit/09-balancer/07-target_event_spec.lua
+++ b/spec/01-unit/09-balancer/07-target_event_spec.lua
@@ -1,0 +1,117 @@
+local mocker = require "spec.fixtures.mocker"
+
+local ws_id = require("kong.tools.uuid").uuid()
+
+local UPSTREAM = {
+  id = "f9e0cb43-7de6-4c73-a89a-5a1b0f4d9c2e",
+  name = "partial-event-upstream",
+  ws_id = ws_id,
+}
+
+local function setup_kong()
+  local kong = {}
+
+  _G.kong = kong
+
+  kong.worker_events = require "resty.events.compat"
+  kong.worker_events.configure({
+    listening = "unix:",
+    testing = true,
+  })
+
+  kong.db = {
+    targets = {
+      select_by_upstream_raw = function()
+        return {}
+      end,
+    },
+    upstreams = {
+      select = function(_, pk)
+        if pk.id == UPSTREAM.id then
+          return UPSTREAM
+        end
+      end,
+    },
+  }
+
+  kong.core_cache = {
+    _cache = {},
+    get = function(self, key, _, loader, arg)
+      local v = self._cache[key]
+      if v == nil then
+        v = loader(arg)
+        self._cache[key] = v
+      end
+      return v
+    end,
+    invalidate_local = function(self, key)
+      self._cache[key] = nil
+    end,
+  }
+
+  return kong
+end
+
+describe("[balancer target events]", function()
+  local targets, balancers
+
+  lazy_teardown(function()
+    ngx.log:revert() -- luacheck: ignore
+  end)
+
+  lazy_setup(function()
+    stub(ngx, "log")
+
+    package.loaded["kong.runloop.balancer"] = nil
+    package.loaded["kong.runloop.balancer.targets"] = nil
+    package.loaded["kong.runloop.balancer.upstreams"] = nil
+    package.loaded["kong.runloop.balancer.balancers"] = nil
+    package.loaded["kong.runloop.balancer.healthcheckers"] = nil
+
+    setup_kong()
+
+    targets = require "kong.runloop.balancer.targets"
+    balancers = require "kong.runloop.balancer.balancers"
+  end)
+
+  local function setup_it_block()
+    mocker.setup(finally, {
+      kong = {
+        configuration = {
+          worker_consistency = "eventual",
+          worker_state_update_frequency = 0.1,
+        },
+      },
+      ngx = {
+        ctx = {
+          workspace = ws_id,
+        },
+      },
+    })
+  end
+
+  it("rebuilds the balancer on a partial delete event with an empty target cache", function()
+    -- a delete event whose entity carries only the upstream reference cannot
+    -- produce a DNS renewal key, and the worker-local target cache may be
+    -- empty; the handler must still proceed to rebuild the balancer
+    setup_it_block()
+
+    stub(balancers, "get_balancer_by_id").returns({})
+    stub(balancers, "create_balancer").returns({})
+
+    finally(function()
+      balancers.get_balancer_by_id:revert() -- luacheck: ignore
+      balancers.create_balancer:revert() -- luacheck: ignore
+    end)
+
+    targets.clean_targets_cache(UPSTREAM)
+
+    assert.has_no.errors(function()
+      targets.on_target_event("delete", {
+        upstream = { id = UPSTREAM.id, name = UPSTREAM.name },
+      })
+    end)
+
+    assert.stub(balancers.create_balancer).was_called()
+  end)
+end)


### PR DESCRIPTION
### Summary

`on_target_event` clears the worker-local target cache on entry and only repopulates it lazily, so `targets_list` can be `nil` when the fallback introduced in #14298 runs (a worker that has not built this balancer yet, or an earlier handler run that aborted). If the event entity cannot produce a renewal key and the cache is empty, `ipairs(targets_list)` throws and the handler never reaches `create_balancer`, leaving that worker on a stale balancer for the upstream.

Guard the fallback iteration and keep the error log when there is nothing left to cancel by key. Adds a unit test for a delete event carrying a partial entity while the target cache is empty.

### Checklist

- [x] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong`
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - not needed, no user-facing behavior change

### Issue reference

Related to #14229, follow-up to #14298.
