### PR TITLE
fix(ai-proxy): preserve cachedContent in gemini driver

### DIFF
--- a/changelog/unreleased/kong/fix-ai-proxy-gemini-cached-content.yml
+++ b/changelog/unreleased/kong/fix-ai-proxy-gemini-cached-content.yml
@@ -1,0 +1,3 @@
+message: "**ai-proxy**: Fixed an issue where the `cachedContent` field was dropped during OpenAI-to-Gemini transformation in the Gemini driver."
+type: bugfix
+scope: Plugin

--- a/kong/llm/drivers/gemini.lua
+++ b/kong/llm/drivers/gemini.lua
@@ -377,6 +377,9 @@ local function to_gemini_chat_openai(request_table, model_info, route_type)
     -- handle function calling translation from OpenAI format
     new_r.tools = request_table.tools and to_tools(request_table.tools)
     new_r.tool_config = request_table.tool_config
+
+    -- handle context caching for Vertex AI / Gemini
+    new_r.cachedContent = request_table.cachedContent or request_table.cached_content
   end
 
   return new_r, "application/json", nil

--- a/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
+++ b/spec/03-plugins/38-ai-proxy/01-unit_spec.lua
@@ -1215,6 +1215,77 @@ describe(PLUGIN_NAME .. ": (unit)", function()
   end)
 
 
+  describe("gemini context caching", function()
+    local gemini_driver
+
+    setup(function()
+      _G._TEST = true
+      package.loaded["kong.llm.drivers.gemini"] = nil
+      gemini_driver = require("kong.llm.drivers.gemini")
+    end)
+
+    teardown(function()
+      _G._TEST = nil
+    end)
+
+    it("preserves cachedContent when provided in request", function()
+      local request = {
+        messages = {
+          {
+            role = "user",
+            content = "Analyze the pre-cached document.",
+          },
+        },
+        cachedContent = "projects/123456/locations/us-central1/cachedContents/987654",
+      }
+
+      local gemini_prompt, content_type, err = gemini_driver._to_gemini_chat_openai(request)
+
+      assert.is_nil(err)
+      assert.not_nil(gemini_prompt)
+      assert.equal("application/json", content_type)
+      assert.equal("projects/123456/locations/us-central1/cachedContents/987654", gemini_prompt.cachedContent)
+    end)
+
+    it("normalizes cached_content (snake_case) to cachedContent", function()
+      local request = {
+        messages = {
+          {
+            role = "user",
+            content = "Analyze the pre-cached document.",
+          },
+        },
+        cached_content = "cachedContents/sample-cache-id",
+      }
+
+      local gemini_prompt, content_type, err = gemini_driver._to_gemini_chat_openai(request)
+
+      assert.is_nil(err)
+      assert.not_nil(gemini_prompt)
+      assert.equal("application/json", content_type)
+      assert.equal("cachedContents/sample-cache-id", gemini_prompt.cachedContent)
+    end)
+
+    it("does not set cachedContent when not provided", function()
+      local request = {
+        messages = {
+          {
+            role = "user",
+            content = "Hello world",
+          },
+        },
+      }
+
+      local gemini_prompt, content_type, err = gemini_driver._to_gemini_chat_openai(request)
+
+      assert.is_nil(err)
+      assert.not_nil(gemini_prompt)
+      assert.equal("application/json", content_type)
+      assert.is_nil(gemini_prompt.cachedContent)
+    end)
+  end)
+
+
   describe("gemini tools", function()
     local gemini_driver
 


### PR DESCRIPTION
### Summary

Fixes an issue where `cachedContent` was silently dropped during OpenAI-to-Gemini request transformation in `ai-proxy`, preventing callers from leveraging Vertex AI / Gemini context caching over the OpenAI-compatible route.

### Changes

- **`kong/llm/drivers/gemini.lua`**: Forward `cachedContent` (and `cached_content`) from `request_table` to `new_r.cachedContent` in `to_gemini_chat_openai()`.
- **`spec/03-plugins/38-ai-proxy/01-unit_spec.lua`**: Added unit tests asserting that:
  - `cachedContent` (camelCase) is retained in the generated Gemini request table.
  - `cached_content` (snake_case) is normalized to `cachedContent`.
  - Omitting `cachedContent` leaves the field unset (`nil`).
- **`changelog/unreleased/kong/fix-ai-proxy-gemini-cached-content.yml`**: Added unreleased changelog entry according to repository conventions.

### Testing

- Added unit tests to `spec/03-plugins/38-ai-proxy/01-unit_spec.lua`.
- Verified formatting and whitespace with `git diff --check`.

### Related Issue

Fixes #14837
