### PR TITLE
fix(api): map INVALID_FOREIGN_KEY and INVALID_WORKSPACE to 400

### DIFF
--- a/changelog/unreleased/kong/fix-admin-api-error-code-mapping.yml
+++ b/changelog/unreleased/kong/fix-admin-api-error-code-mapping.yml
@@ -1,0 +1,9 @@
+message: >-
+  **Admin API**: Fixed a bug where requests that triggered an `INVALID_FOREIGN_KEY`
+  or `INVALID_WORKSPACE` DAO error (for example, looking up an entity by a
+  malformed foreign-key-typed unique field, or writing to an entity whose
+  workspace was concurrently deleted) received a generic
+  `500 An unexpected error occurred` response instead of a `400` with the actual,
+  actionable error message.
+type: bugfix
+scope: Admin API

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -37,6 +37,8 @@ local ERRORS_HTTP_CODES = {
   [Errors.codes.OPERATION_UNSUPPORTED]   = 405,
   [Errors.codes.FOREIGN_KEYS_UNRESOLVED] = 400,
   [Errors.codes.REFERENCED_BY_OTHERS]    = 400,
+  [Errors.codes.INVALID_FOREIGN_KEY]     = 400,
+  [Errors.codes.INVALID_WORKSPACE]       = 400,
 }
 
 local TAGS_AND_REGEX


### PR DESCRIPTION
## Summary

Fixes #14963.

`kong.db.errors` defines `INVALID_FOREIGN_KEY` and `INVALID_WORKSPACE`, both of which are actually raised by the DAO layer with safe, actionable, client-facing messages, but neither was present in `kong/api/endpoints.lua`'s `ERRORS_HTTP_CODES` table. Both codes therefore fell through to the generic `if not status or status == 500` branch and were turned into an opaque `500 "An unexpected error occurred"`, discarding the real error message (which only reached the server logs).

## Changes

- `kong/api/endpoints.lua`: added `INVALID_FOREIGN_KEY` and `INVALID_WORKSPACE` to `ERRORS_HTTP_CODES`, both mapped to `400`, consistent with the neighboring `FOREIGN_KEY_VIOLATION` / `INVALID_PRIMARY_KEY` entries already in the table for analogous client-side validation problems.

I did not touch `TRANSFORMATION_ERROR` (also missing from the table) since it represents a server-side/data-at-rest issue analogous to the already-intentionally-500 `DATABASE_ERROR`, rather than a client-triggerable, message-safe case like the two above — happy to discuss if maintainers feel it should be included too.

## Test plan

- `handle_error` is a private local function in `endpoints.lua` and not covered by an existing unit-test seam; exercising the exact HTTP status without a running Admin API integration test wasn't something I could safely author and verify without a local test-execution environment (see below). The change itself is a minimal, 2-line, same-pattern addition to an existing table.
- [x] `luac -p` syntax-checked the changed file.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if a targeted Admin API spec would be welcome and I'll add one).
