### PR TITLE
fix(db): don't stop iteration early when a page has fewer rows than size

### DIFF
--- a/changelog/unreleased/kong/fix-db-iteration-ttl-truncation.yml
+++ b/changelog/unreleased/kong/fix-db-iteration-ttl-truncation.yml
@@ -1,0 +1,10 @@
+message: >-
+  **DB-less/Hybrid mode**: Fixed a bug where `kong.db.<entity>:each()` (used by
+  `GET /config` export, `kong config db_export`, and `db_cache_warmup_entities`)
+  could silently stop iterating before reaching the end of the data set. This
+  happened whenever a page returned fewer rows than the requested page size while
+  still reporting more data available, which the `off` (DB-less/Hybrid) strategy
+  does when it skips expired TTL'd entities (for example `keyauth_credentials`
+  with per-key TTLs) within a page.
+type: bugfix
+scope: Core

--- a/kong/db/iteration.lua
+++ b/kong/db/iteration.lua
@@ -43,7 +43,11 @@ local function page_iterator(pager, size, options)
       return row, nil, page
     end
 
-    if i > size and offset then
+    -- `rows` is exhausted. Do not assume `#rows == size` before fetching the
+    -- next page: a strategy may legitimately return fewer than `size` rows
+    -- for a page (e.g. the `off` strategy drops expired entities) while
+    -- still returning a non-nil `offset` to indicate more data is available.
+    if offset then
       i, rows, err, offset = 1, pager(size, offset, options)
       if not rows then
         return nil, err

--- a/spec/01-unit/01-db/14-iteration_spec.lua
+++ b/spec/01-unit/01-db/14-iteration_spec.lua
@@ -1,0 +1,45 @@
+require "spec.helpers" -- initialize kong globals expected by kong.db modules
+
+local iteration = require "kong.db.iteration"
+
+
+describe("kong.db.iteration", function()
+  describe(".by_row()", function()
+    it("keeps fetching pages when a page returns fewer rows than `size` " ..
+       "but still reports an offset (regression)", function()
+      -- Regression test: some strategies (e.g. the `off`/DB-less strategy)
+      -- may drop rows from a page (for example, expired TTL'd entities)
+      -- while still returning a non-nil offset because more raw entries
+      -- remain to be read. The iterator used to assume `#rows == size`
+      -- whenever an offset was present, and stopped early in that case.
+      local pages = {
+        { rows = { { id = 1 } }, offset = "cursor-1" },
+        { rows = { { id = 2 }, { id = 3 } }, offset = nil },
+      }
+
+      local call_count = 0
+      local function pager(size, offset, options)
+        call_count = call_count + 1
+        local page = pages[call_count]
+        assert.is_not_nil(page, "pager called more times than expected")
+        return page.rows, nil, page.offset
+      end
+
+      local fake_dao = { schema = { name = "test_entities" } }
+      local next_row = iteration.by_row(fake_dao, pager, 2, nil)
+
+      local ids = {}
+      while true do
+        local row, err = next_row()
+        assert.is_nil(err)
+        if not row then
+          break
+        end
+        table.insert(ids, row.id)
+      end
+
+      assert.same({ 1, 2, 3 }, ids)
+      assert.equal(2, call_count)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

Fixes #14959.

`kong.db.iteration.page_iterator` assumed that a strategy's page always contains exactly `size` rows whenever it also returns a non-nil `offset`. The `off` (DB-less/Hybrid mode) strategy breaks that assumption: it drops rows from a page when the corresponding entity has expired via TTL, while still returning an offset if more raw entries remain. When a page came back short for that reason, the iterator's continuation check (`i > size`) never triggered, so it silently stopped instead of fetching the next page -- dropping the remainder of the data set from `DAO:each()` / `DAO:each_for_export()` (used by Admin API config export, `kong config db_export`, and cache warmup).

## Changes

- `kong/db/iteration.lua`: fetch the next page whenever the current page is exhausted (`rows[i]` is `nil`) and an `offset` is present, instead of additionally requiring `i > size`. This removes the flawed invariant entirely rather than patching around it, and is behavior-preserving for strategies (e.g. postgres) that do always return exactly `size` rows per non-final page: for those, `i` still only exceeds `#rows` once `i > size`, exactly matching the old check.
- Added `spec/01-unit/01-db/14-iteration_spec.lua`, a focused unit test that drives `iteration.by_row()` with a fake pager returning a short first page (1 row where size=2) with a non-nil offset, and asserts all 3 rows across both pages are yielded.

## Test plan

- [x] New unit test reproduces the bug against the fixed code (verified by hand-tracing: with the old code, `i` reaches `nil` at `i=2` while `size=2`, so `i > size` is false and iteration stops after 1 row instead of continuing to fetch the 2nd page).
- [x] `luac -p` syntax-checked the changed files.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if anything needs adjusting).
