### PR TITLE
fix(db): send PostgreSQL host as TLS SNI

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -187,6 +187,23 @@ end
 local setkeepalive
 
 
+local function new_connection(config)
+  local connection = pgmoon.new(config)
+
+  if connection.sock_type == "nginx" then
+    local sslhandshake = connection.sock.sslhandshake
+    connection.sock.sslhandshake = function(sock, reused_session,
+                                             server_name, ssl_verify,
+                                             send_status_req)
+      return sslhandshake(sock, reused_session, server_name or config.host,
+                          ssl_verify, send_status_req)
+    end
+  end
+
+  return connection
+end
+
+
 local function reconnect(config)
   local phase = get_phase()
   if phase == "init" or phase == "init_worker" then
@@ -196,7 +213,7 @@ local function reconnect(config)
     config.socket_type = "nginx"
   end
 
-  local connection = pgmoon.new(config)
+  local connection = new_connection(config)
 
   connection.convert_null = true
   connection.NULL         = null


### PR DESCRIPTION
Fixes #14989

The bundled pgmoon 1.16.2 omits the `server_name` argument when calling the nginx cosocket TLS handshake. This prevents Kong from connecting to PostgreSQL endpoints behind SNI-routing proxies.

This change wraps the pgmoon socket handshake at Kong's PostgreSQL connector boundary and supplies the configured `pg_host` when no explicit SNI value is provided. Explicit server names remain unchanged, and non-nginx sockets are unaffected.

Validation:
- `bin/busted spec/01-unit/01-db/06-postgres_spec.lua`
- `bin/busted --verbose spec/01-unit/01-db/06-postgres_spec.lua`
- No diagnostics reported for the edited file
- `git diff --check` passed