### PR TITLE
fix(balancer): correct off-by-one in consistent-hashing ring traversal

### DIFF
--- a/changelog/unreleased/kong/fix-consistent-hashing-ring-traversal-off-by-one.yml
+++ b/changelog/unreleased/kong/fix-consistent-hashing-ring-traversal-off-by-one.yml
@@ -1,0 +1,8 @@
+message: >-
+  **Load Balancing**: Fixed a bug in the consistent-hashing (ketama) balancer where
+  the ring traversal always skipped the continuum slot immediately after the hashed
+  index, and could loop forever for the hash value equal to the continuum size. This
+  could cause spurious "no peers available" errors while an upstream target was
+  partially unhealthy, even though a healthy target was available on the ring.
+type: bugfix
+scope: Core

--- a/kong/runloop/balancer/consistent_hashing.lua
+++ b/kong/runloop/balancer/consistent_hashing.lua
@@ -156,12 +156,11 @@ function consistent_hashing:getPeer(cacheOnly, handle, valueToHash)
 
   local address
   local index = handle.hashValue
+  local points = self.points
   local ip, port, hostname
-  while (index - 1) ~= handle.hashValue do
-    if index == 0 then
-      index = self.points
-    end
-
+  -- walk the whole continuum exactly once, starting at the hashed index and
+  -- going counter-clockwise, wrapping around back to `points` when we pass 1
+  for _ = 1, points do
     address = self.continuum[index]
     if address ~= nil and address.available and not address.disabled then
       ip, port, hostname = balancers.getAddressPeer(address, cacheOnly)
@@ -187,6 +186,9 @@ function consistent_hashing:getPeer(cacheOnly, handle, valueToHash)
     end
 
     index = index - 1
+    if index == 0 then
+      index = points
+    end
   end
 
   return nil, balancers.errors.ERR_NO_PEERS_AVAILABLE

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -6,7 +6,7 @@ assert:set_parameter("TableFormatLevel", 5) -- when displaying tables, set a big
 ------------------------
 
 local client
-local targets, balancers
+local targets, balancers, consistent_hashing
 
 require "spec.helpers" -- initialize db
 local dns_utils = require "kong.resty.dns.utils"
@@ -216,6 +216,7 @@ describe("[consistent_hashing]" .. (enable_new_dns_client and "[new dns]" or "")
     client = require "kong.resty.dns.client"
     targets = require "kong.runloop.balancer.targets"
     balancers = require "kong.runloop.balancer.balancers"
+    consistent_hashing = require "kong.runloop.balancer.consistent_hashing"
     local healthcheckers = require "kong.runloop.balancer.healthcheckers"
     healthcheckers.init()
     balancers.init()
@@ -417,6 +418,43 @@ describe("[consistent_hashing]" .. (enable_new_dns_client and "[new dns]" or "")
       assert.equal(nil, res["mashape.com:123"]) -- host got no hits, key never gets initialized
       assert.equal(160, res["5.6.7.8:321"])
       assert.equal(160, res["getkong.org:321"])
+    end)
+    it("does not skip the ring slot immediately clockwise of the hashed index (regression)", function()
+      -- regression test: the ring traversal used to apply the wrap-around
+      -- fix-up (`index == 0 -> index = points`) *after* the loop's exit
+      -- check had already been evaluated against the unwrapped value, so it
+      -- always skipped exactly the slot at `hashValue + 1`, even though that
+      -- slot could hold the only available address left in the ring.
+      local available_address = {
+        available = true,
+        disabled = false,
+        ip = "9.9.9.9",
+        port = 9999,
+        host = "test-target",
+      }
+
+      local orig_getAddressPeer = balancers.getAddressPeer
+      balancers.getAddressPeer = function(address)
+        return address.ip, address.port, address.host
+      end
+      finally(function()
+        balancers.getAddressPeer = orig_getAddressPeer
+      end)
+
+      -- a tiny, fully synthetic 5-slot ring where the only available
+      -- address sits at slot 4, and the hashed index is 3. A correct
+      -- counter-clockwise traversal visits 3, 2, 1, 5, 4 (all 5 slots
+      -- exactly once) and must find the address at slot 4.
+      local algo = setmetatable({
+        points = 5,
+        balancer = { healthy = true },
+        continuum = { [4] = available_address },
+      }, consistent_hashing)
+
+      local ip, port, host = algo:getPeer(false, { hashValue = 3, retryCount = 0 }, nil)
+      assert.equal("9.9.9.9", ip)
+      assert.equal(9999, port)
+      assert.equal("test-target", host)
     end)
     it("does not hit the resolver when 'cache_only' is set", function()
       local record = dnsA({


### PR DESCRIPTION
## Summary

Fixes #14957.

The consistent-hashing (ketama) balancer's ring traversal in `getPeer()` applied its wrap-around fix-up (`index == 0 -> index = points`) *after* the loop's exit condition had already been evaluated against the raw, unwrapped index. As a result, the traversal always skipped exactly one continuum slot (`hashValue + 1`) on every call, and could loop forever in the edge case `hashValue == points` with no address available anywhere on the ring.

If the only healthy address on the ring happened to occupy the skipped slot (an ordinary occurrence during partial outages / rolling restarts, no race required), `getPeer()` incorrectly returned `ERR_NO_PEERS_AVAILABLE`.

## Changes

- Rewrote the traversal as a bounded `for` loop over exactly `self.points` iterations, wrapping the index *after* decrementing each iteration, guaranteeing the whole ring is visited exactly once starting from the hashed index. This also removes the possibility of the loop never terminating.
- Added a regression test in `spec/01-unit/09-balancer/03-consistent_hashing_spec.lua` that constructs a minimal synthetic 5-slot ring with the only available address at the slot that used to be skipped, and asserts `getPeer()` finds it.

## Test plan

- [x] Added a unit test reproducing the bug against the fixed algorithm (fails against the old code, as verified by hand-tracing the traversal order: `points=5, hashValue=3` visited `{3,2,1,5}` under the old code, `{3,2,1,5,4}` under the new code).
- [x] `luac -p` syntax-checked the changed files.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if anything needs adjusting).
