### PR TITLE
feat(ai-proxy): add MiniMax provider support

### DIFF
--- a/changelog/unreleased/kong/ai-proxy-minimax-provider.yml
+++ b/changelog/unreleased/kong/ai-proxy-minimax-provider.yml
@@ -1,0 +1,3 @@
+message: '**ai-proxy**: Added support for the MiniMax provider, using its OpenAI-compatible chat completions and completions endpoints.'
+type: feature
+scope: Plugin

--- a/kong/llm/drivers/minimax.lua
+++ b/kong/llm/drivers/minimax.lua
@@ -1,0 +1,165 @@
+local _M = {}
+
+-- imports
+local cjson = require("cjson.safe")
+local fmt = string.format
+local ai_shared = require("kong.llm.drivers.shared")
+local openai_driver = require("kong.llm.drivers.openai")
+local socket_url = require "socket.url"
+local string_gsub = string.gsub
+local ai_plugin_ctx = require("kong.llm.plugin.ctx")
+--
+
+-- globals
+local DRIVER_NAME = "minimax"
+--
+
+-- MiniMax exposes an OpenAI-compatible chat completions API, so the request
+-- and response transformers are delegated to the OpenAI driver. Only the
+-- upstream URL, operation paths and response header cleanup are provider
+-- specific (see "kong.llm.drivers.shared").
+
+function _M.from_format(response_string, model_info, route_type)
+  -- MiniMax uses the OpenAI-compatible response format
+  return openai_driver.from_format(response_string, model_info, route_type)
+end
+
+function _M.to_format(request_table, model_info, route_type)
+  if route_type == "preserve" then
+    -- do nothing
+    return request_table, nil, nil
+  end
+
+  -- MiniMax uses the OpenAI-compatible request format
+  return openai_driver.to_format(request_table, model_info, route_type)
+end
+
+function _M.subrequest(body, conf, http_opts, return_res_table)
+  -- use shared/standard subrequest routine
+  local body_string, err
+
+  if type(body) == "table" then
+    body_string, err = cjson.encode(body)
+    if err then
+      return nil, nil, "failed to parse body to json: " .. err
+    end
+  elseif type(body) == "string" then
+    body_string = body
+  else
+    return nil, nil, "body must be table or string"
+  end
+
+  -- may be overridden
+  local url = (conf.model.options and conf.model.options.upstream_url)
+    or fmt(
+    "%s%s",
+    ai_shared.upstream_url_format[DRIVER_NAME],
+    ai_shared.operation_map[DRIVER_NAME][conf.route_type].path
+  )
+
+  local method = ai_shared.operation_map[DRIVER_NAME][conf.route_type].method
+
+  local headers = {
+    ["Accept"] = "application/json",
+    ["Content-Type"] = "application/json",
+  }
+
+  if conf.auth and conf.auth.header_name then
+    headers[conf.auth.header_name] = conf.auth.header_value
+  end
+
+  local res, err, httpc = ai_shared.http_request(url, body_string, method, headers, http_opts, return_res_table)
+  if err then
+    return nil, nil, "request to ai service failed: " .. err
+  end
+
+  if return_res_table then
+    return res, res.status, nil, httpc
+  else
+    -- At this point, the entire request / response is complete and the connection
+    -- will be closed or back on the connection pool.
+    local status = res.status
+    local body   = res.body
+
+    if status > 299 then
+      return body, res.status, "status code " .. status
+    end
+
+    return body, res.status, nil
+  end
+end
+
+function _M.header_filter_hooks(body)
+  -- nothing to parse in header_filter phase
+end
+
+function _M.post_request(conf)
+  if ai_shared.clear_response_headers[DRIVER_NAME] then
+    for i, v in ipairs(ai_shared.clear_response_headers[DRIVER_NAME]) do
+      kong.response.clear_header(v)
+    end
+  end
+end
+
+function _M.pre_request(conf, body)
+  kong.service.request.set_header("Accept-Encoding", "gzip, identity") -- tell server not to send brotli
+
+  return true, nil
+end
+
+-- returns err or nil
+function _M.configure_request(conf)
+  local model = ai_plugin_ctx.get_request_model_table_inuse()
+  if not model or type(model) ~= "table" or model.provider ~= DRIVER_NAME then
+    return nil, "invalid model parameter"
+  end
+
+  local parsed_url
+
+
+  if (model.options and model.options.upstream_url) then
+    parsed_url = socket_url.parse(model.options.upstream_url)
+  else
+    parsed_url = socket_url.parse(ai_shared.upstream_url_format[DRIVER_NAME])
+    parsed_url.path = (model.options and
+                        model.options.upstream_path)
+                      or (ai_shared.operation_map[DRIVER_NAME][conf.route_type] and
+                        ai_shared.operation_map[DRIVER_NAME][conf.route_type].path)
+                      or "/"
+  end
+
+  ai_shared.override_upstream_url(parsed_url, conf, model)
+
+  -- if the path is read from a URL capture, ensure that it is valid
+  parsed_url.path = string_gsub(parsed_url.path or "/", "^/*", "/")
+
+  kong.service.request.set_path(parsed_url.path)
+  kong.service.request.set_scheme(parsed_url.scheme)
+  kong.service.set_target(parsed_url.host, (tonumber(parsed_url.port) or 443))
+
+  local auth_header_name = conf.auth and conf.auth.header_name
+  local auth_header_value = conf.auth and conf.auth.header_value
+  local auth_param_name = conf.auth and conf.auth.param_name
+  local auth_param_value = conf.auth and conf.auth.param_value
+  local auth_param_location = conf.auth and conf.auth.param_location
+
+  if auth_header_name and auth_header_value then
+    local exist_value = kong.request.get_header(auth_header_name)
+    if exist_value == nil or not conf.auth.allow_override then
+      kong.service.request.set_header(auth_header_name, auth_header_value)
+    end
+  end
+
+  if auth_param_name and auth_param_value and auth_param_location == "query" then
+    local query_table = kong.request.get_query()
+    if query_table[auth_param_name] == nil or not conf.auth.allow_override then
+      query_table[auth_param_name] = auth_param_value
+      kong.service.request.set_query(query_table)
+    end
+  end
+
+  -- if auth_param_location is "form", it will have already been set in a global pre-request hook
+  return true, nil
+end
+
+return _M

--- a/kong/llm/drivers/shared.lua
+++ b/kong/llm/drivers/shared.lua
@@ -101,6 +101,7 @@ _M.upstream_url_format = {
   bedrock       = "https://bedrock-runtime.%s.amazonaws.com",
   mistral       = "https://api.mistral.ai:443",
   huggingface   = "https://api-inference.huggingface.co/models/%s",
+  minimax       = "https://api.minimax.io:443",
 }
 
 _M.operation_map = {
@@ -161,6 +162,16 @@ _M.operation_map = {
       method = "POST",
     },
   },
+  minimax = {
+    ["llm/v1/completions"] = {
+      path = "/v1/completions",
+      method = "POST",
+    },
+    ["llm/v1/chat"] = {
+      path = "/v1/chat/completions",
+      method = "POST",
+    },
+  },
   huggingface = {
     ["llm/v1/completions"] = {
       path = "/models/%s",
@@ -190,6 +201,9 @@ _M.clear_response_headers = {
     "Set-Cookie",
   },
   mistral = {
+    "Set-Cookie",
+  },
+  minimax = {
     "Set-Cookie",
   },
   gemini = {

--- a/kong/llm/schemas/init.lua
+++ b/kong/llm/schemas/init.lua
@@ -209,7 +209,7 @@ local model_schema = {
         type = "string", description = "AI provider request format - Kong translates "
                                     .. "requests to and from the specified backend compatible formats.",
         required = true,
-        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini", "bedrock", "huggingface" }}},
+        one_of = { "openai", "azure", "anthropic", "cohere", "mistral", "llama2", "gemini", "bedrock", "huggingface", "minimax" }}},
     { name = {
         type = "string",
         description = "Model name to execute.",

--- a/spec/03-plugins/38-ai-proxy/00-config_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/00-config_spec.lua
@@ -508,4 +508,51 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     assert.is_truthy(ok)
     assert.is_falsy(err)
   end)
+
+  it("accepts the minimax provider with auth and model options", function()
+    local config = {
+      route_type = "llm/v1/chat",
+      auth = {
+        header_name = "Authorization",
+        header_value = "Bearer token",
+      },
+      model = {
+        name = "MiniMax-M3",
+        provider = "minimax",
+        options = {
+          max_tokens = 256,
+          temperature = 1.0,
+        },
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_truthy(ok)
+    assert.is_falsy(err)
+  end)
+
+  it("accepts the minimax provider with an overridden upstream_url", function()
+    local config = {
+      route_type = "llm/v1/chat",
+      auth = {
+        header_name = "Authorization",
+        header_value = "Bearer token",
+      },
+      model = {
+        name = "MiniMax-M3",
+        provider = "minimax",
+        options = {
+          max_tokens = 256,
+          temperature = 1.0,
+          upstream_url = "https://api.minimaxi.com/v1/chat/completions",
+        },
+      },
+    }
+
+    local ok, err = validate(config)
+
+    assert.is_truthy(ok)
+    assert.is_falsy(err)
+  end)
 end)

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -2504,3 +2504,70 @@ describe("json_array_iterator", function()
     )
   end)
 end)
+
+describe("ai-proxy: (minimax driver)", function()
+  it("transforms chat requests identically to the openai driver", function()
+    local minimax_driver = require("kong.llm.drivers.minimax")
+    local openai_driver = require("kong.llm.drivers.openai")
+    assert.not_nil(minimax_driver)
+
+    local request_json = pl_file.read("spec/fixtures/ai-proxy/unit/requests/llm-v1-chat.json")
+
+    local minimax_model = {
+      route_type = "llm/v1/chat",
+      name = "MiniMax-M3",
+      provider = "minimax",
+      options = {
+        max_tokens = 512,
+        temperature = 0.5,
+      },
+    }
+
+    local openai_model = {
+      route_type = "llm/v1/chat",
+      name = "gpt-4",
+      provider = "openai",
+      options = {
+        max_tokens = 512,
+        temperature = 0.5,
+      },
+    }
+
+    local minimax_request_table, err = cjson.decode(request_json)
+    assert.is_nil(err)
+    local openai_request_table, err = cjson.decode(request_json)
+    assert.is_nil(err)
+
+    local minimax_request, minimax_content_type, err = minimax_driver.to_format(
+      minimax_request_table, minimax_model, minimax_model.route_type
+    )
+    assert.is_nil(err)
+    assert.not_nil(minimax_content_type)
+
+    local openai_request, openai_content_type, err = openai_driver.to_format(
+      openai_request_table, openai_model, openai_model.route_type
+    )
+    assert.is_nil(err)
+    assert.not_nil(openai_content_type)
+
+    -- MiniMax model name should be propagated; everything else matches OpenAI format
+    minimax_request.model = nil
+    openai_request.model = nil
+    assert.same(openai_request, minimax_request)
+  end)
+
+  it("converts from an openai-compatible response format", function()
+    local minimax_driver = require("kong.llm.drivers.minimax")
+
+    local model_config = {
+      route_type = "llm/v1/chat",
+      name = "MiniMax-M3",
+      provider = "minimax",
+    }
+
+    local response_json = pl_file.read("spec/fixtures/ai-proxy/unit/real-responses/openai/llm-v1-chat.json")
+    local response_string, err = minimax_driver.from_format(response_json, model_config, model_config.route_type)
+    assert.is_nil(err)
+    assert.not_nil(response_string)
+  end)
+end)


### PR DESCRIPTION
Reason: provider-add — the ai-proxy provider integration surface did not support MiniMax.

## Changes
- Register `minimax` as a valid `model.provider` in the `ai-proxy` / shared LLM schema (`kong/llm/schemas/init.lua`).
- Add the MiniMax default upstream URL (`https://api.minimax.io:443`), OpenAI-compatible operation paths (`/v1/chat/completions`, `/v1/completions`) and `Set-Cookie` response header cleanup to the shared driver table (`kong/llm/drivers/shared.lua`).
- Add `kong/llm/drivers/minimax.lua`. MiniMax exposes an OpenAI-compatible chat completions API, so request/response transformation is delegated to the existing OpenAI driver; only the upstream URL, operation paths and response header handling are provider-specific. The default upstream targets the global endpoint; operators can override `model.options.upstream_url` to use the regional (China) endpoint.
- Add an unreleased changelog entry.
- Add config validation tests for the `minimax` provider (with and without `upstream_url` override) and unit tests asserting the MiniMax driver transforms requests identically to the OpenAI driver and parses OpenAI-compatible responses.

## Checks
- `luajit -bl` syntax check passed for every modified Lua file (`kong/llm/drivers/minimax.lua`, `kong/llm/drivers/shared.lua`, `kong/llm/schemas/init.lua`, and both modified spec files).
- Full busted test suite was not executed in this environment because the Kong dev/test toolchain is not installed here.
