### PR TITLE
fix(core): correct continuation byte range in UTF-8 validator

### DIFF
--- a/kong/tools/string.lua
+++ b/kong/tools/string.lua
@@ -251,7 +251,7 @@ function _M.validate_utf8(val)
   local i, len = 1, #str
   while i <= len do
     if     i == find(str, "[%z\1-\127]", i) then i = i + 1
-    elseif i == find(str, "[\194-\223][\123-\191]", i) then i = i + 2
+    elseif i == find(str, "[\194-\223][\128-\191]", i) then i = i + 2
     elseif i == find(str,        "\224[\160-\191][\128-\191]", i)
         or i == find(str, "[\225-\236][\128-\191][\128-\191]", i)
         or i == find(str,        "\237[\128-\159][\128-\191]", i)

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -221,6 +221,14 @@ describe("Utils", function()
       assert.False(validate_utf8(string.char(128))) -- unexpected continuation byte
       assert.False(validate_utf8(string.char(192, 32))) -- 2-byte sequence 0xc0 followed by space
       assert.False(validate_utf8(string.char(192))) -- 2-byte sequence with last byte missing
+      assert.False(validate_utf8(string.char(194, 123))) -- invalid 2-byte sequence (second byte too low, ASCII '{')
+      assert.False(validate_utf8(string.char(194, 127))) -- invalid 2-byte sequence (second byte too low, ASCII DEL)
+      assert.True(validate_utf8(string.char(194, 128)))  -- valid 2-byte sequence (boundary min)
+      assert.True(validate_utf8(string.char(194, 191)))  -- valid 2-byte sequence (boundary max)
+      assert.False(validate_utf8(string.char(194, 192))) -- invalid 2-byte sequence (second byte too high)
+      assert.True(validate_utf8(string.char(223, 128)))  -- valid 2-byte sequence (boundary min)
+      assert.True(validate_utf8(string.char(223, 191)))  -- valid 2-byte sequence (boundary max)
+      assert.False(validate_utf8(string.char(223, 192))) -- invalid 2-byte sequence (second byte too high)
       assert.False(validate_utf8(string.char(254))) -- impossible byte
       assert.False(validate_utf8(string.char(255))) -- impossible byte
       assert.False(validate_utf8(string.char(237, 160, 128))) -- Single UTF-16 surrogate


### PR DESCRIPTION
### Summary

This Pull Request fixes a typographical bug in kong.tools.string.validate_utf8 where the byte boundary range for 2-byte UTF-8 sequences was incorrectly defined.

Specifically, the continuation byte's lower limit was written as \123 (decimal 123, representing ASCII {) instead of the correct \128 (decimal 128, representing 0x80). This bug allowed invalid 2-byte sequences with trailing ASCII punctuation or control characters (123..127) to pass UTF-8 validation checks and be saved into database schemas.

Background & Technical Context
In Lua, escape sequences inside string literals (e.g. \ddd) are parsed as decimal values by default, unlike other programming languages where they are parsed as octals.

According to Table 3-7 of the Unicode Standard (referenced in the function comments), a valid 2-byte UTF-8 sequence consists of:

A lead byte in the range 0xC2..0xDF (decimal 194..223).
A continuation byte in the range 0x80..0xBF (decimal 128..191).
Due to a typo on 

kong/tools/string.lua:L254:
elseif i == find(str, "[\194-\223][\123-\191]", i) then i = i + 2

The range was specified as [\123-\191]. This means any lead byte in the 194..223 range followed by any byte between 123 (ASCII {) and 191 (e.g., 123 ({), 124 (|), 125 (}), 126 (~), 127 (DEL)) was incorrectly validated as a valid 2-byte UTF-8 sequence.

Changes Made
1. Code Fix
Updated 

kong/tools/string.lua
 to adjust the 2-byte sequence validation pattern to use the correct \128 lower boundary.
-    elseif i == find(str, "[\194-\223][\123-\191]", i) then i = i + 2
+    elseif i == find(str, "[\194-\223][\128-\191]", i) then i = i + 2

### Checklist

- [✔️] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [✔️] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

Fix #14971 _
