### PR TITLE
fix(ci): gate backport-fail-bot on trusted comment authors

### DIFF
--- a/.github/workflows/backport-fail-bot.yml
+++ b/.github/workflows/backport-fail-bot.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   check_comment:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request != null && contains(github.event.comment.body, 'cherry-pick the changes locally and resolve any conflicts')
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
+      contains(github.event.comment.body, 'cherry-pick the changes locally and resolve any conflicts')
 
     steps:
     - name: Fetch mapping file
@@ -29,11 +32,13 @@ jobs:
       env:
         SLACK_CHANNEL: gateway-notifications
         SLACK_MAPPING: "${{ steps.fetch_mapping.outputs.result }}"
+        PR_URL: ${{ github.event.issue.pull_request.html_url }}
+        PR_AUTHOR: ${{ github.event.issue.user.login }}
       with:
         script: |
-          const pr_url = ${{ github.event.issue.pull_request.html_url }};
+          const pr_url = process.env.PR_URL;
           const slack_mapping = JSON.parse(process.env.SLACK_MAPPING);
-          const pr_author_github_id = ${{ github.event.issue.user.login }};
+          const pr_author_github_id = process.env.PR_AUTHOR;
           const pr_author_slack_id = slack_mapping[pr_author_github_id];
           const author = pr_author_slack_id ? `<@${pr_author_slack_id}>` : pr_author_github_id;
           const payload = {


### PR DESCRIPTION
### Summary

`.github/workflows/backport-fail-bot.yml` triggers on `issue_comment` with no author check, so any authenticated GitHub user can trigger it by posting the trigger comment on a PR. The triggered job reads `secrets.PAT` to fetch a mapping file from a private repo. The Slack-payload step also interpolated `${{ }}` values directly into the script body — a script-injection risk that also causes a JS syntax error, so the step has been broken.

This gates the job on `author_association`, matching the pattern already used in `cherry-picks-v2.yml`, and fixes the script-injection/syntax issue by passing values through `env:` instead of interpolating them into the script body.

### Checklist

- [ ] The Pull Request has tests
- [x] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary.
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference
KAG-9552