### PR TITLE
fix(response-transformer): guard body_filter against unbuffered chunks

### DIFF
--- a/changelog/unreleased/kong/fix-response-transformer-nil-body-log-spam.yml
+++ b/changelog/unreleased/kong/fix-response-transformer-nil-body-log-spam.yml
@@ -1,0 +1,11 @@
+message: >-
+  **response-transformer**: Fixed a bug where the plugin logged a spurious
+  `body transform failed: failed parsing json body` warning on every
+  intermediate `body_filter` invocation for any JSON response whose body
+  didn't fit in a single buffer (e.g. large or chunked responses), because it
+  called `transform_json_body()` without checking whether
+  `kong.response.get_raw_body()` had actually returned the full buffered body
+  yet. The final response was still transformed correctly; this only affected
+  log noise.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -32,6 +32,10 @@ function ResponseTransformerHandler:body_filter(conf)
   end
 
   local body = kong.response.get_raw_body()
+  if not body then
+    -- not the last chunk yet, nothing to transform
+    return
+  end
 
   local json_body, err = transform_json_body(conf, body)
   if err then


### PR DESCRIPTION
## Summary

Fixes #14967.

`kong.response.get_raw_body()` returns `nil` on every `body_filter` call that isn't the last chunk of the response body — documented on the function itself, and already handled correctly by other first-party plugins consuming it (e.g. `proxy-cache`). `response-transformer`'s `body_filter` called `transform_json_body(conf, body)` unconditionally, so on every intermediate chunk of any JSON response that doesn't fit in a single buffer, it tried to JSON-decode `nil`, got a "failed parsing json body" error, and logged a `warn`-level "body transform failed" line — once per intermediate chunk, for completely normal traffic. The final chunk was still transformed correctly, so this is a log-noise-only issue, but at volume it can flood logs and mislead operators debugging real transform failures.

## Changes

- `kong/plugins/response-transformer/handler.lua`: added the standard `if not body then return end` guard after `kong.response.get_raw_body()`, mirroring the pattern already used by `proxy-cache` and documented in the PDK function's own usage example.

## Test plan

- The existing `spec/03-plugins/15-response-transformer/05-big_response_body_spec.lua` already exercises the multi-chunk scenario this bug occurs in end-to-end (1MB JSON body) and should continue to pass unchanged; asserting on the *absence* of the spurious warning log would require extending that integration spec with error-log inspection, which I wasn't able to verify without a local test-execution environment (see below).
- [x] `luac -p` syntax-checked the changed file.
- [ ] CI (I was not able to run the full busted/OpenResty integration suite in my local environment — please let me know if a log-assertion addition to the existing big-response-body spec would be welcome and I'll add one).
