### PR TITLE
fix(ai-prompt-decorator): keep empty JSON arrays when rewriting the body

### DIFF
--- a/changelog/unreleased/kong/fix-ai-prompt-decorator-empty-arrays.yml
+++ b/changelog/unreleased/kong/fix-ai-prompt-decorator-empty-arrays.yml
@@ -1,0 +1,5 @@
+message: >
+  **ai-prompt-decorator**: Fixed empty JSON arrays (such as `tools: []`) being
+  re-encoded as objects after decorating the request body.
+type: bugfix
+scope: Plugin

--- a/kong/plugins/ai-prompt-decorator/filters/decorate-prompt.lua
+++ b/kong/plugins/ai-prompt-decorator/filters/decorate-prompt.lua
@@ -1,6 +1,7 @@
 local new_tab = require("table.new")
 local ai_plugin_ctx = require("kong.llm.plugin.ctx")
 local cycle_aware_deep_copy = require("kong.tools.table").cycle_aware_deep_copy
+local cjson = require("kong.tools.cjson")
 
 local _M = {
   NAME = "decorate-prompt",
@@ -20,6 +21,24 @@ local EMPTY = {}
 local function bad_request(msg)
   kong.log.info(msg)
   return kong.response.exit(400, { error = { message = msg } })
+end
+
+
+-- get_request_body_table_inuse() wraps the real body in an immutable proxy
+-- (empty table + __index). cycle_aware_deep_copy of that proxy keeps the
+-- proxy metatable and no own keys, so cjson encodes it as {}.
+-- Copy the underlying table so array_mt on empty JSON arrays survives.
+local function materialize_request(request)
+  local mt = getmetatable(request)
+  if mt and type(mt.__index) == "table" then
+    request = mt.__index
+  end
+  return cycle_aware_deep_copy(request)
+end
+
+
+local function encode_request_body(request)
+  return cjson.encode(request)
 end
 
 
@@ -58,6 +77,8 @@ end
 if _G._TEST then
   -- only if we're testing export this function (using a different name!)
   _M._execute = execute
+  _M._materialize_request = materialize_request
+  _M._encode_request_body = encode_request_body
 end
 
 
@@ -76,9 +97,16 @@ function _M:run(conf)
 
   -- Deep copy to avoid modifying the immutable table.
   -- Re-assign it to trigger GC of the old one and save memory.
-  request_body_table = execute(cycle_aware_deep_copy(request_body_table), conf)
+  request_body_table = execute(materialize_request(request_body_table), conf)
 
-  kong.service.request.set_body(request_body_table, "application/json")
+  local encoded, err = encode_request_body(request_body_table)
+  if not encoded then
+    return bad_request(err or "failed to encode decorated request")
+  end
+
+  -- set_body uses a cjson instance that turns empty tables without array_mt
+  -- into {}. Encode with kong.tools.cjson so empty JSON arrays stay arrays.
+  kong.service.request.set_raw_body(encoded)
 
   set_ctx("decorated", true)
   ai_plugin_ctx.set_request_body_table_inuse(request_body_table, _M.NAME)

--- a/spec/03-plugins/41-ai-prompt-decorator/01-unit_spec.lua
+++ b/spec/03-plugins/41-ai-prompt-decorator/01-unit_spec.lua
@@ -175,4 +175,38 @@ describe(PLUGIN_NAME .. ": (unit)", function()
 
   end)
 
+  describe("empty JSON arrays (#14983)", function()
+    local cjson
+    local ai_plugin_ctx
+
+    setup(function()
+      cjson = require("kong.tools.cjson")
+      ai_plugin_ctx = require("kong.llm.plugin.ctx")
+    end)
+
+    it("keeps empty tools and nested required arrays after decorate + encode", function()
+      local request = {
+        messages = {
+          { role = "user", content = "ping" },
+        },
+        tools = cjson.decode_with_array_mt("[]"),
+        extra = {
+          required = cjson.decode_with_array_mt("[]"),
+        },
+      }
+
+      local immutable = ai_plugin_ctx.immutable_table(request)
+      local materialized = access_handler._materialize_request(immutable)
+      local decorated, err = access_handler._execute(materialized, injector_conf_prepend)
+      assert.is_nil(err)
+
+      local encoded, encode_err = access_handler._encode_request_body(decorated)
+      assert.is_nil(encode_err)
+      assert.matches('"tools":%s*%[%]', encoded)
+      assert.matches('"required":%s*%[%]', encoded)
+      assert.not_matches('"tools":%s*{}', encoded)
+      assert.not_matches('"required":%s*{}', encoded)
+    end)
+  end)
+
 end)


### PR DESCRIPTION
## Summary

`ai-prompt-decorator` re-serialized the request through the immutable body proxy. `cycle_aware_deep_copy` of that proxy keeps no own keys, so `cjson` wrote `{}` and empty JSON arrays such as `tools: []` or nested `required: []` became objects. Upstream Anthropic then rejects the request with `400 tools: Input should be a valid array`.

Copy the underlying table (so `array_mt` survives), encode with `kong.tools.cjson`, and write the raw body.

Fixes #14983

## Test plan

- [x] Unit: decorate an immutable body whose `tools` and nested `required` are empty JSON arrays; encoded output keeps `[]`
- [x] Existing prepend/append message-order unit cases still pass