### PR TITLE
fix(balancer): clamp latency balancer's P2C set size down, not up

### DIFF
--- a/changelog/unreleased/kong/fix-latency-balancer-p2c-clamp.yml
+++ b/changelog/unreleased/kong/fix-latency-balancer-p2c-clamp.yml
@@ -1,0 +1,11 @@
+message: >-
+  **Load Balancing**: Fixed a bug in the `latency` (EWMA) balancer algorithm
+  where the "power of two choices" candidate-set size was clamped to 2 and then
+  immediately grown back up to the full number of available addresses whenever
+  more than 2 were available. This made the algorithm always pick the single
+  globally-lowest-latency address on every request instead of sampling from 2
+  candidates, defeating the purpose of the algorithm and risking traffic
+  concentration/thundering-herd behavior on the currently-fastest backend for
+  any upstream with 3 or more targets.
+type: bugfix
+scope: Core

--- a/kong/runloop/balancer/latency.lua
+++ b/kong/runloop/balancer/latency.lua
@@ -202,7 +202,11 @@ function ewma:getPeer(cache_only, handle)
 
       local score
       if filtered_addresses_num > 1 then
-        k = filtered_addresses_num > k and filtered_addresses_num or k
+        -- clamp k down to the number of candidates actually left after
+        -- removing previously-failed addresses; never grow it back up,
+        -- otherwise "power of two choices" degrades into a full scan that
+        -- always picks the single globally-lowest-latency address.
+        k = filtered_addresses_num < k and filtered_addresses_num or k
         address, score = pick_and_score(self, filtered_addresses, k)
       else
         address = filtered_addresses[1]

--- a/spec/01-unit/09-balancer/06-latency_spec.lua
+++ b/spec/01-unit/09-balancer/06-latency_spec.lua
@@ -378,6 +378,64 @@ describe("[latency]" .. (enable_new_dns_client and "[new dns]" or ""), function(
       }, counts)
     end)
 
+    it("performs power-of-two-choices instead of a full scan once more " ..
+       "than PICK_SET_SIZE addresses are available (regression)", function()
+      -- Regression test: getPeer() used to clamp its candidate-set size `k`
+      -- to PICK_SET_SIZE (2), but then immediately grow it back up to the
+      -- full number of available addresses whenever that number exceeded
+      -- PICK_SET_SIZE. That turned "power of two choices" into a full scan
+      -- that always finds the single globally-lowest-latency address,
+      -- defeating the purpose of sampling.
+      dnsA({ { name = "latency1.test", address = "10.0.0.1" } })
+      dnsA({ { name = "latency2.test", address = "10.0.0.2" } })
+      dnsA({ { name = "latency3.test", address = "10.0.0.3" } })
+      dnsA({ { name = "latency4.test", address = "10.0.0.4" } })
+      dnsA({ { name = "latency5.test", address = "10.0.0.5" } })
+
+      local b = validate_latency(new_balancer({
+        "latency1.test", "latency2.test", "latency3.test",
+        "latency4.test", "latency5.test",
+      }))
+
+      -- Fresh handles pass through getPeer() with an empty failedAddresses
+      -- set, so the candidate list is built by iterating self.ewma in its
+      -- natural pairs() order -- the very same order we discover here.
+      local ordered_addresses = {}
+      for addr in pairs(b.algorithm.ewma) do
+        t_insert(ordered_addresses, addr)
+      end
+      assert.equal(5, #ordered_addresses)
+
+      -- Give the two addresses a power-of-two-choices pass would compare
+      -- first the worst (highest) scores, and bury the single best score
+      -- on the third address -- one a real 2-candidate sample would never
+      -- see.
+      local now = ngx.now()
+      local scores = { 500, 400, 1, 300, 200 }
+      for i, addr in ipairs(ordered_addresses) do
+        b.algorithm.ewma[addr] = scores[i]
+        b.algorithm.ewma_last_touched_at[addr] = now
+      end
+
+      local best_ip = ordered_addresses[3].ip          -- score 1, globally lowest
+      local first_pair_winner_ip = ordered_addresses[2].ip -- score 400 < 500
+
+      local counts = {}
+      local handles = {}
+      for _ = 1, 20 do
+        -- pass no handle, so every call starts with a fresh, empty
+        -- failedAddresses set and re-samples from the full candidate list.
+        local ip, _, _, handle = assert(b:getPeer())
+        counts[ip] = (counts[ip] or 0) + 1
+        t_insert(handles, handle) -- don't let them get GC'ed
+      end
+
+      assert.is_nil(counts[best_ip],
+        "power-of-two-choices must not always find the single globally-" ..
+        "best address once there are more than PICK_SET_SIZE candidates")
+      assert.same({ [first_pair_winner_ip] = 20 }, counts)
+    end)
+
     it("long time update ewma address score, ewma will use the most accurate value", function()
       dnsSRV({
         { name = srv_name, target = "20.20.20.20", port = 80, weight = 20 },


### PR DESCRIPTION
## Summary

Fixes #14961.

The `latency` (EWMA) balancer's `getPeer()` is meant to implement "power of two choices" (P2C): sample `PICK_SET_SIZE` (2) candidates and pick the better one, specifically to avoid greedily concentrating traffic on whichever backend currently looks fastest. `k` was correctly computed as `min(address_count, PICK_SET_SIZE)`, but the very next line then grew it back up to the full candidate count whenever that count was larger — which is the case on every ordinary request against an upstream with 3+ available targets. This turned P2C into a full scan that deterministically always returns the single globally-lowest-latency address.

## Changes

- `kong/runloop/balancer/latency.lua`: fixed the comparison so `k` is clamped *down* to `filtered_addresses_num` only when there are fewer candidates left than `PICK_SET_SIZE` (e.g. after removing failed addresses on a retry), and otherwise stays at `PICK_SET_SIZE`, matching the originally-computed value and the documented P2C design.
- Added a regression test in `spec/01-unit/09-balancer/06-latency_spec.lua` that sets up 5 addresses with distinct, fixed EWMA scores, deliberately buries the single best score on an address outside the first two candidates in `self.ewma`'s natural iteration order, and asserts `getPeer()` never returns that globally-best address (proving only a 2-candidate sample is compared, not a full scan).

## Test plan

- [x] New unit test reproduces the bug against the fixed code (verified by hand-tracing `pick_and_score`'s behavior with `k=2` vs. the old `k=filtered_addresses_num`).
- [x] `luac -p` syntax-checked the changed files.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if anything needs adjusting).
