### PR TITLE
fix(pdk): dedupe pending vault secrets by reference, not cache_key

### DIFF
--- a/changelog/unreleased/kong/fix-vault-init-secrets-dedup-key.yml
+++ b/changelog/unreleased/kong/fix-vault-init-secrets-dedup-key.yml
@@ -1,0 +1,10 @@
+message: >-
+  **Vault**: Fixed a bug where `kong.vault.get()` deduplicated pending secret
+  references by the wrong table key during the `init` phase (e.g. when using
+  `KONG_DECLARATIVE_CONFIG` before LMDB is populated), causing the same
+  reference to be appended to the pending-secrets list once per lookup instead
+  of once per distinct reference. This caused redundant vault resolution work
+  and unbounded growth of the pending-secrets list proportional to the number
+  of lookups rather than the number of distinct references.
+type: bugfix
+scope: Core

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -886,7 +886,7 @@ local function new(self)
       -- this can fail on init as the lmdb cannot be accessed and secondly,
       -- because the data is not yet inserted into LMDB when using KONG_DECLARATIVE_CONFIG.
       if get_phase() == "init" then
-        if not INIT_SECRETS[cache_key] then
+        if not INIT_SECRETS[reference] then
           INIT_SECRETS[reference] = true
           INIT_SECRETS[#INIT_SECRETS + 1] = reference
         end


### PR DESCRIPTION
## Summary

Fixes #14965.

`get_strategy(reference)` only returns a `cache_key` on its success path; every failure path returns `(nil, err)`. The `init`-phase branch of `kong.vault.get()` runs precisely when `get_strategy` failed, so `cache_key` is always `nil` there, making the dedup guard `if not INIT_SECRETS[cache_key] then` always true (`INIT_SECRETS[nil]` is always falsy) even though the entry is actually stored under `INIT_SECRETS[reference]`. Every lookup of the same unresolved reference during `init` therefore appended a duplicate entry instead of deduplicating.

## Changes

- `kong/pdk/vault.lua`: check `INIT_SECRETS[reference]` instead of `INIT_SECRETS[cache_key]`, matching both the key actually being written and the already-correct equivalent pattern used for the `init_worker` phase a few lines below (`INIT_WORKER_SECRETS[cache_key]`, valid there since it runs on `get_strategy`'s success path).

## Test plan

- `INIT_SECRETS` and the `init`-phase branch are only reachable behind `ngx.get_phase() == "init"`, and the module captures `get_phase` as a direct upvalue at load time (`local get_phase = ngx.get_phase`), so it isn't monkey-patchable post-hoc from a test in the usual way; reliably forcing this phase in a unit test would require reloading the module with `ngx.get_phase` pre-stubbed, which I wasn't able to verify without a local test-execution environment (see below).
- [x] `luac -p` syntax-checked the changed file.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if a targeted spec would be welcome and I'll add one).
