### PR TITLE
docs(*): use https for Community Slack invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ https://konghq.com/kong-enterprise-edition/ or contact us at
 
 For questions about the use of the Community Edition, please use
 [GitHub Discussions](https://github.com/Kong/kong/discussions).  You
-can also join our [Community Slack](http://kongcommunity.slack.com/)
+can also join our [Community Slack](https://kongcommunity.slack.com/)
 for real-time conversations around Kong Gateway.
 
 **Please avoid opening GitHub issues for general questions or help**, as those

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Please see the [Changelog](CHANGELOG.md) for more details about a given release.
 - Check out the [docs](https://docs.konghq.com/)
 - Join the [Kong discussions forum](https://github.com/Kong/kong/discussions)
 - Join the Kong discussions at the Kong Nation forum: [https://discuss.konghq.com/](https://discuss.konghq.com/)
-- Join our [Community Slack](http://kongcommunity.slack.com/)
+- Join our [Community Slack](https://kongcommunity.slack.com/)
 - Read up on the latest happenings at our [blog](https://konghq.com/blog/)
 - Follow us on [X](https://x.com/thekonginc)
 - Subscribe to our [YouTube channel](https://www.youtube.com/c/KongInc/videos)


### PR DESCRIPTION
## Problem

Community Slack is linked as `http://kongcommunity.slack.com/` in `README.md` and `CONTRIBUTING.md`. The URL works via redirect. Public docs should use TLS.

## Fix

Use `https://kongcommunity.slack.com/` in both files.

## Testing

- [x] Links are `https://` only
- [x] Docs-only; no changelog

## Checklist

- [x] Commit message follows CONTRIBUTING