### PR TITLE
fix(request-response-transformer): validate header values correctly

### DIFF
--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -1,7 +1,9 @@
 local pl_template = require "pl.template"
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
 local typedefs = require "kong.db.schema.typedefs"
-local validate_header_name = require("kong.tools.http").validate_header_name
+local http = require "kong.tools.http"
+local validate_header_name = http.validate_header_name
+local validate_header_value = http.validate_header_value
 
 
 local compile_opts = {
@@ -26,23 +28,27 @@ local function check_for_value(entry)
 end
 
 
-local function validate_headers(pair, validate_value)
+local function validate_headers(pair, value_validator)
   local name, value = pair:match("^([^:]+):*(.-)$")
   if validate_header_name(name) == nil then
     return nil, string.format("'%s' is not a valid header", tostring(name))
   end
 
-  if validate_value then
-    if validate_header_name(value) == nil then
-      return nil, string.format("'%s' is not a valid header", tostring(value))
-    end
+  if value_validator and value_validator(value) == nil then
+    return nil, string.format("'%s' is not a valid header", tostring(value))
   end
+
   return true
 end
 
 
+local function validate_colon_header_values(pair)
+  return validate_headers(pair, validate_header_value)
+end
+
+
 local function validate_colon_headers(pair)
-  return validate_headers(pair, true)
+  return validate_headers(pair, validate_header_name)
 end
 
 
@@ -84,7 +90,7 @@ local colon_header_value_array = {
   type = "array",
   default = {},
   required = true,
-  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_headers },
+  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_colon_header_values },
 }
 
 

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -1,24 +1,30 @@
 local typedefs = require "kong.db.schema.typedefs"
-local validate_header_name = require("kong.tools.http").validate_header_name
+local http = require "kong.tools.http"
+local validate_header_name = http.validate_header_name
+local validate_header_value = http.validate_header_value
 
 
-local function validate_headers(pair, validate_value)
+local function validate_headers(pair, value_validator)
   local name, value = pair:match("^([^:]+):*(.-)$")
   if validate_header_name(name) == nil then
     return nil, string.format("'%s' is not a valid header", tostring(name))
   end
 
-  if validate_value then
-    if validate_header_name(value) == nil then
-      return nil, string.format("'%s' is not a valid header", tostring(value))
-    end
+  if value_validator and value_validator(value) == nil then
+    return nil, string.format("'%s' is not a valid header", tostring(value))
   end
+
   return true
 end
 
 
+local function validate_colon_header_values(pair)
+  return validate_headers(pair, validate_header_value)
+end
+
+
 local function validate_colon_headers(pair)
-  return validate_headers(pair, true)
+  return validate_headers(pair, validate_header_name)
 end
 
 local string_array = {
@@ -46,6 +52,14 @@ local string_record = {
 }
 
 
+local colon_header_values_array = {
+  type = "array",
+  default = {},
+  required = true,
+  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_colon_header_values },
+}
+
+
 local colon_string_record = {
   type = "record",
   fields = {
@@ -58,7 +72,7 @@ local colon_string_record = {
         one_of = { "boolean", "number", "string" }
       }
     } },
-    { headers = colon_string_array },
+    { headers = colon_header_values_array },
   },
 }
 

--- a/kong/tools/http.lua
+++ b/kong/tools/http.lua
@@ -252,6 +252,7 @@ local CONTROLS = [[\x00-\x1F\x7F]]
 local HIGHBIT = [[\x80-\xFF]]
 local SEPARATORS = [==[ \t()<>@,;:\\\"\/?={}\[\]]==]
 local HTTP_TOKEN_FORBID_PATTERN = "[".. CONTROLS .. HIGHBIT .. SEPARATORS .. "]"
+local HTTP_HEADER_VALUE_FORBID_PATTERN = [[\x00-\x08\x0A-\x1F\x7F]]
 
 
 --- Validates a token defined by RFC 2616.
@@ -289,6 +290,25 @@ function _M.validate_header_name(name)
 
   return nil, "bad header name '" .. name ..
               "', allowed characters are A-Z, a-z, 0-9, '_', and '-'"
+end
+
+
+--- Validates a header field value according to RFC 9110.
+-- Empty values, horizontal tabs, spaces, visible ASCII characters, and
+-- obs-text (0x80-0xFF) are allowed. Other control characters are forbidden.
+-- @param value (string) the header value to verify
+-- @return the valid header value, or `nil+error`
+function _M.validate_header_value(value)
+  if value == nil then
+    return nil, "no header value provided"
+  end
+
+  if not re_match(value, "[" .. HTTP_HEADER_VALUE_FORBID_PATTERN .. "]", "jo") then
+    return value
+  end
+
+  return nil, "bad header value, control characters other than horizontal " ..
+              "tab are not allowed"
 end
 
 

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -703,6 +703,25 @@ describe("Utils", function()
       end
     end
   end)
+
+  it("validate_header_value() validates header values", function()
+    assert.equal("", tools_http.validate_header_value(""))
+    assert.is_nil(tools_http.validate_header_value(nil))
+
+    for i = 0, 255 do
+      local c = string.char(i)
+      local valid = i == 9 or i >= 32 and i ~= 127
+
+      if valid then
+        assert.equal(c, tools_http.validate_header_value(c),
+          "ascii character " .. i .. " should have been allowed")
+      else
+        assert.is_nil(tools_http.validate_header_value(c),
+          "ascii character " .. i .. " should not have been allowed")
+      end
+    end
+  end)
+
   it("validate_cookie_name() validates cookie names", function()
     local cookie_chars = [[~`|!#$%&'*+-._-^0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
 

--- a/spec/03-plugins/36-request-transformer/01-schema_spec.lua
+++ b/spec/03-plugins/36-request-transformer/01-schema_spec.lua
@@ -12,6 +12,34 @@ describe("Plugin: request-transformer(schema)", function()
     assert.falsy(ok)
     assert.equal("invalid value: HELLO!", err.config.http_method)
   end)
+
+  for _, operation in ipairs({ "add", "append", "replace" }) do
+    it("validates " .. operation .. " header values", function()
+      local ok, err = v({
+        [operation] = {
+          headers = { "X-Test:a value with spaces; and punctuation!" },
+        },
+      }, request_transformer_schema)
+      assert.truthy(ok)
+      assert.is_nil(err)
+
+      ok = v({
+        [operation] = {
+          headers = { "X-Test:invalid\rvalue" },
+        },
+      }, request_transformer_schema)
+      assert.falsy(ok)
+    end)
+  end
+
+  it("validates renamed header names", function()
+    local ok = v({
+      rename = {
+        headers = { "X-Test:not a header name" },
+      },
+    }, request_transformer_schema)
+    assert.falsy(ok)
+  end)
   it("validate regex pattern as value", function()
     local config = {
       add = {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR adds RFC 9110 compliant HTTP header value validation and fixes request/response transformer from failing during deployment time. 

Deployments were failing due to header values being returned as invalid, yet these header values were being validated against header name standards. The new logic now  rejects invalid control characters while allowing valid whitespace, and visible characters.

### Checklist

- [x] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/blob/main/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_

No issue was created