### PR TITLE
chore(changelog): fix typo in cors ACAO entry

### DIFF
--- a/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
+++ b/changelog/unreleased/kong/feat-cors-skip-return-acao-when-no-origin-in-request.yml
@@ -1,3 +1,3 @@
-message: "**CORS**: Added an option to skip returning the Access-Control-Allow-Origin response headeer when requests don't have the Origin Header"
+message: "**CORS**: Added an option to skip returning the Access-Control-Allow-Origin response header when requests don't have the Origin Header"
 type: feature
 scope: Plugin


### PR DESCRIPTION
Correct "headeer" to "header" in the CORS changelog entry describing the option to skip returning the ACAO response header when requests have no Origin header.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
