### PR TITLE
Fix gateway start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Whether you’re running in the cloud, on bare metal, or using containers, you c
 
 2) Start the Gateway stack using:
 ```cmd
-  $ KONG_DATABASE=postgres docker-compose --profile database up
+  $ KONG_DATABASE=postgres docker compose --profile database up
 ```
 
 The Gateway is now available on the following ports on localhost:


### PR DESCRIPTION
### Summary

Corrected the gateway start command in the documentation .

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary.
- [ ] There is a user-facing docs PR against https://github.com/Kong/developer.konghq.com - PUT DOCS PR HERE

### Issue reference

None
